### PR TITLE
Removed un-used function converterFor from class ParquetMetricsRowGroupFilter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -564,19 +564,4 @@ public class ParquetMetricsRowGroupFilter {
   private static boolean mayContainNull(Statistics statistics) {
     return !statistics.isNumNullsSet() || statistics.getNumNulls() > 0;
   }
-
-  private static Function<Object, Object> converterFor(PrimitiveType parquetType, Type icebergType) {
-    Function<Object, Object> fromParquet = ParquetConversions.converterFromParquet(parquetType);
-    if (icebergType != null) {
-      if (icebergType.typeId() == Type.TypeID.LONG &&
-          parquetType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32) {
-        return value -> ((Integer) fromParquet.apply(value)).longValue();
-      } else if (icebergType.typeId() == Type.TypeID.DOUBLE &&
-          parquetType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.FLOAT) {
-        return value -> ((Float) fromParquet.apply(value)).doubleValue();
-      }
-    }
-
-    return fromParquet;
-  }
 }


### PR DESCRIPTION
While running `./gradlew build -x test -x integrationTest` to build the iceberg project, I noticed that the private function `converterFor` from class `ParquetMetricsRowGroupFilter` was not used in the repo. This is why I wanted to remove it. Please feel free to let me know if that makes sense.