### PR TITLE
Flink: support watermark and computed columns

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -378,7 +378,7 @@ public class FlinkCatalog extends AbstractCatalog {
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
 
-    Schema icebergSchema = FlinkSchemaUtil.convert(table.getSchema());
+    Schema icebergSchema = FlinkSchemaUtil.convert(((ResolvedCatalogTable) table).getResolvedSchema());
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
 
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -22,10 +22,10 @@ package org.apache.iceberg.flink;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -65,7 +65,7 @@ public class FlinkSchemaUtil {
 
   public static final String FLINK_PREFIX = "flink.";
 
-  public static final String COMPUTED_COLUMNS = "computed-columns.";
+  public static final String COMPUTED_COLUMNS = "computed-column.";
   public static final String COMPUTED_COLUMNS_PREFIX = FLINK_PREFIX + COMPUTED_COLUMNS;
 
   public static final String WATERMARK = "watermark.";
@@ -271,9 +271,9 @@ public class FlinkSchemaUtil {
    * @return Flink ResolvedSchema.
    */
   public static ResolvedSchema convertToResolvedSchema(CatalogTable table) {
-    StreamExecutionEnvironment env =  StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
-    StreamTableEnvironment streamTableEnvironment = StreamTableEnvironment.create(env);
-    CatalogManager catalogManager = ((TableEnvironmentImpl) streamTableEnvironment).getCatalogManager();
+    Configuration configuration = ExecutionEnvironment.getExecutionEnvironment().getConfiguration();
+    TableEnvironment tableEnvironment = TableEnvironment.create(configuration);
+    CatalogManager catalogManager = ((TableEnvironmentImpl) tableEnvironment).getCatalogManager();
     SchemaResolver schemaResolver = catalogManager.getSchemaResolver();
     return table.getUnresolvedSchema().resolve(schemaResolver);
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
@@ -78,7 +79,9 @@ public abstract class FlinkTestBase extends TestBaseUtils {
               .build();
 
           TableEnvironment env = TableEnvironment.create(settings);
-          env.getConfig().getConfiguration().set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false);
+          env.getConfig().getConfiguration()
+              .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false)
+              .set(TableConfigOptions.LOCAL_TIME_ZONE, "UTC");
           tEnv = env;
         }
       }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -565,9 +565,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     expectResult.add("1");
     expectResult.add("2");
     expectResult.add("abc");
-    expectResult.add("1970-01-01T08:00:03");
-    expectResult.add("1970-01-01T08:00:24");
-    expectResult.add("1970-01-01T08:00:24");
+    expectResult.add("1970-01-01T00:00:03");
+    expectResult.add("1970-01-01T00:00:24");
+    expectResult.add("1970-01-01T00:00:24");
 
     List<String> result = Lists.newArrayList();
     Row row = sql("SELECT id, id2, s, f1, t1, t2 FROM tl").get(0);
@@ -584,7 +584,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
     List<String> expectResult2 = Lists.newArrayList();
     expectResult2.add("abc");
-    expectResult2.add("1970-01-01T08:00:24");
+    expectResult2.add("1970-01-01T00:00:24");
 
     List<String> result2 = Lists.newArrayList();
     Row row2 = sql("SELECT * FROM tl").get(0);

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -445,9 +445,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         "watermark for t2 as t2 - INTERVAL '5' SECOND )");
 
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("flink.computed-columns.id2", "`id` * 2");
-    properties.put("flink.computed-columns.f1", "TO_TIMESTAMP(FROM_UNIXTIME(`id` * 3))");
-    properties.put("flink.computed-columns.t2", "CAST(`t1` AS TIMESTAMP(3))");
+    properties.put("flink.computed-column.id2", "`id` * 2");
+    properties.put("flink.computed-column.f1", "TO_TIMESTAMP(FROM_UNIXTIME(`id` * 3))");
+    properties.put("flink.computed-column.t2", "CAST(`t1` AS TIMESTAMP(3))");
     properties.put("flink.watermark.t2", "`t2` - INTERVAL '5' SECOND");
     Assert.assertEquals(properties, table("tl").properties());
 
@@ -466,9 +466,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         "watermark for t2 as t2 - INTERVAL '5' SECOND )");
 
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("flink.computed-columns.id2", "`id` * 2");
-    properties.put("flink.computed-columns.f1", "TO_TIMESTAMP(FROM_UNIXTIME(`id` * 3))");
-    properties.put("flink.computed-columns.t2", "CAST(`t1` AS TIMESTAMP(2))");
+    properties.put("flink.computed-column.id2", "`id` * 2");
+    properties.put("flink.computed-column.f1", "TO_TIMESTAMP(FROM_UNIXTIME(`id` * 3))");
+    properties.put("flink.computed-column.t2", "CAST(`t1` AS TIMESTAMP(2))");
     properties.put("flink.watermark.t2", "`t2` - INTERVAL '5' SECOND");
     Assert.assertEquals(properties, table("tl").properties());
 
@@ -553,7 +553,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     // reset computed column t2, error because watermark t2 depend on computed column t2
     AssertHelpers.assertThrows("should throw TableException.",
         TableException.class,
-        () -> sql("ALTER TABLE tl RESET ('flink.computed-columns.t2')"));
+        () -> sql("ALTER TABLE tl RESET ('flink.computed-column.t2')"));
   }
 
   @Test

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -324,6 +324,6 @@ public class TestFlinkSchemaUtil {
     AssertHelpers.assertThrows("Does not support the nested columns in flink schema's primary keys",
         ValidationException.class,
         "Column 'struct.inner' does not exist",
-        () -> FlinkSchemaUtil.toSchema(icebergSchema, Maps.newHashMap()));
+        () -> FlinkSchemaUtil.toSchema(icebergSchema));
   }
 }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -306,10 +307,10 @@ public class TestFlinkSchemaUtil {
         Sets.newHashSet(1, 2)
     );
 
-    TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
+    org.apache.flink.table.api.Schema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema, Maps.newHashMap());
     Assert.assertTrue(tableSchema.getPrimaryKey().isPresent());
     Assert.assertEquals(ImmutableSet.of("int", "string"),
-        ImmutableSet.copyOf(tableSchema.getPrimaryKey().get().getColumns()));
+        ImmutableSet.copyOf(tableSchema.getPrimaryKey().get().getColumnNames()));
   }
 
   @Test
@@ -323,6 +324,6 @@ public class TestFlinkSchemaUtil {
     AssertHelpers.assertThrows("Does not support the nested columns in flink schema's primary keys",
         ValidationException.class,
         "Column 'struct.inner' does not exist",
-        () -> FlinkSchemaUtil.toSchema(icebergSchema));
+        () -> FlinkSchemaUtil.toSchema(icebergSchema, Maps.newHashMap()));
   }
 }


### PR DESCRIPTION
We hope iceberg can support watermark and computed columns.
The specific implementation details are as follows:


# Background and Motivation

There is a temporal table in iceberg, which needs to be used for real-time join with other tables, so a watermark needs to be defined. However, the watermark has requirements for the attributes of the fields, and the fields representing time in the source table may not meet this requirement, so it is necessary to convert the time fields of the source table by recalculating or calling functions.

**Why not directly use the iceberg connector table supported by flink?**

1. All flink tables are stored in memory. When the task ends, the table disappears. If you want to use it next time, you need to create it again.
2. In the scenes we use, a temporal table needs to be joined with multiple tables, and the attributes of the watermark are only related to the temporal table, so the watermark attributes of these tasks are consistent, so we hope to directly associate these attributes with Temporal table binding, when you use this table again in the future, you don't need to go to other tasks to check the watermark attribute setting parameters of the table.

# Goal

1. Iceberg supports flink-sql to set watermark and computed columns.
2. The watermark attribute and computed column attribute can be modified by modifying the table properties.

# Proposal

## Table property save format

### Example

```sql
CREATE TABLE tl (
  id INT, 
  id2 AS id * 2, 
  f1 AS TO_TIMESTAMP(FROM_UNIXTIME(id*3)),
  t1 TIMESTAMP(6), 
  t2 AS cast(t1 AS TIMESTAMP(3)), 
  watermark FOR t2 AS t2 - INTERVAL '5' SECOND
);
```

Then the table properties are saved as:

```sql
flink.computed-columns.id2 = `id` * 2
flink.computed-columns.f1 = TO_TIMESTAMP(FROM_UNIXTIME(`id` * 3))
flink.computed-columns.t2 = CAST(`t1` AS TIMESTAMP(3))
flink.watermark.t2 = `t2` - INTERVAL '5' SECOND
```

### key format

fixed prefix + field name:

- fixed prefix for watermark: `flink.watermark.`
- fixed prefix  for computed columns: `flink.computed-columns.`

### value format

defined expression from user.

## The way of addition, deletion and modification

1、DDL of flink-sql, only supports adding

```sql
CREATE TABLE `hive_catalog`.`default`.`sample` (
  id INT, 
  id2 AS id * 2, 
  f1 AS TO_TIMESTAMP(FROM_UNIXTIME(id*3)),
  t1 TIMESTAMP(6), 
  t2 AS cast(t1 AS TIMESTAMP(3)), 
  watermark FOR t2 AS t2 - INTERVAL '5' SECOND
);
```

2、Syntax of table properties

- add or update

```sql
ALTER TABLE `hive_catalog`.`default`.`sample` SET (
	'flink.computed-columns.id2'='id*3'
)
```

- delete

```sql
ALTER TABLE `hive_catalog`.`default`.`sample` RESET (
	'flink.computed-columns.id2'
)
```

## Solution

### add table process

1. If there is a defined computed column in the table, save its expression to the table property.
2. If there is a defined watermark in the table, save its expression to the table property.

### alter table properties process

1. Merge the modified properties with the original properties to get the updated properties of the table.

2. Generate the table of flink from the merged table properties and the schema of the original table, and verify the schema. (To prevent errors in expression, such as writing a non-existing function or column name in the expression of the computed column.)

3. If the verification in the previous step is successful, submit this property modification, 
   if not, report exception and do not make the final submission.

### get table process

1. Generate the flink table by combining the current table properties with the table schema, and verify the schema. (To prevent the schema of the table from being modified by other engines, resulting in an error in the expression of the calculated column. For example, in the expression of the computed column: `id` * 3, but then the `id` column was deleted using spark, and the corresponding property for computed column was not deleted.)

2. If the verification is successful, the table is returned. 
   If it is unsuccessful, the computed columns and watermarks in the table properties are ignored, and the original table physical schema is returned directly.





