### PR TITLE
Core: Update Remove Snapshots procedure for branching and tagging

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -415,12 +415,15 @@ public class TableMetadataParser {
 
     // parse properties map
     Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, node);
-    long currentVersionId = JsonUtil.getLong(CURRENT_SNAPSHOT_ID, node);
+    long currentSnapshotId = JsonUtil.getLong(CURRENT_SNAPSHOT_ID, node);
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
 
     Map<String, SnapshotRef> refs;
     if (node.has(REFS)) {
       refs = refsFromJson(node.get(REFS));
+    } else if (currentSnapshotId != -1) {
+      // initialize the main branch if there are no refs
+      refs = ImmutableMap.of(SnapshotRef.MAIN_BRANCH, SnapshotRef.branchBuilder(currentSnapshotId).build());
     } else {
       refs = ImmutableMap.of();
     }
@@ -457,7 +460,7 @@ public class TableMetadataParser {
 
     return new TableMetadata(metadataLocation, formatVersion, uuid, location,
         lastSequenceNumber, lastUpdatedMillis, lastAssignedColumnId, currentSchemaId, schemas, defaultSpecId, specs,
-        lastAssignedPartitionId, defaultSortOrderId, sortOrders, properties, currentVersionId,
+        lastAssignedPartitionId, defaultSortOrderId, sortOrders, properties, currentSnapshotId,
         snapshots, entries.build(), metadataEntries.build(), refs,
         ImmutableList.of() /* no changes from the file */);
   }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -303,6 +303,9 @@ public class TableProperties {
   public static final String MIN_SNAPSHOTS_TO_KEEP = "history.expire.min-snapshots-to-keep";
   public static final int MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 1;
 
+  public static final String MAX_REF_AGE_MS = "history.expire.max-ref-age-ms";
+  public static final long MAX_REF_AGE_MS_DEFAULT = Long.MAX_VALUE;
+
   public static final String DELETE_ISOLATION_LEVEL = "write.delete.isolation-level";
   public static final String DELETE_ISOLATION_LEVEL_DEFAULT = "serializable";
 


### PR DESCRIPTION
This PR contains the updated expire snapshots procedure for branching and tagging. Implements the algorithm outlined here https://github.com/apache/iceberg/blob/master/format/spec.md#snapshot-retention-policy.