### PR TITLE
Core: Make snapshot summary return default values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -185,9 +185,9 @@ public class SnapshotSummary {
       builder.putAll(properties);
 
       metrics.addTo(builder);
-      setIf(deletedDuplicateFiles > 0, builder, DELETED_DUPLICATE_FILES, deletedDuplicateFiles);
+      builder.put(DELETED_DUPLICATE_FILES, String.valueOf(deletedDuplicateFiles));
       Set<String> changedPartitions = partitionMetrics.keySet();
-      setIf(trustPartitionMetrics, builder, CHANGED_PARTITION_COUNT_PROP, changedPartitions.size());
+      builder.put(CHANGED_PARTITION_COUNT_PROP, String.valueOf(changedPartitions.size()));
 
       if (trustPartitionMetrics && changedPartitions.size() <= maxChangedPartitionsForSummaries) {
         setIf(changedPartitions.size() > 0, builder, PARTITION_SUMMARY_PROP, "true");
@@ -246,24 +246,24 @@ public class SnapshotSummary {
     }
 
     void addTo(ImmutableMap.Builder<String, String> builder) {
-      setIf(addedFiles > 0, builder, ADDED_FILES_PROP, addedFiles);
-      setIf(removedFiles > 0, builder, DELETED_FILES_PROP, removedFiles);
-      setIf(addedEqDeleteFiles > 0, builder, ADD_EQ_DELETE_FILES_PROP, addedEqDeleteFiles);
-      setIf(removedEqDeleteFiles > 0, builder, REMOVED_EQ_DELETE_FILES_PROP, removedEqDeleteFiles);
-      setIf(addedPosDeleteFiles > 0, builder, ADD_POS_DELETE_FILES_PROP, addedPosDeleteFiles);
-      setIf(removedPosDeleteFiles > 0, builder, REMOVED_POS_DELETE_FILES_PROP, removedPosDeleteFiles);
-      setIf(addedDeleteFiles > 0, builder, ADDED_DELETE_FILES_PROP, addedDeleteFiles);
-      setIf(removedDeleteFiles > 0, builder, REMOVED_DELETE_FILES_PROP, removedDeleteFiles);
-      setIf(addedRecords > 0, builder, ADDED_RECORDS_PROP, addedRecords);
-      setIf(deletedRecords > 0, builder, DELETED_RECORDS_PROP, deletedRecords);
+      builder.put(ADDED_FILES_PROP, String.valueOf(addedFiles));
+      builder.put(DELETED_FILES_PROP, String.valueOf(removedFiles));
+      builder.put(ADD_EQ_DELETE_FILES_PROP, String.valueOf(addedEqDeleteFiles));
+      builder.put(REMOVED_EQ_DELETE_FILES_PROP, String.valueOf(removedEqDeleteFiles));
+      builder.put(ADD_POS_DELETE_FILES_PROP, String.valueOf(addedPosDeleteFiles));
+      builder.put(REMOVED_POS_DELETE_FILES_PROP, String.valueOf(removedPosDeleteFiles));
+      builder.put(ADDED_DELETE_FILES_PROP, String.valueOf(addedDeleteFiles));
+      builder.put(REMOVED_DELETE_FILES_PROP, String.valueOf(removedDeleteFiles));
+      builder.put(ADDED_RECORDS_PROP, String.valueOf(addedRecords));
+      builder.put(DELETED_RECORDS_PROP, String.valueOf(deletedRecords));
 
       if (trustSizeAndDeleteCounts) {
-        setIf(addedSize > 0, builder, ADDED_FILE_SIZE_PROP, addedSize);
-        setIf(removedSize > 0, builder, REMOVED_FILE_SIZE_PROP, removedSize);
-        setIf(addedPosDeletes > 0, builder, ADDED_POS_DELETES_PROP, addedPosDeletes);
-        setIf(removedPosDeletes > 0, builder, REMOVED_POS_DELETES_PROP, removedPosDeletes);
-        setIf(addedEqDeletes > 0, builder, ADDED_EQ_DELETES_PROP, addedEqDeletes);
-        setIf(removedEqDeletes > 0, builder, REMOVED_EQ_DELETES_PROP, removedEqDeletes);
+        builder.put(ADDED_FILE_SIZE_PROP, String.valueOf(addedSize));
+        builder.put(REMOVED_FILE_SIZE_PROP, String.valueOf(removedSize));
+        builder.put(ADDED_POS_DELETES_PROP, String.valueOf(addedPosDeletes));
+        builder.put(REMOVED_POS_DELETES_PROP, String.valueOf(removedPosDeletes));
+        builder.put(ADDED_EQ_DELETES_PROP, String.valueOf(addedEqDeletes));
+        builder.put(REMOVED_EQ_DELETES_PROP, String.valueOf(removedEqDeletes));
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -452,7 +452,10 @@ public class TestFastAppend extends TableTestBase {
     String partitionSummary = table.currentSnapshot().summary()
         .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
     Assert.assertEquals("Summary should include 1 file with 1 record that is 10 bytes",
-        "added-data-files=1,added-records=1,added-files-size=10", partitionSummary);
+        "added-data-files=1,deleted-data-files=0,added-eq-delete-files=0,removed-eq-delete-files=0," +
+            "added-pos-delete-files=0,removed-pos-delete-files=0,added-delete-files=0,removed-delete-files=0," +
+            "added-records=1,deleted-records=0,added-files-size=10,removed-files-size=0,added-position-deletes=0," +
+            "removed-position-deletes=0,added-equality-deletes=0,removed-equality-deletes=0", partitionSummary);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -1247,7 +1247,10 @@ public class TestMergeAppend extends TableTestBase {
     String partitionSummary = table.currentSnapshot().summary()
         .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
     Assert.assertEquals("Summary should include 1 file with 1 record that is 10 bytes",
-        "added-data-files=1,added-records=1,added-files-size=10", partitionSummary);
+        "added-data-files=1,deleted-data-files=0,added-eq-delete-files=0,removed-eq-delete-files=0," +
+            "added-pos-delete-files=0,removed-pos-delete-files=0,added-delete-files=0,removed-delete-files=0," +
+            "added-records=1,deleted-records=0,added-files-size=10,removed-files-size=0,added-position-deletes=0," +
+            "removed-position-deletes=0,added-equality-deletes=0,removed-equality-deletes=0", partitionSummary);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -46,7 +46,7 @@ public class TestSnapshotSummary extends TableTestBase {
         .commit();
     Map<String, String> summary = table.currentSnapshot().summary();
     Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("0", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
     Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
 
     // merge append
@@ -55,7 +55,7 @@ public class TestSnapshotSummary extends TableTestBase {
         .commit();
     summary = table.currentSnapshot().summary();
     Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
-    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("0", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
     Assert.assertEquals("20", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
 
     table.newOverwrite()
@@ -75,7 +75,7 @@ public class TestSnapshotSummary extends TableTestBase {
         .deleteFile(FILE_D)
         .commit();
     summary = table.currentSnapshot().summary();
-    Assert.assertNull(summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertEquals("0", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
     Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
     Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
   }

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -153,7 +153,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "0", null, null);
+    validateSnapshot(currentSnapshot, "overwrite", "0", "0", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(2, "hardware"), row(null, "hr")),
@@ -175,7 +175,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "2", "3", null);
+    validateSnapshot(currentSnapshot, "delete", "2", "3", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(),
@@ -197,7 +197,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "2", "2", null);
+    validateSnapshot(currentSnapshot, "delete", "2", "2", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "dep1")),
@@ -220,7 +220,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be an overwrite since cannot be executed using a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "1", "1", null);
+    validateSnapshot(currentSnapshot, "overwrite", "1", "1", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(null, "hr")),
@@ -301,7 +301,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "1", "1", null);
+    validateSnapshot(currentSnapshot, "delete", "1", "1", "0");
   }
 
   @Test

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -191,7 +191,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "0", null, null);
+    validateSnapshot(currentSnapshot, "overwrite", "0", "0", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(2, "hardware"), row(null, "hr")),

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -153,7 +153,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "0", null, null);
+    validateSnapshot(currentSnapshot, "overwrite", "0", "0", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(2, "hardware"), row(null, "hr")),
@@ -175,7 +175,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "2", "3", null);
+    validateSnapshot(currentSnapshot, "delete", "2", "3", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(),
@@ -197,7 +197,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be a delete instead of an overwrite as it is done through a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "2", "2", null);
+    validateSnapshot(currentSnapshot, "delete", "2", "2", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "dep1")),
@@ -220,7 +220,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // should be an overwrite since cannot be executed using a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "1", "1", null);
+    validateSnapshot(currentSnapshot, "overwrite", "1", "1", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(null, "hr")),
@@ -301,7 +301,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "delete", "1", "1", null);
+    validateSnapshot(currentSnapshot, "delete", "1", "1", "0");
   }
 
   @Test

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -191,7 +191,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Assert.assertEquals("Should have 2 snapshots", 2, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateSnapshot(currentSnapshot, "overwrite", "0", null, null);
+    validateSnapshot(currentSnapshot, "overwrite", "0", "0", "0");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(1, "hr"), row(2, "hardware"), row(null, "hr")),

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -199,17 +199,17 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
   }
 
   protected void validateDelete(Snapshot snapshot, String changedPartitionCount, String deletedDataFiles) {
-    validateSnapshot(snapshot, DELETE, changedPartitionCount, deletedDataFiles, null, null);
+    validateSnapshot(snapshot, DELETE, changedPartitionCount, deletedDataFiles, "0", "0");
   }
 
   protected void validateCopyOnWrite(Snapshot snapshot, String changedPartitionCount,
                                      String deletedDataFiles, String addedDataFiles) {
-    validateSnapshot(snapshot, OVERWRITE, changedPartitionCount, deletedDataFiles, null, addedDataFiles);
+    validateSnapshot(snapshot, OVERWRITE, changedPartitionCount, deletedDataFiles, "0", addedDataFiles);
   }
 
   protected void validateMergeOnRead(Snapshot snapshot, String changedPartitionCount,
                                      String addedDeleteFiles, String addedDataFiles) {
-    validateSnapshot(snapshot, OVERWRITE, changedPartitionCount, null, addedDeleteFiles, addedDataFiles);
+    validateSnapshot(snapshot, OVERWRITE, changedPartitionCount, "0", addedDeleteFiles, addedDataFiles);
   }
 
   protected void validateSnapshot(Snapshot snapshot, String operation, String changedPartitionCount,

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -186,7 +186,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     if (mode(table) == COPY_ON_WRITE) {
       validateCopyOnWrite(currentSnapshot, "1", "1", "1");
     } else {
-      validateMergeOnRead(currentSnapshot, "1", "1", null);
+      validateMergeOnRead(currentSnapshot, "1", "1", "0");
     }
 
     assertEquals("Should have expected rows",
@@ -208,12 +208,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Snapshot currentSnapshot = table.currentSnapshot();
 
     if (fileFormat.equals("orc") || fileFormat.equals("parquet")) {
-      validateDelete(currentSnapshot, "0", null);
+      validateDelete(currentSnapshot, "0", "0");
     } else {
       if (mode(table) == COPY_ON_WRITE) {
-        validateCopyOnWrite(currentSnapshot, "0", null, null);
+        validateCopyOnWrite(currentSnapshot, "0", "0", "0");
       } else {
-        validateMergeOnRead(currentSnapshot, "0", null, null);
+        validateMergeOnRead(currentSnapshot, "0", "0", "0");
       }
     }
 
@@ -283,9 +283,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     // should be an overwrite since cannot be executed using a metadata operation
     Snapshot currentSnapshot = table.currentSnapshot();
     if (mode(table) == COPY_ON_WRITE) {
-      validateCopyOnWrite(currentSnapshot, "1", "1", null);
+      validateCopyOnWrite(currentSnapshot, "1", "1", "0");
     } else {
-      validateMergeOnRead(currentSnapshot, "1", "1", null);
+      validateMergeOnRead(currentSnapshot, "1", "1", "0");
     }
 
     assertEquals("Should have expected rows",
@@ -794,7 +794,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     if (mode(table) == COPY_ON_WRITE) {
       validateCopyOnWrite(currentSnapshot, "2", "2", "2");
     } else {
-      validateMergeOnRead(currentSnapshot, "2", "2", null);
+      validateMergeOnRead(currentSnapshot, "2", "2", "0");
     }
     assertEquals("Should have expected rows",
         ImmutableList.of(row(2, "hardware"), row(3, "hr")),
@@ -838,7 +838,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
       // that's why the number of changed partitions is 4 for copy-on-write
       validateCopyOnWrite(currentSnapshot, "4", "4", "1");
     } else {
-      validateMergeOnRead(currentSnapshot, "3", "3", null);
+      validateMergeOnRead(currentSnapshot, "3", "3", "0");
     }
 
     assertEquals("Should have expected rows",

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -207,9 +207,9 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     Snapshot currentSnapshot = table.currentSnapshot();
     if (mode(table) == COPY_ON_WRITE) {
-      validateCopyOnWrite(currentSnapshot, "0", null, null);
+      validateCopyOnWrite(currentSnapshot, "0", "0", "0");
     } else {
-      validateMergeOnRead(currentSnapshot, "0", null, null);
+      validateMergeOnRead(currentSnapshot, "0", "0", "0");
     }
 
     assertEquals("Should have expected rows",


### PR DESCRIPTION
Fixes: https://github.com/apache/iceberg/pull/4660

Currently snapshot summary, which is a map, contains values only if they were affected by changes in that snapshot.
It'd be good to return default values, like 0s, for most of the fields. 
This is needed in trino in order to  reliably provide number of deleted rows to the user, also when delete happens to delete no files.