### PR TITLE
Core - Add serde for TableMetadata for REST catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -155,7 +155,7 @@ public class TableMetadataParser {
     }
   }
 
-  private static void toJson(TableMetadata metadata, JsonGenerator generator) throws IOException {
+  public static void toJson(TableMetadata metadata, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
 
     generator.writeNumberField(FORMAT_VERSION, metadata.formatVersion());
@@ -299,6 +299,10 @@ public class TableMetadataParser {
 
   static TableMetadata fromJson(FileIO io, InputFile file, JsonNode node) {
     return fromJson(io, file.location(), node);
+  }
+
+  public static TableMetadata fromJson(JsonNode node) {
+    return fromJson(null, (String) null, node);
   }
 
   @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -35,6 +35,8 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.UnboundPartitionSpec;
 import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
@@ -65,8 +67,26 @@ public class RESTSerializers {
         .addSerializer(UnboundSortOrder.class, new UnboundSortOrderSerializer())
         .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer())
         .addSerializer(MetadataUpdate.class, new MetadataUpdateSerializer())
-        .addDeserializer(MetadataUpdate.class, new MetadataUpdateDeserializer());
+        .addDeserializer(MetadataUpdate.class, new MetadataUpdateDeserializer())
+        .addSerializer(TableMetadata.class, new TableMetadataSerializer())
+        .addDeserializer(TableMetadata.class, new TableMetadataDeserializer());
     mapper.registerModule(module);
+  }
+
+  public static class TableMetadataDeserializer extends JsonDeserializer<TableMetadata> {
+    @Override
+    public TableMetadata deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode node = p.getCodec().readTree(p);
+      return TableMetadataParser.fromJson(node);
+    }
+  }
+
+  public static class TableMetadataSerializer extends JsonSerializer<TableMetadata> {
+    @Override
+    public void serialize(TableMetadata metadata, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      TableMetadataParser.toJson(metadata, gen);
+    }
   }
 
   public static class MetadataUpdateDeserializer extends JsonDeserializer<MetadataUpdate> {


### PR DESCRIPTION
The REST catalog sends and receives `TableMetadata` objects as JSON.

There is an existing parser for `TableMetadata` that can convert metadata into JSON and also can parse JSON into `TableMetadata`.

Adds Jackson serializers to the `RESTSerializers` so that accessing tables via the REST catalog works.

There are existing tests for `TableMetadataParser`, and I intend to add further tests in a follow up PR around `LoadTableResponse`. This PR is intended so allow people to continue implementing REST catalogs and be able to work with TableMetadata, but more extensive coverage will come in a follow up.