### PR TITLE
docs:Add an example of CTAS with PARTITIONED BY (fix #3854)

### DIFF
--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -106,6 +106,8 @@ TBLPROPERTIES ('key'='value')
 AS SELECT ...
 ```
 
+The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
+
 ## `REPLACE TABLE ... AS SELECT`
 
 Iceberg supports RTAS as an atomic operation when using a [`SparkCatalog`](../spark-configuration#catalog-configuration). RTAS is supported, but is not atomic when using [`SparkSessionCatalog`](../spark-configuration#replacing-the-session-catalog).

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -98,6 +98,9 @@ CREATE TABLE prod.db.sample
 USING iceberg
 AS SELECT ...
 ```
+
+The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
+
 ```sql
 CREATE TABLE prod.db.sample
 USING iceberg
@@ -105,8 +108,6 @@ PARTITIONED BY (part)
 TBLPROPERTIES ('key'='value')
 AS SELECT ...
 ```
-
-The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
 
 ## `REPLACE TABLE ... AS SELECT`
 

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -98,6 +98,13 @@ CREATE TABLE prod.db.sample
 USING iceberg
 AS SELECT ...
 ```
+```sql
+CREATE TABLE prod.db.sample
+USING iceberg
+PARTITIONED BY (part)
+TBLPROPERTIES ('key'='value')
+AS SELECT ...
+```
 
 ## `REPLACE TABLE ... AS SELECT`
 


### PR DESCRIPTION
Add an example of CTAS with PARTITIONED BY, make it clear that we can use PARTITIONED BY in CTAS. @samredai 

<img width="896" alt="image" src="https://user-images.githubusercontent.com/10529123/164487990-67048237-3f68-49dd-9788-02efef62b864.png">

fix https://github.com/apache/iceberg/issues/3854