### PR TITLE
Remove allow static imports for unrelocated Preconditions

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -107,7 +107,6 @@
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
-                com.google.common.base.Preconditions.*,
                 com.palantir.logsafe.Preconditions.*,
                 java.util.Collections.*,
                 java.util.stream.Collectors.*,


### PR DESCRIPTION
`BanUnrelocatedGuavaClasses` requires that `Preconditions` are imported
from a relocated package, so allowing *static* imports for unrelocated
`Preconditions` is not useful.