### PR TITLE
Core:Optimize Error msg in validateDeletedManifests (fix #3466)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -165,7 +165,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     List<ManifestFile> currentManifests = base.currentSnapshot().dataManifests();
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(currentManifestSet, base.currentSnapshot().snapshotId());
+    validateDeletedManifests(currentManifestSet);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);
@@ -251,15 +251,16 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     }
   }
 
-  private void validateDeletedManifests(Set<ManifestFile> currentManifests, long currentSnapshotId) {
+  private void validateDeletedManifests(Set<ManifestFile> currentManifests) {
     // directly deleted manifests must be still present in the current snapshot
     deletedManifests.stream()
         .filter(manifest -> !currentManifests.contains(manifest))
         .findAny()
         .ifPresent(manifest -> {
-          throw new ValidationException("Cannot apply RewriteManifests result, " +
-                  "since some manifests being deleted have already been removed in current snapshot or not exist" +
-                  " at all. current-snapshot-id:%d, missing-manifest-path:%s", currentSnapshotId, manifest.path());
+          throw new ValidationException("Cannot commit RewriteManifests; " +
+                  "manifests that existed at the beginning of this rewrite have already been removed by another " +
+                  "operation. Manifest %s, which would be replaced by this operation, has already been removed.",
+                  manifest.path());
         });
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -895,7 +895,7 @@ public class TestRewriteManifests extends TableTestBase {
         .commit();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "Cannot apply RewriteManifests result, since some manifests",
+        ValidationException.class, "Cannot commit RewriteManifests; manifests that ",
         rewriteManifests::commit);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -895,7 +895,7 @@ public class TestRewriteManifests extends TableTestBase {
         .commit();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "Manifest is missing",
+        ValidationException.class, "Cannot apply RewriteManifests result, since some manifests",
         rewriteManifests::commit);
   }
 


### PR DESCRIPTION
Error msg "Manifest is missing" in BaseRewriteManifests.validateDeletedManifests()  is correct but a bit confusing, I optimize it to make user easier found out what happened. and now it looks like:
```
"Cannot apply RewriteManifests result, " +
                  "since some manifests being deleted have already been removed in current snapshot or not exist" +
                  " at all. current-snapshot-id:%d, missing-manifest-path:%s"
```


fix https://github.com/apache/iceberg/issues/3466
follow the suggestion from https://github.com/apache/iceberg/issues/3466#issuecomment-1104404998
cc: @RussellSpitzer 