### PR TITLE
Core - Use singleton RESTObjectMapper in REST RequestResponseTestBase class

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
@@ -19,28 +19,14 @@
 
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public abstract class RequestResponseTestBase<T extends RESTMessage> {
 
-  private static final JsonFactory FACTORY = new JsonFactory();
-  private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
-
-  @BeforeClass
-  public static void beforeClass() {
-    RESTSerializers.registerAll(MAPPER);
-    // This is a workaround for Jackson since Iceberg doesn't use the standard get/set bean notation.
-    // This allows Jackson to work with the fields directly (both public and private) and not require
-    // custom serializers for all the request/response objects.
-    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
-  }
+  private static final ObjectMapper MAPPER = RESTObjectMapper.mapper();
 
   public static ObjectMapper mapper() {
     return MAPPER;

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -90,7 +90,8 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
     String jsonMisspelledKeys = "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
     AssertHelpers.assertThrows(
         "A JSON request with the keys spelled incorrectly should fail to deserialize and validate",
-        JsonProcessingException.class, "Unrecognized field \"namepsace\"",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
         () -> deserialize(jsonMisspelledKeys)
     );
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -101,7 +101,8 @@ public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateN
     String jsonMisspelledKeys = "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
     AssertHelpers.assertThrows(
         "A JSON response with the keys spelled incorrectly should fail to deserialize and validate",
-        JsonProcessingException.class,
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
         () -> deserialize(jsonMisspelledKeys)
     );
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -88,7 +88,8 @@ public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespa
         "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
     AssertHelpers.assertThrows(
         "A JSON response with the keys spelled incorrectly should fail to deserialize",
-        JsonProcessingException.class,
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
         () -> deserialize(jsonWithKeysSpelledIncorrectly)
     );
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
@@ -67,7 +67,8 @@ public class TestListNamespacesResponse extends RequestResponseTestBase<ListName
         "{\"namepsacezz\":[\"accounting\",\"tax\"]}";
     AssertHelpers.assertThrows(
         "A JSON response with the keys spelled incorrectly should fail to deserialize",
-        JsonProcessingException.class,
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
         () -> deserialize(jsonWithKeysSpelledIncorrectly)
     );
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -64,7 +64,8 @@ public class TestListTablesResponse extends RequestResponseTestBase<ListTablesRe
         "{\"identifyrezzzz\":[{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}]}";
     AssertHelpers.assertThrows(
         "A JSON response with the keys spelled incorrectly should fail to deserialize",
-        JsonProcessingException.class,
+        IllegalArgumentException.class,
+        "Invalid identifier list: null",
         () -> deserialize(jsonWithKeysSpelledIncorrectly));
 
     String jsonWithInvalidIdentifiersInList =

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestRESTCatalogConfigResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestRESTCatalogConfigResponse.java
@@ -156,14 +156,6 @@ public class TestRESTCatalogConfigResponse extends RequestResponseTestBase<Confi
         () -> deserialize(jsonOverridesHasWrongType)
     );
 
-    String jsonMisspelledKeys =
-        "{\"defaultzzzzzzz\":{\"warehouse\":\"s3://bucket/warehouse\"},\"overrrrrrrrides\":{\"clients\":\"5\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON response with the keys spelled incorrectly should fail to deserialize and validate",
-        JsonProcessingException.class,
-        () -> deserialize(jsonMisspelledKeys)
-    );
-
     AssertHelpers.assertThrows(
         "A null JSON response body should fail to deserialize",
         IllegalArgumentException.class,


### PR DESCRIPTION
There is now a global singleton object mapper for the `RESCatalog`, which already has the necessary serializers and deserializers registered.

The rest / response objects are all tested via the `RequestResponseTestBase` class, which currently repeats the object mapper instantiation and initialization logic that the `RESTObjectMapper` is ultimately responsible for.

We should be testing the rest objects using the correct object mapper (which should also reduce allocations during testing and other minor advantages).

cc @rdblue @danielcweeks 