### PR TITLE
[CORE] - Add MetadataUpdateParser and Jackson SerDe with implementation covering UpgradeFormatVersion

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -107,7 +107,7 @@ public class MetadataUpdateParser {
       case ASSIGN_UUID:
         throw new UnsupportedOperationException("Not Implemented: MetadataUpdate#toJson for AssignUUID");
       case UPGRADE_FORMAT_VERSION:
-        writeUpgradeFormatVersion(metadataUpdate, generator);
+        writeUpgradeFormatVersion((MetadataUpdate.UpgradeFormatVersion) metadataUpdate, generator);
         break;
       default:
         throw new IllegalArgumentException(
@@ -149,9 +149,9 @@ public class MetadataUpdateParser {
   }
 
   // Write all fields specific to UpgradeFormatVersion
-  private static void writeUpgradeFormatVersion(MetadataUpdate metadataUpdate, JsonGenerator gen) throws IOException {
-    MetadataUpdate.UpgradeFormatVersion upgradeFormatVersion = (MetadataUpdate.UpgradeFormatVersion) metadataUpdate;
-    gen.writeNumberField(FORMAT_VERSION, upgradeFormatVersion.formatVersion());
+  private static void writeUpgradeFormatVersion(MetadataUpdate.UpgradeFormatVersion update, JsonGenerator gen)
+      throws IOException {
+    gen.writeNumberField(FORMAT_VERSION, update.formatVersion());
   }
 
   private static MetadataUpdate readAsUpgradeFormatVersion(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -47,7 +47,7 @@ public class MetadataUpdateParser {
   private static final String ADD_SORT_ORDER = "add-sort-order";
   private static final String SET_DEFAULT_SORT_ORDER = "set-default-sort-order";
   private static final String ADD_SNAPSHOT = "add-snapshot";
-  private static final String REMOVE_SNAPSHOT = "remove-snapshots";
+  private static final String REMOVE_SNAPSHOTS = "remove-snapshots";
   private static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
   private static final String SET_PROPERTIES = "set-properties";
   private static final String REMOVE_PROPERTIES = "remove-properties";
@@ -67,7 +67,7 @@ public class MetadataUpdateParser {
       .put(MetadataUpdate.AddSortOrder.class, ADD_SORT_ORDER)
       .put(MetadataUpdate.SetDefaultSortOrder.class, SET_DEFAULT_SORT_ORDER)
       .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
-      .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOT)
+      .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
       .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
       .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
       .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.JsonUtil;
+
+public class MetadataUpdateParser {
+
+  private MetadataUpdateParser() {
+  }
+
+  private static final String ACTION = "action";
+
+  // action types
+  private static final String ASSIGN_UUID = "assign-uuid";
+  private static final String UPGRADE_FORMAT_VERSION = "upgrade-format-version";
+  private static final String ADD_SCHEMA = "add-schema";
+  private static final String SET_CURRENT_SCHEMA = "set-current-schema";
+  private static final String ADD_PARTITION_SPEC = "add-spec";
+  private static final String SET_DEFAULT_PARTITION_SPEC = "set-default-spec";
+  private static final String ADD_SORT_ORDER = "add-sort-order";
+  private static final String SET_DEFAULT_SORT_ORDER = "set-default-sort-order";
+  private static final String ADD_SNAPSHOT = "add-snapshot";
+  private static final String REMOVE_SNAPSHOT = "remove-snapshot";
+  private static final String REMOVE_SNAPSHOT_REF = "remove-snapshot-ref";
+  private static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
+  private static final String SET_PROPERTIES = "set-properties";
+  private static final String REMOVE_PROPERTIES = "remove-properties";
+  private static final String SET_LOCATION = "set-location";
+
+  // UpgradeFormatVersion
+  private static final String FORMAT_VERSION = "format-version";
+
+  private static final Map<Class<? extends MetadataUpdate>, String> ACTIONS = ImmutableMap
+      .<Class<? extends MetadataUpdate>, String>builder()
+      .put(MetadataUpdate.AssignUUID.class, ASSIGN_UUID)
+      .put(MetadataUpdate.UpgradeFormatVersion.class, UPGRADE_FORMAT_VERSION)
+      .put(MetadataUpdate.AddSchema.class, ADD_SCHEMA)
+      .put(MetadataUpdate.SetCurrentSchema.class, SET_CURRENT_SCHEMA)
+      .put(MetadataUpdate.AddPartitionSpec.class, ADD_PARTITION_SPEC)
+      .put(MetadataUpdate.SetDefaultPartitionSpec.class, SET_DEFAULT_PARTITION_SPEC)
+      .put(MetadataUpdate.AddSortOrder.class, ADD_SORT_ORDER)
+      .put(MetadataUpdate.SetDefaultSortOrder.class, SET_DEFAULT_SORT_ORDER)
+      .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
+      .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOT)
+      .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
+      .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
+      .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
+      .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)
+      .put(MetadataUpdate.SetLocation.class, SET_LOCATION)
+      .build();
+
+  public static String toJson(MetadataUpdate metadataUpdate) {
+    return toJson(metadataUpdate, false);
+  }
+
+  public static String toJson(MetadataUpdate metadataUpdate, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+      toJson(metadataUpdate, generator);
+      generator.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(String.format("Failed to write metadata update json for: %s", metadataUpdate), e);
+    }
+  }
+
+  public static void toJson(MetadataUpdate metadataUpdate, JsonGenerator generator) throws IOException {
+    String updateAction = ACTIONS.get(metadataUpdate.getClass());
+
+    // Add shared `action` field used to differentiate between implementations of MetadataUpdate
+    generator.writeStartObject();
+    generator.writeStringField(ACTION, updateAction);
+
+    // Write subclass specific fields
+    switch (updateAction) {
+      case ASSIGN_UUID:
+        throw new UnsupportedOperationException("Not Implemented: MetadataUpdate#toJson for AssignUUID");
+      case UPGRADE_FORMAT_VERSION:
+        writeUpgradeFormatVersion(metadataUpdate, generator);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Cannot convert metadata update to json. Unrecognized action: %s", updateAction));
+    }
+
+    generator.writeEndObject();
+  }
+
+  /**
+   * Read MetadataUpdate from a JSON string.
+   *
+   * @param json a JSON string of a MetadataUpdate
+   * @return a MetadataUpdate object
+   */
+  public static MetadataUpdate fromJson(String json) {
+    try {
+      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read JSON string: " + json, e);
+    }
+  }
+
+  public static MetadataUpdate fromJson(JsonNode jsonNode) {
+    Preconditions.checkArgument(jsonNode != null && jsonNode.isObject(),
+        "Cannot parse metadata update from non-object value: %s", jsonNode);
+    Preconditions.checkArgument(jsonNode.hasNonNull(ACTION), "Cannot parse metadata update. Missing field: action");
+    String action = JsonUtil.getString(ACTION, jsonNode).toLowerCase(Locale.ROOT);
+
+    switch (action) {
+      case ASSIGN_UUID:
+        throw new UnsupportedOperationException("Not implemented: AssignUUID");
+      case UPGRADE_FORMAT_VERSION:
+        return readAsUpgradeFormatVersion(jsonNode);
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Cannot convert metadata update action to json: %s", action));
+    }
+  }
+
+  // Write all fields specific to UpgradeFormatVersion
+  private static void writeUpgradeFormatVersion(MetadataUpdate metadataUpdate, JsonGenerator gen) throws IOException {
+    MetadataUpdate.UpgradeFormatVersion upgradeFormatVersion = (MetadataUpdate.UpgradeFormatVersion) metadataUpdate;
+    gen.writeNumberField(FORMAT_VERSION, upgradeFormatVersion.formatVersion());
+  }
+
+  private static MetadataUpdate readAsUpgradeFormatVersion(JsonNode node) {
+    int formatVersion = JsonUtil.getInt(FORMAT_VERSION, node);
+    return new MetadataUpdate.UpgradeFormatVersion(formatVersion);
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -47,7 +47,7 @@ public class MetadataUpdateParser {
   private static final String ADD_SORT_ORDER = "add-sort-order";
   private static final String SET_DEFAULT_SORT_ORDER = "set-default-sort-order";
   private static final String ADD_SNAPSHOT = "add-snapshot";
-  private static final String REMOVE_SNAPSHOT = "remove-snapshot";
+  private static final String REMOVE_SNAPSHOT = "remove-snapshots";
   private static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
   private static final String SET_PROPERTIES = "set-properties";
   private static final String REMOVE_PROPERTIES = "remove-properties";

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -48,7 +48,6 @@ public class MetadataUpdateParser {
   private static final String SET_DEFAULT_SORT_ORDER = "set-default-sort-order";
   private static final String ADD_SNAPSHOT = "add-snapshot";
   private static final String REMOVE_SNAPSHOT = "remove-snapshot";
-  private static final String REMOVE_SNAPSHOT_REF = "remove-snapshot-ref";
   private static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
   private static final String SET_PROPERTIES = "set-properties";
   private static final String REMOVE_PROPERTIES = "remove-properties";
@@ -69,7 +68,6 @@ public class MetadataUpdateParser {
       .put(MetadataUpdate.SetDefaultSortOrder.class, SET_DEFAULT_SORT_ORDER)
       .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
       .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOT)
-      .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
       .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
       .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
       .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.MetadataUpdateParser;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
@@ -61,8 +63,27 @@ public class RESTSerializers {
         .addSerializer(UnboundPartitionSpec.class, new UnboundPartitionSpecSerializer())
         .addDeserializer(UnboundPartitionSpec.class, new UnboundPartitionSpecDeserializer())
         .addSerializer(UnboundSortOrder.class, new UnboundSortOrderSerializer())
-        .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer());
+        .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer())
+        .addSerializer(MetadataUpdate.class, new MetadataUpdateSerializer())
+        .addDeserializer(MetadataUpdate.class, new MetadataUpdateDeserializer());
     mapper.registerModule(module);
+  }
+
+  public static class MetadataUpdateDeserializer extends JsonDeserializer<MetadataUpdate> {
+    @Override
+    public MetadataUpdate deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+      JsonNode node = p.getCodec().readTree(p);
+      return MetadataUpdateParser.fromJson(node);
+    }
+  }
+
+  public static class MetadataUpdateSerializer extends JsonSerializer<MetadataUpdate> {
+    @Override
+    public void serialize(MetadataUpdate value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      MetadataUpdateParser.toJson(value, gen);
+    }
   }
 
   public static class ErrorResponseDeserializer extends JsonDeserializer<ErrorResponse> {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMetadataUpdateParser {
+
+  @Test
+  public void testMetadataUpdateWithoutActionCannotDeserialize() {
+    List<String> invalidJson = ImmutableList.of(
+        "{\"action\":null,\"format-version\":2}",
+        "{\"format-version\":2}"
+    );
+
+    for (String json : invalidJson) {
+      AssertHelpers.assertThrows(
+          "MetadataUpdate without a recognized action should fail to deserialize",
+          IllegalArgumentException.class,
+          "Cannot parse metadata update. Missing field: action",
+          () -> MetadataUpdateParser.fromJson(json));
+    }
+  }
+
+  @Test
+  public void testUpgradeFormatVersionToJson() {
+    int formatVersion = 2;
+    String action = "upgrade-format-version";
+    String json = "{\"action\":\"upgrade-format-version\",\"format-version\":2}";
+    MetadataUpdate.UpgradeFormatVersion expected = new MetadataUpdate.UpgradeFormatVersion(formatVersion);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testUpgradeFormatVersionFromJson() {
+    int formatVersion = 2;
+    String expected = "{\"action\":\"upgrade-format-version\",\"format-version\":2}";
+    MetadataUpdate.UpgradeFormatVersion actual = new MetadataUpdate.UpgradeFormatVersion(formatVersion);
+    Assert.assertEquals("Upgrade format version should convert to the correct JSON value",
+        expected, MetadataUpdateParser.toJson(actual));
+  }
+
+  public void assertEquals(String action, MetadataUpdate expectedUpdate, MetadataUpdate actualUpdate) {
+    switch (action) {
+      case "upgrade-format-version":
+        MetadataUpdate.UpgradeFormatVersion expected = (MetadataUpdate.UpgradeFormatVersion) expectedUpdate;
+        MetadataUpdate.UpgradeFormatVersion actual = (MetadataUpdate.UpgradeFormatVersion) actualUpdate;
+        Assert.assertEquals("Format version should be equal", expected.formatVersion(), actual.formatVersion());
+        break;
+      default:
+        Assert.fail("Unrecognized metadata update action: " + action);
+    }
+  }
+}

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1161,7 +1161,7 @@ components:
             - set-default-sort-order
             - add-snapshot
             - set-snapshot-ref
-            - remove-snapshot
+            - remove-snapshots
             - set-location
             - set-properties
             - remove-properties

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1161,7 +1161,7 @@ components:
             - set-default-sort-order
             - add-snapshot
             - set-snapshot-ref
-            - remove-snapshots
+            - remove-snapshot
             - set-location
             - set-properties
             - remove-properties


### PR DESCRIPTION
We need to be able to serialize and deserialize instances of `MetadataUpdate`.

Because `MetadataUpdate` is an interface that has multiple implementations, I've added a serializer / deserializer that handles `MetadataUpdate` and then reads or write the correct value based on the `action` field, as defined in the open-api spec.

I've only implemented  and tested`MetadataUpdate#UpgradeFormatVersion`, and have laid the foundation for the remaining classes which I will handle in a follow up PR.