### PR TITLE
Solution for InterpreterNotFound errors from tox

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -35,8 +35,21 @@ pip install -e .
 Testing is done using tox. The config can be found in `tox.ini` within the python directory of the iceberg project.
 
 ```
-# simply run tox within the python dir
 tox
+```
+
+## Solution for `InterpreterNotFound` Errors
+
+Currently, tests run against python `3.7.12`, `3.8.12`, and `3.9.10`. It's recommended to install and manage multiple interpreters using [pyenv](https://github.com/pyenv/pyenv).
+```
+pyenv install 3.7.12
+pyenv install 3.8.12
+pyenv install 3.9.10
+```
+
+Once all three versions are installed, you can set an application-specific pyenv environment by running the following in the python directory.
+```
+pyenv local 3.7.12 3.8.12 3.9.10
 ```
 
 ## Get in Touch


### PR DESCRIPTION
It's expected that developers won't conveniently have python 3.7, 3.8 and 3.9 installed for tox to use for tests so I've added a recommendation to use pyenv to the python README. This is what I do locally and it works nicely. The content here is definitely more for the CONTRIBUTING.md file but I think it's ok here in the readme during the refactoring.

If anyone else feels there's a better local setup to recommend, let me know!