### PR TITLE
Core: Fix Partitions table filtering for evolved partition specs

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -647,7 +647,7 @@ public class TestMetadataTableScans extends TableTestBase {
     // Four original files of original spec, one data file written by new spec
     Assert.assertEquals(5, Iterables.size(tasks));
 
-    // Filter for an older partition spec field.  Correct behavior is that files of old partition specs are returned.
+    // Filter for a dropped partition spec field.  Correct behavior is that only old partitions are returned.
     filter = Expressions.and(
         Expressions.equal("partition.data_bucket", 0),
         Expressions.greaterThan("record_count", 0));
@@ -659,11 +659,12 @@ public class TestMetadataTableScans extends TableTestBase {
       Assert.assertEquals(1, Iterables.size(tasks));
     } else {
       // 1 original data/delete files written by old spec, plus both of new data file/delete file written by new spec
-      // Unlike in V1, V2 does not write null for dropped partition field 'data' on newer files' partition data,
-      // so these cannot be filtered out early in scan planning here.
       //
-      // However, these metadata rows are filtered out later in Spark data filtering, as the newer partition rows
-      // will have 'data' field added as null as part of normalization to the Partitions table final schema.
+      // Unlike in V1, V2 does not write (data=null) on newer files' partition data, so these cannot be filtered out
+      // early in scan planning here.
+      //
+      // However, these partition rows are filtered out later in Spark data filtering, as the newer partitions
+      // will have 'data=null' field added as part of normalization to the Partitions table final schema.
       // The Partitions table final schema is a union of fields of all specs, including dropped fields.
       Assert.assertEquals(3, Iterables.size(tasks));
     }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -557,8 +557,8 @@ public class TestMetadataTableScans extends TableTestBase {
 
     // Change spec and add two data files
     table.updateSpec()
-            .addField("id")
-            .commit();
+        .addField("id")
+        .commit();
     PartitionSpec newSpec = table.spec();
 
     // Add two data files with new spec
@@ -566,28 +566,28 @@ public class TestMetadataTableScans extends TableTestBase {
     data10Key.set(0, 0); // data=0
     data10Key.set(1, 10); // id=10
     DataFile data10 = DataFiles.builder(newSpec)
-            .withPath("/path/to/data-10.parquet")
-            .withRecordCount(10)
-            .withFileSizeInBytes(10)
-            .withPartition(data10Key)
-            .build();
+        .withPath("/path/to/data-10.parquet")
+        .withRecordCount(10)
+        .withFileSizeInBytes(10)
+        .withPartition(data10Key)
+        .build();
     PartitionKey data11Key = new PartitionKey(newSpec, table.schema());
     data11Key.set(0, 1); // data=0
     data10Key.set(1, 11); // id=11
     DataFile data11 = DataFiles.builder(newSpec)
-            .withPath("/path/to/data-11.parquet")
-            .withRecordCount(10)
-            .withFileSizeInBytes(10)
-            .withPartition(data11Key)
-            .build();
+        .withPath("/path/to/data-11.parquet")
+        .withRecordCount(10)
+        .withFileSizeInBytes(10)
+        .withPartition(data11Key)
+        .build();
 
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
     Table metadataTable = new PartitionsTable(table.ops(), table);
     Expression filter = Expressions.and(
-            Expressions.equal("partition.id", 10),
-            Expressions.greaterThan("record_count", 0));
+        Expressions.equal("partition.id", 10),
+        Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
     CloseableIterable<FileScanTask> tasks = PartitionsTable.planFiles((StaticTableScan) scan);
 
@@ -595,8 +595,8 @@ public class TestMetadataTableScans extends TableTestBase {
     Assert.assertEquals(5, Iterables.size(tasks));
 
     filter = Expressions.and(
-            Expressions.equal("partition.data_bucket", 0),
-            Expressions.greaterThan("record_count", 0));
+        Expressions.equal("partition.data_bucket", 0),
+        Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = PartitionsTable.planFiles((StaticTableScan) scan);
 
@@ -611,51 +611,49 @@ public class TestMetadataTableScans extends TableTestBase {
 
     // Change spec and add two data and delete files each
     table.updateSpec()
-            .addField("id")
-            .commit();
+        .addField("id")
+        .commit();
     PartitionSpec newSpec = table.spec();
 
     // Add two data files and two delete files with new spec
     DataFile data10 = DataFiles.builder(newSpec)
-            .withPath("/path/to/data-10.parquet")
-            .withRecordCount(10)
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0/id=10")
-            .build();
+        .withPath("/path/to/data-10.parquet")
+        .withRecordCount(10)
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0/id=10")
+        .build();
     DataFile data11 = DataFiles.builder(newSpec)
-            .withPath("/path/to/data-11.parquet")
-            .withRecordCount(10)
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=1/id=11")
-            .build();
+        .withPath("/path/to/data-11.parquet")
+        .withRecordCount(10)
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=1/id=11")
+        .build();
 
     DeleteFile delete10 = FileMetadata.deleteFileBuilder(newSpec)
-            .ofPositionDeletes()
-            .withPath("/path/to/data-10-deletes.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0/id=10")
-            .withRecordCount(1)
-            .build();
+        .ofPositionDeletes()
+        .withPath("/path/to/data-10-deletes.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0/id=10")
+        .withRecordCount(1)
+        .build();
     DeleteFile delete11 = FileMetadata.deleteFileBuilder(newSpec)
-            .ofPositionDeletes()
-            .withPath("/path/to/data-11-deletes.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=1/id=11")
-            .withRecordCount(1)
-            .build();
+        .ofPositionDeletes()
+        .withPath("/path/to/data-11-deletes.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=1/id=11")
+        .withRecordCount(1)
+        .build();
 
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
-    if (formatVersion == 2) {
-      table.newRowDelta().addDeletes(delete10).commit();
-      table.newRowDelta().addDeletes(delete11).commit();
-    }
+    table.newRowDelta().addDeletes(delete10).commit();
+    table.newRowDelta().addDeletes(delete11).commit();
 
     Table metadataTable = new PartitionsTable(table.ops(), table);
     Expression filter = Expressions.and(
-            Expressions.equal("partition.id", 10),
-            Expressions.greaterThan("record_count", 0));
+        Expressions.equal("partition.id", 10),
+        Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
     CloseableIterable<FileScanTask> tasks = PartitionsTable.planFiles((StaticTableScan) scan);
 
@@ -663,8 +661,8 @@ public class TestMetadataTableScans extends TableTestBase {
     Assert.assertEquals(5, Iterables.size(tasks));
 
     filter = Expressions.and(
-            Expressions.equal("partition.data_bucket", 0),
-            Expressions.greaterThan("record_count", 0));
+        Expressions.equal("partition.data_bucket", 0),
+        Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = PartitionsTable.planFiles((StaticTableScan) scan);
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -382,8 +382,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
   }
   @Test
   public void testPartitionsTableAddRemoveFields() throws ParseException {
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg ", tableName);
     initTable();
     sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
     sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
@@ -447,8 +446,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
   @Test
   public void testPartitionsTableRenameFields() throws ParseException {
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -549,8 +547,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
   @Test
   public void testPartitionTableFilterAddRemoveFields() throws ParseException {
     // Create un-partitioned table
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
 
     sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
@@ -668,8 +665,7 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
   @Test
   public void testPartitionsTableFilterRenameFields() throws ParseException {
-    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
-        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
 
     Table table = validationCatalog.loadTable(tableIdent);


### PR DESCRIPTION
The Partitions metadata table filter pushdown logic is always using the current table's partition spec and not the original spec of the manifest file.  This would lead to errors if the table has data written to via different partition specs and a filter is applied to partitions table, like

```
Cannot find field 'data' in struct: struct<>
org.apache.iceberg.exceptions.ValidationException: Cannot find field 'data' in struct: struct<>
	at app//org.apache.iceberg.exceptions.ValidationException.check(ValidationException.java:50)
	at app//org.apache.iceberg.expressions.NamedReference.bind(NamedReference.java:46)
	at app//org.apache.iceberg.expressions.NamedReference.bind(NamedReference.java:27)
	at app//org.apache.iceberg.expressions.UnboundPredicate.bind(UnboundPredicate.java:106)
	at app//org.apache.iceberg.expressions.Binder$BindVisitor.predicate(Binder.java:145)
	at app//org.apache.iceberg.expressions.Binder$BindVisitor.predicate(Binder.java:104)
	at app//org.apache.iceberg.expressions.ExpressionVisitors.visit(ExpressionVisitors.java:330)
	at app//org.apache.iceberg.expressions.Binder.bind(Binder.java:62)
	at app//org.apache.iceberg.expressions.ManifestEvaluator.<init>(ManifestEvaluator.java:68)
	at app//org.apache.iceberg.expressions.ManifestEvaluator.forPartitionFilter(ManifestEvaluator.java:63)
	at app//org.apache.iceberg.ManifestGroup.lambda$entries$9(ManifestGroup.java:209)
	at app//com.github.benmanes.caffeine.cache.LocalLoadingCache.lambda$newMappingFunction$2(LocalLoadingCache.java:141)
	at app//com.github.benmanes.caffeine.cache.UnboundedLocalCache.lambda$computeIfAbsent$2(UnboundedLocalCache.java:238)
	at java.base@11.0.14/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at app//com.github.benmanes.caffeine.cache.UnboundedLocalCache.computeIfAbsent(UnboundedLocalCache.java:234)
	at app//com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108)
	at app//com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:54)
	at app//org.apache.iceberg.ManifestGroup.lambda$entries$10(ManifestGroup.java:222)
	at app//org.apache.iceberg.relocated.com.google.common.collect.Iterators$5.computeNext(Iterators.java:670)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:141)
	at app//org.apache.iceberg.relocated.com.google.common.collect.Iterators$5.computeNext(Iterators.java:668)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:141)
	at app//org.apache.iceberg.relocated.com.google.common.collect.Iterators$5.computeNext(Iterators.java:668)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146)
	at app//org.apache.iceberg.relocated.com.google.common.collect.AbstractIterator.hasNext(AbstractIterator.java:141)
	at app//org.apache.iceberg.relocated.com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
	at app//org.apache.iceberg.relocated.com.google.common.collect.TransformedIterator.hasNext(TransformedIterator.java:46)
	at app//org.apache.iceberg.util.ParallelIterable$ParallelIterator.submitNextTask(ParallelIterable.java:130)
	at app//org.apache.iceberg.util.ParallelIterable$ParallelIterator.checkTasks(ParallelIterable.java:118)
	at app//org.apache.iceberg.util.ParallelIterable$ParallelIterator.hasNext(ParallelIterable.java:155)
	at app//org.apache.iceberg.PartitionsTable.partitions(PartitionsTable.java:106)
	at app//org.apache.iceberg.PartitionsTable.task(PartitionsTable.java:77)
	at app//org.apache.iceberg.PartitionsTable.access$400(PartitionsTable.java:36)
	at app//org.apache.iceberg.PartitionsTable$PartitionsScan.lambda$new$0(PartitionsTable.java:187)
	at app//org.apache.iceberg.StaticTableScan.doPlanFiles(StaticTableScan.java:47)
	at app//org.apache.iceberg.BaseTableScan.planFiles(BaseTableScan.java:195)
	at app//org.apache.iceberg.spark.source.SparkBatchQueryScan.files(SparkBatchQueryScan.java:114)
	at app//org.apache.iceberg.spark.source.SparkBatchQueryScan.tasks(SparkBatchQueryScan.java:128)
	at app//org.apache.iceberg.spark.source.SparkScan.toBatch(SparkScan.java:108)
```

This pr fixes this issue by making a cache of specs to ManifestEvaluators, and using it in the filtering.  This fix is similar to https://github.com/apache/iceberg/pull/4520.