### PR TITLE
Spark: Add custom metric for number of deletes applied by a SparkScan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/DeleteCounter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DeleteCounter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+/** A counter to be used to count deletes as they are applied. */
+public class DeleteCounter {
+
+  private long count = 0L;
+
+  /** Increment the counter by one. */
+  public void increment() {
+    count++;
+  }
+
+  /** Return the current value of the counter. */
+  public long get() {
+    return count;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -62,7 +62,14 @@ public class Deletes {
     return equalityFilter.filter(rows);
   }
 
-  /** Returns the same rows that are input, while marking the deleted ones. */
+  /**
+   * Returns the same rows that are input, while marking the deleted ones.
+   *
+   * @param rows the rows to process
+   * @param isDeleted a predicate that determines if a row is deleted
+   * @param deleteMarker a function that marks a row as deleted
+   * @return the processed rows
+   */
   public static <T> CloseableIterable<T> markDeleted(
       CloseableIterable<T> rows, Predicate<T> isDeleted, Consumer<T> deleteMarker) {
     return CloseableIterable.transform(
@@ -71,12 +78,18 @@ public class Deletes {
           if (isDeleted.test(row)) {
             deleteMarker.accept(row);
           }
+
           return row;
         });
   }
 
   /**
    * Returns the remaining rows (the ones that are not deleted), while counting the deleted ones.
+   *
+   * @param rows the rows to process
+   * @param isDeleted a predicate that determines if a row is deleted
+   * @param counter a counter that counts deleted rows
+   * @return the processed rows
    */
   public static <T> CloseableIterable<T> filterDeleted(
       CloseableIterable<T> rows, Predicate<T> isDeleted, DeleteCounter counter) {
@@ -88,6 +101,7 @@ public class Deletes {
             if (deleted) {
               counter.increment();
             }
+
             return !deleted;
           }
         };
@@ -259,6 +273,7 @@ public class Deletes {
           if (deleted) {
             counter.increment();
           }
+
           return !deleted;
         }
       };

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -62,6 +62,7 @@ public class Deletes {
     return equalityFilter.filter(rows);
   }
 
+  /** Returns the same rows that are input, while marking the deleted ones. */
   public static <T> CloseableIterable<T> markDeleted(
       CloseableIterable<T> rows, Predicate<T> isDeleted, Consumer<T> deleteMarker) {
     return CloseableIterable.transform(
@@ -74,9 +75,24 @@ public class Deletes {
         });
   }
 
+  /**
+   * Returns the remaining rows (the ones that are not deleted), while counting the deleted ones.
+   */
   public static <T> CloseableIterable<T> filterDeleted(
-      CloseableIterable<T> rows, Predicate<T> isDeleted) {
-    return CloseableIterable.filter(rows, isDeleted.negate());
+      CloseableIterable<T> rows, Predicate<T> isDeleted, DeleteCounter counter) {
+    Filter<T> remainingRowsFilter =
+        new Filter<T>() {
+          @Override
+          protected boolean shouldKeep(T item) {
+            boolean deleted = isDeleted.test(item);
+            if (deleted) {
+              counter.increment();
+            }
+            return !deleted;
+          }
+        };
+
+    return remainingRowsFilter.filter(rows);
   }
 
   public static StructLikeSet toEqualitySet(
@@ -116,7 +132,15 @@ public class Deletes {
       CloseableIterable<T> rows,
       Function<T, Long> rowToPosition,
       CloseableIterable<Long> posDeletes) {
-    return new PositionStreamDeleteFilter<>(rows, rowToPosition, posDeletes);
+    return streamingFilter(rows, rowToPosition, posDeletes, new DeleteCounter());
+  }
+
+  public static <T> CloseableIterable<T> streamingFilter(
+      CloseableIterable<T> rows,
+      Function<T, Long> rowToPosition,
+      CloseableIterable<Long> posDeletes,
+      DeleteCounter counter) {
+    return new PositionStreamDeleteFilter<>(rows, rowToPosition, posDeletes, counter);
   }
 
   public static <T> CloseableIterable<T> streamingMarker(
@@ -215,11 +239,15 @@ public class Deletes {
   }
 
   private static class PositionStreamDeleteFilter<T> extends PositionStreamDeleteIterable<T> {
-    private PositionStreamDeleteFilter(
+    private final DeleteCounter counter;
+
+    PositionStreamDeleteFilter(
         CloseableIterable<T> rows,
         Function<T, Long> rowToPosition,
-        CloseableIterable<Long> deletePositions) {
+        CloseableIterable<Long> deletePositions,
+        DeleteCounter counter) {
       super(rows, rowToPosition, deletePositions);
+      this.counter = counter;
     }
 
     @Override
@@ -227,7 +255,11 @@ public class Deletes {
       return new FilterIterator<T>(items) {
         @Override
         protected boolean shouldKeep(T item) {
-          return !isDeleted(item);
+          boolean deleted = isDeleted(item);
+          if (deleted) {
+            counter.increment();
+          }
+          return !deleted;
         }
       };
     }

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.data.avro.DataReader;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.expressions.Expressions;
@@ -52,8 +53,11 @@ import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.StructProjection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class DeleteFilter<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteFilter.class);
   private static final long DEFAULT_SET_FILTER_THRESHOLD = 100_000L;
   private static final Schema POS_DELETE_SCHEMA =
       new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
@@ -66,24 +70,32 @@ public abstract class DeleteFilter<T> {
   private final Accessor<StructLike> posAccessor;
   private final boolean hasIsDeletedColumn;
   private final int isDeletedColumnPosition;
+  private final DeleteCounter counter;
 
   private PositionDeleteIndex deleteRowPositions = null;
   private List<Predicate<T>> isInDeleteSets = null;
   private Predicate<T> eqDeleteRows = null;
 
   protected DeleteFilter(
-      String filePath, List<DeleteFile> deletes, Schema tableSchema, Schema requestedSchema) {
+      String filePath,
+      List<DeleteFile> deletes,
+      Schema tableSchema,
+      Schema requestedSchema,
+      DeleteCounter counter) {
     this.setFilterThreshold = DEFAULT_SET_FILTER_THRESHOLD;
     this.filePath = filePath;
+    this.counter = counter;
 
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
     for (DeleteFile delete : deletes) {
       switch (delete.content()) {
         case POSITION_DELETES:
+          LOG.debug("Adding position delete file {} to filter", delete.path());
           posDeleteBuilder.add(delete);
           break;
         case EQUALITY_DELETES:
+          LOG.debug("Adding equality delete file {} to filter", delete.path());
           eqDeleteBuilder.add(delete);
           break;
         default:
@@ -101,6 +113,11 @@ public abstract class DeleteFilter<T> {
     this.isDeletedColumnPosition = requiredSchema.columns().indexOf(MetadataColumns.IS_DELETED);
   }
 
+  protected DeleteFilter(
+      String filePath, List<DeleteFile> deletes, Schema tableSchema, Schema requestedSchema) {
+    this(filePath, deletes, tableSchema, requestedSchema, new DeleteCounter());
+  }
+
   protected int columnIsDeletedPosition() {
     return isDeletedColumnPosition;
   }
@@ -115,6 +132,10 @@ public abstract class DeleteFilter<T> {
 
   public boolean hasEqDeletes() {
     return !eqDeletes.isEmpty();
+  }
+
+  public void incrementDeleteCount() {
+    counter.increment();
   }
 
   Accessor<StructLike> posAccessor() {
@@ -234,14 +255,15 @@ public abstract class DeleteFilter<T> {
     return hasIsDeletedColumn
         ? Deletes.streamingMarker(
             records, this::pos, Deletes.deletePositions(filePath, deletes), this::markRowDeleted)
-        : Deletes.streamingFilter(records, this::pos, Deletes.deletePositions(filePath, deletes));
+        : Deletes.streamingFilter(
+            records, this::pos, Deletes.deletePositions(filePath, deletes), counter);
   }
 
   private CloseableIterable<T> createDeleteIterable(
       CloseableIterable<T> records, Predicate<T> isDeleted) {
     return hasIsDeletedColumn
         ? Deletes.markDeleted(records, isDeleted, this::markRowDeleted)
-        : Deletes.filterDeleted(records, isDeleted);
+        : Deletes.filterDeleted(records, isDeleted, counter);
   }
 
   private CloseableIterable<Record> openPosDeletes(DeleteFile file) {
@@ -249,6 +271,7 @@ public abstract class DeleteFilter<T> {
   }
 
   private CloseableIterable<Record> openDeletes(DeleteFile deleteFile, Schema deleteSchema) {
+    LOG.trace("Opening delete file {}", deleteFile.path());
     InputFile input = getInputFile(deleteFile.path().toString());
     switch (deleteFile.format()) {
       case AVRO:

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -212,8 +212,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 3L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(3L);
   }
 
   @Test
@@ -262,8 +261,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(dateTableName, dateTable, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 3L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(3L);
   }
 
   @Test
@@ -295,8 +293,7 @@ public abstract class DeleteReadTests {
           "Table should contain expected rows", expected, selectColumns(actual, "id"));
     }
 
-    long expectedDeletes = 3L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(3L);
   }
 
   @Test
@@ -331,9 +328,8 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes =
-        7L; // 3 deletes in the first data file and 4 deletes in the second data file
-    checkDeleteCount(expectedDeletes);
+    // 3 deletes in the first data file and 4 deletes in the second data file
+    checkDeleteCount(7L);
   }
 
   @Test
@@ -358,8 +354,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 3L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(3L);
   }
 
   @Test
@@ -397,8 +392,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 3L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(3L);
   }
 
   @Test
@@ -436,8 +430,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 4L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(4L);
   }
 
   @Test
@@ -473,8 +466,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 4L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(4L);
   }
 
   @Test
@@ -511,8 +503,7 @@ public abstract class DeleteReadTests {
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    long expectedDeletes = 1L;
-    checkDeleteCount(expectedDeletes);
+    checkDeleteCount(1L);
   }
 
   private StructLikeSet selectColumns(StructLikeSet rows, String... columns) {

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -305,8 +305,9 @@ public abstract class DeleteReadTests {
     this.dataFile =
         FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), Row.of(0), records);
 
+    // At this point, the table has two data files, with 7 and 8 rows respectively, of which all but
+    // one are in duplicate.
     table.newAppend().appendFile(dataFile).commit();
-    // At this point, the table has 7 + 8 = 15 rows, of which all but one are in duplicate.
 
     Schema deleteRowSchema = table.schema().select("data");
     Record dataDelete = GenericRecord.create(deleteRowSchema);
@@ -321,14 +322,13 @@ public abstract class DeleteReadTests {
         FileHelpers.writeDeleteFile(
             table, Files.localOutput(temp.newFile()), Row.of(0), dataDeletes, deleteRowSchema);
 
+    // At this point, 3 rows in the first data file and 4 rows in the second data file are deleted.
     table.newRowDelta().addDeletes(eqDeletes).commit();
-    // At ths point, the table has (7 - 3) + (8 - 4) = 8 rows. 7 rows in all are deleted.
 
     StructLikeSet expected = rowSetWithoutIds(table, records, 29, 89, 122, 144);
     StructLikeSet actual = rowSet(tableName, table, "*");
 
     Assert.assertEquals("Table should contain expected rows", expected, actual);
-    // 3 deletes in the first data file and 4 deletes in the second data file
     checkDeleteCount(7L);
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -181,9 +181,10 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
         if (!deletedRowPositions.isDeleted(originalRowId + rowStartPosInBatch)) {
           posDelRowIdMapping[currentRowId] = originalRowId;
           currentRowId++;
-        } else if (hasIsDeletedColumn) {
-          isDeleted[originalRowId] = true;
         } else {
+          if (hasIsDeletedColumn) {
+            isDeleted[originalRowId] = true;
+          }
           deletes.incrementDeleteCount();
         }
         originalRowId++;
@@ -229,9 +230,10 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           // skip deleted rows by pointing to the next undeleted row Id
           rowIdMapping[currentRowId] = rowIdMapping[rowId];
           currentRowId++;
-        } else if (hasIsDeletedColumn) {
-          isDeleted[rowIdMapping[rowId]] = true;
         } else {
+          if (hasIsDeletedColumn) {
+            isDeleted[rowIdMapping[rowId]] = true;
+          }
           deletes.incrementDeleteCount();
         }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -185,6 +185,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           if (hasIsDeletedColumn) {
             isDeleted[originalRowId] = true;
           }
+
           deletes.incrementDeleteCount();
         }
         originalRowId++;
@@ -206,6 +207,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           eqDeleteRowIdMapping[i] = i;
         }
       }
+
       return eqDeleteRowIdMapping;
     }
 
@@ -234,6 +236,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           if (hasIsDeletedColumn) {
             isDeleted[rowIdMapping[rowId]] = true;
           }
+
           deletes.incrementDeleteCount();
         }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -35,8 +35,6 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@link VectorizedReader} that returns Spark's {@link ColumnarBatch} to support Spark's vectorized
@@ -44,7 +42,6 @@ import org.slf4j.LoggerFactory;
  * populated via delegated read calls to {@linkplain VectorizedArrowReader VectorReader(s)}.
  */
 public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
-  private static final Logger LOG = LoggerFactory.getLogger(ColumnarBatchReader.class);
   private final boolean hasIsDeletedColumn;
   private DeleteFilter<InternalRow> deletes = null;
   private long rowStartPosInBatch = 0;
@@ -173,7 +170,6 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
      * @return the mapping array and the new num of rows in a batch, null if no row is deleted
      */
     Pair<int[], Integer> buildPosDelRowIdMapping(PositionDeleteIndex deletedRowPositions) {
-      LOG.debug("Building row id mapping from positional deletes");
       if (deletedRowPositions == null) {
         return null;
       }
@@ -223,7 +219,6 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
      * @param columnarBatch the {@link ColumnarBatch} to apply the equality delete
      */
     void applyEqDelete(ColumnarBatch columnarBatch) {
-      LOG.debug("Applying equality deletes to row id mapping");
       Iterator<InternalRow> it = columnarBatch.rowIterator();
       int rowId = 0;
       int currentRowId = 0;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedInputFile;
 import org.apache.iceberg.io.CloseableIterator;
@@ -77,6 +78,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private final NameMapping nameMapping;
   private final ScanTaskGroup<TaskT> taskGroup;
   private final Iterator<TaskT> tasks;
+  private final DeleteCounter counter;
 
   private Map<String, InputFile> lazyInputFiles;
   private CloseableIterator<T> currentIterator;
@@ -94,6 +96,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     String nameMappingString = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     this.nameMapping =
         nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;
+    this.counter = new DeleteCounter();
   }
 
   protected abstract CloseableIterator<T> open(TaskT task);
@@ -114,6 +117,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
   protected Table table() {
     return table;
+  }
+
+  protected DeleteCounter counter() {
+    return counter;
   }
 
   public boolean next() throws IOException {
@@ -244,8 +251,8 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   protected class SparkDeleteFilter extends DeleteFilter<InternalRow> {
     private final InternalRowWrapper asStructLike;
 
-    SparkDeleteFilter(String filePath, List<DeleteFile> deletes) {
-      super(filePath, deletes, table.schema(), expectedSchema);
+    SparkDeleteFilter(String filePath, List<DeleteFile> deletes, DeleteCounter counter) {
+      super(filePath, deletes, table.schema(), expectedSchema, counter);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -268,7 +268,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
     @Override
     protected void markRowDeleted(InternalRow row) {
-      row.setBoolean(columnIsDeletedPosition(), true);
+      if (!row.getBoolean(columnIsDeletedPosition())) {
+        row.setBoolean(columnIsDeletedPosition(), true);
+        counter().increment();
+      }
     }
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -91,13 +91,13 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask> {
 
   CloseableIterable<InternalRow> openAddedRowsScanTask(AddedRowsScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes());
+    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes(), counter());
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 
   private CloseableIterable<InternalRow> openDeletedDataFileScanTask(DeletedDataFileScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.existingDeletes());
+    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.existingDeletes(), counter());
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -37,7 +37,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     SparkDeleteFilter matches =
-        new SparkDeleteFilter(task.file().path().toString(), task.deletes());
+        new SparkDeleteFilter(task.file().path().toString(), task.deletes(), counter());
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -32,8 +32,12 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RowDataReader extends BaseRowReader<FileScanTask> {
+  private static final Logger LOG = LoggerFactory.getLogger(RowDataReader.class);
+
   RowDataReader(
       ScanTaskGroup<FileScanTask> task, Table table, Schema expectedSchema, boolean caseSensitive) {
     super(table, task, expectedSchema, caseSensitive);
@@ -47,7 +51,8 @@ class RowDataReader extends BaseRowReader<FileScanTask> {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deleteFilter = new SparkDeleteFilter(filePath, task.deletes());
+    LOG.debug("Opening data file {}", filePath);
+    SparkDeleteFilter deleteFilter = new SparkDeleteFilter(filePath, task.deletes(), counter());
 
     // schema or rows returned by readers
     Schema requiredSchema = deleteFilter.requiredSchema();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.text.NumberFormat;
+import org.apache.spark.sql.connector.metric.CustomMetric;
+
+public class NumDeletes implements CustomMetric {
+
+  public static final String DISPLAY_STRING = "number of row deletes applied";
+
+  @Override
+  public String name() {
+    return "numDeletes";
+  }
+
+  @Override
+  public String description() {
+    return DISPLAY_STRING;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long sum = initialValue;
+    for (int i = 0; i < taskMetrics.length; i++) {
+      sum += taskMetrics[i];
+    }
+    return NumberFormat.getIntegerInstance().format(sum);
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
@@ -41,6 +41,7 @@ public class NumDeletes implements CustomMetric {
     for (int i = 0; i < taskMetrics.length; i++) {
       sum += taskMetrics[i];
     }
+
     return NumberFormat.getIntegerInstance().format(sum);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.text.NumberFormat;
+import org.apache.spark.sql.connector.metric.CustomMetric;
+
+public class NumSplits implements CustomMetric {
+
+  @Override
+  public String name() {
+    return "numSplits";
+  }
+
+  @Override
+  public String description() {
+    return "number of file splits read";
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long sum = initialValue;
+    for (int i = 0; i < taskMetrics.length; i++) {
+      sum += taskMetrics[i];
+    }
+    return NumberFormat.getIntegerInstance().format(sum);
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
@@ -39,6 +39,7 @@ public class NumSplits implements CustomMetric {
     for (int i = 0; i < taskMetrics.length; i++) {
       sum += taskMetrics[i];
     }
+
     return NumberFormat.getIntegerInstance().format(sum);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumDeletes.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumDeletes.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+
+public class TaskNumDeletes implements CustomTaskMetric {
+  private final long value;
+
+  public TaskNumDeletes(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return "numDeletes";
+  }
+
+  @Override
+  public long value() {
+    return value;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumSplits.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumSplits.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+
+public class TaskNumSplits implements CustomTaskMetric {
+  private final long value;
+
+  public TaskNumSplits(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return "numSplits";
+  }
+
+  @Override
+  public long value() {
+    return value;
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.ui.SQLAppStatusStore;
+import org.apache.spark.sql.execution.ui.SQLExecutionUIData;
+import org.apache.spark.sql.execution.ui.SQLPlanMetric;
+import org.junit.Assert;
+import scala.Option;
+
+public class SparkSQLExecutionHelper {
+
+  private SparkSQLExecutionHelper() {}
+
+  /**
+   * Finds the value of a specified metric for the last SQL query that was executed. Metric values
+   * are stored in the `SQLAppStatusStore` as strings.
+   *
+   * @param spark SparkSession used to run the SQL query
+   * @param metricName name of the metric
+   * @return value of the metric
+   */
+  public static String lastExecutedMetricValue(SparkSession spark, String metricName) {
+    SQLAppStatusStore statusStore = spark.sharedState().statusStore();
+    SQLExecutionUIData lastExecution = statusStore.executionsList().last();
+    Option<SQLPlanMetric> sqlPlanMetric =
+        lastExecution.metrics().find(metric -> metric.name().equals(metricName));
+    Assert.assertTrue(
+        String.format("Metric '%s' not found in last execution", metricName),
+        sqlPlanMetric.isDefined());
+    long metricId = sqlPlanMetric.get().accumulatorId();
+
+    // Refresh metricValues, they will remain null until the execution is complete and metrics are
+    // aggregated
+    int attempts = 3;
+    while (lastExecution.metricValues() == null && attempts > 0) {
+      try {
+        Thread.sleep(100);
+        attempts -= 1;
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      lastExecution = statusStore.execution(lastExecution.executionId()).get();
+    }
+
+    Assert.assertNotNull("Metric values were not finalized", lastExecution.metricValues());
+    String metricValue = lastExecution.metricValues().get(metricId).getOrElse(null);
+    Assert.assertNotNull(String.format("Metric '%s' was not finalized", metricName), metricValue);
+    return metricValue;
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
@@ -53,10 +53,11 @@ public class SparkSQLExecutionHelper {
     while (lastExecution.metricValues() == null && attempts > 0) {
       try {
         Thread.sleep(100);
-        attempts -= 1;
+        attempts--;
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
+
       lastExecution = statusStore.execution(lastExecution.executionId()).get();
     }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -357,6 +357,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 4L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -386,6 +388,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 3L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -429,6 +433,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 4L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -501,6 +507,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     StructLikeSet actual =
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 0L;
+    checkDeleteCount(expectedDeletes);
   }
 
   private static final Schema PROJECTION_SCHEMA =

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -149,8 +149,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
               TableProperties.PARQUET_BATCH_SIZE,
               "4") // split 7 records to two batches to cover more code paths
           .commit();
-    } else {
+    } else if (format.equals("parquet")) { // in this case, non-vectorized
       table.updateProperties().set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false").commit();
+    } else if (format.equals("orc")) { // we only have non-vectorized for orc in our parameters
+      table.updateProperties().set(TableProperties.ORC_VECTORIZATION_ENABLED, "false").commit();
     }
     return table;
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -181,9 +181,10 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
         if (!deletedRowPositions.isDeleted(originalRowId + rowStartPosInBatch)) {
           posDelRowIdMapping[currentRowId] = originalRowId;
           currentRowId++;
-        } else if (hasIsDeletedColumn) {
-          isDeleted[originalRowId] = true;
         } else {
+          if (hasIsDeletedColumn) {
+            isDeleted[originalRowId] = true;
+          }
           deletes.incrementDeleteCount();
         }
         originalRowId++;
@@ -229,9 +230,10 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           // skip deleted rows by pointing to the next undeleted row Id
           rowIdMapping[currentRowId] = rowIdMapping[rowId];
           currentRowId++;
-        } else if (hasIsDeletedColumn) {
-          isDeleted[rowIdMapping[rowId]] = true;
         } else {
+          if (hasIsDeletedColumn) {
+            isDeleted[rowIdMapping[rowId]] = true;
+          }
           deletes.incrementDeleteCount();
         }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -185,6 +185,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           if (hasIsDeletedColumn) {
             isDeleted[originalRowId] = true;
           }
+
           deletes.incrementDeleteCount();
         }
         originalRowId++;
@@ -206,6 +207,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           eqDeleteRowIdMapping[i] = i;
         }
       }
+
       return eqDeleteRowIdMapping;
     }
 
@@ -234,6 +236,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
           if (hasIsDeletedColumn) {
             isDeleted[rowIdMapping[rowId]] = true;
           }
+
           deletes.incrementDeleteCount();
         }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -35,8 +35,6 @@ import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * {@link VectorizedReader} that returns Spark's {@link ColumnarBatch} to support Spark's vectorized
@@ -44,7 +42,6 @@ import org.slf4j.LoggerFactory;
  * populated via delegated read calls to {@linkplain VectorizedArrowReader VectorReader(s)}.
  */
 public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
-  private static final Logger LOG = LoggerFactory.getLogger(ColumnarBatchReader.class);
   private final boolean hasIsDeletedColumn;
   private DeleteFilter<InternalRow> deletes = null;
   private long rowStartPosInBatch = 0;
@@ -173,7 +170,6 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
      * @return the mapping array and the new num of rows in a batch, null if no row is deleted
      */
     Pair<int[], Integer> buildPosDelRowIdMapping(PositionDeleteIndex deletedRowPositions) {
-      LOG.debug("Building row id mapping from positional deletes");
       if (deletedRowPositions == null) {
         return null;
       }
@@ -223,7 +219,6 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
      * @param columnarBatch the {@link ColumnarBatch} to apply the equality delete
      */
     void applyEqDelete(ColumnarBatch columnarBatch) {
-      LOG.debug("Applying equality deletes to row id mapping");
       Iterator<InternalRow> it = columnarBatch.rowIterator();
       int rowId = 0;
       int currentRowId = 0;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedInputFile;
 import org.apache.iceberg.io.CloseableIterator;
@@ -77,6 +78,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private final NameMapping nameMapping;
   private final ScanTaskGroup<TaskT> taskGroup;
   private final Iterator<TaskT> tasks;
+  private final DeleteCounter counter;
 
   private Map<String, InputFile> lazyInputFiles;
   private CloseableIterator<T> currentIterator;
@@ -94,6 +96,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     String nameMappingString = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
     this.nameMapping =
         nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;
+    this.counter = new DeleteCounter();
   }
 
   protected abstract CloseableIterator<T> open(TaskT task);
@@ -114,6 +117,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
   protected Table table() {
     return table;
+  }
+
+  protected DeleteCounter counter() {
+    return counter;
   }
 
   public boolean next() throws IOException {
@@ -244,8 +251,8 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   protected class SparkDeleteFilter extends DeleteFilter<InternalRow> {
     private final InternalRowWrapper asStructLike;
 
-    SparkDeleteFilter(String filePath, List<DeleteFile> deletes) {
-      super(filePath, deletes, table.schema(), expectedSchema);
+    SparkDeleteFilter(String filePath, List<DeleteFile> deletes, DeleteCounter counter) {
+      super(filePath, deletes, table.schema(), expectedSchema, counter);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
     }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -268,7 +268,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
 
     @Override
     protected void markRowDeleted(InternalRow row) {
-      row.setBoolean(columnIsDeletedPosition(), true);
+      if (!row.getBoolean(columnIsDeletedPosition())) {
+        row.setBoolean(columnIsDeletedPosition(), true);
+        counter().increment();
+      }
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -91,13 +91,13 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask> {
 
   CloseableIterable<InternalRow> openAddedRowsScanTask(AddedRowsScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes());
+    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.deletes(), counter());
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 
   private CloseableIterable<InternalRow> openDeletedDataFileScanTask(DeletedDataFileScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.existingDeletes());
+    SparkDeleteFilter deletes = new SparkDeleteFilter(filePath, task.existingDeletes(), counter());
     return deletes.filter(rows(task, deletes.requiredSchema()));
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -37,7 +37,7 @@ public class EqualityDeleteRowReader extends RowDataReader {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     SparkDeleteFilter matches =
-        new SparkDeleteFilter(task.file().path().toString(), task.deletes());
+        new SparkDeleteFilter(task.file().path().toString(), task.deletes(), counter());
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -32,8 +32,12 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RowDataReader extends BaseRowReader<FileScanTask> {
+  private static final Logger LOG = LoggerFactory.getLogger(RowDataReader.class);
+
   RowDataReader(
       ScanTaskGroup<FileScanTask> task, Table table, Schema expectedSchema, boolean caseSensitive) {
     super(table, task, expectedSchema, caseSensitive);
@@ -47,7 +51,8 @@ class RowDataReader extends BaseRowReader<FileScanTask> {
   @Override
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     String filePath = task.file().path().toString();
-    SparkDeleteFilter deleteFilter = new SparkDeleteFilter(filePath, task.deletes());
+    LOG.debug("Opening data file {}", filePath);
+    SparkDeleteFilter deleteFilter = new SparkDeleteFilter(filePath, task.deletes(), counter());
 
     // schema or rows returned by readers
     Schema requiredSchema = deleteFilter.requiredSchema();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.text.NumberFormat;
+import org.apache.spark.sql.connector.metric.CustomMetric;
+
+public class NumDeletes implements CustomMetric {
+
+  public static final String DISPLAY_STRING = "number of row deletes applied";
+
+  @Override
+  public String name() {
+    return "numDeletes";
+  }
+
+  @Override
+  public String description() {
+    return DISPLAY_STRING;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long sum = initialValue;
+    for (int i = 0; i < taskMetrics.length; i++) {
+      sum += taskMetrics[i];
+    }
+    return NumberFormat.getIntegerInstance().format(sum);
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumDeletes.java
@@ -41,6 +41,7 @@ public class NumDeletes implements CustomMetric {
     for (int i = 0; i < taskMetrics.length; i++) {
       sum += taskMetrics[i];
     }
+
     return NumberFormat.getIntegerInstance().format(sum);
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.text.NumberFormat;
+import org.apache.spark.sql.connector.metric.CustomMetric;
+
+public class NumSplits implements CustomMetric {
+
+  @Override
+  public String name() {
+    return "numSplits";
+  }
+
+  @Override
+  public String description() {
+    return "number of file splits read";
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long sum = initialValue;
+    for (int i = 0; i < taskMetrics.length; i++) {
+      sum += taskMetrics[i];
+    }
+    return NumberFormat.getIntegerInstance().format(sum);
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/NumSplits.java
@@ -39,6 +39,7 @@ public class NumSplits implements CustomMetric {
     for (int i = 0; i < taskMetrics.length; i++) {
       sum += taskMetrics[i];
     }
+
     return NumberFormat.getIntegerInstance().format(sum);
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumDeletes.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumDeletes.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+
+public class TaskNumDeletes implements CustomTaskMetric {
+  private final long value;
+
+  public TaskNumDeletes(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return "numDeletes";
+  }
+
+  @Override
+  public long value() {
+    return value;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumSplits.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskNumSplits.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+
+public class TaskNumSplits implements CustomTaskMetric {
+  private final long value;
+
+  public TaskNumSplits(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return "numSplits";
+  }
+
+  @Override
+  public long value() {
+    return value;
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.ui.SQLAppStatusStore;
+import org.apache.spark.sql.execution.ui.SQLExecutionUIData;
+import org.apache.spark.sql.execution.ui.SQLPlanMetric;
+import org.junit.Assert;
+import scala.Option;
+
+public class SparkSQLExecutionHelper {
+
+  private SparkSQLExecutionHelper() {}
+
+  /**
+   * Finds the value of a specified metric for the last SQL query that was executed. Metric values
+   * are stored in the `SQLAppStatusStore` as strings.
+   *
+   * @param spark SparkSession used to run the SQL query
+   * @param metricName name of the metric
+   * @return value of the metric
+   */
+  public static String lastExecutedMetricValue(SparkSession spark, String metricName) {
+    SQLAppStatusStore statusStore = spark.sharedState().statusStore();
+    SQLExecutionUIData lastExecution = statusStore.executionsList().last();
+    Option<SQLPlanMetric> sqlPlanMetric =
+        lastExecution.metrics().find(metric -> metric.name().equals(metricName));
+    Assert.assertTrue(
+        String.format("Metric '%s' not found in last execution", metricName),
+        sqlPlanMetric.isDefined());
+    long metricId = sqlPlanMetric.get().accumulatorId();
+
+    // Refresh metricValues, they will remain null until the execution is complete and metrics are
+    // aggregated
+    int attempts = 3;
+    while (lastExecution.metricValues() == null && attempts > 0) {
+      try {
+        Thread.sleep(100);
+        attempts -= 1;
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      lastExecution = statusStore.execution(lastExecution.executionId()).get();
+    }
+
+    Assert.assertNotNull("Metric values were not finalized", lastExecution.metricValues());
+    String metricValue = lastExecution.metricValues().get(metricId).getOrElse(null);
+    Assert.assertNotNull(String.format("Metric '%s' was not finalized", metricName), metricValue);
+    return metricValue;
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/SparkSQLExecutionHelper.java
@@ -53,10 +53,11 @@ public class SparkSQLExecutionHelper {
     while (lastExecution.metricValues() == null && attempts > 0) {
       try {
         Thread.sleep(100);
-        attempts -= 1;
+        attempts--;
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
+
       lastExecution = statusStore.execution(lastExecution.executionId()).get();
     }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -357,6 +357,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 4L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -386,6 +388,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 3L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -429,6 +433,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
 
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 4L;
+    checkDeleteCount(expectedDeletes);
   }
 
   @Test
@@ -501,6 +507,8 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     StructLikeSet actual =
         rowSet(tableName, PROJECTION_SCHEMA.asStruct(), "id", "data", "_deleted");
     Assert.assertEquals("Table should contain expected row", expected, actual);
+    long expectedDeletes = 0L;
+    checkDeleteCount(expectedDeletes);
   }
 
   private static final Schema PROJECTION_SCHEMA =

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -149,8 +149,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
               TableProperties.PARQUET_BATCH_SIZE,
               "4") // split 7 records to two batches to cover more code paths
           .commit();
-    } else {
+    } else if (format.equals("parquet")) { // in this case, non-vectorized
       table.updateProperties().set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false").commit();
+    } else if (format.equals("orc")) { // we only have non-vectorized for orc in our parameters
+      table.updateProperties().set(TableProperties.ORC_VECTORIZATION_ENABLED, "false").commit();
     }
     return table;
   }


### PR DESCRIPTION
This is an extension of #4395.
Here we add a custom metric for the number of delete rows that have been applied in a scan of a format v2 table.

We introduce a counter in `BatchDataReader` and `RowDataReader`, that is incremented when a delete is applied. This counter is passed into `DeleteFilter`, and in the cases where we construct a `PositionDeleteIndex`, is passed into the implementation of the `PositionDeleteIndex`. In all the read paths, the counter is incremented whenever a delete is applied. When Spark calls `currentMetricsValues()` on a `PartitionReader`, which is a subclass of either `BatchDataReader` or `RowDataReader`, we get the current value of the counter and return that.

Tested manually by creating a format v2 table using each of Parquet, ORC, and Avro files, deleting and updating rows in the tables, and reading from the table. The expected number of deletes show up in the Spark UI.
Also extended existing unit tests (`DeleteReadTests`) to count the number of deletes applied during the scan.

<img width="529" alt="Screen Shot 2022-04-19 at 8 59 31 PM" src="https://user-images.githubusercontent.com/3925490/164147620-7085eafd-304d-45d1-aa53-0c6029638d48.png">
