### PR TITLE
Core - Fix field name bug in LoadTableResponse object to match REST spec and properly deserialize

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -33,16 +33,16 @@ import org.apache.iceberg.rest.RESTResponse;
 public class LoadTableResponse implements RESTResponse {
 
   private String metadataLocation;
-  private TableMetadata meta;
+  private TableMetadata metadata;
   private Map<String, String> config;
 
   public LoadTableResponse() {
     // Required for Jackson deserialization
   }
 
-  private LoadTableResponse(String metadataLocation, TableMetadata meta, Map<String, String> config) {
+  private LoadTableResponse(String metadataLocation, TableMetadata metadata, Map<String, String> config) {
     this.metadataLocation = metadataLocation;
-    this.meta = meta;
+    this.metadata = metadata;
     this.config = config;
   }
 
@@ -55,7 +55,7 @@ public class LoadTableResponse implements RESTResponse {
   }
 
   public TableMetadata tableMetadata() {
-    return TableMetadata.buildFrom(meta).withMetadataLocation(metadataLocation).build();
+    return TableMetadata.buildFrom(metadata).withMetadataLocation(metadataLocation).build();
   }
 
   public Map<String, String> config() {
@@ -65,7 +65,8 @@ public class LoadTableResponse implements RESTResponse {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("metadata", meta)
+        .add("metadataLocation", metadataLocation)
+        .add("metadata", metadata)
         .add("config", config)
         .toString();
   }
@@ -76,15 +77,15 @@ public class LoadTableResponse implements RESTResponse {
 
   public static class Builder {
     private String metadataLocation;
-    private TableMetadata meta;
+    private TableMetadata metadata;
     private Map<String, String> config = Maps.newHashMap();
 
     private Builder() {
     }
 
-    public Builder withTableMetadata(TableMetadata metadata) {
-      this.metadataLocation = metadata.metadataFileLocation();
-      this.meta = metadata;
+    public Builder withTableMetadata(TableMetadata tableMetadata) {
+      this.metadataLocation = tableMetadata.metadataFileLocation();
+      this.metadata = tableMetadata;
       return this;
     }
 
@@ -99,8 +100,8 @@ public class LoadTableResponse implements RESTResponse {
     }
 
     public LoadTableResponse build() {
-      Preconditions.checkNotNull(meta, "Invalid metadata: null");
-      return new LoadTableResponse(metadataLocation, meta, config);
+      Preconditions.checkNotNull(metadata, "Invalid metadata: null");
+      return new LoadTableResponse(metadataLocation, metadata, config);
     }
   }
 }


### PR DESCRIPTION
The `LoadTableResponse` class has a `TableMetadata` field called `metadata`.

It's currently called `meta`. Using Jackson to infer the fields will result in incorrect results because the name is not correct / does not match the spec.

I am updating this as a hot fix, and am working on a comprehensive test suite for this class that I'll open after a few other earlier PRs come in. But this will make the REST objects match the spec now, so that anybody implementing it can work with the correct objects.

cc @rdblue @danielcweeks 