### PR TITLE
[0.13] Core: Fixes read metadata failed after dropped partition transform for V1 format

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -20,7 +20,9 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 
@@ -44,15 +46,12 @@ public class ManifestsTable extends BaseMetadataTable {
       )))
   );
 
-  private final PartitionSpec spec;
-
   ManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".manifests");
   }
 
   ManifestsTable(TableOperations ops, Table table, String name) {
     super(ops, table, name);
-    this.spec = table.spec();
   }
 
   @Override
@@ -73,10 +72,15 @@ public class ManifestsTable extends BaseMetadataTable {
   protected DataTask task(TableScan scan) {
     TableOperations ops = operations();
     String location = scan.snapshot().manifestListLocation();
+    Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
+
     return StaticDataTask.of(
         ops.io().newInputFile(location != null ? location : ops.current().metadataFileLocation()),
         schema(), scan.schema(), scan.snapshot().allManifests(),
-        manifest -> ManifestsTable.manifestFileToRow(spec, manifest)
+        manifest -> {
+          PartitionSpec spec = specs.get(manifest.partitionSpecId());
+          return ManifestsTable.manifestFileToRow(spec, manifest);
+        }
     );
   }
 


### PR DESCRIPTION
This backs port #3411 to 0.13.x branch.

This patch fixes two problems:
1. For V1 tables, we use a `VoidTransform` to replace the removed partition field. While the result type of `VoidTransform` same as the type of the field. For example, the result type of `Bucket(2, string_type_field)` is int, while is string for `VoidTransform(string_type_field)`. So we should use the original partition field type(int instead of string) to build the common partitioning type.
2. We should use the matched `PartitionSpec` to convert the `PartitionFiedlSummary` to human string, not the current table spec.