### PR TITLE
Spark: `DESC TABLE EXTENDED` shows table format-version

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -72,14 +72,17 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.iceberg.TableProperties.CURRENT_SNAPSHOT_ID;
+import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
+
 public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
     SupportsRead, SupportsWrite, SupportsDelete, SupportsRowLevelOperations, SupportsMetadataColumns {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
-      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order", "identifier-fields",
-          "format-version");
+      ImmutableSet.of("provider", "format", CURRENT_SNAPSHOT_ID, "location", FORMAT_VERSION, "sort-order",
+          "identifier-fields");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,
@@ -159,10 +162,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
     propsBuilder.put("provider", "iceberg");
     String currentSnapshotId = icebergTable.currentSnapshot() != null ?
         String.valueOf(icebergTable.currentSnapshot().snapshotId()) : "none";
-    propsBuilder.put("current-snapshot-id", currentSnapshotId);
+    propsBuilder.put(CURRENT_SNAPSHOT_ID, currentSnapshotId);
     propsBuilder.put("location", icebergTable.location());
     int formatVersion = ((HasTableOperations) icebergTable).operations().current().formatVersion();
-    propsBuilder.put("format-version", String.valueOf(formatVersion));
+    propsBuilder.put(FORMAT_VERSION, String.valueOf(formatVersion));
 
     if (!icebergTable.sortOrder().isUnsorted()) {
       propsBuilder.put("sort-order", Spark3Util.describe(icebergTable.sortOrder()));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
@@ -77,7 +78,8 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
-      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order", "identifier-fields");
+      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order", "identifier-fields",
+          "format-version");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,
@@ -159,6 +161,8 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
         String.valueOf(icebergTable.currentSnapshot().snapshotId()) : "none";
     propsBuilder.put("current-snapshot-id", currentSnapshotId);
     propsBuilder.put("location", icebergTable.location());
+    int formatVersion = ((HasTableOperations) icebergTable).operations().current().formatVersion();
+    propsBuilder.put("format-version", String.valueOf(formatVersion));
 
     if (!icebergTable.sortOrder().isUnsorted()) {
       propsBuilder.put("sort-order", Spark3Util.describe(icebergTable.sortOrder()));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -22,14 +22,15 @@ package org.apache.iceberg.spark.source;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -164,8 +165,12 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
         String.valueOf(icebergTable.currentSnapshot().snapshotId()) : "none";
     propsBuilder.put(CURRENT_SNAPSHOT_ID, currentSnapshotId);
     propsBuilder.put("location", icebergTable.location());
-    int formatVersion = ((HasTableOperations) icebergTable).operations().current().formatVersion();
-    propsBuilder.put(FORMAT_VERSION, String.valueOf(formatVersion));
+
+    if (icebergTable instanceof BaseTable) {
+      TableOperations ops = ((BaseTable) icebergTable).operations();
+      int formatVersion = ops.current().formatVersion();
+      propsBuilder.put(FORMAT_VERSION, String.valueOf(formatVersion));
+    }
 
     if (!icebergTable.sortOrder().isUnsorted()) {
       propsBuilder.put("sort-order", Spark3Util.describe(icebergTable.sortOrder()));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -168,8 +168,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
     if (icebergTable instanceof BaseTable) {
       TableOperations ops = ((BaseTable) icebergTable).operations();
-      int formatVersion = ops.current().formatVersion();
-      propsBuilder.put(FORMAT_VERSION, String.valueOf(formatVersion));
+      propsBuilder.put(FORMAT_VERSION, String.valueOf(ops.current().formatVersion()));
     }
 
     if (!icebergTable.sortOrder().isUnsorted()) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -490,6 +490,11 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Assert.assertEquals("Unexpected format", "iceberg/parquet", table.properties().get("format"));
     Assert.assertNotEquals("No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
     Assert.assertTrue("Location isn't correct", table.properties().get("location").endsWith(destTableName));
+
+    Assert.assertNotNull("Missing format-version", table.properties().get("format-version"));
+    table.table().updateProperties().set("format-version", "2").commit();
+    Assert.assertEquals("Missing format-version", "2", table.properties().get("format-version"));
+
     Assert.assertEquals("Sort-order isn't correct", "id ASC NULLS FIRST, data DESC NULLS LAST",
         table.properties().get("sort-order"));
     Assert.assertNull("Identifier fields should be null", table.properties().get("identifier-fields"));

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -491,9 +491,9 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Assert.assertNotEquals("No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
     Assert.assertTrue("Location isn't correct", table.properties().get("location").endsWith(destTableName));
 
-    Assert.assertNotNull("Missing format-version", table.properties().get("format-version"));
+    Assert.assertEquals("Unexpected format-version", "1", table.properties().get("format-version"));
     table.table().updateProperties().set("format-version", "2").commit();
-    Assert.assertEquals("Missing format-version", "2", table.properties().get("format-version"));
+    Assert.assertEquals("Unexpected format-version", "2", table.properties().get("format-version"));
 
     Assert.assertEquals("Sort-order isn't correct", "id ASC NULLS FIRST, data DESC NULLS LAST",
         table.properties().get("sort-order"));


### PR DESCRIPTION
Currently Spark SQL does not show table `format-version` in `SHOW TBLPROPERTIES`, `DESCRIBE TABLE` or `SHOW CREATE TABLE`. This could be based on the fact that `format-version` is a reserved table property and it's not persisted as usual table properties.

Still users may find it useful to inspect the table `format-version` via Spark SQL. One way is to show it via `DESC TABLE EXTENDED`. Towards that, this pull requests has 3 small commits:
1. Add a one liner test which explains the intention and fails
2. Show `format-version` for command `DESC TABLE EXTENDED` by adding it to Spark table properties
3. (cosmetic) Replace some literals with constants defined in `TableProperties.java`