### PR TITLE
Change Data Capture(CDC)[Draft]

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -74,4 +74,11 @@ public interface ActionsProvider {
   default DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /**
+   * Instantiates an action to generate CDC records.
+   */
+  default Cdc generateCdcRecords(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement generateCdcRecords");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/Cdc.java
+++ b/api/src/main/java/org/apache/iceberg/actions/Cdc.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public interface Cdc extends Action<Cdc, Cdc.Result> {
+  /**
+   * Emit changed data set by a snapshot id.
+   *
+   * @param snapshotId id of the snapshot to generate changed data
+   * @return this for method chaining
+   */
+  Cdc useSnapshot(long snapshotId);
+
+  /**
+   * Emit changed data set by a range of snapshots
+   *
+   * @param fromSnapshotId id of the first snapshot
+   * @param toSnapshotId id of the last snapshot
+   * @return this for method chaining
+   */
+  Cdc between(long fromSnapshotId, long toSnapshotId);
+
+  /**
+   * The action result that contains a dataset of changed rows.
+   */
+  interface Result {
+    /**
+     * Returns CDC records.
+     */
+    Object cdcRecords();
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -104,6 +104,10 @@ public class VectorHolder {
     return new ConstantVectorHolder(numRows, constantValue);
   }
 
+  public static <T> VectorHolder deleteMetaColumnHolder(int numRows) {
+    return new DeletedVectorHolder(numRows);
+  }
+
   public static VectorHolder dummyHolder(int numRows) {
     return new ConstantVectorHolder(numRows);
   }
@@ -143,6 +147,19 @@ public class VectorHolder {
   public static class PositionVectorHolder extends VectorHolder {
     public PositionVectorHolder(FieldVector vector, Type type, NullabilityHolder nulls) {
       super(vector, type, nulls);
+    }
+  }
+
+  public static class DeletedVectorHolder extends VectorHolder {
+    private final int numRows;
+
+    public DeletedVectorHolder(int numRows) {
+      this.numRows = numRows;
+    }
+
+    @Override
+    public int numValues() {
+      return this.numRows;
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -517,5 +517,32 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     }
   }
 
+  /**
+   * A Dummy Vector Reader which doesn't actually read files, instead it returns a dummy
+   * VectorHolder which indicates whether the row is deleted.
+   */
+  public static class DeletedVectorReader<T> extends VectorizedArrowReader {
+    public DeletedVectorReader() {
+    }
+
+    @Override
+    public VectorHolder read(VectorHolder reuse, int numValsToRead) {
+      return VectorHolder.deleteMetaColumnHolder(numValsToRead);
+    }
+
+    @Override
+    public void setRowGroupInfo(PageReadStore source, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition) {
+    }
+
+    @Override
+    public String toString() {
+      return "DeletedVectorReader";
+    }
+
+    @Override
+    public void setBatchSize(int batchSize) {
+    }
+  }
+
 }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -91,7 +91,7 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
           reorderedFields.add(VectorizedArrowReader.positions());
         }
       } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
-        reorderedFields.add(new VectorizedArrowReader.ConstantVectorReader<>(false));
+        reorderedFields.add(new VectorizedArrowReader.DeletedVectorReader<>());
       } else if (reader != null) {
         reorderedFields.add(reader);
       } else {

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -47,6 +47,10 @@ public class BaseFileScanTask implements FileScanTask {
     this.residuals = residuals;
   }
 
+  public BaseFileScanTask cloneWithoutDeletes() {
+    return new BaseFileScanTask(file, null, schemaString, specString, residuals);
+  }
+
   @Override
   public DataFile file() {
     return file;

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -290,8 +290,6 @@ public abstract class DeleteFilter<T> {
       requiredIds.addAll(eqDelete.equalityFieldIds());
     }
 
-    requiredIds.add(MetadataColumns.IS_DELETED.fieldId());
-
     Set<Integer> missingIds = Sets.newLinkedHashSet(
         Sets.difference(requiredIds, TypeUtil.getProjectedIds(requestedSchema)));
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCdcWithMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCdcWithMerge.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.Cdc;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
+import static org.apache.iceberg.spark.actions.BaseCdcSparkAction.RECORD_TYPE;
+
+public class TestCdcWithMerge extends SparkRowLevelOperationsTestBase {
+  public TestCdcWithMerge(String catalogName, String implementation, Map<String, String> config, String fileFormat,
+                          boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
+  }
+
+  /**
+   * Overwrite the parameters in the parent class. We need different combinations.
+   */
+  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}," +
+      " format = {3}, vectorized = {4}, distributionMode = {5}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        { "testhive", SparkCatalog.class.getName(),
+            ImmutableMap.of(
+                "type", "hive",
+                "default-namespace", "default"
+            ),
+            "parquet",
+            true,
+            WRITE_DISTRIBUTION_MODE_NONE
+        }
+    };
+  }
+
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(TableProperties.MERGE_MODE, "copy-on-write");
+  }
+
+  @BeforeClass
+  public static void setupSparkConf() {
+    spark.conf().set("spark.sql.shuffle.partitions", "4");
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS source");
+  }
+
+  private ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  @Test
+  public void testMergeWithOnlyUpdateClause() throws ParseException, NoSuchTableException {
+    createAndInitTable("id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" +
+            "{ \"id\": 6, \"dep\": \"emp-id-six\" }");
+
+    createOrReplaceView("source", "id INT, dep STRING",
+        "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n" +
+            "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n" +
+            "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    sql("MERGE INTO %s AS t USING source AS s " +
+        "ON t.id == s.id " +
+        "WHEN MATCHED AND t.id = 1 THEN " +
+        "  UPDATE SET *", tableName);
+
+    Table testTable = Spark3Util.loadIcebergTable(spark, tableName);
+    Cdc.Result result = actions().generateCdcRecords(testTable).execute();
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+
+    // verify results
+    List<Object[]> actualRecords = rowsToJava(resultDF.sort(RECORD_TYPE, "id").collectAsList());
+    long snapshotId = testTable.currentSnapshot().snapshotId();
+    long snapshotTs = testTable.currentSnapshot().timestampMillis();
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(1, "emp-id-one", "D", snapshotId, snapshotTs, 0),
+        row(6, "emp-id-six", "D", snapshotId, snapshotTs, 0),
+        row(1, "emp-id-1", "I", snapshotId, snapshotTs, 0),
+        row(6, "emp-id-six", "I", snapshotId, snapshotTs, 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  @Test
+  public void testMergeWithPositionDelete() throws ParseException, NoSuchTableException {
+    createAndInitTable("id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" +
+            "{ \"id\": 6, \"dep\": \"emp-id-six\" }");
+
+    withV2MergeOnRead();
+
+    createOrReplaceView("source", "id INT, dep STRING",
+        "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n" +
+            "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n" +
+            "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    sql("MERGE INTO %s AS t USING source AS s " +
+        "ON t.id == s.id " +
+        "WHEN MATCHED AND t.id = 1 THEN " +
+        "  UPDATE SET *", tableName);
+
+    Table testTable = Spark3Util.loadIcebergTable(spark, tableName);
+    Cdc.Result result = actions().generateCdcRecords(testTable).execute();
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+
+    // verify results
+    List<Object[]> actualRecords = rowsToJava(resultDF.sort(RECORD_TYPE, "id").collectAsList());
+    long snapshotId = testTable.currentSnapshot().snapshotId();
+    long snapshotTs = testTable.currentSnapshot().timestampMillis();
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(1, "emp-id-one", "D", snapshotId, snapshotTs, 0),
+        row(1, "emp-id-1", "I", snapshotId, snapshotTs, 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  private void withV2MergeOnRead() {
+    sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tableName, TableProperties.FORMAT_VERSION, "2");
+    sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tableName, TableProperties.MERGE_MODE, "merge-on-read");
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCdcSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCdcSparkAction.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataOperations;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestGroup;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.Cdc;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.FileScanTaskSetManager;
+import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.spark.sql.functions.lit;
+
+public class BaseCdcSparkAction extends BaseSparkAction<Cdc, Cdc.Result> implements Cdc {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCdcSparkAction.class);
+  public static final String RECORD_TYPE = "_record_type";
+  public static final String COMMIT_SNAPSHOT_ID = "_commit_snapshot_id";
+  public static final String COMMIT_TIMESTAMP = "_commit_timestamp";
+  public static final String COMMIT_ORDER = "_commit_order";
+  private final List<Long> snapshotIds = Lists.newLinkedList();
+  private final Table table;
+  private final List<Dataset<Row>> dfs = Lists.newLinkedList();
+  private boolean ignoreRowsDeletedWithinSnapshot = true;
+
+  private Expression filter = Expressions.alwaysTrue();
+
+  protected BaseCdcSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+  }
+
+  @Override
+  public Result execute() {
+    // use the current snapshot by default
+    if (snapshotIds.isEmpty()) {
+      if (table.currentSnapshot() != null) {
+        snapshotIds.add(table.currentSnapshot().snapshotId());
+      }
+    }
+
+    for(int i = 0; i < snapshotIds.size(); i++) {
+      generateCdcRecordsPerSnapshot(snapshotIds.get(i), i);
+    }
+
+    Dataset<Row> outputDf = null;
+    for (Dataset<Row> df : dfs) {
+      if (outputDf == null) {
+        outputDf = df;
+      } else {
+        outputDf = outputDf.unionByName(df, true);
+      }
+    }
+    return new BaseCdcSparkActionResult(outputDf);
+  }
+
+  private void generateCdcRecordsPerSnapshot(long snapshotId, int commitOrder) {
+    Snapshot snapshot = table.snapshot(snapshotId);
+    if (snapshot.operation().equals(DataOperations.REPLACE)) {
+      return;
+    }
+
+    // new data file as the insert
+    Dataset<Row> df = readAppendDataFiles(snapshotId, commitOrder);
+    if (df != null) {
+      dfs.add(df);
+    }
+
+    // metadata deleted data files
+    Dataset<Row> deletedDf = readMetadataDeletedFiles(snapshotId, commitOrder);
+    if (deletedDf != null) {
+      dfs.add(deletedDf);
+    }
+
+    // pos and eq deletes
+    Dataset<Row> rowLevelDeleteDf = readRowLevelDeletes(snapshotId, commitOrder);
+    if (rowLevelDeleteDf != null) {
+      dfs.add(rowLevelDeleteDf);
+    }
+  }
+
+  private Dataset<Row> readAppendDataFiles(long snapshotId, int commitOrder) {
+    List<FileScanTask> appendedFileTasks = planAppendedFiles(snapshotId);
+    if (appendedFileTasks.size() <= 0) {
+      return null;
+    }
+
+    String groupID = UUID.randomUUID().toString();
+    FileScanTaskSetManager manager = FileScanTaskSetManager.get();
+    manager.stageTasks(table, groupID, appendedFileTasks);
+    Dataset<Row> scanDF = spark().read().format("iceberg")
+        .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID, groupID)
+        .load(table.name());
+
+    return withCdcColumns(scanDF, snapshotId, "I", commitOrder);
+  }
+
+  private List<FileScanTask> planAppendedFiles(long snapshotId) {
+    CloseableIterable<FileScanTask> fileScanTasks = table.newScan()
+        .useSnapshot(snapshotId)
+        .filter(filter)
+        .ignoreResiduals()
+        .planFiles();
+
+    Set<CharSequence> dataFiles = Sets.newHashSet();
+    for (DataFile dataFile : table.snapshot(snapshotId).addedFiles()) {
+      dataFiles.add(dataFile.path());
+    }
+
+    List<FileScanTask> appendedFiles = Lists.newLinkedList();
+    if (dataFiles.size() <= 0) {
+      return appendedFiles;
+    }
+
+    fileScanTasks.forEach(fileScanTask -> {
+      if (fileScanTask.file().content().equals(FileContent.DATA) && dataFiles.contains(fileScanTask.file().path())) {
+        FileScanTask newFileScanTask = fileScanTask;
+        if (!ignoreRowsDeletedWithinSnapshot) {
+          // remove delete files so that no delete will apply to the data file
+          Preconditions.checkArgument(fileScanTask instanceof BaseFileScanTask,
+              "Object fileScanTask should be an instance of BaseFileScanTask");
+          newFileScanTask = ((BaseFileScanTask) fileScanTask).cloneWithoutDeletes();
+        }
+        appendedFiles.add(newFileScanTask);
+      }
+    });
+
+    return appendedFiles;
+  }
+
+  private Dataset<Row> readMetadataDeletedFiles(long snapshotId, int commitOrder) {
+    List<FileScanTask> appendedFileTasks = planMetadataDeletedFiles(snapshotId);
+    if (appendedFileTasks.size() <= 0) {
+      return null;
+    }
+
+    String groupID = UUID.randomUUID().toString();
+    FileScanTaskSetManager manager = FileScanTaskSetManager.get();
+    manager.stageTasks(table, groupID, appendedFileTasks);
+    Dataset<Row> scanDF = spark().read().format("iceberg")
+        .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID, groupID)
+        .load(table.name());
+
+    return withCdcColumns(scanDF, snapshotId, "D", commitOrder);
+  }
+
+  private List<FileScanTask> planMetadataDeletedFiles(long snapshotId) {
+    Snapshot snapshot = table.snapshot(snapshotId);
+    ManifestGroup manifestGroup = new ManifestGroup(table.io(), snapshot.dataManifests(), snapshot.deleteManifests())
+        .filterData(filter)
+        .ignoreAdded()
+        .specsById(((HasTableOperations) table).operations().current().specsById());
+
+    return ImmutableList.copyOf(manifestGroup.planFiles());
+  }
+
+  private Dataset<Row> readRowLevelDeletes(long snapshotId, int commitOrder) {
+    List<FileScanTask> fileScanTasks = planRowLevelDeleteFiles(snapshotId);
+    if (fileScanTasks.size() <= 0) {
+      return null;
+    }
+
+    String groupID = UUID.randomUUID().toString();
+    FileScanTaskSetManager manager = FileScanTaskSetManager.get();
+    manager.stageTasks(table, groupID, fileScanTasks);
+    Dataset<Row> scanDF = spark().read().format("iceberg")
+        .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID, groupID)
+        .load(table.name())
+        .filter(functions.column(MetadataColumns.IS_DELETED.name()).equalTo(true));
+
+    return withCdcColumns(scanDF, snapshotId, "D", commitOrder);
+  }
+
+  private List<FileScanTask> planRowLevelDeleteFiles(long snapshotId) {
+    Snapshot snapshot = table.snapshot(snapshotId);
+    List<ManifestFile> manifestFiles = snapshot.deleteManifests().stream()
+        .filter(manifestFile -> manifestFile.snapshotId().equals(snapshotId))
+        .collect(Collectors.toList());
+
+    // todo create a partition filter to filter out unrelated partitions
+    ManifestGroup manifestGroup = new ManifestGroup(table.io(), snapshot.dataManifests(), manifestFiles)
+        .filterData(filter)
+        .onlyWithDeletes()
+        .specsById(((HasTableOperations) table).operations().current().specsById());
+
+    return ImmutableList.copyOf(manifestGroup.planFiles());
+  }
+
+  private Dataset<Row> withCdcColumns(Dataset<Row> df, long snapshotId, String cdcType, int commitOrder) {
+    return df.withColumn(RECORD_TYPE, lit(cdcType))
+        .withColumn(COMMIT_SNAPSHOT_ID, lit(snapshotId))
+        .withColumn(COMMIT_TIMESTAMP, lit(table.snapshot(snapshotId).timestampMillis()))
+        .withColumn(COMMIT_ORDER, lit(commitOrder));
+  }
+
+  @Override
+  public Cdc useSnapshot(long snapshotId) {
+    if (table.snapshot(snapshotId) != null) {
+      snapshotIds.add(snapshotId);
+    }
+    return this;
+  }
+
+  @Override
+  public Cdc between(long fromSnapshotId, long toSnapshotId) {
+    Preconditions.checkArgument(table.snapshot(fromSnapshotId) != null,
+        "The fromSnapshotId(%s) is invalid", fromSnapshotId);
+    Preconditions.checkArgument(table.snapshot(toSnapshotId) != null,
+        "The toSnapshotId(%s) is invalid", toSnapshotId);
+
+    snapshotIds.add(fromSnapshotId);
+    SnapshotUtil.ancestorIdsBetween(toSnapshotId, fromSnapshotId, table::snapshot).forEach(snapshotIds::add);
+    return this;
+  }
+
+  @Override
+  protected Cdc self() {
+    return this;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCdcSparkActionResult.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCdcSparkActionResult.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.Cdc;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+
+public class BaseCdcSparkActionResult implements Cdc.Result {
+  private final Dataset<Row> cdcRecords;
+
+  public BaseCdcSparkActionResult(Dataset<Row> cdcRecords) {
+    this.cdcRecords = cdcRecords;
+  }
+
+  @Override
+  public Object cdcRecords() {
+    return cdcRecords;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.Cdc;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
@@ -94,5 +95,10 @@ public class SparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
+  }
+
+  @Override
+  public Cdc generateCdcRecords(Table table) {
+    return new BaseCdcSparkAction(spark, table);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/DeletedMetaColumnVector.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/DeletedMetaColumnVector.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class DeletedMetaColumnVector extends ColumnVector {
+  private final boolean[] isDeleted;
+
+  public DeletedMetaColumnVector(Type type, boolean[] isDeleted) {
+    super(SparkSchemaUtil.convert(type));
+    this.isDeleted = isDeleted;
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public boolean hasNull() {
+    return false;
+  }
+
+  @Override
+  public int numNulls() {
+    return 0;
+  }
+
+  @Override
+  public boolean isNullAt(int rowId) {
+    return false;
+  }
+
+  @Override
+  public boolean getBoolean(int rowId) {
+    return isDeleted[rowId];
+  }
+
+  @Override
+  public byte getByte(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public short getShort(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public int getInt(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public long getLong(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public float getFloat(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public double getDouble(int rowId) {
+    return 0;
+  }
+
+  @Override
+  public ColumnarArray getArray(int rowId) {
+    return null;
+  }
+
+  @Override
+  public ColumnarMap getMap(int ordinal) {
+    return null;
+  }
+
+  @Override
+  public Decimal getDecimal(int rowId, int precision, int scale) {
+    return null;
+  }
+
+  @Override
+  public UTF8String getUTF8String(int rowId) {
+    return null;
+  }
+
+  @Override
+  public byte[] getBinary(int rowId) {
+    return new byte[0];
+  }
+
+  @Override
+  public ColumnVector getChild(int ordinal) {
+    return null;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
@@ -153,10 +153,15 @@ public class IcebergArrowColumnVector extends ColumnVector {
     return accessor.childColumn(ordinal);
   }
 
-  static ColumnVector forHolder(VectorHolder holder, int numRows) {
-    return holder.isDummy() ?
-        new ConstantColumnVector(Types.IntegerType.get(), numRows, ((ConstantVectorHolder) holder).getConstant()) :
-        new IcebergArrowColumnVector(holder);
+  static ColumnVector forHolder(VectorHolder holder, int numRows, boolean[] isDeleted) {
+    if (holder.isDummy()) {
+      if (holder instanceof VectorHolder.DeletedVectorHolder) {
+        return new DeletedMetaColumnVector(Types.BooleanType.get(), isDeleted);
+      }
+      return new ConstantColumnVector(Types.IntegerType.get(), numRows, ((ConstantVectorHolder) holder).getConstant());
+    }
+
+    return new IcebergArrowColumnVector(holder);
   }
 
   public ArrowVectorAccessor<Decimal, UTF8String, ColumnarArray, ArrowColumnVector> vectorAccessor() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -87,7 +87,7 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
               fileSchema, /* setArrowValidityVector */ NullCheckingForGet.NULL_CHECKING_ENABLED, idToConstant,
               deleteFilter))
           .recordsPerBatch(batchSize)
-          .filter(task.residual())
+          .filter(task.residual()) // todo we may need to remove _delete filter in case of filter pushdown
           .caseSensitive(caseSensitive)
           // Spark eagerly consumes the batches. So the underlying memory allocated could be reused
           // without worrying about subsequent reads clobbering over each other. This improves

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
@@ -23,8 +23,10 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -43,6 +45,16 @@ class SparkFilesScan extends SparkScan {
 
   SparkFilesScan(SparkSession spark, Table table, SparkReadConf readConf) {
     super(spark, table, readConf, table.schema(), ImmutableList.of());
+
+    this.taskSetID = readConf.fileScanTaskSetId();
+    this.splitSize = readConf.splitSize();
+    this.splitLookback = readConf.splitLookback();
+    this.splitOpenFileCost = readConf.splitOpenFileCost();
+  }
+
+  SparkFilesScan(SparkSession spark, Table table, SparkReadConf readConf, Schema expectedSchema,
+                 List<Expression> filterExpressions) {
+    super(spark, table, readConf, expectedSchema == null ? table.schema() : expectedSchema, ImmutableList.of());
 
     this.taskSetID = readConf.fileScanTaskSetId();
     this.splitSize = readConf.splitSize();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScanBuilder.java
@@ -19,27 +19,112 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkFilters;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
+import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-class SparkFilesScanBuilder implements ScanBuilder {
+class SparkFilesScanBuilder implements ScanBuilder, SupportsPushDownRequiredColumns, SupportsPushDownFilters {
+  private static final Filter[] NO_FILTERS = new Filter[0];
 
   private final SparkSession spark;
   private final Table table;
   private final SparkReadConf readConf;
+  private Schema schema = null;
+  private final List<String> metaColumns = Lists.newArrayList();
+  private List<Expression> filterExpressions = null;
+  private Filter[] pushedFilters = NO_FILTERS;
 
   SparkFilesScanBuilder(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
     this.spark = spark;
     this.table = table;
     this.readConf = new SparkReadConf(spark, table, options);
+    this.schema = table.schema();
   }
 
   @Override
   public Scan build() {
-    return new SparkFilesScan(spark, table, readConf);
+    Schema expectedSchema = schemaWithMetadataColumns();
+    return new SparkFilesScan(spark, table, readConf, expectedSchema, filterExpressions);
+  }
+
+  @Override
+  public void pruneColumns(StructType requestedSchema) {
+    StructType requestedProjection = new StructType(Stream.of(requestedSchema.fields())
+        .filter(field -> MetadataColumns.nonMetadataColumn(field.name()))
+        .toArray(StructField[]::new));
+
+    // the projection should include all columns that will be returned, including those only used in filters
+    schema = SparkSchemaUtil.prune(schema, requestedProjection, Expressions.alwaysTrue(), false);
+
+    Stream.of(requestedSchema.fields())
+        .map(StructField::name)
+        .filter(MetadataColumns::isMetadataColumn)
+        .distinct()
+        .forEach(metaColumns::add);
+  }
+
+  private Schema schemaWithMetadataColumns() {
+    // metadata columns
+    List<Types.NestedField> fields = metaColumns.stream()
+        .distinct()
+        .map(name -> MetadataColumns.metadataColumn(table, name))
+        .collect(Collectors.toList());
+    Schema meta = new Schema(fields);
+
+    // schema or rows returned by readers
+    return TypeUtil.join(schema, meta);
+  }
+
+  @Override
+  public Filter[] pushFilters(Filter[] filters) {
+    List<Expression> expressions = Lists.newArrayListWithExpectedSize(filters.length);
+    List<Filter> pushed = Lists.newArrayListWithExpectedSize(filters.length);
+
+    for (Filter filter : filters) {
+      Expression expr = SparkFilters.convert(filter);
+      if (expr != null) {
+        try {
+          Binder.bind(schema.asStruct(), expr, false);
+          expressions.add(expr);
+          pushed.add(filter);
+        } catch (ValidationException e) {
+          // binding to the table schema failed, so this expression cannot be pushed down
+        }
+      }
+    }
+
+    this.filterExpressions = expressions;
+    this.pushedFilters = pushed.toArray(new Filter[0]);
+
+    // Spark doesn't support residuals per task, so return all filters
+    // to get Spark to handle record-level filtering
+    return filters;
+  }
+
+  @Override
+  public Filter[] pushedFilters() {
+    return pushedFilters;
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -188,7 +188,8 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
         new SparkMetadataColumn(MetadataColumns.SPEC_ID.name(), DataTypes.IntegerType, false),
         new SparkMetadataColumn(MetadataColumns.PARTITION_COLUMN_NAME, sparkPartitionType, true),
         new SparkMetadataColumn(MetadataColumns.FILE_PATH.name(), DataTypes.StringType, false),
-        new SparkMetadataColumn(MetadataColumns.ROW_POSITION.name(), DataTypes.LongType, false)
+        new SparkMetadataColumn(MetadataColumns.ROW_POSITION.name(), DataTypes.LongType, false),
+        new SparkMetadataColumn(MetadataColumns.IS_DELETED.name(), DataTypes.BooleanType, false)
     };
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCdcSparkAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCdcSparkAction.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.Cdc;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestCdcSparkAction extends SparkTestBase {
+  protected ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA = new Schema(
+      optional(1, "c1", Types.IntegerType.get()),
+      optional(2, "c2", Types.StringType.get()),
+      optional(3, "c3", Types.StringType.get())
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+  private final String tableName = "tbl";
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createATableWith2Snapshots(tableLocation);
+
+    // setup the catalog
+    spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog.hive.type", "hive");
+    spark.conf().set("spark.sql.catalog.hive.default-namespace", "default");
+    spark.conf().set("spark.sql.catalog.hive.cache-enabled", "false");
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS hive.default.%s", tableName);
+  }
+
+  private Table createATableWith2Snapshots(String location) {
+    return createTableWithSnapshots(location, 2);
+  }
+
+  private Table createTableWithSnapshots(String location, int snapshotNumber) {
+    return createTableWithSnapshots(location, snapshotNumber, Maps.newHashMap());
+  }
+
+  protected Table createTableWithSnapshots(String location, int snapshotNumber, Map<String, String> properties) {
+    Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(location);
+    }
+
+    return newTable;
+  }
+
+  @Test
+  public void testAppendOnly() {
+    // the current snapshot should only have one row
+    Cdc.Result result = actions().generateCdcRecords(table).execute();
+
+    // verifyData
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+    List<Object[]> actualRecords = rowsToJava(resultDF.collectAsList());
+    Snapshot snapshot = table.currentSnapshot();
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(1, "AAAAAAAAAA", "AAAA", "I", snapshot.snapshotId(), snapshot.timestampMillis(), 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  @Test
+  public void testDeleteNothing() throws IOException {
+    Table sourceTable = createMetastoreTable(Maps.newHashMap());
+    // delete nothing, however, it generates a new snapshot with nothing has been changed
+    sql("delete from hive.default.%s where c1 = 1", tableName);
+    sourceTable.refresh();
+    Cdc.Result result = actions().generateCdcRecords(sourceTable).execute();
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+    Assert.assertEquals("Incorrect result", null, resultDF);
+  }
+
+  @Test
+  public void testMetadataDeleteOnly() throws IOException {
+    Table tbl = createMetastoreTable(Maps.newHashMap());
+    // delete the only row
+    sql("delete from hive.default.%s where c1 = 0", tableName);
+    tbl.refresh();
+    Cdc.Result result = actions().generateCdcRecords(tbl).execute();
+
+    // verify results
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+    List<Object[]> actualRecords = rowsToJava(resultDF.collectAsList());
+    Snapshot snapshot = tbl.currentSnapshot();
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(0, "AAAAAAAAAA", "AAAA", "D", snapshot.snapshotId(), snapshot.timestampMillis(), 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  @Test
+  public void testReadEqualityDeleteRows() throws IOException {
+    Table tbl = createMetastoreTable(Maps.newHashMap(), 3);
+    TableOperations ops = ((BaseTable) tbl).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+
+    // vectorized
+    tbl.updateProperties()
+        .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+        .commit();
+
+    Schema deleteSchema = tbl.schema().select("c1");
+    Record idDelete = GenericRecord.create(deleteSchema);
+    List<Record> idDeletes = Lists.newArrayList(
+        idDelete.copy("c1", 0),
+        idDelete.copy("c1", 1)
+    );
+
+    DeleteFile eqDelete = FileHelpers.writeDeleteFile(
+        tbl, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), idDeletes, deleteSchema);
+
+    tbl.newRowDelta()
+        .addDeletes(eqDelete)
+        .commit();
+
+    Cdc.Result result = actions().generateCdcRecords(tbl).execute();
+    // verify the results
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+    List<Object[]> actualRecords = rowsToJava(resultDF.sort("c1").collectAsList());
+    Snapshot snapshot = tbl.currentSnapshot();
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(0, "AAAAAAAAAA", "AAAA", "D", snapshot.snapshotId(), snapshot.timestampMillis(), 0),
+        row(1, "AAAAAAAAAA", "AAAA", "D", snapshot.snapshotId(), snapshot.timestampMillis(), 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  @Test
+  public void testReadEqualityDeleteRowsWithNoResult() throws IOException {
+    Table tbl = createMetastoreTable(Maps.newHashMap());
+    TableOperations ops = ((BaseTable) tbl).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+
+    // vectorized
+    tbl.updateProperties()
+        .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+        .commit();
+
+    Schema deleteSchema = tbl.schema().select("c1");
+    Record idDelete = GenericRecord.create(deleteSchema);
+    List<Record> idDeletes = Lists.newArrayList(
+        idDelete.copy("c1", 8),
+        idDelete.copy("c1", 9)
+    );
+
+    DeleteFile eqDelete = FileHelpers.writeDeleteFile(
+        tbl, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), idDeletes, deleteSchema);
+
+    tbl.newRowDelta()
+        .addDeletes(eqDelete)
+        .commit();
+
+    Cdc.Result result = actions().generateCdcRecords(tbl).execute();
+    Assert.assertTrue("Must be no result since the c1 value in the eq delete file couldn't match any data file",
+        result.cdcRecords() == null);
+  }
+
+  @Test
+  public void testEqDeleteWithMultipleSnapshots() throws IOException {
+    Table tbl = createMetastoreTable(Maps.newHashMap(), 3);
+    TableOperations ops = ((BaseTable) tbl).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+
+    // vectorized
+    tbl.updateProperties()
+        .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "true")
+        .commit();
+
+    Schema deleteSchema1 = tbl.schema().select("c1");
+    Record dataDelete = GenericRecord.create(deleteSchema1);
+    List<Record> deleteList1 = Lists.newArrayList(
+        dataDelete.copy("c1", 0)
+    );
+
+    Schema deleteSchema2 = tbl.schema().select("c1");
+    Record idDelete = GenericRecord.create(deleteSchema2);
+    List<Record> deleteList2 = Lists.newArrayList(
+        idDelete.copy("c1", 1)
+    );
+
+    DeleteFile eqDelete1 = FileHelpers.writeDeleteFile(
+        tbl, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deleteList1, deleteSchema1);
+    tbl.newRowDelta()
+        .addDeletes(eqDelete1)
+        .commit();
+    long snapshotId1 = tbl.currentSnapshot().snapshotId();
+
+    DeleteFile eqDelete2 = FileHelpers.writeDeleteFile(
+        tbl, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deleteList2, deleteSchema2);
+    tbl.newRowDelta()
+        .addDeletes(eqDelete2)
+        .commit();
+    Snapshot snapshotId2 = tbl.currentSnapshot();
+
+    Cdc.Result result = actions().generateCdcRecords(tbl).execute();
+    // verify the results
+    Dataset<Row> resultDF = (Dataset<Row>) result.cdcRecords();
+    List<Object[]> actualRecords = rowsToJava(resultDF.sort("c1").collectAsList());
+    ImmutableList<Object[]> expectedRows = ImmutableList.of(
+        row(1, "AAAAAAAAAA", "AAAA", "D", snapshotId2.snapshotId(), snapshotId2.timestampMillis(), 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+
+    // select the first eq delete snapshot
+    result = actions().generateCdcRecords(tbl).useSnapshot(snapshotId1).execute();
+    // verify the results
+    resultDF = (Dataset<Row>) result.cdcRecords();
+    actualRecords = rowsToJava(resultDF.sort("c1").collectAsList());
+    expectedRows = ImmutableList.of(
+        row(0, "AAAAAAAAAA", "AAAA", "D", snapshotId1, tbl.snapshot(snapshotId1).timestampMillis(), 0)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+
+    // select two snapshots
+    result = actions().generateCdcRecords(tbl).between(snapshotId1, snapshotId2.snapshotId()).execute();
+    // verify the results
+    resultDF = (Dataset<Row>) result.cdcRecords();
+    actualRecords = rowsToJava(resultDF.sort("c1").collectAsList());
+    expectedRows = ImmutableList.of(
+        row(0, "AAAAAAAAAA", "AAAA", "D", snapshotId1, tbl.snapshot(snapshotId1).timestampMillis(), 0),
+        row(1, "AAAAAAAAAA", "AAAA", "D", snapshotId2.snapshotId(), snapshotId2.timestampMillis(), 1)
+    );
+    assertEquals("Should have expected rows", expectedRows, actualRecords);
+  }
+
+  private Table createMetastoreTable(Map<String, String> properties) throws IOException {
+    return createMetastoreTable(properties, 1);
+  }
+
+  private Table createMetastoreTable(Map<String, String> properties, int rowCount) throws IOException {
+    StringBuilder propertiesStr = new StringBuilder();
+    properties.forEach((k, v) -> propertiesStr.append("'" + k + "'='" + v + "',"));
+    String tblProperties = propertiesStr.substring(0, propertiesStr.length() > 0 ? propertiesStr.length() - 1 : 0);
+    String location = newTableLocation();
+
+    if (tblProperties.isEmpty()) {
+      sql("CREATE TABLE hive.default.%s (c1 int, c2 string, c3 string) USING iceberg LOCATION '%s'",
+          tableName, location);
+    } else {
+      sql("CREATE TABLE hive.default.%s (c1 int, c2 string, c3 string) USING iceberg LOCATION '%s' TBLPROPERTIES " +
+          "(%s)", tableName, location, tblProperties);
+    }
+
+    for (int i = 0; i < rowCount; i++) {
+      sql("insert into hive.default.%s values (%s, 'AAAAAAAAAA', 'AAAA')", tableName, i);
+    }
+    return catalog.loadTable(TableIdentifier.of("default", tableName));
+  }
+
+  private String newTableLocation() throws IOException {
+    return temp.newFolder().toURI().toString();
+  }
+}


### PR DESCRIPTION
The draft PR for change data capture. It largely aligns with the MVP we discussed in the [design doc](https://docs.google.com/document/d/1bN6rdLNcYOHnT3xVBfB33BoiPO06aKBo56SZmuU9pnY/edit?usp=sharing) and mail list. 
1. To emit delete and insert CDC records only
2. Create a Spark action for CDC generation
3. Leverage the `_deleted` metadata column for both pos deletes and eq deletes. Both deleted(pos and eq) rows are in the same format.

It is a draft PR though. So there are limitations
1. For row-level deletes, it only support parquet vectorized read at this moment. 
2. Multiple optimization can be done, for example, meta column `_delete` pushdown.
3. Need to expand interface to support query by timestamp instead of snapshot ids.
5. Test cases need to be added.

Happy to take feedbacks and file the formal PRs.
cc @aokolnychyi @RussellSpitzer @szehon-ho @jackye1995 @kbendick @karuppayya @chenjunjiedada 