### PR TITLE
Support insert overwrite table for hive-mr engine.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
@@ -26,4 +26,5 @@ public class ConfigProperties {
 
   public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
   public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
+  public static final String IS_OVERWRITE = "iceberg.mr.write.is.overwrite";
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -296,11 +296,14 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
         dataFiles.forEach(overwrite::addFile);
         overwrite.commit();
         LOG.info("Overwrite commit took {} ms for table: {} with {} file(s)", System.currentTimeMillis() - startTime,
-          table, dataFiles.size());
+            table, dataFiles.size());
       } else if (table.spec().isUnpartitioned()) {
         table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
         LOG.info("Cleared table contents as part of empty overwrite for unpartitioned table. " +
-          "Commit took {} ms for table: {}", System.currentTimeMillis() - startTime, table);
+            "Commit took {} ms for table: {}", System.currentTimeMillis() - startTime, table);
+      } else {
+        LOG.info("Do nothing when empty datafiles is to overwrite for partitioned table. " +
+            "Commit took {} ms for table: {}", System.currentTimeMillis() - startTime, table);
       }
       LOG.debug("Overwrote partitions with files {}", dataFiles);
     } else if (dataFiles.size() > 0) {
@@ -310,11 +313,11 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
       dataFiles.forEach(append::appendFile);
       append.commit();
       LOG.info("Append commit took {} ms for table: {} with {} file(s)", System.currentTimeMillis() - startTime, table,
-        dataFiles.size());
+          dataFiles.size());
       LOG.debug("Added files {}", dataFiles);
     } else {
       LOG.info("Not creating a new commit for table: {}, jobID: {}, since there were no new files to append",
-        table, jobContext.getJobID());
+          table, jobContext.getJobID());
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -346,22 +346,22 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     TableIdentifier target = TableIdentifier.of("default", "target");
     Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-      fileFormat, ImmutableList.of());
+        fileFormat, ImmutableList.of());
 
     shell.executeStatement("set iceberg.mr.write.is.overwrite = true");
 
     // IOW overwrites the whole table (empty target table)
     testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-      fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source");
 
     HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
 
     // IOW overwrites the whole table (non-empty target table)
     List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-      .add(0L, "Mike", "Taylor")
-      .add(1L, "Christy", "Hubert")
-      .build();
+        .add(0L, "Mike", "Taylor")
+        .add(1L, "Christy", "Hubert")
+        .build();
     shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
 
     HiveIcebergTestUtils.validateData(table, newRecords, 0);
@@ -378,26 +378,26 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     TableIdentifier target = TableIdentifier.of("default", "target");
     PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-      .identity("last_name").build();
+        .identity("last_name").build();
     Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-      spec, fileFormat, ImmutableList.of());
+        spec, fileFormat, ImmutableList.of());
 
     shell.executeStatement("set iceberg.mr.write.is.overwrite = true");
 
     // IOW into empty target table -> whole source result set is inserted
     List<Record> expected = Lists.newArrayList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     expected.add(TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-      .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
+        .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
     shell.executeStatement(testTables.getInsertQuery(expected, target, true));
 
     HiveIcebergTestUtils.validateData(table, expected, 0);
 
     // IOW into non-empty target table -> only the affected partitions are overwritten
     List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-      .add(0L, "Mike", "Brown") // overwritten
-      .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
-      .add(3L, "Bill", "Purple") // appended (new partition)
-      .build();
+        .add(0L, "Mike", "Brown") // overwritten
+        .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
+        .add(3L, "Bill", "Purple") // appended (new partition)
+        .build();
     shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
 
     expected = Lists.newArrayList(newRecords);


### PR DESCRIPTION
Support insert overwrite table for hive-mr engine by setting runtime conf with `set iceberg.mr.write.is.overwrite = true` , otherwise we need to modify hive-module to adapt syntax.
 