### PR TITLE
[Python] Add a symlink to the OpenAPI rest catalog spec and package it with the python library

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -45,6 +45,8 @@ python_requires = >=3.7
 install_requires =
     mmh3
     singledispatch
+    pyyaml
+include_package_data = true
 [options.extras_require]
 arrow =
     pyarrow
@@ -53,3 +55,6 @@ dev=
     pytest
 [options.packages.find]
 where = src
+[options.package_data]
+""=
+    ../src/iceberg/assets/rest-catalog-open-api.yaml

--- a/python/src/iceberg/assets/__init__.py
+++ b/python/src/iceberg/assets/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/python/src/iceberg/assets/rest-catalog-open-api.yaml
+++ b/python/src/iceberg/assets/rest-catalog-open-api.yaml
@@ -1,0 +1,1 @@
+../../../../open-api/rest-catalog-open-api.yaml

--- a/python/src/iceberg/utils/openapi.py
+++ b/python/src/iceberg/utils/openapi.py
@@ -1,0 +1,15 @@
+import os
+from functools import lru_cache
+
+import yaml
+
+from iceberg import assets
+
+
+@lru_cache(maxsize=1)
+def read_yaml_file(path: str):
+    return yaml.safe_load(open(path))
+
+
+def load_openapi_spec():
+    return read_yaml_file(os.path.join(list(assets.__path__)[0], "rest-catalog-open-api.yaml"))

--- a/python/src/iceberg/utils/openapi.py
+++ b/python/src/iceberg/utils/openapi.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import os
 from functools import lru_cache
 

--- a/python/src/iceberg/utils/openapi.py
+++ b/python/src/iceberg/utils/openapi.py
@@ -23,7 +23,7 @@ import yaml
 from iceberg import assets
 
 
-@lru_cache(maxsize=1)
+@cache
 def read_yaml_file(path: str):
     return yaml.safe_load(open(path))
 

--- a/python/tests/utils/test_openapi.py
+++ b/python/tests/utils/test_openapi.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import tempfile
+
+import yaml
+
+from iceberg.utils import openapi
+
+
+def test_reading_a_yaml_file():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        data = {"foo": "bar"}
+        file_location = os.path.join(tmpdirname, "foo.yaml")
+        with open(file_location, "w") as f:
+            yaml.dump(data, f)
+        assert openapi.read_yaml_file(file_location) == {"foo": "bar"}
+
+
+def test_loading_rest_catalog_openapi_spec():
+    rest_catalog_openapi_spec = openapi.load_openapi_spec()
+    assert rest_catalog_openapi_spec["info"]["title"] == "Apache Iceberg REST Catalog API"


### PR DESCRIPTION
This adds a symlink for the REST catalog OpenAPI spec contained in `open-api/rest-catalog-open-api.yaml` and a utility function to load it. The function uses `@lru_cache` to cache the file after it's loaded once.