### PR TITLE
Core: Fix Partitions table for evolved partition specs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -134,20 +134,20 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   /**
-   * Convert a partition data written by an old spec, to table's normalized partition form, which is a common partition
+   * Convert a partition data written by an old spec, to table's normalized partition type, which is a common partition
    * type for all specs of the table.
    * @param originalPartition un-normalized partition data
-   * @param normalizedPartitionSchema table's normalized partition form {@link Partitioning#partitionType(Table)}
+   * @param normalizedPartitionType table's normalized partition type {@link Partitioning#partitionType(Table)}
    * @param originalPartitionFieldPositions an array of positional indexes of the spec's partition fields indexed by
-   *                                       position in the normalized partition type
+   *                                       position in the normalized partition schema
    * @return the normalized partition data
    */
   private static PartitionData normalizePartition(PartitionData originalPartition,
-                                                  Types.StructType normalizedPartitionSchema,
+                                                  Types.StructType normalizedPartitionType,
                                                   Integer[] originalPartitionFieldPositions) {
-    PartitionData normalizedPartition = new PartitionData(normalizedPartitionSchema);
+    PartitionData normalizedPartition = new PartitionData(normalizedPartitionType);
 
-    IntStream.range(0, normalizedPartitionSchema.fields().size()).forEach(normalizedPartitionFieldIndex -> {
+    IntStream.range(0, normalizedPartitionType.fields().size()).forEach(normalizedPartitionFieldIndex -> {
       Integer originalPartitionPosition = originalPartitionFieldPositions[normalizedPartitionFieldIndex];
       if (originalPartitionPosition != null) {
         Object originalPartitionValue = originalPartition.get(originalPartitionPosition);

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -127,11 +127,10 @@ public class PartitionsTable extends BaseMetadataTable {
       originalFieldIdsToPosition.put(originalField.fieldId(), originalPartitionIndex);
       originalPartitionIndex++;
     }
-    Integer[] result = normalizedPartitionType.fields().stream().map(f -> {
-      Integer originalFieldPosition = originalFieldIdsToPosition.get(f.fieldId());
-      return (originalFieldPosition == null) ? null : originalFieldPosition;
-    }).toArray(Integer[]::new);
-    return result;
+
+    return normalizedPartitionType.fields().stream()
+        .map(f -> originalFieldIdsToPosition.get(f.fieldId()))
+        .toArray(Integer[]::new);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -95,11 +95,11 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
     CloseableIterable<FileScanTask> tasks = planFiles(scan);
-
-    PartitionMap partitions = new PartitionMap(Partitioning.partitionType(table));
+    Types.StructType partitionType = Partitioning.partitionType(table);
+    PartitionMap partitions = new PartitionMap(partitionType);
     for (FileScanTask task : tasks) {
       PartitionData original = (PartitionData) task.file().partition();
-      PartitionData normalized = normalizePartition(original, Partitioning.partitionType(table));
+      PartitionData normalized = normalizePartition(original, partitionType);
       partitions.get(normalized).update(task.file());
     }
     return partitions.all();

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
@@ -106,9 +105,7 @@ public class PartitionsTable extends BaseMetadataTable {
     return partitions.all();
   }
 
-  private static PartitionData normalizePartition(PartitionData partition, Types.StructType newSchema) {
-    Preconditions.checkArgument(partition.getPartitionType().fields().size() == partition.size(),
-        "Partition values must match size");
+  private static PartitionData normalizePartition(PartitionData partition, Types.StructType normalizedPartitionSchema) {
     Map<Integer, Object> fieldIdToValues = Maps.newHashMap();
     int originalPartitionIndex = 0;
     for (Types.NestedField f : partition.getPartitionType().fields()) {
@@ -116,14 +113,14 @@ public class PartitionsTable extends BaseMetadataTable {
       originalPartitionIndex++;
     }
 
-    PartitionData result = new PartitionData(newSchema);
+    PartitionData normalizedPartition = new PartitionData(normalizedPartitionSchema);
 
-    int finalPartitionIndex = 0;
-    for (Types.NestedField f : newSchema.fields()) {
-      result.set(finalPartitionIndex, fieldIdToValues.get(f.fieldId()));
-      finalPartitionIndex++;
+    int normalizedPartitionIndex = 0;
+    for (Types.NestedField f : normalizedPartitionSchema.fields()) {
+      normalizedPartition.set(normalizedPartitionIndex, fieldIdToValues.get(f.fieldId()));
+      normalizedPartitionIndex++;
     }
-    return result;
+    return normalizedPartition;
   }
 
   @VisibleForTesting

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -57,6 +57,7 @@ import static org.apache.iceberg.MetadataTableType.ALL_DATA_FILES;
 import static org.apache.iceberg.MetadataTableType.ALL_ENTRIES;
 import static org.apache.iceberg.MetadataTableType.ENTRIES;
 import static org.apache.iceberg.MetadataTableType.FILES;
+import static org.apache.iceberg.MetadataTableType.PARTITIONS;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
@@ -380,6 +381,88 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
   }
 
   @Test
+  public void testPartitionMetadataTable() throws ParseException {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
+        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    initTable();
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    // verify the metadata tables while the current spec is still unpartitioned
+    Dataset<Row> df = loadMetadataTable(PARTITIONS);
+    Assert.assertTrue("Partition must be skipped", df.schema().getFieldIndex("partition").isEmpty());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateSpec()
+        .addField("data")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    // verify the metadata tables after adding the first partition column
+    assertPartitions(
+        ImmutableList.of(row(new Object[]{null}), row("d1"), row("d2")),
+        "STRUCT<data:STRING>",
+        PARTITIONS);
+
+    table.updateSpec()
+        .addField("category")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    // verify the metadata tables after adding the second partition column
+    assertPartitions(ImmutableList.of(
+            row(null, null),
+            row("d1", null),
+            row("d1", "c1"),
+            row("d2", null),
+            row("d2", "c2")),
+        "STRUCT<data:STRING,category:STRING>",
+        PARTITIONS);
+
+    table.updateSpec()
+        .removeField("data")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    assertPartitions(
+        ImmutableList.of(
+            row(null, null),
+            row(null, "c1"),
+            row(null, "c2"),
+            row("d1", null),
+            row("d1", "c1"),
+            row("d2", null),
+            row("d2", "c2")),
+        "STRUCT<data:STRING,category:STRING>",
+        PARTITIONS);
+
+    table.updateSpec()
+        .renameField("category", "category_another_name")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+
+    assertPartitions(
+        ImmutableList.of(
+            row(null, null),
+            row(null, "c1"),
+            row(null, "c2"),
+            row("d1", null),
+            row("d1", "c1"),
+            row("d2", null),
+            row("d2", "c2")),
+        "STRUCT<data:STRING,category_another_name:STRING>",
+        PARTITIONS);
+  }
+
+  @Test
   public void testMetadataTablesWithUnknownTransforms() {
     sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
@@ -429,6 +512,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
     DataType expectedType = spark.sessionState().sqlParser().parseDataType(expectedTypeAsString);
     switch (tableType) {
+      case PARTITIONS:
       case FILES:
       case ALL_DATA_FILES:
         DataType actualFilesType = df.schema().apply("partition").dataType();
@@ -447,6 +531,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
     }
 
     switch (tableType) {
+      case PARTITIONS:
       case FILES:
       case ALL_DATA_FILES:
         List<Row> actualFilesPartitions = df.orderBy("partition")

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -214,6 +214,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
     sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
         "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
     initTable();
+
     sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
     sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
 
@@ -312,6 +313,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
   public void testEntriesMetadataTable() throws ParseException {
     sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
+
     sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1')", tableName);
 
     // verify the metadata tables while the current spec is still unpartitioned
@@ -487,8 +489,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
     // In V2, re-added field currently conflicts with its deleted form
     Assume.assumeTrue(formatVersion == 1);
 
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
     Table table = validationCatalog.loadTable(tableIdent);
 
@@ -547,8 +548,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
   @Test
   public void testMetadataTablesWithUnknownTransforms() {
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a1', 'b1')", tableName);


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/4516 fixes the schema of the partitions table in the case of changed partition specs to use Partitioning.partitionType (a union of all previous partition specs), but the data is still wrong in some cases:

* The PartitionsMap is constructed with the table's current spec, which is used to generate hashcode of partition values.  This leads to colliding of some values which get lost. 
  * Ref:  https://github.com/apache/iceberg/blob/apache-iceberg-0.13.1/core/src/main/java/org/apache/iceberg/PartitionsTable.java#L99.  
  * Example:  p1=foo, p2=bar collides with p1=foo if PartitionMap is instantiated with current spec of {p1}, and other instance is lost.
* The partition values are just listed in order without any transformation, meaning they may in the wrong field in the unified schema.
  * Ref: https://github.com/apache/iceberg/blob/a78aa2dbdb98634f26066c457cc1aef93166be9f/core/src/main/java/org/apache/iceberg/PartitionsTable.java#L93.  
  * Example, spec evolution of p1,p2 => p2,p1 leads to wrong ordering of earlier partitions.

This fixes the problem by :
1.  Instantiating the PartitionMap by Partitioning.partitionType, so all types are used in the hashcode generation.
2. Transforming the PartitionDatas to fit the final schema Partioning.partitionType()