### PR TITLE
Flink - Fix flakey, order-dependent FlinkTableSource tests for Flink 1.14

### DIFF
--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -101,5 +102,11 @@ public abstract class FlinkTestBase extends TestBaseUtils {
     } catch (Exception e) {
       throw new RuntimeException("Failed to collect table result", e);
     }
+  }
+
+  protected void assertSameElements(Iterable<Row> expected, Iterable<Row> actual) {
+    Assertions.assertThat(actual)
+        .isNotNull()
+        .containsExactlyInAnyOrderElementsOf(expected);
   }
 }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -109,4 +109,11 @@ public abstract class FlinkTestBase extends TestBaseUtils {
         .isNotNull()
         .containsExactlyInAnyOrderElementsOf(expected);
   }
+
+  protected void assertSameElements(String message, Iterable<Row> expected, Iterable<Row> actual) {
+    Assertions.assertThat(actual)
+        .isNotNull()
+        .as(message)
+        .containsExactlyInAnyOrderElementsOf(expected);
+  }
 }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -136,7 +136,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    assertSameElements(result, expectedRecords);
+    assertSameElements(expectedRecords, result);
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
   }
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -271,7 +271,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    assertSameElements(expectedGT, resultGT);;
+    assertSameElements(expectedGT, resultGT);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -289,7 +289,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    assertSameElements(resultGTE, expectedGTE);
+    assertSameElements(expectedGTE, resultGTE);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.flink;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.TableEnvironment;
@@ -32,7 +31,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,12 +114,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     String sqlLimitExceed = String.format("SELECT * FROM %s LIMIT 4", TABLE_NAME);
     List<Row> resultExceed = sql(sqlLimitExceed);
     Assert.assertEquals("Should have 3 records", 3, resultExceed.size());
-    Set<Row> expectedList = Sets.newHashSet(
+    List<Row> expectedList = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected records", expectedList, Sets.newHashSet(resultExceed));
+    assertSameElements(expectedList, resultExceed);
 
     String sqlMixed = String.format("SELECT * FROM %s WHERE id = 1 LIMIT 2", TABLE_NAME);
     List<Row> mixedResult = sql(sqlMixed);
@@ -132,13 +131,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void testNoFilterPushDown() {
     String sql = String.format("SELECT * FROM %s ", TABLE_NAME);
     List<Row> result = sql(sql);
-    Set<Row> expectedRecords = Sets.newHashSet(
+    List<Row> expectedRecords = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should have 3 records", 3, expectedRecords.size());
-    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(result));
+    assertSameElements(result, expectedRecords);
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
   }
 
@@ -185,12 +183,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultNE = sql(sqlNE);
     Assert.assertEquals("Should have 2 records", 2, resultNE.size());
 
-    Set<Row> expectedNE = Sets.newHashSet(
+    List<Row> expectedNE = Lists.newArrayList(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should have two records", 2, resultNE.size());
-    Assert.assertEquals("Should produce the expected record", expectedNE, Sets.newHashSet(resultNE));
+    assertSameElements(expectedNE, resultNE);
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
@@ -225,11 +222,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultOr = sql(sqlOr);
     Assert.assertEquals("Should have 2 record", 2, resultOr.size());
 
-    Set<Row> expectedOR = Sets.newHashSet(
+    List<Row> expectedOR = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedOR, Sets.newHashSet(resultOr));
+    assertSameElements(expectedOR, resultOr);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -243,11 +240,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGT = sql(sqlGT);
     Assert.assertEquals("Should have 2 record", 2, resultGT.size());
 
-    Set<Row> expectedGT = Sets.newHashSet(
+    List<Row> expectedGT = Lists.newArrayList(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGT, Sets.newHashSet(resultGT));
+    assertSameElements(expectedGT, resultGT);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -270,11 +267,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGT = sql(sqlGT);
     Assert.assertEquals("Should have 2 records", 2, resultGT.size());
 
-    Set<Row> expectedGT = Sets.newHashSet(
+    List<Row> expectedGT = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGT, Sets.newHashSet(resultGT));
+    assertSameElements(expectedGT, resultGT);;
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -288,11 +285,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGTE = sql(sqlGTE);
     Assert.assertEquals("Should have 2 records", 2, resultGTE.size());
 
-    Set<Row> expectedGTE = Sets.newHashSet(
+    List<Row> expectedGTE = Lists.newArrayList(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGTE, Sets.newHashSet(resultGTE));
+    assertSameElements(resultGTE, expectedGTE);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -315,11 +312,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGTE = sql(sqlGTE);
     Assert.assertEquals("Should have 2 records", 2, resultGTE.size());
 
-    Set<Row> expectedGTE = Sets.newHashSet(
+    List<Row> expectedGTE = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGTE, Sets.newHashSet(resultGTE));
+    assertSameElements(expectedGTE, resultGTE);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -402,11 +399,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultIN = sql(sqlIN);
     Assert.assertEquals("Should have 2 records", 2, resultIN.size());
 
-    Set<Row> expectedIN = Sets.newHashSet(
+    List<Row> expectedIN = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedIN, Sets.newHashSet(resultIN));
+    assertSameElements(expectedIN, resultIN);
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
@@ -449,11 +446,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultNotNull = sql(sqlNotNull);
     Assert.assertEquals("Should have 2 record", 2, resultNotNull.size());
 
-    Set<Row> expected = Sets.newHashSet(
+    List<Row> expected = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expected, Sets.newHashSet(resultNotNull));
+    assertSameElements(expected, resultNotNull);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -492,12 +489,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultBetween = sql(sqlBetween);
     Assert.assertEquals("Should have 2 record", 2, resultBetween.size());
 
-    Set<Row> expectedBetween = Sets.newHashSet(
+    List<Row> expectedBetween = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should have 2 records", 2, resultBetween.size());
-    Assert.assertEquals("Should produce the expected record", expectedBetween, Sets.newHashSet(resultBetween));
+    assertSameElements(expectedBetween, resultBetween);
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     String expected = "(ref(name=\"id\") >= 1 and ref(name=\"id\") <= 2)";
@@ -553,12 +549,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     sqlNoPushDown = "SELECT * FROM  " + TABLE_NAME + "  WHERE data LIKE '%%' ";
     resultLike = sql(sqlNoPushDown);
     Assert.assertEquals("Should have 3 records", 3, resultLike.size());
-    Set<Row> expectedRecords = Sets.newHashSet(
+    List<Row> expectedRecords = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(resultLike));
+    assertSameElements(expectedRecords, resultLike);
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
 
     sqlNoPushDown = "SELECT * FROM  " + TABLE_NAME + "  WHERE data LIKE 'iceber_' ";
@@ -578,13 +574,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void testFilterPushDown2Literal() {
     String sql2Literal = String.format("SELECT * FROM %s WHERE 1 > 0 ", TABLE_NAME);
     List<Row> result = sql(sql2Literal);
-    Set<Row> expectedRecords = Sets.newHashSet(
+    List<Row> expectedRecords = Lists.newArrayList(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should have 3 records", 3, result.size());
-    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(result));
+    assertSameElements(expectedRecords, result);
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
   }
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.flink;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.TableEnvironment;
@@ -31,7 +32,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -114,12 +115,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     String sqlLimitExceed = String.format("SELECT * FROM %s LIMIT 4", TABLE_NAME);
     List<Row> resultExceed = sql(sqlLimitExceed);
     Assert.assertEquals("Should have 3 records", 3, resultExceed.size());
-    List<Row> expectedList = Lists.newArrayList(
+    Set<Row> expectedList = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected records", expectedList, resultExceed);
+    Assert.assertEquals("Should produce the expected records", expectedList, Sets.newHashSet(resultExceed));
 
     String sqlMixed = String.format("SELECT * FROM %s WHERE id = 1 LIMIT 2", TABLE_NAME);
     List<Row> mixedResult = sql(sqlMixed);
@@ -131,12 +132,13 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void testNoFilterPushDown() {
     String sql = String.format("SELECT * FROM %s ", TABLE_NAME);
     List<Row> result = sql(sql);
-    List<Row> expectedRecords = Lists.newArrayList(
+    Set<Row> expectedRecords = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertArrayEquals("Should produce the expected record", expectedRecords.toArray(), result.toArray());
+    Assert.assertEquals("Should have 3 records", 3, expectedRecords.size());
+    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(result));
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
   }
 
@@ -183,11 +185,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultNE = sql(sqlNE);
     Assert.assertEquals("Should have 2 records", 2, resultNE.size());
 
-    List<Row> expectedNE = Lists.newArrayList(
+    Set<Row> expectedNE = Sets.newHashSet(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedNE, resultNE);
+    Assert.assertEquals("Should have two records", 2, resultNE.size());
+    Assert.assertEquals("Should produce the expected record", expectedNE, Sets.newHashSet(resultNE));
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
@@ -222,11 +225,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultOr = sql(sqlOr);
     Assert.assertEquals("Should have 2 record", 2, resultOr.size());
 
-    List<Row> expectedOR = Lists.newArrayList(
+    Set<Row> expectedOR = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedOR, resultOr);
+    Assert.assertEquals("Should produce the expected record", expectedOR, Sets.newHashSet(resultOr));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -240,11 +243,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGT = sql(sqlGT);
     Assert.assertEquals("Should have 2 record", 2, resultGT.size());
 
-    List<Row> expectedGT = Lists.newArrayList(
+    Set<Row> expectedGT = Sets.newHashSet(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGT, resultGT);
+    Assert.assertEquals("Should produce the expected record", expectedGT, Sets.newHashSet(resultGT));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -267,11 +270,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGT = sql(sqlGT);
     Assert.assertEquals("Should have 2 records", 2, resultGT.size());
 
-    List<Row> expectedGT = Lists.newArrayList(
+    Set<Row> expectedGT = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGT, resultGT);
+    Assert.assertEquals("Should produce the expected record", expectedGT, Sets.newHashSet(resultGT));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -285,11 +288,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGTE = sql(sqlGTE);
     Assert.assertEquals("Should have 2 records", 2, resultGTE.size());
 
-    List<Row> expectedGTE = Lists.newArrayList(
+    Set<Row> expectedGTE = Sets.newHashSet(
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGTE, resultGTE);
+    Assert.assertEquals("Should produce the expected record", expectedGTE, Sets.newHashSet(resultGTE));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -312,11 +315,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultGTE = sql(sqlGTE);
     Assert.assertEquals("Should have 2 records", 2, resultGTE.size());
 
-    List<Row> expectedGTE = Lists.newArrayList(
+    Set<Row> expectedGTE = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedGTE, resultGTE);
+    Assert.assertEquals("Should produce the expected record", expectedGTE, Sets.newHashSet(resultGTE));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -399,11 +402,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultIN = sql(sqlIN);
     Assert.assertEquals("Should have 2 records", 2, resultIN.size());
 
-    List<Row> expectedIN = Lists.newArrayList(
+    Set<Row> expectedIN = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedIN, resultIN);
+    Assert.assertEquals("Should produce the expected record", expectedIN, Sets.newHashSet(resultIN));
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
@@ -446,11 +449,11 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultNotNull = sql(sqlNotNull);
     Assert.assertEquals("Should have 2 record", 2, resultNotNull.size());
 
-    List<Row> expected = Lists.newArrayList(
+    Set<Row> expected = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expected, resultNotNull);
+    Assert.assertEquals("Should produce the expected record", expected, Sets.newHashSet(resultNotNull));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
@@ -489,11 +492,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> resultBetween = sql(sqlBetween);
     Assert.assertEquals("Should have 2 record", 2, resultBetween.size());
 
-    List<Row> expectedBetween = Lists.newArrayList(
+    Set<Row> expectedBetween = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedBetween, resultBetween);
+    Assert.assertEquals("Should have 2 records", 2, resultBetween.size());
+    Assert.assertEquals("Should produce the expected record", expectedBetween, Sets.newHashSet(resultBetween));
 
     Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     String expected = "(ref(name=\"id\") >= 1 and ref(name=\"id\") <= 2)";
@@ -549,12 +553,12 @@ public class TestFlinkTableSource extends FlinkTestBase {
     sqlNoPushDown = "SELECT * FROM  " + TABLE_NAME + "  WHERE data LIKE '%%' ";
     resultLike = sql(sqlNoPushDown);
     Assert.assertEquals("Should have 3 records", 3, resultLike.size());
-    List<Row> expectedRecords = Lists.newArrayList(
+    Set<Row> expectedRecords = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertEquals("Should produce the expected record", expectedRecords, resultLike);
+    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(resultLike));
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
 
     sqlNoPushDown = "SELECT * FROM  " + TABLE_NAME + "  WHERE data LIKE 'iceber_' ";
@@ -574,12 +578,13 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void testFilterPushDown2Literal() {
     String sql2Literal = String.format("SELECT * FROM %s WHERE 1 > 0 ", TABLE_NAME);
     List<Row> result = sql(sql2Literal);
-    List<Row> expectedRecords = Lists.newArrayList(
+    Set<Row> expectedRecords = Sets.newHashSet(
         Row.of(1, "iceberg", 10.0),
         Row.of(2, "b", 20.0),
         Row.of(3, null, 30.0)
     );
-    Assert.assertArrayEquals("Should produce the expected record", expectedRecords.toArray(), result.toArray());
+    Assert.assertEquals("Should have 3 records", 3, result.size());
+    Assert.assertEquals("Should produce the expected record", expectedRecords, Sets.newHashSet(result));
     Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
   }
 


### PR DESCRIPTION
When upgrading our Flink code for the upcoming Flink 1.15 release in https://github.com/apache/iceberg/pull/4553, it was discovered that there is a failing test: https://github.com/apache/iceberg/pull/4553#issuecomment-1107688576

Looking closer, the expected and actual results are the same, just in a different order.

Because we are not testing the ordering of records returned from the source here, using list comparison doesn't make sense and we can just use set comparison (with an initial size check) for any query that returns more than 1 record.

I have updated all queries in this test to use set comparison semantics as list comparison is inherently flakey.

I will port this over to Flink 1.15 in https://github.com/apache/iceberg/pull/4553 as that's where tests are failing (though we don't have any guarantee that they will pass at present in 1.14 and it's simply implementation specific that they do).

cc @openinx @yittg 
