### PR TITLE
System Printing: Removing System.out and System.err

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -372,7 +372,7 @@
         <module name="RegexpSinglelineJava">
             <property name="id" value="BanSystemErr"/>
             <property name="format" value="System\.err\."/>
-            <property name="message" value="Logging with System.err is not allowed because it has no metadata and can't be configured at runtime. Please use an SLF4J logger instead, e.g. log.info(&quot;Message&quot;)."/>
+            <property name="message" value="Logging with System.err is not allowed because it has no metadata and can't be configured at runtime. Please use an SLF4J logger instead, e.g. log.error(&quot;Message&quot;)."/>
             <property name="ignoreComments" value="true"/>
         </module>
         <module name="RegexpSinglelineJava">

--- a/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
@@ -24,14 +24,11 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestReadabilityChecks {
-  private static final Logger LOG = LoggerFactory.getLogger(TestReadabilityChecks.class);
   private static final Type.PrimitiveType[] PRIMITIVES = new Type.PrimitiveType[] {
       Types.BooleanType.get(),
       Types.IntegerType.get(),
@@ -365,7 +362,6 @@ public class TestReadabilityChecks {
     List<String> errors = CheckCompatibility.writeCompatibilityErrors(read, write);
     Assert.assertEquals("Should produce 1 error message", 1, errors.size());
 
-    LOG.error(errors.toString());
     Assert.assertTrue("Should complain about field_b before field_a",
         errors.get(0).contains("field_b is out of order, before field_a"));
   }

--- a/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
@@ -24,11 +24,14 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestReadabilityChecks {
+  private static final Logger LOG = LoggerFactory.getLogger(TestReadabilityChecks.class);
   private static final Type.PrimitiveType[] PRIMITIVES = new Type.PrimitiveType[] {
       Types.BooleanType.get(),
       Types.IntegerType.get(),
@@ -362,7 +365,7 @@ public class TestReadabilityChecks {
     List<String> errors = CheckCompatibility.writeCompatibilityErrors(read, write);
     Assert.assertEquals("Should produce 1 error message", 1, errors.size());
 
-    System.err.println(errors);
+    LOG.error(errors.toString());
     Assert.assertTrue("Should complain about field_b before field_a",
         errors.get(0).contains("field_b is out of order, before field_a"));
   }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -53,6 +53,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 public class TestSchemaUnionByFieldName {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestSchemaUnionByFieldName.class);
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -44,15 +44,11 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestSchemaUnionByFieldName {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestSchemaUnionByFieldName.class);
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -202,7 +198,6 @@ public class TestSchemaUnionByFieldName {
     Schema newSchema = new Schema(optional(1, "aMap",
         Types.MapType.ofOptional(2, 3, StringType.get(), LongType.get())));
     Schema apply = new SchemaUpdate(currentSchema, 3).unionByNameWith(newSchema).apply();
-    LOG.info(apply.toString());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -44,12 +44,15 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestSchemaUnionByFieldName {
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestSchemaUnionByFieldName.class);
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -198,7 +201,7 @@ public class TestSchemaUnionByFieldName {
     Schema newSchema = new Schema(optional(1, "aMap",
         Types.MapType.ofOptional(2, 3, StringType.get(), LongType.get())));
     Schema apply = new SchemaUpdate(currentSchema, 3).unionByNameWith(newSchema).apply();
-    System.out.println(apply.toString());
+    LOG.info(apply.toString());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -62,6 +62,8 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.SortDirection.ASC;
@@ -69,6 +71,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestJdbcCatalog.class);
   static final Schema SCHEMA = new Schema(
       required(1, "id", Types.IntegerType.get(), "unique ID"),
       required(2, "data", Types.StringType.get())
@@ -486,7 +489,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
     List<Namespace> nsp3 = catalog.listNamespaces();
     Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(Namespace::toString).iterator());
-    System.out.println(tblSet2.toString());
+    LOG.info(tblSet2.toString());
     Assert.assertEquals(tblSet2.size(), 3);
     Assert.assertTrue(tblSet2.contains("db"));
     Assert.assertTrue(tblSet2.contains("db2"));

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -62,8 +62,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.SortDirection.ASC;
@@ -71,7 +69,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestJdbcCatalog.class);
   static final Schema SCHEMA = new Schema(
       required(1, "id", Types.IntegerType.get(), "unique ID"),
       required(2, "data", Types.StringType.get())
@@ -489,7 +486,6 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
 
     List<Namespace> nsp3 = catalog.listNamespaces();
     Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(Namespace::toString).iterator());
-    LOG.info(tblSet2.toString());
     Assert.assertEquals(tblSet2.size(), 3);
     Assert.assertTrue(tblSet2.contains("db"));
     Assert.assertTrue(tblSet2.contains("db2"));

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,11 +37,14 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -116,8 +119,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        System.err.println("XOR val: " + val);
-        System.err.println(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: " + val);
+        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
 
         if (i >= warmups) {
           sum += duration;
@@ -129,7 +132,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    System.err.println(String.format(
+    LOG.error(String.format(
         "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
   }
 
@@ -156,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -178,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
       }
     }
   }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -45,6 +45,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
+
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -119,8 +120,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: " + val);
-        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: {}", val);
+        LOG.error("Reassembled {} records in {} ms", count, duration);
 
         if (i >= warmups) {
           sum += duration;
@@ -132,8 +133,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    LOG.error(String.format(
-        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
+    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -159,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -181,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,15 +37,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
-  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
-
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -120,9 +116,6 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: {}", val);
-        LOG.error("Reassembled {} records in {} ms", count, duration);
-
         if (i >= warmups) {
           sum += duration;
           sumSq += duration * duration;
@@ -132,8 +125,6 @@ public class TestParquetAvroReader {
 
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
-
-    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -158,9 +149,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -180,9 +168,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
   private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
+
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -25,12 +25,8 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
-  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
-
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -50,7 +46,6 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -70,7 +65,6 @@ public class TestSparkDateTimes {
   public void checkSparkTimestamp(String timestampString, String sparkRepr) {
     Literal<Long> ts = Literal.of(timestampString).to(Types.TimestampType.withZone());
     String sparkTimestamp = DateTimeUtils.timestampToString(ts.value());
-    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -25,8 +25,11 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -46,7 +49,7 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    System.err.println(dateString + ": " + date.value());
+    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -66,7 +69,7 @@ public class TestSparkDateTimes {
   public void checkSparkTimestamp(String timestampString, String sparkRepr) {
     Literal<Long> ts = Literal.of(timestampString).to(Types.TimestampType.withZone());
     String sparkTimestamp = DateTimeUtils.timestampToString(ts.value());
-    System.err.println(timestampString + ": " + ts.value());
+    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,11 +37,14 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -116,8 +119,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        System.err.println("XOR val: " + val);
-        System.err.println(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: " + val);
+        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
 
         if (i >= warmups) {
           sum += duration;
@@ -129,7 +132,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    System.err.println(String.format(
+    LOG.error(String.format(
         "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
   }
 
@@ -156,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -178,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
       }
     }
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -45,6 +45,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
+
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -119,8 +120,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: " + val);
-        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: {}", val);
+        LOG.error("Reassembled {} records in {} ms", count, duration);
 
         if (i >= warmups) {
           sum += duration;
@@ -132,8 +133,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    LOG.error(String.format(
-        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
+    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -159,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -181,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,15 +37,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
-  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
-
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -120,9 +116,6 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: {}", val);
-        LOG.error("Reassembled {} records in {} ms", count, duration);
-
         if (i >= warmups) {
           sum += duration;
           sumSq += duration * duration;
@@ -132,8 +125,6 @@ public class TestParquetAvroReader {
 
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
-
-    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -158,9 +149,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -180,9 +168,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,12 +27,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
-  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
-
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -52,7 +48,6 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -74,7 +69,6 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = DateTimeUtils.timestampToString(formatter, ts.value());
-    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,8 +27,11 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -48,7 +51,7 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    System.err.println(dateString + ": " + date.value());
+    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -70,7 +73,7 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = DateTimeUtils.timestampToString(formatter, ts.value());
-    System.err.println(timestampString + ": " + ts.value());
+    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
   private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
+
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -120,8 +120,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: " + val);
-        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: {}", val);
+        LOG.error("Reassembled {} records in {} ms", count, duration);
 
         if (i >= warmups) {
           sum += duration;
@@ -133,8 +133,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    LOG.error(String.format(
-        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
+    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -160,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -182,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,11 +37,14 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -116,8 +119,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        System.err.println("XOR val: " + val);
-        System.err.println(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: " + val);
+        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
 
         if (i >= warmups) {
           sum += duration;
@@ -129,7 +132,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    System.err.println(String.format(
+    LOG.error(String.format(
         "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
   }
 
@@ -156,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -178,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
       }
     }
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -45,6 +45,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
+
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,15 +37,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
-  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
-
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -120,9 +116,6 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: {}", val);
-        LOG.error("Reassembled {} records in {} ms", count, duration);
-
         if (i >= warmups) {
           sum += duration;
           sumSq += duration * duration;
@@ -132,8 +125,6 @@ public class TestParquetAvroReader {
 
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
-
-    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -158,9 +149,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -180,9 +168,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,12 +27,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
-  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
-
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -52,7 +48,6 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -74,7 +69,6 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,8 +27,11 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -48,7 +51,7 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    System.err.println(dateString + ": " + date.value());
+    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -70,7 +73,7 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    System.err.println(timestampString + ": " + ts.value());
+    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
   private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
+
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,11 +37,14 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
+  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -116,8 +119,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        System.err.println("XOR val: " + val);
-        System.err.println(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: " + val);
+        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
 
         if (i >= warmups) {
           sum += duration;
@@ -129,7 +132,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    System.err.println(String.format(
+    LOG.error(String.format(
         "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
   }
 
@@ -156,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -178,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        System.err.println("XOR val: " + val);
-        System.err.println("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: " + val);
+        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -45,6 +45,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
   private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
+
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -119,8 +120,8 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: " + val);
-        LOG.error(String.format("Reassembled %d records in %d ms", count, duration));
+        LOG.error("XOR val: {}", val);
+        LOG.error("Reassembled {} records in {} ms", count, duration);
 
         if (i >= warmups) {
           sum += duration;
@@ -132,8 +133,7 @@ public class TestParquetAvroReader {
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
 
-    LOG.error(String.format(
-        "Ran %d trials: mean time: %.3f ms, stddev: %.3f ms", trials, mean, stddev));
+    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -159,8 +159,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("Old read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -181,8 +181,8 @@ public class TestParquetAvroReader {
         }
         long end = System.currentTimeMillis();
 
-        LOG.error("XOR val: " + val);
-        LOG.error("New read path: read " + count + " records in " + (end - start) + " ms");
+        LOG.error("XOR val: {}", val);
+        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -37,15 +37,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetAvroReader {
-  private static final Logger LOG = LoggerFactory.getLogger(TestParquetAvroReader.class);
-
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
@@ -120,9 +116,6 @@ public class TestParquetAvroReader {
         long end = System.currentTimeMillis();
         long duration = end - start;
 
-        LOG.error("XOR val: {}", val);
-        LOG.error("Reassembled {} records in {} ms", count, duration);
-
         if (i >= warmups) {
           sum += duration;
           sumSq += duration * duration;
@@ -132,8 +125,6 @@ public class TestParquetAvroReader {
 
     double mean = ((double) sum) / trials;
     double stddev = Math.sqrt((((double) sumSq) / trials) - (mean * mean));
-
-    LOG.error("Ran {} trials: mean time: {} ms, stddev: {} ms", trials, mean, stddev);
   }
 
   @Ignore
@@ -158,9 +149,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("Old read path: read {} records in {} ms", count, end - start);
       }
 
       // clean up as much memory as possible to avoid a large GC during the timed run
@@ -180,9 +168,6 @@ public class TestParquetAvroReader {
           count += 1;
         }
         long end = System.currentTimeMillis();
-
-        LOG.error("XOR val: {}", val);
-        LOG.error("New read path: read {} records in {} ms", count, end - start);
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,12 +27,8 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
-  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
-
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -52,7 +48,6 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -74,7 +69,6 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -27,8 +27,11 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.catalyst.util.TimestampFormatter;
 import org.junit.Assert;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
+  private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428
@@ -48,7 +51,7 @@ public class TestSparkDateTimes {
   public void checkSparkDate(String dateString) {
     Literal<Integer> date = Literal.of(dateString).to(Types.DateType.get());
     String sparkDate = DateTimeUtils.toJavaDate(date.value()).toString();
-    System.err.println(dateString + ": " + date.value());
+    LOG.error(dateString + ": " + date.value());
     Assert.assertEquals("Should be the same date (" + date.value() + ")", dateString, sparkDate);
   }
 
@@ -70,7 +73,7 @@ public class TestSparkDateTimes {
     ZoneId zoneId = DateTimeUtils.getZoneId("UTC");
     TimestampFormatter formatter = TimestampFormatter.getFractionFormatter(zoneId);
     String sparkTimestamp = formatter.format(ts.value());
-    System.err.println(timestampString + ": " + ts.value());
+    LOG.error(timestampString + ": " + ts.value());
     Assert.assertEquals("Should be the same timestamp (" + ts.value() + ")",
         sparkRepr, sparkTimestamp);
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkDateTimes.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 public class TestSparkDateTimes {
   private static final Logger LOG = LoggerFactory.getLogger(TestSparkDateTimes.class);
+
   @Test
   public void testSparkDate() {
     // checkSparkDate("1582-10-14"); // -141428


### PR DESCRIPTION
in checkstyle.xml, `Logging with System.out and System.err are not allowed because it has no metadata and can't be configured at runtime. Please use an SLF4J logger instead`. so use SLF4J logger instead System.out and System.err. 

- Current strategy:  Removing System.out and System.err

cc: @RussellSpitzer @rdblue 