### PR TITLE
Nessie: Use memoized Supplier to avoid unnecessary API calls

### DIFF
--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.FluentIterable;
@@ -92,6 +93,7 @@ public class GuavaClasses {
     ThreadFactoryBuilder.class.getName();
     Iterables.class.getName();
     CountingOutputStream.class.getName();
+    Suppliers.class.getName();
   }
 
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.base.Suppliers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.Tasks;
 import org.projectnessie.client.NessieConfigConstants;
@@ -70,7 +71,7 @@ public class NessieIcebergClient implements AutoCloseable {
       NessieApiV1 api, String requestedRef, String requestedHash, Map<String, String> catalogOptions) {
     this.api = api;
     this.catalogOptions = catalogOptions;
-    this.reference = () -> loadReference(requestedRef, requestedHash);
+    this.reference = Suppliers.memoize(() -> loadReference(requestedRef, requestedHash));
   }
 
   public NessieApiV1 getApi() {


### PR DESCRIPTION
Note that this also reverts the test changes that were done in https://github.com/apache/iceberg/commit/9618147b6de8f8627052a205b86e45263394b0c2#diff-a92127e5d74e2be0c013d0eddf4c9d2af29a71f05e21d7289808271d4c97db78L326-R348