### PR TITLE
Core - Rename test class for ConfigResponse to match updated name.

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestConfigResponse.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class TestRESTCatalogConfigResponse extends RequestResponseTestBase<ConfigResponse> {
+public class TestConfigResponse extends RequestResponseTestBase<ConfigResponse> {
 
   private static final Map<String, String> DEFAULTS = ImmutableMap.of("warehouse", "s3://bucket/warehouse");
   private static final Map<String, String> OVERRIDES = ImmutableMap.of("clients", "5");


### PR DESCRIPTION
The class previously called `RESTCatalogConfigResponse` was renamed to `ConfigResponse` in https://github.com/apache/iceberg/pull/4554

However, the corresponding test class was not renamed.