### PR TITLE
Use bounded queue to avoid consuming too much memory

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -377,7 +377,7 @@ class DeleteFileIndex {
     }
 
     DeleteFileIndex build() {
-      // read all the matching delete manifests in parallel and accumulate the matching files in a queue
+      // read all of the matching delete manifests in parallel and accumulate the matching files in a queue
       Queue<ManifestEntry<DeleteFile>> deleteEntries = new ConcurrentLinkedQueue<>();
       Tasks.foreach(deleteManifestReaders())
           .stopOnFailure().throwFailureWhenFinished()

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -377,7 +377,7 @@ class DeleteFileIndex {
     }
 
     DeleteFileIndex build() {
-      // read all of the matching delete manifests in parallel and accumulate the matching files in a queue
+      // read all the matching delete manifests in parallel and accumulate the matching files in a queue
       Queue<ManifestEntry<DeleteFile>> deleteEntries = new ConcurrentLinkedQueue<>();
       Tasks.foreach(deleteManifestReaders())
           .stopOnFailure().throwFailureWhenFinished()

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -39,10 +39,24 @@ public class SystemProperties {
    */
   public static final String SCAN_THREAD_POOL_ENABLED = "iceberg.scan.plan-in-worker-pool";
 
-  static boolean getBoolean(String systemProperty, boolean defaultValue) {
+  /**
+   * Sets the size of the queue, which is used to avoid consuming too much memory.
+   */
+  public static final String SCAN_SHARED_QUEUE_SIZE = "iceberg.scan.shared-queue-size";
+  public static final int SCAN_SHARED_QUEUE_SIZE_DEFAULT = 1000;
+
+  public static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);
     if (value != null) {
       return Boolean.parseBoolean(value);
+    }
+    return defaultValue;
+  }
+
+  public static int getInt(String systemProperty, int defaultValue) {
+    String value = System.getProperty(systemProperty);
+    if (value != null) {
+      return Integer.parseInt(value);
     }
     return defaultValue;
   }

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
 /**
  * Configuration properties that are controlled by Java system properties.
  */
@@ -45,7 +47,7 @@ public class SystemProperties {
   public static final String SCAN_SHARED_QUEUE_SIZE = "iceberg.scan.shared-queue-size";
   public static final int SCAN_SHARED_QUEUE_SIZE_DEFAULT = 1000;
 
-  public static boolean getBoolean(String systemProperty, boolean defaultValue) {
+  static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);
     if (value != null) {
       return Boolean.parseBoolean(value);
@@ -54,6 +56,7 @@ public class SystemProperties {
   }
 
   public static int getInt(String systemProperty, int defaultValue) {
+    Preconditions.checkNotNull(systemProperty, "System property name should not be null");
     String value = System.getProperty(systemProperty);
     if (value != null) {
       return Integer.parseInt(value);

--- a/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
+++ b/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java
@@ -55,13 +55,15 @@ public class ParallelIterable<T> extends CloseableGroup implements CloseableIter
     private final Iterator<Runnable> tasks;
     private final ExecutorService workerPool;
     private final Future<?>[] taskFutures;
-    private final int queueSize = SystemProperties.getInt(SystemProperties.SCAN_SHARED_QUEUE_SIZE,
-        SystemProperties.SCAN_SHARED_QUEUE_SIZE_DEFAULT);
-    private final LinkedBlockingQueue<T> queue = new LinkedBlockingQueue<>(queueSize);
+    private final int queueSize;
+    private final LinkedBlockingQueue<T> queue;
     private boolean closed = false;
 
     private ParallelIterator(Iterable<? extends Iterable<T>> iterables,
                              ExecutorService workerPool) {
+      this.queueSize = SystemProperties.getInt(SystemProperties.SCAN_SHARED_QUEUE_SIZE,
+          SystemProperties.SCAN_SHARED_QUEUE_SIZE_DEFAULT);
+      this.queue = new LinkedBlockingQueue<>(queueSize);
       this.tasks = Iterables.transform(iterables, iterable ->
           (Runnable) () -> {
             try (Closeable ignored = (iterable instanceof Closeable) ?


### PR DESCRIPTION
In my scene, there are hundreds of thousands of datafiles. If `iceberg.scan.plan-in-worker-pool` is enabled, OOM exception happend continually. The root cause is an unbounded queue `ConcurrentLinkedQueue` is used in `ParallelIterator`. The queue will consume much memory.