### PR TITLE
Infra - Remove Szehon from collaborators list in asf.yaml as they are now a committer

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,7 +38,6 @@ github:
     - marton-bod
     - nastra
     - samarthjain
-    - szehon-ho
     - findepi
     - SreeramGarlapati
     - samredai


### PR DESCRIPTION
Noticed that @szehon-ho is listed in the ASF collaborators file.

Given that Szehon has become a committer, I don't believe it's necessary to have this entry in the asf.yaml file.

cc @RussellSpitzer @szehon-ho @aokolnychyi @rdblue 