### PR TITLE
Only delete will throw ValidationException instead of IllegalArgumentException

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -255,14 +255,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
       return;
     }
 
-    try {
-      icebergTable.newDelete()
-          .set("spark.app.id", sparkSession().sparkContext().applicationId())
-          .deleteFromRowFilter(deleteExpr)
-          .commit();
-    } catch (ValidationException e) {
-      throw new IllegalArgumentException("Failed to cleanly delete data files matching: " + deleteExpr, e);
-    }
+    icebergTable.newDelete()
+        .set("spark.app.id", sparkSession().sparkContext().applicationId())
+        .deleteFromRowFilter(deleteExpr)
+        .commit();
   }
 
   @Override

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -63,7 +64,7 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     AssertHelpers.assertThrows("Should not delete when not all rows of a file match the filter",
-        IllegalArgumentException.class, "Failed to cleanly delete data files",
+        ValidationException.class, "Cannot delete file where some, but not all, rows match filter",
         () -> sql("DELETE FROM %s WHERE id < 2", tableName));
 
     sql("DELETE FROM %s WHERE id < 4", tableName);
@@ -114,7 +115,7 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     AssertHelpers.assertThrows("Should not delete when not all rows of a file match the filter",
-        IllegalArgumentException.class, "Failed to cleanly delete data files",
+        ValidationException.class, "Cannot delete file where some, but not all, rows match filter",
         () -> sql("DELETE FROM %s WHERE id > 2", tableName));
 
     sql("DELETE FROM %s WHERE id < 2", tableName);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -251,14 +251,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
       return;
     }
 
-    try {
-      icebergTable.newDelete()
-          .set("spark.app.id", sparkSession().sparkContext().applicationId())
-          .deleteFromRowFilter(deleteExpr)
-          .commit();
-    } catch (ValidationException e) {
-      throw new IllegalArgumentException("Failed to cleanly delete data files matching: " + deleteExpr, e);
-    }
+    icebergTable.newDelete()
+        .set("spark.app.id", sparkSession().sparkContext().applicationId())
+        .deleteFromRowFilter(deleteExpr)
+        .commit();
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -281,7 +281,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   }
 
   @Override
-  public void deleteWhere(Filter[] filters) {
+  public void deleteWhere(Filter[] filters) throws ValidationException {
     Expression deleteExpr = SparkFilters.convert(filters);
 
     if (deleteExpr == Expressions.alwaysFalse()) {
@@ -289,14 +289,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
       return;
     }
 
-    try {
-      icebergTable.newDelete()
-          .set("spark.app.id", sparkSession().sparkContext().applicationId())
-          .deleteFromRowFilter(deleteExpr)
-          .commit();
-    } catch (ValidationException e) {
-      throw new ValidationException(e, "Failed to cleanly delete data files matching: %s", deleteExpr);
-    }
+    icebergTable.newDelete()
+            .set("spark.app.id", sparkSession().sparkContext().applicationId())
+            .deleteFromRowFilter(deleteExpr)
+            .commit();
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -281,7 +281,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   }
 
   @Override
-  public void deleteWhere(Filter[] filters) throws ValidationException {
+  public void deleteWhere(Filter[] filters) {
     Expression deleteExpr = SparkFilters.convert(filters);
 
     if (deleteExpr == Expressions.alwaysFalse()) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -289,9 +289,9 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
     }
 
     icebergTable.newDelete()
-            .set("spark.app.id", sparkSession().sparkContext().applicationId())
-            .deleteFromRowFilter(deleteExpr)
-            .commit();
+        .set("spark.app.id", sparkSession().sparkContext().applicationId())
+        .deleteFromRowFilter(deleteExpr)
+        .commit();
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -33,7 +33,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -295,7 +295,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
           .deleteFromRowFilter(deleteExpr)
           .commit();
     } catch (ValidationException e) {
-      throw new IllegalArgumentException("Failed to cleanly delete data files matching: " + deleteExpr, e);
+      throw new ValidationException(e, "Failed to cleanly delete data files matching: %s", deleteExpr);
     }
   }
 


### PR DESCRIPTION
`SparkTables metadata only delete` should throw `ValidationException` instead of `IllegalArgumentException` based on @[szehon-ho](https://github.com/szehon-ho) comment.