### PR TITLE
Docs: To set table comment using `SET TBLPROPERTIES`

### DIFF
--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -171,6 +171,14 @@ Iceberg uses table properties to control table behavior. For a list of available
 ALTER TABLE prod.db.sample UNSET TBLPROPERTIES ('read.split.target-size')
 ```
 
+`SET TABLE COMMENT` Using SET TBLPROPERTIES
+
+```sql
+ALTER TABLE prod.db.sample SET TBLPROPERTIES (
+    'comment' = 'A table comment.'
+)
+```
+
 ### `ALTER TABLE ... ADD COLUMN`
 
 To add a column to Iceberg, use the `ADD COLUMNS` clause with `ALTER TABLE`:

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -171,7 +171,7 @@ Iceberg uses table properties to control table behavior. For a list of available
 ALTER TABLE prod.db.sample UNSET TBLPROPERTIES ('read.split.target-size')
 ```
 
-Set table comment using SET PROPERTIES:
+To set table comment using `SET TBLPROPERTIES`:
 
 ```sql
 ALTER TABLE prod.db.sample SET TBLPROPERTIES (

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -171,7 +171,7 @@ Iceberg uses table properties to control table behavior. For a list of available
 ALTER TABLE prod.db.sample UNSET TBLPROPERTIES ('read.split.target-size')
 ```
 
-`SET TABLE COMMENT` Using SET TBLPROPERTIES
+Set table comment using SET TBLPROPERTIES:
 
 ```sql
 ALTER TABLE prod.db.sample SET TBLPROPERTIES (

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -171,7 +171,7 @@ Iceberg uses table properties to control table behavior. For a list of available
 ALTER TABLE prod.db.sample UNSET TBLPROPERTIES ('read.split.target-size')
 ```
 
-Set table comment using SET TBLPROPERTIES:
+Set table comment using SET PROPERTIES:
 
 ```sql
 ALTER TABLE prod.db.sample SET TBLPROPERTIES (

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -171,7 +171,7 @@ Iceberg uses table properties to control table behavior. For a list of available
 ALTER TABLE prod.db.sample UNSET TBLPROPERTIES ('read.split.target-size')
 ```
 
-To set table comment using `SET TBLPROPERTIES`:
+`SET TBLPROPERTIES` can also be used to set the table comment (description):
 
 ```sql
 ALTER TABLE prod.db.sample SET TBLPROPERTIES (


### PR DESCRIPTION
This PR is close #4615

the syntax of spark sql

```
ALTER TABLE prod.db.sample SET TBLPROPERTIES (
    'comment' = 'A table comment.'
)
```