### PR TITLE
Style: Add checkstyle rule to prevent using Objects.requireNonNull

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -337,6 +337,10 @@
             <property name="format" value="Preconditions\.checkNotNull\((?!.*,)([^()]*(\(([^()]*|\(([^()]*|\([^()]*\))*\))*\)[^()]*)*)\)"/>
             <property name="message" value="Use Preconditions.checkNotNull(Object, String)."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="Objects\.(require|)[Nn]onNull.*\(.*\)"/>
+            <property name="message" value="Prefer using Preconditions.checkNotNull(Object, String)."/>
+        </module>
         <module name="RegexpSinglelineJava"> <!-- Java Coding Guidelines: Check parameters for validity -->
             <property name="format" value="Validate\.notNull\((?!.*,)([^()]*(\(([^()]*|\(([^()]*|\([^()]*\))*\))*\)[^()]*)*)\)"/>
             <property name="message" value="Use Validate.notNull(Object, String)."/>


### PR DESCRIPTION
Hi, this closes #4613.

running the checks on this simple example, :
```
    public static void main(String[] args)  {
        String str = null;

        // not allowed
        Objects.nonNull(str);
        Objects.nonNull(Integer.valueOf(123));
        Objects.requireNonNull(str);
        Objects.requireNonNullElse(str, "123");
        Objects.requireNonNullElseGet(str, () -> "1");

        // allowed
        Objects.isNull(str);
    }
```
generates: `<error line="..." severity="error" message="Prefer using Preconditions.checkNotNull(Object, String)." source=...` for the 'not allowed' lines above.
