### PR TITLE
Core: Refactor metadata tables and scans

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -66,7 +66,7 @@ public class AllDataFilesTable extends BaseFilesTable {
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return allManifests(Snapshot::dataManifests);
+      return reachableManifests(Snapshot::dataManifests);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -19,12 +19,7 @@
 
 package org.apache.iceberg;
 
-import java.io.IOException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.util.ParallelIterable;
 
 /**
  * A {@link Table} implementation that exposes a table's valid data files as rows.
@@ -53,47 +48,25 @@ public class AllDataFilesTable extends BaseFilesTable {
     return MetadataTableType.ALL_DATA_FILES;
   }
 
-  public static class AllDataFilesTableScan extends BaseFilesTableScan {
+  public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema, MetadataTableType.ALL_DATA_FILES);
+    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.ALL_DATA_FILES);
     }
 
-    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
+    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema,
                                   TableScanContext context) {
-      super(ops, table, schema, fileSchema, context, MetadataTableType.ALL_DATA_FILES);
+      super(ops, table, schema, MetadataTableType.ALL_DATA_FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, fileSchema(), context);
-    }
-
-    @Override
-    public TableScan useSnapshot(long scanSnapshotId) {
-      throw new UnsupportedOperationException("Cannot select snapshot: all_data_files is for all snapshots");
-    }
-
-    @Override
-    public TableScan asOfTime(long timestampMillis) {
-      throw new UnsupportedOperationException("Cannot select snapshot: all_data_files is for all snapshots");
-    }
-
-    @Override
-    public CloseableIterable<FileScanTask> planFiles() {
-      return super.planFilesAllSnapshots();
+      return new AllDataFilesTableScan(ops, table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
-          Iterables.transform(table().snapshots(),
-              snapshot -> (Iterable<ManifestFile>) () -> snapshot.dataManifests().iterator()),
-          context().planExecutor())) {
-        return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
-      } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to close parallel iterable");
-      }
+      return allManifests(Snapshot::dataManifests);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -84,7 +84,7 @@ public class AllEntriesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> doPlanFiles() {
-      CloseableIterable<ManifestFile> manifests = allManifests(Snapshot::allManifests);
+      CloseableIterable<ManifestFile> manifests = reachableManifests(Snapshot::allManifests);
 
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -19,19 +19,14 @@
 
 package org.apache.iceberg;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.ManifestEntriesTable.ManifestReadTask;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.StructType;
-import org.apache.iceberg.util.ParallelIterable;
 
 /**
  * A {@link Table} implementation that exposes a table's manifest entries as rows, for both delete and data files.
@@ -74,11 +69,11 @@ public class AllEntriesTable extends BaseMetadataTable {
   private static class Scan extends BaseAllMetadataTableScan {
 
     Scan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema);
+      super(ops, table, schema, MetadataTableType.ALL_ENTRIES);
     }
 
     private Scan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, context);
+      super(ops, table, schema, MetadataTableType.ALL_ENTRIES, context);
     }
 
     @Override
@@ -88,34 +83,16 @@ public class AllEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected String tableType() {
-      return MetadataTableType.ALL_ENTRIES.name();
-    }
+    protected CloseableIterable<FileScanTask> doPlanFiles() {
+      CloseableIterable<ManifestFile> manifests = allManifests(Snapshot::allManifests);
 
-    @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
-      CloseableIterable<ManifestFile> manifests = allManifestFiles(
-          ops.current().snapshots(), context().planExecutor());
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
+      Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
-      return CloseableIterable.transform(manifests, manifest -> new ManifestEntriesTable.ManifestReadTask(
-          ops.io(), manifest, schema(), schemaString, specString, residuals, ops.current().specsById()));
-    }
-  }
-
-  private static CloseableIterable<ManifestFile> allManifestFiles(
-      List<Snapshot> snapshots, ExecutorService workerPool) {
-    try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
-        Iterables.transform(snapshots, snapshot -> (Iterable<ManifestFile>) () -> snapshot.allManifests().iterator()),
-        workerPool)) {
-      return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to close parallel iterable");
+      return CloseableIterable.transform(manifests, manifest ->
+          new ManifestReadTask(table(), manifest, schema(), schemaString, specString, residuals));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -120,7 +120,7 @@ public class AllManifestsTable extends BaseMetadataTable {
               schemaString, specString, residuals));
         } else {
           return StaticDataTask.of(
-              io.newInputFile(ops().current().metadataFileLocation()),
+              io.newInputFile(tableOps().current().metadataFileLocation()),
               MANIFEST_FILE_SCHEMA, schema(), snap.allManifests(),
               manifest -> ManifestsTable.manifestFileToRow(specs.get(manifest.partitionSpecId()), manifest)
           );

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -85,12 +85,12 @@ public class AllManifestsTable extends BaseMetadataTable {
   public static class AllManifestsTableScan extends BaseAllMetadataTableScan {
 
     AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
+      super(ops, table, fileSchema, MetadataTableType.ALL_MANIFESTS);
     }
 
     private AllManifestsTableScan(TableOperations ops, Table table, Schema schema,
                                   TableScanContext context) {
-      super(ops, table, schema, context);
+      super(ops, table, schema, MetadataTableType.ALL_MANIFESTS, context);
     }
 
     @Override
@@ -100,43 +100,27 @@ public class AllManifestsTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan useSnapshot(long scanSnapshotId) {
-      throw new UnsupportedOperationException("Cannot select snapshot: all_manifests is for all snapshots");
-    }
-
-    @Override
-    public TableScan asOfTime(long timestampMillis) {
-      throw new UnsupportedOperationException("Cannot select snapshot: all_manifests is for all snapshots");
-    }
-
-    @Override
-    protected String tableType() {
-      return MetadataTableType.ALL_MANIFESTS.name();
-    }
-
-    @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
+    protected CloseableIterable<FileScanTask> doPlanFiles() {
+      FileIO io = table().io();
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
+      Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
+      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
-      return CloseableIterable.withNoopClose(Iterables.transform(ops.current().snapshots(), snap -> {
+      return CloseableIterable.withNoopClose(Iterables.transform(table().snapshots(), snap -> {
         if (snap.manifestListLocation() != null) {
-          Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
-          ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
           DataFile manifestListAsDataFile = DataFiles.builder(PartitionSpec.unpartitioned())
-              .withInputFile(ops.io().newInputFile(snap.manifestListLocation()))
+              .withInputFile(io.newInputFile(snap.manifestListLocation()))
               .withRecordCount(1)
               .withFormat(FileFormat.AVRO)
               .build();
-          return new ManifestListReadTask(ops.io(), schema(), specs, new BaseFileScanTask(
+          return new ManifestListReadTask(io, schema(), specs, new BaseFileScanTask(
               manifestListAsDataFile, null,
               schemaString, specString, residuals));
         } else {
           return StaticDataTask.of(
-              ops.io().newInputFile(ops.current().metadataFileLocation()),
+              io.newInputFile(ops().current().metadataFileLocation()),
               MANIFEST_FILE_SCHEMA, schema(), snap.allManifests(),
               manifest -> ManifestsTable.manifestFileToRow(specs.get(manifest.partitionSpecId()), manifest)
           );

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -61,7 +61,7 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
     return doPlanFiles();
   }
 
-  protected CloseableIterable<ManifestFile> allManifests(Function<Snapshot, Iterable<ManifestFile>> toManifests) {
+  protected CloseableIterable<ManifestFile> reachableManifests(Function<Snapshot, Iterable<ManifestFile>> toManifests) {
     Iterable<Snapshot> snapshots = table().snapshots();
     Iterable<Iterable<ManifestFile>> manifestIterables = Iterables.transform(snapshots, toManifests);
 

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,40 +19,56 @@
 
 package org.apache.iceberg;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.apache.iceberg.events.Listeners;
+import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Function;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ParallelIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseAllMetadataTableScan.class);
 
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
-    super(ops, table, fileSchema);
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
+    super(ops, table, schema, tableType);
   }
 
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
-  }
-
-  /**
-   * Type of scan being performed, such as {@link MetadataTableType#ALL_DATA_FILES} when scanning
-   * a table's {@link org.apache.iceberg.AllDataFilesTable}.
-   * <p>
-   * Used for logging and error messages.
-   */
-  protected abstract String tableType();
-
-  @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
-    throw new UnsupportedOperationException(
-        String.format("Cannot incrementally scan table of type %s", tableType()));
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType,
+                           TableScanContext context) {
+    super(ops, table, schema, tableType, context);
   }
 
   @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
-    throw new UnsupportedOperationException(
-        String.format("Cannot incrementally scan table of type %s", tableType()));
+  public TableScan useSnapshot(long scanSnapshotId) {
+    throw new UnsupportedOperationException("Cannot select snapshot in table: " + tableType());
+  }
+
+  @Override
+  public TableScan asOfTime(long timestampMillis) {
+    throw new UnsupportedOperationException("Cannot select snapshot in table: " + tableType());
   }
 
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
-    return super.planFilesAllSnapshots();
+    LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
+    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
+
+    return doPlanFiles();
+  }
+
+  protected CloseableIterable<ManifestFile> allManifests(Function<Snapshot, Iterable<ManifestFile>> toManifests) {
+    Iterable<Snapshot> snapshots = table().snapshots();
+    Iterable<Iterable<ManifestFile>> manifestIterables = Iterables.transform(snapshots, toManifests);
+
+    try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(manifestIterables, planExecutor())) {
+      return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close parallel iterable", e);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -19,39 +19,50 @@
 
 package org.apache.iceberg;
 
-import org.apache.iceberg.events.Listeners;
-import org.apache.iceberg.events.ScanEvent;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.PropertyUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 abstract class BaseMetadataTableScan extends BaseTableScan {
-  private static final Logger LOG = LoggerFactory.getLogger(BaseMetadataTableScan.class);
 
-  protected BaseMetadataTableScan(TableOperations ops, Table table, Schema schema) {
+  private final MetadataTableType tableType;
+
+  protected BaseMetadataTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
     super(ops, table, schema);
+    this.tableType = tableType;
   }
 
-  protected BaseMetadataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+  protected BaseMetadataTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType,
+                                  TableScanContext context) {
     super(ops, table, schema, context);
+    this.tableType = tableType;
+  }
+
+  /**
+   * Type of scan being performed, such as {@link MetadataTableType#ALL_DATA_FILES} when scanning
+   * a table's {@link org.apache.iceberg.AllDataFilesTable}.
+   * <p>
+   * Used for logging and error messages.
+   */
+  protected MetadataTableType tableType() {
+    return tableType;
+  }
+
+  @Override
+  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Cannot incrementally scan table of type %s", tableType()));
+  }
+
+  @Override
+  public TableScan appendsAfter(long fromSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Cannot incrementally scan table of type %s", tableType()));
   }
 
   @Override
   public long targetSplitSize() {
-    long tableValue = tableOps().current().propertyAsLong(
+    long tableValue = ops().current().propertyAsLong(
         TableProperties.METADATA_SPLIT_SIZE,
         TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_SIZE, tableValue);
-  }
-
-  /**
-   * Alternative to {@link #planFiles()}, allows exploring old snapshots even for an empty table.
-   */
-  protected CloseableIterable<FileScanTask> planFilesAllSnapshots() {
-    LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
-    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
-
-    return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -60,7 +60,7 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
 
   @Override
   public long targetSplitSize() {
-    long tableValue = ops().current().propertyAsLong(
+    long tableValue = tableOps().current().propertyAsLong(
         TableProperties.METADATA_SPLIT_SIZE,
         TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_SIZE, tableValue);

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -63,7 +63,7 @@ abstract class BaseTableScan implements TableScan {
     this.context = context;
   }
 
-  protected TableOperations ops() {
+  protected TableOperations tableOps() {
     return ops;
   }
 
@@ -209,7 +209,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public int splitLookback() {
-    int tableValue = ops().current().propertyAsInt(
+    int tableValue = tableOps().current().propertyAsInt(
         TableProperties.SPLIT_LOOKBACK,
         TableProperties.SPLIT_LOOKBACK_DEFAULT);
     return PropertyUtil.propertyAsInt(options(), TableProperties.SPLIT_LOOKBACK, tableValue);
@@ -217,7 +217,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public long splitOpenFileCost() {
-    long tableValue = ops().current().propertyAsLong(
+    long tableValue = tableOps().current().propertyAsLong(
         TableProperties.SPLIT_OPEN_FILE_COST,
         TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_OPEN_FILE_COST, tableValue);

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -63,8 +63,12 @@ abstract class BaseTableScan implements TableScan {
     this.context = context;
   }
 
-  protected TableOperations tableOps() {
+  protected TableOperations ops() {
     return ops;
+  }
+
+  protected Schema tableSchema() {
+    return schema;
   }
 
   protected Long snapshotId() {
@@ -83,22 +87,23 @@ abstract class BaseTableScan implements TableScan {
     return context.selectedColumns();
   }
 
+  protected ExecutorService planExecutor() {
+    return context.planExecutor();
+  }
+
   protected Map<String, String> options() {
     return context.options();
   }
 
-  protected  TableScanContext context() {
+  protected TableScanContext context() {
     return context;
   }
 
   @SuppressWarnings("checkstyle:HiddenField")
-  protected abstract TableScan newRefinedScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context);
+  protected abstract TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
+                                              TableScanContext context);
 
-  @SuppressWarnings("checkstyle:HiddenField")
-  protected abstract CloseableIterable<FileScanTask> planFiles(
-      TableOperations ops, Snapshot snapshot, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats);
+  protected abstract CloseableIterable<FileScanTask> doPlanFiles();
 
   @Override
   public Table table() {
@@ -122,56 +127,49 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public TableScan useSnapshot(long scanSnapshotId) {
-    Preconditions.checkArgument(context.snapshotId() == null,
-        "Cannot override snapshot, already set to id=%s", context.snapshotId());
+    Preconditions.checkArgument(snapshotId() == null,
+        "Cannot override snapshot, already set to id=%s", snapshotId());
     Preconditions.checkArgument(ops.current().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s", scanSnapshotId);
-    return newRefinedScan(
-        ops, table, schema, context.useSnapshotId(scanSnapshotId));
+    return newRefinedScan(ops, table, schema, context.useSnapshotId(scanSnapshotId));
   }
 
   @Override
   public TableScan asOfTime(long timestampMillis) {
-    Preconditions.checkArgument(context.snapshotId() == null,
-        "Cannot override snapshot, already set to id=%s", context.snapshotId());
+    Preconditions.checkArgument(snapshotId() == null,
+        "Cannot override snapshot, already set to id=%s", snapshotId());
 
     return useSnapshot(SnapshotUtil.snapshotIdAsOfTime(table(), timestampMillis));
   }
 
   @Override
   public TableScan option(String property, String value) {
-    return newRefinedScan(
-        ops, table, schema, context.withOption(property, value));
+    return newRefinedScan(ops, table, schema, context.withOption(property, value));
   }
 
   @Override
   public TableScan project(Schema projectedSchema) {
-    return newRefinedScan(
-        ops, table, schema, context.project(projectedSchema));
+    return newRefinedScan(ops, table, schema, context.project(projectedSchema));
   }
 
   @Override
   public TableScan caseSensitive(boolean scanCaseSensitive) {
-    return newRefinedScan(
-        ops, table, schema, context.setCaseSensitive(scanCaseSensitive));
+    return newRefinedScan(ops, table, schema, context.setCaseSensitive(scanCaseSensitive));
   }
 
   @Override
   public TableScan includeColumnStats() {
-    return newRefinedScan(
-        ops, table, schema, context.shouldReturnColumnStats(true));
+    return newRefinedScan(ops, table, schema, context.shouldReturnColumnStats(true));
   }
 
   @Override
   public TableScan select(Collection<String> columns) {
-    return newRefinedScan(
-        ops, table, schema, context.selectColumns(columns));
+    return newRefinedScan(ops, table, schema, context.selectColumns(columns));
   }
 
   @Override
   public TableScan filter(Expression expr) {
-    return newRefinedScan(ops, table, schema,
-        context.filterRows(Expressions.and(context.rowFilter(), expr)));
+    return newRefinedScan(ops, table, schema, context.filterRows(Expressions.and(filter(), expr)));
   }
 
   @Override
@@ -181,8 +179,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public TableScan ignoreResiduals() {
-    return newRefinedScan(
-        ops, table, schema, context.ignoreResiduals(true));
+    return newRefinedScan(ops, table, schema, context.ignoreResiduals(true));
   }
 
   @Override
@@ -191,13 +188,11 @@ abstract class BaseTableScan implements TableScan {
     if (snapshot != null) {
       LOG.info("Scanning table {} snapshot {} created at {} with filter {}", table,
           snapshot.snapshotId(), DateTimeUtil.formatTimestampMillis(snapshot.timestampMillis()),
-          context.rowFilter());
+          filter());
 
-      Listeners.notifyAll(
-          new ScanEvent(table.name(), snapshot.snapshotId(), context.rowFilter(), schema()));
+      Listeners.notifyAll(new ScanEvent(table.name(), snapshot.snapshotId(), filter(), schema()));
 
-      return planFiles(ops, snapshot,
-          context.rowFilter(), context.ignoreResiduals(), context.caseSensitive(), context.returnColumnStats());
+      return doPlanFiles();
 
     } else {
       LOG.info("Scanning empty table {}", table);
@@ -214,7 +209,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public int splitLookback() {
-    int tableValue = tableOps().current().propertyAsInt(
+    int tableValue = ops().current().propertyAsInt(
         TableProperties.SPLIT_LOOKBACK,
         TableProperties.SPLIT_LOOKBACK_DEFAULT);
     return PropertyUtil.propertyAsInt(options(), TableProperties.SPLIT_LOOKBACK, tableValue);
@@ -222,7 +217,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public long splitOpenFileCost() {
-    long tableValue = tableOps().current().propertyAsLong(
+    long tableValue = ops().current().propertyAsLong(
         TableProperties.SPLIT_OPEN_FILE_COST,
         TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_OPEN_FILE_COST, tableValue);
@@ -235,8 +230,8 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public Snapshot snapshot() {
-    return context.snapshotId() != null ?
-        ops.current().snapshot(context.snapshotId()) :
+    return snapshotId() != null ?
+        ops.current().snapshot(snapshotId()) :
         ops.current().currentSnapshot();
   }
 
@@ -250,9 +245,9 @@ abstract class BaseTableScan implements TableScan {
     return MoreObjects.toStringHelper(this)
         .add("table", table)
         .add("projection", schema().asStruct())
-        .add("filter", context.rowFilter())
-        .add("ignoreResiduals", context.ignoreResiduals())
-        .add("caseSensitive", context.caseSensitive())
+        .add("filter", filter())
+        .add("ignoreResiduals", shouldIgnoreResiduals())
+        .add("caseSensitive", isCaseSensitive())
         .toString();
   }
 
@@ -263,21 +258,20 @@ abstract class BaseTableScan implements TableScan {
    * @return the Schema to project
    */
   private Schema lazyColumnProjection() {
-    Collection<String> selectedColumns = context.selectedColumns();
-    if (selectedColumns != null) {
+    if (selectedColumns() != null) {
       Set<Integer> requiredFieldIds = Sets.newHashSet();
 
       // all of the filter columns are required
       requiredFieldIds.addAll(
           Binder.boundReferences(schema.asStruct(),
-              Collections.singletonList(context.rowFilter()), context.caseSensitive()));
+              Collections.singletonList(filter()), isCaseSensitive()));
 
       // all of the projection columns are required
       Set<Integer> selectedIds;
-      if (context.caseSensitive()) {
-        selectedIds = TypeUtil.getProjectedIds(schema.select(selectedColumns));
+      if (isCaseSensitive()) {
+        selectedIds = TypeUtil.getProjectedIds(schema.select(selectedColumns()));
       } else {
-        selectedIds = TypeUtil.getProjectedIds(schema.caseInsensitiveSelect(selectedColumns));
+        selectedIds = TypeUtil.getProjectedIds(schema.caseInsensitiveSelect(selectedColumns()));
       }
       requiredFieldIds.addAll(selectedIds);
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -46,17 +46,17 @@ public class DataFilesTable extends BaseFilesTable {
 
   public static class DataFilesTableScan extends BaseFilesTableScan {
 
-    DataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema, MetadataTableType.DATA_FILES);
+    DataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.DATA_FILES);
     }
 
-    DataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, TableScanContext context) {
-      super(ops, table, schema, fileSchema, context, MetadataTableType.DATA_FILES);
+    DataFilesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, MetadataTableType.DATA_FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DataFilesTableScan(ops, table, schema, fileSchema(), context);
+      return new DataFilesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -49,7 +49,7 @@ public class DataTableScan extends BaseTableScan {
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     Preconditions.checkState(snapshotId() == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", snapshotId());
-    return new IncrementalDataTableScan(ops(), table(), schema(),
+    return new IncrementalDataTableScan(tableOps(), table(), schema(),
         context().fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId));
   }
 
@@ -67,7 +67,7 @@ public class DataTableScan extends BaseTableScan {
     // we do not use its return value
     super.useSnapshot(scanSnapshotId);
     Schema snapshotSchema = SnapshotUtil.schemaFor(table(), scanSnapshotId);
-    return newRefinedScan(ops(), table(), snapshotSchema, context().useSnapshotId(scanSnapshotId));
+    return newRefinedScan(tableOps(), table(), snapshotSchema, context().useSnapshotId(scanSnapshotId));
   }
 
   @Override
@@ -100,7 +100,7 @@ public class DataTableScan extends BaseTableScan {
 
   @Override
   public long targetSplitSize() {
-    long tableValue = ops().current().propertyAsLong(
+    long tableValue = tableOps().current().propertyAsLong(
         TableProperties.SPLIT_SIZE,
         TableProperties.SPLIT_SIZE_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_SIZE, tableValue);

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -46,17 +46,17 @@ public class DeleteFilesTable extends BaseFilesTable {
 
   public static class DeleteFilesTableScan extends BaseFilesTableScan {
 
-    DeleteFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema, MetadataTableType.DELETE_FILES);
+    DeleteFilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.DELETE_FILES);
     }
 
-    DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, TableScanContext context) {
-      super(ops, table, schema, fileSchema, context, MetadataTableType.DELETE_FILES);
+    DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, MetadataTableType.DELETE_FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DeleteFilesTableScan(ops, table, schema, fileSchema(), context);
+      return new DeleteFilesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/FilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/FilesTable.java
@@ -46,17 +46,17 @@ public class FilesTable extends BaseFilesTable {
 
   public static class FilesTableScan extends BaseFilesTableScan {
 
-    FilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema, MetadataTableType.FILES);
+    FilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.FILES);
     }
 
-    FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, TableScanContext context) {
-      super(ops, table, schema, fileSchema, context, MetadataTableType.FILES);
+    FilesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, MetadataTableType.FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new FilesTableScan(ops, table, schema, fileSchema(), context);
+      return new FilesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -75,12 +75,11 @@ public class HistoryTable extends BaseMetadataTable {
 
   private class HistoryScan extends StaticTableScan {
     HistoryScan(TableOperations ops, Table table) {
-      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.metadataTableType().name(), HistoryTable.this::task);
+      super(ops, table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task);
     }
 
     HistoryScan(TableOperations ops, Table table, TableScanContext context) {
-      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.metadataTableType().name(),
-              HistoryTable.this::task, context);
+      super(ops, table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -55,7 +55,7 @@ class IncrementalDataTableScan extends DataTableScan {
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     validateSnapshotIdsRefinement(fromSnapshotId, toSnapshotId);
-    return new IncrementalDataTableScan(tableOps(), table(), schema(),
+    return new IncrementalDataTableScan(ops(), table(), schema(),
         context().fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId));
   }
 
@@ -69,8 +69,10 @@ class IncrementalDataTableScan extends DataTableScan {
 
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
-    List<Snapshot> snapshots = snapshotsWithin(table(),
-        context().fromSnapshotId(), context().toSnapshotId());
+    Long fromSnapshotId = context().fromSnapshotId();
+    Long toSnapshotId = context().toSnapshotId();
+
+    List<Snapshot> snapshots = snapshotsWithin(table(), fromSnapshotId, toSnapshotId);
     Set<Long> snapshotIds = Sets.newHashSet(Iterables.transform(snapshots, Snapshot::snapshotId));
     Set<ManifestFile> manifests = FluentIterable
         .from(snapshots)
@@ -78,7 +80,7 @@ class IncrementalDataTableScan extends DataTableScan {
         .filter(manifestFile -> snapshotIds.contains(manifestFile.snapshotId()))
         .toSet();
 
-    ManifestGroup manifestGroup = new ManifestGroup(tableOps().io(), manifests)
+    ManifestGroup manifestGroup = new ManifestGroup(table().io(), manifests)
         .caseSensitive(isCaseSensitive())
         .select(colStats() ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
         .filterData(filter())
@@ -86,19 +88,17 @@ class IncrementalDataTableScan extends DataTableScan {
             manifestEntry ->
                 snapshotIds.contains(manifestEntry.snapshotId()) &&
                 manifestEntry.status() == ManifestEntry.Status.ADDED)
-        .specsById(tableOps().current().specsById())
+        .specsById(table().specs())
         .ignoreDeleted();
 
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();
     }
 
-    Listeners.notifyAll(new IncrementalScanEvent(table().name(), context().fromSnapshotId(),
-        context().toSnapshotId(), context().rowFilter(), schema()));
+    Listeners.notifyAll(new IncrementalScanEvent(table().name(), fromSnapshotId, toSnapshotId, filter(), schema()));
 
-    if (manifests.size() > 1 &&
-        (PLAN_SCANS_WITH_WORKER_POOL || context().planWithCustomizedExecutor())) {
-      manifestGroup = manifestGroup.planWith(context().planExecutor());
+    if (manifests.size() > 1 && (PLAN_SCANS_WITH_WORKER_POOL || context().planWithCustomizedExecutor())) {
+      manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
     return manifestGroup.planFiles();

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -55,7 +55,7 @@ class IncrementalDataTableScan extends DataTableScan {
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     validateSnapshotIdsRefinement(fromSnapshotId, toSnapshotId);
-    return new IncrementalDataTableScan(ops(), table(), schema(),
+    return new IncrementalDataTableScan(tableOps(), table(), schema(),
         context().fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId));
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -73,23 +74,11 @@ public class ManifestEntriesTable extends BaseMetadataTable {
   private static class EntriesTableScan extends BaseMetadataTableScan {
 
     EntriesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema);
+      super(ops, table, schema, MetadataTableType.ENTRIES);
     }
 
     private EntriesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, context);
-    }
-
-    @Override
-    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
-      throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
-    }
-
-    @Override
-    public TableScan appendsAfter(long fromSnapshotId) {
-      throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
+      super(ops, table, schema, MetadataTableType.ENTRIES, context);
     }
 
     @Override
@@ -99,19 +88,16 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
+    protected CloseableIterable<FileScanTask> doPlanFiles() {
       // return entries from both data and delete manifests
-      CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot.allManifests());
+      CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot().allManifests());
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
+      Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest ->
-          new ManifestReadTask(ops.io(), manifest, schema(), schemaString, specString, residuals,
-              ops.current().specsById()));
+          new ManifestReadTask(table(), manifest, schema(), schemaString, specString, residuals));
     }
   }
 
@@ -122,13 +108,13 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     private final ManifestFile manifest;
     private final Map<Integer, PartitionSpec> specsById;
 
-    ManifestReadTask(FileIO io, ManifestFile manifest, Schema schema, String schemaString,
-                     String specString, ResidualEvaluator residuals, Map<Integer, PartitionSpec> specsById) {
+    ManifestReadTask(Table table, ManifestFile manifest, Schema schema, String schemaString,
+                     String specString, ResidualEvaluator residuals) {
       super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
       this.schema = schema;
-      this.io = io;
+      this.io = table.io();
       this.manifest = manifest;
-      this.specsById = specsById;
+      this.specsById = Maps.newHashMap(table.specs());
 
       Type fileProjection = schema.findType("data_file");
       this.fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : new Schema();

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -86,7 +86,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
   private class ManifestsTableScan extends StaticTableScan {
     ManifestsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this.metadataTableType().name(), ManifestsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.MANIFESTS, ManifestsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -135,8 +135,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private class PartitionsScan extends StaticTableScan {
     PartitionsScan(TableOperations ops, Table table) {
-      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this.metadataTableType().name(),
-            PartitionsTable.this::task);
+      super(ops, table, PartitionsTable.this.schema(), MetadataTableType.PARTITIONS, PartitionsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -72,12 +72,11 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private class SnapshotsTableScan extends StaticTableScan {
     SnapshotsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.metadataTableType().name(), SnapshotsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.SNAPSHOTS, SnapshotsTable.this::task);
     }
 
     SnapshotsTableScan(TableOperations ops, Table table, TableScanContext context) {
-      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.metadataTableType().name(),
-              SnapshotsTable.this::task, context);
+      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.SNAPSHOTS, SnapshotsTable.this::task, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.util.StructProjection;
 class StaticDataTask implements DataTask {
 
   static <T> DataTask of(InputFile metadata, Schema tableSchema, Schema projectedSchema, Iterable<T> values,
-      Function<T, Row> transform) {
+                         Function<T, Row> transform) {
     return new StaticDataTask(metadata,
         tableSchema,
         projectedSchema,

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -20,49 +20,30 @@
 package org.apache.iceberg;
 
 import java.util.function.Function;
-import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 
 class StaticTableScan extends BaseMetadataTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
-  private final String tableType;
 
-  StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
+  StaticTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType,
                   Function<StaticTableScan, DataTask> buildTask) {
-    super(ops, table, schema);
+    super(ops, table, schema, tableType);
     this.buildTask = buildTask;
-    this.tableType = tableType;
   }
 
-  StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
-                          Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
-    super(ops, table, schema, context);
+  StaticTableScan(TableOperations ops, Table table, Schema schema, MetadataTableType tableType,
+                  Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
+    super(ops, table, schema, tableType, context);
     this.buildTask = buildTask;
-    this.tableType = tableType;
-  }
-
-  @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
-    throw new UnsupportedOperationException(
-        String.format("Cannot incrementally scan table of type %s", tableType));
-  }
-
-  @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
-    throw new UnsupportedOperationException(
-        String.format("Cannot incrementally scan table of type %s", tableType));
   }
 
   @Override
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new StaticTableScan(
-        ops, table, schema, tableType, buildTask, context);
+    return new StaticTableScan(ops, table, schema, tableType(), buildTask, context);
   }
 
   @Override
-  protected CloseableIterable<FileScanTask> planFiles(
-      TableOperations ops, Snapshot snapshot, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
+  protected CloseableIterable<FileScanTask> doPlanFiles() {
     return CloseableIterable.withNoopClose(buildTask.apply(this));
   }
 }


### PR DESCRIPTION
This PR refactors metadata tables and scans. The project has evolved since the initial implementation was done and I think that metadata tables and scans can be cleaned up a little bit.