### PR TITLE
Orc : Fix inner struct field as partition (#4604)

### DIFF
--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -482,4 +482,59 @@ public class TestTypeUtil {
     Schema actualNoStruct = TypeUtil.selectNot(schema, Sets.newHashSet(2));
     Assert.assertEquals(schema.asStruct(), actualNoStruct.asStruct());
   }
+
+  @Test
+  public void testSelectNotInnerStruct() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(1, "id", Types.LongType.get()),
+            required(2, "location", Types.StructType.of(
+                required(3, "lat", Types.DoubleType.get()),
+                required(4, "long", Types.DoubleType.get()),
+                required(5, "address", Types.StructType.of(
+                    required(6, "number", Types.DoubleType.get()),
+                    required(7, "street", Types.DoubleType.get())
+                )
+        )))));
+
+    // Expected that filter inner struct if all struct is not filtered
+    Schema expectedFilteredStruct = new Schema(
+        Lists.newArrayList(
+            required(1, "id", Types.LongType.get()),
+            required(2, "location", Types.StructType.of(
+                required(4, "long", Types.DoubleType.get()),
+                required(5, "address", Types.StructType.of(
+                    required(6, "number", Types.DoubleType.get()),
+                    required(7, "street", Types.DoubleType.get())
+                )
+        )))));
+    Schema actualFilteredStruct = TypeUtil.selectNot(schema, Sets.newHashSet(3),
+        true /* doesNeedToKeepInnerStruct */);
+    Assert.assertEquals(expectedFilteredStruct.asStruct(), actualFilteredStruct.asStruct());
+
+    // Expected that do not filter inner struct if all struct is filtered
+    Schema actualNotInnerStruct = TypeUtil.selectNot(schema, Sets.newHashSet(3, 4, 5),
+        true /* doesNeedToKeepInnerStruct */);
+    Assert.assertEquals(schema.asStruct(), actualNotInnerStruct.asStruct());
+
+    Schema actualNotSubInnerStruct = TypeUtil.selectNot(schema, Sets.newHashSet(6, 7),
+        true /* doesNeedToKeepInnerStruct */);
+    Assert.assertEquals(schema.asStruct(), actualNotSubInnerStruct.asStruct());
+
+    Schema expectedFilteredInnerStruct = new Schema(
+        Lists.newArrayList(
+            required(1, "id", Types.LongType.get()),
+            required(2, "location", Types.StructType.of(
+                required(3, "lat", Types.DoubleType.get()),
+                required(4, "long", Types.DoubleType.get()),
+                required(5, "address", Types.StructType.of(
+                    required(7, "street", Types.DoubleType.get())
+                )
+        )))));
+
+    Schema actualSubInnerStruct = TypeUtil.selectNot(schema, Sets.newHashSet(6),
+        true /* doesNeedToFilteredInnerStruct */);
+    Assert.assertEquals(expectedFilteredInnerStruct.asStruct(), actualSubInnerStruct.asStruct());
+  }
+
 }

--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -125,7 +125,7 @@ class GenericReader implements Serializable {
 
       case ORC:
         Schema projectionWithoutConstantAndMetadataFields = TypeUtil.selectNot(fileProjection,
-            Sets.union(partition.keySet(), MetadataColumns.metadataFieldIds()));
+            Sets.union(partition.keySet(), MetadataColumns.metadataFieldIds()), true);
         ORC.ReadBuilder orc = ORC.read(input)
             .project(projectionWithoutConstantAndMetadataFields)
             .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(fileProjection, fileSchema, partition))

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -149,7 +149,7 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
   private CloseableIterable<RowData> newOrcIterable(
       FileScanTask task, Schema schema, Map<Integer, ?> idToConstant, InputFilesDecryptor inputFilesDecryptor) {
     Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(schema,
-        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
+        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()), true);
 
     ORC.ReadBuilder builder = ORC.read(inputFilesDecryptor.getInputFile(task))
         .project(readSchemaWithoutConstantAndMetadataFields)

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -393,7 +393,7 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     private CloseableIterable<T> newOrcIterable(InputFile inputFile, FileScanTask task, Schema readSchema) {
       Map<Integer, ?> idToConstant = constantsMap(task, IdentityPartitionConverters::convertConstant);
       Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(readSchema,
-          Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
+          Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()), true);
 
       CloseableIterable<T> orcIterator = null;
       // ORC does not support reuse containers yet

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -103,7 +103,8 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
       Set<Integer> constantFieldIds = idToConstant.keySet();
       Set<Integer> metadataFieldIds = MetadataColumns.metadataFieldIds();
       Sets.SetView<Integer> constantAndMetadataFieldIds = Sets.union(constantFieldIds, metadataFieldIds);
-      Schema schemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(expectedSchema, constantAndMetadataFieldIds);
+      Schema schemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(
+          expectedSchema, constantAndMetadataFieldIds, true);
       ORC.ReadBuilder builder = ORC.read(location)
           .project(schemaWithoutConstantAndMetadataFields)
           .split(task.start(), task.length())

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -155,7 +155,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       Schema readSchema,
       Map<Integer, ?> idToConstant) {
     Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(readSchema,
-        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
+        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()), true);
 
     ORC.ReadBuilder builder = ORC.read(location)
         .project(readSchemaWithoutConstantAndMetadataFields)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
@@ -54,6 +55,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 public abstract class SparkTestBase {
 
   protected static final Object ANY = new Object();
+  protected static final List<String> FORMATS = Lists.newArrayList("orc", "parquet", "avro");
 
   protected static TestHiveMetastore metastore = null;
   protected static HiveConf hiveConf = null;


### PR DESCRIPTION
Fix : https://github.com/apache/iceberg/issues/4604
When you you add a inner struct field as partition field without any transformation on an Iceberg orc table, you can not select anymore only this field because the as is a partition, iceberg do not read it from the file as it's inside a struct OrcValueReaders it's not able to reconstruct a constant struct.

It's working when you select also another field from the struct because as OrcValueReaders is able to read from the file using the another field reader

So instead of trying to add it as a constant, read directly from the files
the value of a hidden partition based on inner struct value even if you only read this column