### PR TITLE
Docs : Update EMR docs links

### DIFF
--- a/docs/emr/_index.md
+++ b/docs/emr/_index.md
@@ -3,7 +3,7 @@ title: "Amazon EMR"
 bookIconImage: ../img/emr-logo.png
 bookFlatSection: true
 weight: 450
-bookExternalUrlNewWindow: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html
+bookExternalUrlNewWindow: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -484,7 +484,7 @@ More details could be found [here](https://docs.aws.amazon.com/athena/latest/ug/
 [Trino](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-presto.html) that can run Iceberg.
 
 Starting with EMR version 6.5.0, EMR clusters can be configured to have the necessary Apache Iceberg dependencies installed without requiring bootstrap actions. 
-Please refer to the [official documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html) on how to create a cluster with Iceberg installed.
+Please refer to the [official documentation](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html) on how to create a cluster with Iceberg installed.
 
 For versions before 6.5.0, you can use a [bootstrap action](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-bootstrap.html) similar to the following to pre-install all necessary dependencies:
 ```sh


### PR DESCRIPTION
EMR docs have been recently updated from : 
- https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-create-cluster.html

to 
- https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-iceberg-use-cluster.html

This PR attempts to update the doc links to the most recent one, present link redirects (since it's removed) to default landing page : https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-components.html


cc @rajarshisarkar 