### PR TITLE
Core : Strip trailing slash from tableLocation in LocationProvider

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.aws.AwsClientFactories;
@@ -53,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +133,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
 
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = LocationProviders.stripTrailingSlash(path);
+    this.warehousePath = LocationUtil.stripTrailingSlash(path);
     this.dynamo = client;
     this.fileIO = io;
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -48,7 +48,6 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -129,7 +128,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
   void initialize(String name, String path, AwsProperties properties, DynamoDbClient client, FileIO io) {
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = cleanWarehousePath(path);
+    this.warehousePath = CatalogUtil.cleanWarehousePath(path);
     this.dynamo = client;
     this.fileIO = io;
 
@@ -498,17 +497,6 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
       return io;
     } else {
       return CatalogUtil.loadFileIO(fileIOImpl, properties, hadoopConf);
-    }
-  }
-
-  private String cleanWarehousePath(String path) {
-    Preconditions.checkArgument(path != null && path.length() > 0,
-        "Cannot initialize DynamoDbCatalog because warehousePath must not be null");
-    int len = path.length();
-    if (path.charAt(len - 1) == '/') {
-      return path.substring(0, len - 1);
-    } else {
-      return path;
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.aws.AwsClientFactories;
@@ -48,6 +49,7 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -126,9 +128,12 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
 
   @VisibleForTesting
   void initialize(String name, String path, AwsProperties properties, DynamoDbClient client, FileIO io) {
+    Preconditions.checkArgument(path != null && path.length() > 0,
+        "Cannot initialize DynamoDbCatalog because warehousePath must not be null or empty");
+
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = CatalogUtil.cleanWarehousePath(path);
+    this.warehousePath = LocationProviders.stripTrailingSlash(path);
     this.dynamo = client;
     this.fileIO = io;
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -55,6 +54,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.LockManagers;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -169,7 +169,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = LocationProviders.stripTrailingSlash(path);
+    this.warehousePath = LocationUtil.stripTrailingSlash(path);
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -163,9 +164,12 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @VisibleForTesting
   void initialize(String name, String path, AwsProperties properties, GlueClient client, LockManager lock, FileIO io) {
+    Preconditions.checkArgument(path != null && path.length() > 0,
+        "Cannot initialize GlueCatalog because warehousePath must not be null or empty");
+
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = CatalogUtil.cleanWarehousePath(path);
+    this.warehousePath = LocationProviders.stripTrailingSlash(path);
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -165,7 +165,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
   void initialize(String name, String path, AwsProperties properties, GlueClient client, LockManager lock, FileIO io) {
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = cleanWarehousePath(path);
+    this.warehousePath = CatalogUtil.cleanWarehousePath(path);
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;
@@ -175,17 +175,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
     closeableGroup.addCloseable(lockManager);
     closeableGroup.addCloseable(fileIO);
     closeableGroup.setSuppressCloseFailure(true);
-  }
-
-  private String cleanWarehousePath(String path) {
-    Preconditions.checkArgument(path != null && path.length() > 0,
-        "Cannot initialize GlueCatalog because warehousePath must not be null");
-    int len = path.length();
-    if (path.charAt(len - 1) == '/') {
-      return path.substring(0, len - 1);
-    } else {
-      return path;
-    }
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -83,7 +83,7 @@ public class TestGlueCatalog {
   public void testConstructorEmptyWarehousePath() {
     AssertHelpers.assertThrows("warehouse path cannot be null",
         IllegalArgumentException.class,
-        "Cannot initialize Catalog because warehousePath must not be null or empty",
+        "Cannot initialize GlueCatalog because warehousePath must not be null or empty",
         () -> {
             GlueCatalog catalog = new GlueCatalog();
             catalog.initialize(CATALOG_NAME, null, new AwsProperties(), glue,

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -83,7 +83,7 @@ public class TestGlueCatalog {
   public void testConstructorEmptyWarehousePath() {
     AssertHelpers.assertThrows("warehouse path cannot be null",
         IllegalArgumentException.class,
-        "Cannot initialize GlueCatalog because warehousePath must not be null",
+        "Cannot initialize Catalog because warehousePath must not be null or empty",
         () -> {
             GlueCatalog catalog = new GlueCatalog();
             catalog.initialize(CATALOG_NAME, null, new AwsProperties(), glue,

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -341,15 +341,4 @@ public class CatalogUtil {
 
     setConf.invoke(conf);
   }
-
-  public static String cleanWarehousePath(String path) {
-    Preconditions.checkArgument(path != null && path.length() > 0,
-        "Cannot initialize Catalog because warehousePath must not be null or empty");
-    int len = path.length();
-    if (path.charAt(len - 1) == '/') {
-      return path.substring(0, len - 1);
-    } else {
-      return path;
-    }
-  }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -341,4 +341,15 @@ public class CatalogUtil {
 
     setConf.invoke(conf);
   }
+
+  public static String cleanWarehousePath(String path) {
+    Preconditions.checkArgument(path != null && path.length() > 0,
+        "Cannot initialize Catalog because warehousePath must not be null or empty");
+    int len = path.length();
+    if (path.charAt(len - 1) == '/') {
+      return path.substring(0, len - 1);
+    } else {
+      return path;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -35,6 +35,7 @@ public class LocationProviders {
   }
 
   public static LocationProvider locationsFor(String location, Map<String, String> properties) {
+    String sanitizedLocation = stripTrailingSlash(location);
     if (properties.containsKey(TableProperties.WRITE_LOCATION_PROVIDER_IMPL)) {
       String impl = properties.get(TableProperties.WRITE_LOCATION_PROVIDER_IMPL);
       DynConstructors.Ctor<LocationProvider> ctor;
@@ -51,7 +52,7 @@ public class LocationProviders {
             impl, LocationProvider.class), e);
       }
       try {
-        return ctor.newInstance(location, properties);
+        return ctor.newInstance(sanitizedLocation, properties);
       } catch (ClassCastException e) {
         throw new IllegalArgumentException(
             String.format("Provided implementation for dynamic instantiation should implement %s.",
@@ -60,9 +61,9 @@ public class LocationProviders {
     } else if (PropertyUtil.propertyAsBoolean(properties,
         TableProperties.OBJECT_STORE_ENABLED,
         TableProperties.OBJECT_STORE_ENABLED_DEFAULT)) {
-      return new ObjectStoreLocationProvider(location, properties);
+      return new ObjectStoreLocationProvider(sanitizedLocation, properties);
     } else {
-      return new DefaultLocationProvider(location, properties);
+      return new DefaultLocationProvider(sanitizedLocation, properties);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.PropertyUtil;
 
 public class LocationProviders {
@@ -35,7 +36,7 @@ public class LocationProviders {
   }
 
   public static LocationProvider locationsFor(String inputLocation, Map<String, String> properties) {
-    String location = stripTrailingSlash(inputLocation);
+    String location = LocationUtil.stripTrailingSlash(inputLocation);
     if (properties.containsKey(TableProperties.WRITE_LOCATION_PROVIDER_IMPL)) {
       String impl = properties.get(TableProperties.WRITE_LOCATION_PROVIDER_IMPL);
       DynConstructors.Ctor<LocationProvider> ctor;
@@ -71,7 +72,7 @@ public class LocationProviders {
     private final String dataLocation;
 
     DefaultLocationProvider(String tableLocation, Map<String, String> properties) {
-      this.dataLocation = stripTrailingSlash(dataLocation(properties, tableLocation));
+      this.dataLocation = LocationUtil.stripTrailingSlash(dataLocation(properties, tableLocation));
     }
 
     private static String dataLocation(Map<String, String> properties, String tableLocation) {
@@ -104,7 +105,7 @@ public class LocationProviders {
     private final String context;
 
     ObjectStoreLocationProvider(String tableLocation, Map<String, String> properties) {
-      this.storageLocation = stripTrailingSlash(dataLocation(properties, tableLocation));
+      this.storageLocation = LocationUtil.stripTrailingSlash(dataLocation(properties, tableLocation));
       // if the storage location is within the table prefix, don't add table and database name context
       if (storageLocation.startsWith(tableLocation)) {
         this.context = null;
@@ -159,13 +160,5 @@ public class LocationProviders {
 
       return resolvedContext;
     }
-  }
-
-  public static String stripTrailingSlash(String path) {
-    String result = path;
-    while (result.endsWith("/")) {
-      result = result.substring(0, result.length() - 1);
-    }
-    return result;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -34,8 +34,8 @@ public class LocationProviders {
   private LocationProviders() {
   }
 
-  public static LocationProvider locationsFor(String location, Map<String, String> properties) {
-    String sanitizedLocation = stripTrailingSlash(location);
+  public static LocationProvider locationsFor(String inputLocation, Map<String, String> properties) {
+    String location = stripTrailingSlash(inputLocation);
     if (properties.containsKey(TableProperties.WRITE_LOCATION_PROVIDER_IMPL)) {
       String impl = properties.get(TableProperties.WRITE_LOCATION_PROVIDER_IMPL);
       DynConstructors.Ctor<LocationProvider> ctor;
@@ -52,7 +52,7 @@ public class LocationProviders {
             impl, LocationProvider.class), e);
       }
       try {
-        return ctor.newInstance(sanitizedLocation, properties);
+        return ctor.newInstance(location, properties);
       } catch (ClassCastException e) {
         throw new IllegalArgumentException(
             String.format("Provided implementation for dynamic instantiation should implement %s.",
@@ -61,9 +61,9 @@ public class LocationProviders {
     } else if (PropertyUtil.propertyAsBoolean(properties,
         TableProperties.OBJECT_STORE_ENABLED,
         TableProperties.OBJECT_STORE_ENABLED_DEFAULT)) {
-      return new ObjectStoreLocationProvider(sanitizedLocation, properties);
+      return new ObjectStoreLocationProvider(location, properties);
     } else {
-      return new DefaultLocationProvider(sanitizedLocation, properties);
+      return new DefaultLocationProvider(location, properties);
     }
   }
 
@@ -161,7 +161,7 @@ public class LocationProviders {
     }
   }
 
-  private static String stripTrailingSlash(String path) {
+  public static String stripTrailingSlash(String path) {
     String result = path;
     while (result.endsWith("/")) {
       result = result.substring(0, result.length() - 1);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -98,11 +98,8 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
-    String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
-    Preconditions.checkArgument(inputWarehouseLocation != null && !inputWarehouseLocation.equals(""),
-        "Cannot instantiate hadoop catalog. No location provided for warehouse (Set warehouse config)");
     this.catalogName = name;
-    this.warehouseLocation = inputWarehouseLocation.replaceAll("/*$", "");
+    this.warehouseLocation = CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION));
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -98,8 +99,12 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
+    Preconditions.checkArgument(inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
+        "Cannot initialize HadoopCatalog because warehousePath must not be null or empty");
+
     this.catalogName = name;
-    this.warehouseLocation = CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+    this.warehouseLocation = LocationProviders.stripTrailingSlash(inputWarehouseLocation);
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -59,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.LockManagers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -104,7 +104,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
         "Cannot initialize HadoopCatalog because warehousePath must not be null or empty");
 
     this.catalogName = name;
-    this.warehouseLocation = LocationProviders.stripTrailingSlash(inputWarehouseLocation);
+    this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
 
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -81,7 +82,11 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     String uri = properties.get(CatalogProperties.URI);
     Preconditions.checkNotNull(uri, "JDBC connection URI is required");
 
-    this.warehouseLocation = CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+    String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
+    Preconditions.checkArgument(inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
+        "Cannot initialize JDBCCatalog because warehousePath must not be null or empty");
+
+    this.warehouseLocation = LocationProviders.stripTrailingSlash(inputWarehouseLocation);
 
     if (name != null) {
       this.catalogName = name;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -57,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.LocationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +86,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     Preconditions.checkArgument(inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
         "Cannot initialize JDBCCatalog because warehousePath must not be null or empty");
 
-    this.warehouseLocation = LocationProviders.stripTrailingSlash(inputWarehouseLocation);
+    this.warehouseLocation = LocationUtil.stripTrailingSlash(inputWarehouseLocation);
 
     if (name != null) {
       this.catalogName = name;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -81,9 +81,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     String uri = properties.get(CatalogProperties.URI);
     Preconditions.checkNotNull(uri, "JDBC connection URI is required");
 
-    String warehouse = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
-    Preconditions.checkNotNull(warehouse, "JDBC warehouse location is required");
-    this.warehouseLocation = warehouse.replaceAll("/*$", "");
+    this.warehouseLocation = CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION));
 
     if (name != null) {
       this.catalogName = name;

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class LocationUtil {
+  private LocationUtil() {
+
+  }
+
+  public static String stripTrailingSlash(String path) {
+    Preconditions.checkArgument(path != null && path.length() > 0, "path must not be null or empty");
+
+    String result = path;
+    while (result.endsWith("/")) {
+      result = result.substring(0, result.length() - 1);
+    }
+    return result;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -229,7 +229,7 @@ public class TestTables {
     @Override
     public LocationProvider locationProvider() {
       Preconditions.checkNotNull(current,
-          "Current metadata should not be null when locatinProvider is called");
+          "Current metadata should not be null when locationProvider is called");
       return LocationProviders.locationsFor(current.location(), current.properties());
     }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import org.apache.iceberg.AssertHelpers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLocationUtil {
+
+  @Test
+  public void testStripTrailingSlash() {
+    String pathWithoutTrailingSlash = "s3://bucket/db/tbl";
+    Assert.assertEquals("Should have no trailing slashes", pathWithoutTrailingSlash,
+        LocationUtil.stripTrailingSlash(pathWithoutTrailingSlash));
+
+    String pathWithSingleTrailingSlash = pathWithoutTrailingSlash  + "/";
+    Assert.assertEquals("Should have no trailing slashes", pathWithoutTrailingSlash,
+        LocationUtil.stripTrailingSlash(pathWithSingleTrailingSlash));
+
+    String pathWithMultipleTrailingSlash = pathWithoutTrailingSlash  + "////";
+    Assert.assertEquals("Should have no trailing slashes", pathWithoutTrailingSlash,
+        LocationUtil.stripTrailingSlash(pathWithMultipleTrailingSlash));
+
+    String pathWithOnlySlash = "////";
+    Assert.assertEquals("Should have no trailing slashes", "",
+        LocationUtil.stripTrailingSlash(pathWithOnlySlash));
+  }
+
+  @Test
+  public void testStripTrailingSlashWithInvalidPath() {
+    String [] invalidPaths = new String[] {null, ""};
+
+    for (String invalidPath : invalidPaths) {
+      AssertHelpers.assertThrows("path must be valid", IllegalArgumentException.class, "path must not be null or empty",
+          () -> LocationUtil.stripTrailingSlash(invalidPath));
+    }
+
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -102,9 +103,12 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
+    Preconditions.checkArgument(inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
+        "Cannot initialize EcsCatalog because warehousePath must not be null or empty");
+
     this.catalogName = name;
-    this.warehouseLocation =
-        new EcsURI(CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+    this.warehouseLocation = new EcsURI(LocationProviders.stripTrailingSlash(inputWarehouseLocation));
     this.client = DellClientFactories.from(properties).ecsS3();
     this.fileIO = initializeFileIO(properties);
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -59,6 +58,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.apache.iceberg.util.LocationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +108,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
         "Cannot initialize EcsCatalog because warehousePath must not be null or empty");
 
     this.catalogName = name;
-    this.warehouseLocation = new EcsURI(LocationProviders.stripTrailingSlash(inputWarehouseLocation));
+    this.warehouseLocation = new EcsURI(LocationUtil.stripTrailingSlash(inputWarehouseLocation));
     this.client = DellClientFactories.from(properties).ecsS3();
     this.fileIO = initializeFileIO(properties);
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -103,7 +103,8 @@ public class EcsCatalog extends BaseMetastoreCatalog
   @Override
   public void initialize(String name, Map<String, String> properties) {
     this.catalogName = name;
-    this.warehouseLocation = cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+    this.warehouseLocation =
+        new EcsURI(CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
     this.client = DellClientFactories.from(properties).ecsS3();
     this.fileIO = initializeFileIO(properties);
 
@@ -111,17 +112,6 @@ public class EcsCatalog extends BaseMetastoreCatalog
     closeableGroup.addCloseable(client::destroy);
     closeableGroup.addCloseable(fileIO);
     closeableGroup.setSuppressCloseFailure(true);
-  }
-
-  private EcsURI cleanWarehousePath(String path) {
-    Preconditions.checkArgument(path != null && path.length() > 0,
-            "Cannot initialize EcsCatalog because warehousePath must not be null or empty string");
-    int len = path.length();
-    if (path.charAt(len - 1) == '/') {
-      return new EcsURI(path.substring(0, len - 1));
-    } else {
-      return new EcsURI(path);
-    }
   }
 
   private FileIO initializeFileIO(Map<String, String> properties) {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
@@ -90,7 +91,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
       this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
-          CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+          LocationProviders.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
     }
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -90,7 +90,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
       this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
-          cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+          CatalogUtil.cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
     }
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));
@@ -541,16 +541,5 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   @VisibleForTesting
   void setListAllTables(boolean listAllTables) {
     this.listAllTables = listAllTables;
-  }
-
-  private String cleanWarehousePath(String path) {
-    Preconditions.checkArgument(path != null && path.length() > 0,
-        "Cannot initialize HiveCatalog because warehousePath must not be null or empty");
-    int len = path.length();
-    if (path.charAt(len - 1) == '/') {
-      return path.substring(0, len - 1);
-    } else {
-      return path;
-    }
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -40,7 +40,6 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ClientPool;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
@@ -58,6 +57,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,7 +91,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
       this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
-          LocationProviders.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+          LocationUtil.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
     }
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -89,7 +89,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
     }
 
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
-      this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+      this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+          cleanWarehousePath(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
     }
 
     this.listAllTables = Boolean.parseBoolean(properties.getOrDefault(LIST_ALL_TABLES, LIST_ALL_TABLES_DEFAULT));
@@ -540,5 +541,16 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   @VisibleForTesting
   void setListAllTables(boolean listAllTables) {
     this.listAllTables = listAllTables;
+  }
+
+  private String cleanWarehousePath(String path) {
+    Preconditions.checkArgument(path != null && path.length() > 0,
+        "Cannot initialize HiveCatalog because warehousePath must not be null or empty");
+    int len = path.length();
+    if (path.charAt(len - 1) == '/') {
+      return path.substring(0, len - 1);
+    } else {
+      return path;
+    }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -569,7 +569,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
     catalogWithSlash.initialize("hive_catalog", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION,
         wareHousePath + "/"));
-    Assert.assertEquals("Should have trailing slash stripped", "s3://bucket/db/tbl", catalogWithSlash.getConf().get(
+    Assert.assertEquals("Should have trailing slash stripped", wareHousePath, catalogWithSlash.getConf().get(
         HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -558,5 +560,16 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     parameters.remove(TableProperties.CURRENT_SNAPSHOT_SUMMARY);
     spyOps.setSnapshotSummary(parameters, snapshot);
     Assert.assertEquals("The snapshot summary must not be in parameters due to the size limit", 0, parameters.size());
+  }
+
+  @Test
+  public void testConstructorWarehousePathWithEndSlash() {
+    HiveCatalog catalogWithSlash = new HiveCatalog();
+    String wareHousePath = "s3://bucket/db/tbl";
+
+    catalogWithSlash.initialize("hive_catalog", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION,
+        wareHousePath + "/"));
+    Assert.assertEquals("Should have trailing slash stripped", "s3://bucket/db/tbl", catalogWithSlash.getConf().get(
+        HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -167,7 +167,7 @@ class TestTables {
     @Override
     public LocationProvider locationProvider() {
       Preconditions.checkNotNull(current,
-          "Current metadata should not be null when locatinProvider is called");
+          "Current metadata should not be null when locationProvider is called");
       return LocationProviders.locationsFor(current.location(), current.properties());
     }
 


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/4582

This change attempts to fix :
1. In `locationsFor` we don't sanitize the location (i.e strip the trailing slash), this attempts to do this stripping
2. The warehouse location for hiveCatalog is also missing this handling rest all catalogs such as Hadoop / Glue have these handling 
3. Had to refactor a bit, slash stripping logic was duplicated in all catalogs. 
   Note : nessie Catalog also  doesn't have this handling, will do the same in next iteration of this pr if experts from nessie   suggests this is required (appologies I am new to nessie)
4. Fixes a minor typo.

cc @szehon-ho , @RussellSpitzer , @jackye1995 , @flyrain 