### PR TITLE
Spark: Implement the architecture to read default values

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -415,27 +415,42 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type, null);
+      return new NestedField(true, id, name, type, null, null, null);
     }
 
     public static NestedField optional(int id, String name, Type type, String doc) {
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, null, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc,
+        Object initialDefault, Object writeDefault) {
+      return new NestedField(true, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type, null);
+      return new NestedField(false, id, name, type, null, null, null);
     }
 
     public static NestedField required(int id, String name, Type type, String doc) {
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, null, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc,
+        Object initialDefault, Object writeDefault) {
+      return new NestedField(false, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
-      return new NestedField(isOptional, id, name, type, null);
+      return new NestedField(isOptional, id, name, type, null, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
-      return new NestedField(isOptional, id, name, type, doc);
+      return new NestedField(isOptional, id, name, type, doc, null, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc,
+        Object initialDefault, Object writeDefault) {
+      return new NestedField(isOptional, id, name, type, doc, initialDefault, writeDefault);
     }
 
     private final boolean isOptional;
@@ -443,8 +458,12 @@ public class Types {
     private final String name;
     private final Type type;
     private final String doc;
+    private final Object initialDefault;
+    private final Object writeDefault;
 
-    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc,
+        Object initialDefault, Object writeDefault) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
       this.isOptional = isOptional;
@@ -452,6 +471,8 @@ public class Types {
       this.name = name;
       this.type = type;
       this.doc = doc;
+      this.initialDefault = initialDefault;
+      this.writeDefault = writeDefault;
     }
 
     public boolean isOptional() {
@@ -462,7 +483,7 @@ public class Types {
       if (isOptional) {
         return this;
       }
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public boolean isRequired() {
@@ -473,7 +494,11 @@ public class Types {
       if (!isOptional) {
         return this;
       }
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, initialDefault, writeDefault);
+    }
+
+    public NestedField updateWriteDefault(Object newWriteDefault) {
+      return new NestedField(isOptional, id, name, type, doc, initialDefault, newWriteDefault);
     }
 
     public int fieldId() {
@@ -490,6 +515,14 @@ public class Types {
 
     public String doc() {
       return doc;
+    }
+
+    public Object initialDefaultValue() {
+      return initialDefault;
+    }
+
+    public Object writeDefaultValue() {
+      return writeDefault;
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -267,6 +267,12 @@ public final class ORCSchemaUtil {
       case STRUCT:
         orcType = TypeDescription.createStruct();
         for (Types.NestedField nestedField : type.asStructType().fields()) {
+          // When we have a new evolved field in Iceberg schema which has an initial default value,
+          // but the underlying orc file lacks that field, we ignore projecting this field to the orc
+          // file reader schema, but instead populate this field inside Iceberg using a ConstantReader
+          if (mapping.get(nestedField.fieldId()) == null && nestedField.initialDefaultValue() != null) {
+            continue;
+          }
           // Using suffix _r to avoid potential underlying issues in ORC reader
           // with reused column names between ORC and Iceberg;
           // e.g. renaming column c -> d and adding new column d

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -35,7 +35,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
   public static <T> T visit(Type iType, TypeDescription schema, OrcSchemaWithTypeVisitor<T> visitor) {
     switch (schema.getCategory()) {
       case STRUCT:
-        return visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
+        return visitor.visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
 
       case UNION:
         throw new UnsupportedOperationException("Cannot handle " + schema);
@@ -58,7 +58,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     }
   }
 
-  private static <T> T visitRecord(
+  public T visitRecord(
       Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
     List<TypeDescription> fields = record.getChildren();
     List<String> names = record.getFieldNames();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkDefaultValueAwareOrcSchemaWithTypeVisitor.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkDefaultValueAwareOrcSchemaWithTypeVisitor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.iceberg.spark.data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.orc.ORCSchemaUtil;
+import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.source.BaseDataReader;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+
+public class SparkDefaultValueAwareOrcSchemaWithTypeVisitor<T> extends OrcSchemaWithTypeVisitor<T> {
+
+  protected final Map<Integer, Object> idToConstant;
+
+  protected SparkDefaultValueAwareOrcSchemaWithTypeVisitor(Map<Integer, ?> idToConstant) {
+    this.idToConstant = new HashMap<>();
+    this.idToConstant.putAll(idToConstant);
+  }
+
+  /**
+   * This visitor differs from the parent visitor on how it handles Struct type visiting,
+   * particularly, it assumes the iceberg schema represented by {@code struct} might have
+   * additional fields than the ORCSchemaUtil.buildOrcProjection projected orc file reader
+   * schema {@code record}, at this point, we know for sure those additional fields have
+   * initial default values, and we build an idToConstant map here to supply to ORC value
+   * readers.
+   */
+  @Override
+  public T visitRecord(
+      Types.StructType struct, TypeDescription record, OrcSchemaWithTypeVisitor<T> visitor) {
+
+    List<Types.NestedField> iFields = struct.fields();
+    List<TypeDescription> fields = record.getChildren();
+    List<String> names = record.getFieldNames();
+    List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+
+    for (int i = 0, j = 0; i < iFields.size(); i++) {
+      Types.NestedField iField = iFields.get(i);
+      TypeDescription field = j < fields.size() ? fields.get(j) : null;
+      if (field == null || (iField.fieldId() != ORCSchemaUtil.fieldId(field))) {
+        if (!idToConstant.containsKey(iField.fieldId())) {
+          idToConstant.put(iField.fieldId(), BaseDataReader.convertConstant(iField.type(), iField.initialDefaultValue()));
+        }
+      } else {
+        results.add(visit(iField.type(), field, visitor));
+        j++;
+      }
+    }
+    return visitor.record(struct, record, names, results);
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -62,11 +62,10 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
     reader.setBatchContext(batchOffsetInFile);
   }
 
-  private static class ReadBuilder extends OrcSchemaWithTypeVisitor<OrcValueReader<?>> {
-    private final Map<Integer, ?> idToConstant;
+  private static class ReadBuilder extends SparkDefaultValueAwareOrcSchemaWithTypeVisitor<OrcValueReader<?>> {
 
     private ReadBuilder(Map<Integer, ?> idToConstant) {
-      this.idToConstant = idToConstant;
+      super(idToConstant);
     }
 
     @Override

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadDefaultValue.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadDefaultValue.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.spark.source.BaseDataReader;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.spark.data.TestHelpers.assertEquals;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestSparkOrcReadDefaultValue {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testOrcDefaultValues() throws IOException {
+
+    Schema writeSchema = new Schema(
+        required(1, "col1", Types.IntegerType.get())
+    );
+    List<InternalRow> data = Collections.nCopies(
+        100,
+        RandomData.generateSpark(writeSchema, 1, 0L).iterator().next());
+
+    Type[] defaultValueTypes = {
+        Types.StringType.get(),
+        Types.ListType.ofRequired(10, Types.IntegerType.get()),
+        Types.MapType.ofRequired(11, 12, Types.StringType.get(),
+            Types.IntegerType.get()),
+        Types.StructType.of(
+            Types.NestedField.required(13, "nested_col1", Types.IntegerType.get())),
+        Types.ListType.ofRequired(14, Types.StructType.of(
+            Types.NestedField.required(15, "nested_col2", Types.StringType.get())))
+    };
+
+    Object[] defaultValues = {
+        "foo",  // string default
+        ImmutableList.of(1, 2), // array default
+        ImmutableMap.of("bar", 1), // map default
+        ImmutableMap.of(13, 1), // struct default
+        ImmutableList.of(ImmutableMap.of(15, "xyz"), ImmutableMap.of(15, "baz")) // array of struct default
+    };
+
+    Object[] expectedDefaults =
+        IntStream.range(0, defaultValues.length).mapToObj(i -> BaseDataReader.convertConstant(
+            defaultValueTypes[i],
+            defaultValues[i])).toArray();
+
+    List<InternalRow> expected = data.stream().map(internalRow -> {
+      Object[] values = new Object[6];
+      values[0] = internalRow.getInt(0);
+      System.arraycopy(expectedDefaults, 0, values, 1, expectedDefaults.length);
+      return new GenericInternalRow(values);
+    }).collect(Collectors.toList());
+
+    // evolve the schema to add col2, col3, col4, col5, col6 with default value
+    List<Types.NestedField> newSchemaFields = Lists.newArrayList(writeSchema.findField(1));
+    newSchemaFields.addAll(IntStream.range(0, defaultValues.length).mapToObj(i -> Types.NestedField.required(i + 2,
+        String.format("col%d", i + 2), defaultValueTypes[i], "doc", defaultValues[i], defaultValues[i])).collect(
+        Collectors.toList()));
+    Schema readSchema = new Schema(newSchemaFields);
+
+    final File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<InternalRow> writer = ORC.write(Files.localOutput(testFile))
+        .createWriterFunc(SparkOrcWriter::new)
+        .schema(writeSchema)
+        .build()) {
+      writer.addAll(data);
+    }
+
+    // Try to read back the data using the evolved readSchema, the returned data should
+    // have default values populated in them.
+
+    // non-vectorized read
+    try (CloseableIterable<InternalRow> reader = ORC.read(Files.localInput(testFile))
+        .project(readSchema)
+        .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema))
+        .build()) {
+
+      final Iterator<InternalRow> actualRows = reader.iterator();
+      final Iterator<InternalRow> expectedRows = expected.iterator();
+      while (expectedRows.hasNext()) {
+        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        assertEquals(readSchema, expectedRows.next(), actualRows.next());
+      }
+      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+    }
+
+    // vectorized-read
+    // try (CloseableIterable<ColumnarBatch> reader = ORC.read(Files.localInput(orcFile))
+    //     .project(readSchema)
+    //     .createBatchedReaderFunc(readOrcSchema ->
+    //         VectorizedSparkOrcReaders.buildReader(readSchema, readOrcSchema, ImmutableMap.of()))
+    //     .build()) {
+    //   final Iterator<InternalRow> actualRows = batchesToRows(reader.iterator());
+    //   final InternalRow actualFirstRow = actualRows.next();
+    //
+    //   assertEquals(readSchema, expectedFirstRow, actualFirstRow);
+    // }
+  }
+
+  private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
+    return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
+  }
+}


### PR DESCRIPTION
This PR is the sequel to #4525, it implements the default value reading semantics specified by spec #4301.

The current version of the code showcase the core change in `BaseDataReader` to convert default values to Spark-expected constant value objects.

It also showcases the architecture of modifying/extending the `OrcSchemaWithTypeVisitor` and `ORCSchemaUtil.buildOrcProjection` to achieve the default value reading in ORC non-vectorized readers. I will do similar changes in the upcoming days to implement reading default in ORC vectorized reader and also Avro reader.

@rdblue Please take a look, Thanks!
