### PR TITLE
Add BoundReference class

### DIFF
--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -20,7 +20,7 @@ from functools import reduce
 from typing import Any, Generic, TypeVar
 
 from iceberg.files import StructProtocol
-from iceberg.types import IcebergType, NestedField, Singleton
+from iceberg.types import NestedField, Singleton
 
 T = TypeVar("T")
 
@@ -272,6 +272,12 @@ class Accessor:
     def __init__(self, position: int):
         self._position = position
 
+    def __str__(self):
+        return f"Accessor(position={self._position})"
+
+    def __repr__(self):
+        return f"Accessor(position={self._position})"
+
     @property
     def position(self):
         """The position in the container to access"""
@@ -290,7 +296,7 @@ class Accessor:
 
 
 class BoundReference:
-    """A reference bound to a field with an accessor for acquiring the field's value
+    """A reference bound to a field in a schema
 
     Args:
         field (NestedField): A referenced field in an Iceberg schema
@@ -302,38 +308,15 @@ class BoundReference:
         self._accessor = accessor
 
     def __str__(self):
-        return f"ref(id={self.field_id})"
+        return f"BoundReference(field={repr(self.field)}, accessor={repr(self._accessor)})"
 
     def __repr__(self):
-        return f"BoundReference(field={repr(self.field)}, accessor={repr(self.accessor)})"
+        return f"BoundReference(field={repr(self.field)}, accessor={repr(self._accessor)})"
 
     @property
     def field(self) -> NestedField:
         """The referenced field"""
         return self._field
-
-    @property
-    def field_id(self) -> int:
-        """The ID referenced field"""
-        return self._field.field_id
-
-    @property
-    def field_type(self) -> IcebergType:
-        """The type of the referenced field"""
-        return self._field.type
-
-    @property
-    def accessor(self) -> Accessor:
-        """The accessor for retrieving the value at the referenced field's position"""
-        return self._accessor
-
-    def __eq__(self, other) -> bool:
-        if self is other:
-            return True
-        elif not isinstance(other, BoundReference):
-            return False
-
-        return self.field_id == other.field_id and self.field_type == other.field_type
 
     def eval(self, struct: StructProtocol) -> Any:
         """Returns the value at the referenced field's position in an object that abides by the StructProtocol
@@ -344,4 +327,4 @@ class BoundReference:
         Returns:
             Any: The value at the referenced field's position in `struct`
         """
-        return self.accessor.get(struct)
+        return self._accessor.get(struct)

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -330,7 +330,7 @@ class BoundReference:
     def __eq__(self, other) -> bool:
         if id(self) == id(other):
             return True
-        elif other is None or not isinstance(other, BoundReference):
+        elif not isinstance(other, BoundReference):
             return False
 
         return self.field_id == other.field_id and self.field_type == other.field_type

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -328,7 +328,7 @@ class BoundReference:
         return self._accessor
 
     def __eq__(self, other) -> bool:
-        if id(self) == id(other):
+        if self is other:
             return True
         elif not isinstance(other, BoundReference):
             return False

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 import pytest
 
 from iceberg.expressions import base
-from iceberg.types import IntegerType, NestedField, Singleton, StringType
+from iceberg.types import NestedField, Singleton, StringType
 
 
 @pytest.mark.parametrize(
@@ -224,76 +224,16 @@ def test_bound_reference_str_and_repr():
     field = NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False)
     position1_accessor = base.Accessor(position=1)
     bound_ref = base.BoundReference(field=field, accessor=position1_accessor)
-    assert str(bound_ref) == "ref(id=1)"
+    assert str(bound_ref) == f"BoundReference(field={repr(field)}, accessor={repr(position1_accessor)})"
     assert repr(bound_ref) == f"BoundReference(field={repr(field)}, accessor={repr(position1_accessor)})"
 
 
-@pytest.mark.parametrize(
-    "bound_ref1,bound_ref2,expected_equality",
-    [
-        (
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            True,
-        ),
-        (
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            base.BoundReference(
-                field=NestedField(field_id=2, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            False,
-        ),
-        (
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            base.BoundReference(
-                field=NestedField(field_id=1, name="bar", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            True,
-        ),
-        (
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            base.BoundReference(
-                field=NestedField(field_id=1, name="foo", field_type=IntegerType(), is_optional=False),
-                accessor=base.Accessor(position=1),
-            ),
-            False,
-        ),
-    ],
-)
-def test_equality_between_bound_references(bound_ref1, bound_ref2, expected_equality):
-    """Test equality between BoundReference instances"""
-    assert (bound_ref1 == bound_ref2) == expected_equality
-    assert bound_ref1 == bound_ref1
-    assert bound_ref2 == bound_ref2
-    assert bound_ref1 != "foo"
-    assert bound_ref2 != "foo"
-
-
-def test_bound_reference_properties():
+def test_bound_reference_field_property():
     """Test str and repr of BoundReference"""
     field = NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False)
     position1_accessor = base.Accessor(position=1)
     bound_ref = base.BoundReference(field=field, accessor=position1_accessor)
     assert bound_ref.field == NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False)
-    assert bound_ref.field_id == 1
-    assert bound_ref.field_type == StringType()
 
 
 def test_bound_reference(table_schema_simple, foo_struct):


### PR DESCRIPTION
This adds a `BoundReference` class that takes a field and an accessor and allows you to evaluate a struct (a row object that abides by the `StructProtocol`) to retrieve the value at the referenced field's position.

For some more context, expressions are initially built with references (`x` in x = 1`) that are not bound to an actual field. The binding of the reference to the actual field `x` will return a `BoundReference` instance. The instance includes an `eval` method that uses the accessor to get the field at that position, given a row object.