### PR TITLE
Flink: support modify table properties with primary key.

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -414,8 +414,8 @@ public class FlinkCatalog extends AbstractCatalog {
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
     if (!equalsPrimary &&
-            ts1.getTableColumns().equals(ts2.getTableColumns()) &&
-            ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
+          ts1.getTableColumns().equals(ts2.getTableColumns()) &&
+          ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
       throw new UnsupportedOperationException("Altering schema is not supported yet.");
     }
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -404,18 +404,18 @@ public class FlinkCatalog extends AbstractCatalog {
     TableSchema ts1 = ct1.getSchema();
     TableSchema ts2 = ct2.getSchema();
     boolean equalsPrimary = false;
+
     if (ts1.getPrimaryKey().isPresent() && ts2.getPrimaryKey().isPresent()) {
-      equalsPrimary = ts1.getPrimaryKey().get().getType().equals(ts2.getPrimaryKey().get().getType()) &&
-              ts1.getPrimaryKey().get().getColumns().equals(ts2.getPrimaryKey().get().getColumns());
+      equalsPrimary =
+          Objects.equals(ts1.getPrimaryKey().get().getType(), ts2.getPrimaryKey().get().getType()) &&
+          Objects.equals(ts1.getPrimaryKey().get().getColumns(), ts2.getPrimaryKey().get().getColumns());
     } else if (!ts1.getPrimaryKey().isPresent() && !ts2.getPrimaryKey().isPresent()) {
       equalsPrimary = true;
     }
 
-    // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
-    // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    if (!equalsPrimary &&
-          ts1.getTableColumns().equals(ts2.getTableColumns()) &&
-          ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
+    if (!(Objects.equals(ts1.getTableColumns(), ts2.getTableColumns()) &&
+          Objects.equals(ts1.getWatermarkSpecs(), ts2.getWatermarkSpecs()) &&
+          equalsPrimary)) {
       throw new UnsupportedOperationException("Altering schema is not supported yet.");
     }
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -405,17 +405,17 @@ public class FlinkCatalog extends AbstractCatalog {
     TableSchema ts2 = ct2.getSchema();
     boolean equalsPrimary = false;
     if (ts1.getPrimaryKey().isPresent() && ts2.getPrimaryKey().isPresent()) {
-      equalsPrimary = ts1.getPrimaryKey().get().getType().equals(ts2.getPrimaryKey().get().getType())
-              && ts1.getPrimaryKey().get().getColumns().equals(ts2.getPrimaryKey().get().getColumns());
+      equalsPrimary = ts1.getPrimaryKey().get().getType().equals(ts2.getPrimaryKey().get().getType()) &&
+              ts1.getPrimaryKey().get().getColumns().equals(ts2.getPrimaryKey().get().getColumns());
     } else if (!ts1.getPrimaryKey().isPresent() && !ts2.getPrimaryKey().isPresent()) {
       equalsPrimary = true;
     }
 
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    if (!equalsPrimary
-            && ts1.getTableColumns().equals(ts2.getTableColumns())
-            && ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
+    if (!equalsPrimary &&
+            ts1.getTableColumns().equals(ts2.getTableColumns()) &&
+            ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
       throw new UnsupportedOperationException("Altering schema is not supported yet.");
     }
 
@@ -446,7 +446,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    validateTableSchemaAndPartition(table, (CatalogTable)newTable);
+    validateTableSchemaAndPartition(table, (CatalogTable) newTable);
 
     Map<String, String> oldProperties = table.getOptions();
     Map<String, String> setProperties = Maps.newHashMap();

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -400,6 +400,30 @@ public class FlinkCatalog extends AbstractCatalog {
     }
   }
 
+  private static void validateTableSchemaAndPartition(CatalogTable ct1, CatalogTable ct2) {
+    TableSchema ts1 = ct1.getSchema();
+    TableSchema ts2 = ct2.getSchema();
+    boolean equalsPrimary = false;
+    if (ts1.getPrimaryKey().isPresent() && ts2.getPrimaryKey().isPresent()) {
+      equalsPrimary = ts1.getPrimaryKey().get().getType().equals(ts2.getPrimaryKey().get().getType())
+              && ts1.getPrimaryKey().get().getColumns().equals(ts2.getPrimaryKey().get().getColumns());
+    } else if (!ts1.getPrimaryKey().isPresent() && !ts2.getPrimaryKey().isPresent()) {
+      equalsPrimary = true;
+    }
+
+    // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
+    // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
+    if (!equalsPrimary
+            && ts1.getTableColumns().equals(ts2.getTableColumns())
+            && ts1.getWatermarkSpecs().equals(ts2.getWatermarkSpecs())) {
+      throw new UnsupportedOperationException("Altering schema is not supported yet.");
+    }
+
+    if (!ct1.getPartitionKeys().equals(ct2.getPartitionKeys())) {
+      throw new UnsupportedOperationException("Altering partition keys is not supported yet.");
+    }
+  }
+
   @Override
   public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
       throws CatalogException, TableNotExistException {
@@ -422,13 +446,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    if (!table.getSchema().equals(newTable.getSchema())) {
-      throw new UnsupportedOperationException("Altering schema is not supported yet.");
-    }
-
-    if (!table.getPartitionKeys().equals(((CatalogTable) newTable).getPartitionKeys())) {
-      throw new UnsupportedOperationException("Altering partition keys is not supported yet.");
-    }
+    validateTableSchemaAndPartition(table, (CatalogTable)newTable);
 
     Map<String, String> oldProperties = table.getOptions();
     Map<String, String> setProperties = Maps.newHashMap();

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -318,6 +318,30 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
   }
 
   @Test
+  public void testAlterTableWithPrimaryKey() throws TableNotExistException {
+    sql("CREATE TABLE tl(id BIGINT, PRIMARY KEY(id) NOT ENFORCED) WITH ('oldK'='oldV')");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("oldK", "oldV");
+
+    // new
+    sql("ALTER TABLE tl SET('newK'='newV')");
+    properties.put("newK", "newV");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // update old
+    sql("ALTER TABLE tl SET('oldK'='oldV2')");
+    properties.put("oldK", "oldV2");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // remove property
+    CatalogTable catalogTable = catalogTable("tl");
+    properties.remove("oldK");
+    getTableEnv().getCatalog(getTableEnv().getCurrentCatalog()).get().alterTable(
+            new ObjectPath(DATABASE, "tl"), catalogTable.copy(properties), false);
+    Assert.assertEquals(properties, table("tl").properties());
+  }
+
+  @Test
   public void testRelocateTable() {
     Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
 


### PR DESCRIPTION
Because we have iceberg table with primary key, and we want to alter table properties.
This PR supports `ALTER TABLE ... SET ...` and `ALTER TABLE ... RESET ...` to modify a table properties which has primary key.   #4562 