### PR TITLE
[REST] Update Snapshot ref in Open-API spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1015,6 +1015,7 @@ components:
         - snapshot-id
         - timestamp-ms
         - manifest-list
+        - summary
       properties:
         snapshot-id:
           type: integer
@@ -1027,10 +1028,8 @@ components:
           type: integer
         summary:
           type: object
-          required:
-            - summary
           properties:
-            summary:
+            operation:
               type: string
               enum: ["append", "replace", "overwrite", "delete"]
             additionalProperties:


### PR DESCRIPTION
This is a small fix to the OpenAPI spec. It looks like summary is actually a top level requirement for a snapshot object and the property "operation" is mislabeled "summary".