### PR TITLE
Core: Metadata table queries fail if a partition column was reused in V2

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -106,8 +106,8 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   /**
    * Calculates a field ID to the newly added PartitionField.
    * New field ID is assigned in every case for V1 tables, but for V2 we try to recycle a former ID if possible.
-   * @param sourceTransform - pair of source ID and transform for this PartitionField addition
-   * @return - the calculated field ID
+   * @param sourceTransform pair of source ID and transform for this PartitionField addition
+   * @return the calculated field ID
    */
   private int assignFieldId(Pair<Integer, Transform<?, ?>> sourceTransform) {
     if (formatVersion == 2 && base != null) {
@@ -115,8 +115,8 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
       Transform<?, ?> transform = sourceTransform.second();
 
       Set<PartitionField> allHistoricalFields = Sets.newHashSet();
-      for (PartitionSpec partitionSpecpec : base.specs()) {
-        allHistoricalFields.addAll(partitionSpecpec.fields());
+      for (PartitionSpec partitionSpec : base.specs()) {
+        allHistoricalFields.addAll(partitionSpec.fields());
       }
 
       for (PartitionField field : allHistoricalFields) {

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -110,7 +110,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
    * @return - the calculated field ID
    */
   private int assignFieldId(Pair<Integer, Transform<?, ?>> sourceTransform) {
-    if (formatVersion == 2) {
+    if (formatVersion == 2 && base != null) {
       int sourceId = sourceTransform.first();
       Transform<?, ?> transform = sourceTransform.second();
 

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -228,9 +228,14 @@ public class Partitioning {
         PartitionField existingField = fieldMap.get(fieldId);
 
         if (existingField == null) {
+          String fieldName = structField.name();
+          if (nameMap.containsValue(fieldName)) {
+            fieldName += "_" + fieldId;
+          }
+
           fieldMap.put(fieldId, field);
           typeMap.put(fieldId, structField.type());
-          nameMap.put(fieldId, structField.name());
+          nameMap.put(fieldId, fieldName);
 
         } else {
           // verify the fields are compatible as they may conflict in v1 tables

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -228,14 +228,9 @@ public class Partitioning {
         PartitionField existingField = fieldMap.get(fieldId);
 
         if (existingField == null) {
-          String fieldName = structField.name();
-          if (nameMap.containsValue(fieldName)) {
-            fieldName += "_" + fieldId;
-          }
-
           fieldMap.put(fieldId, field);
           typeMap.put(fieldId, structField.type());
-          nameMap.put(fieldId, fieldName);
+          nameMap.put(fieldId, structField.name());
 
         } else {
           // verify the fields are compatible as they may conflict in v1 tables

--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
@@ -28,6 +29,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -132,5 +134,64 @@ public abstract class ScanTestBase<T extends Scan<T>> extends TableTestBase {
         }));
     Assert.assertEquals(2, Iterables.size(scan.planFiles()));
     Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
+  }
+
+  @Test
+  public void testReaddingPartitionField() throws Exception {
+    Assume.assumeTrue(formatVersion == 2);
+    Schema schema = new Schema(
+        required(1, "a", Types.IntegerType.get()),
+        required(2, "b", Types.StringType.get()),
+        required(3, "data", Types.IntegerType.get())
+    );
+    PartitionSpec spec_a = PartitionSpec.builderFor(schema).identity("a").build();
+    File dir = temp.newFolder();
+    dir.delete();
+    this.table = TestTables.create(dir, "test_part_evolution", schema, spec_a, formatVersion);
+    table.newFastAppend().appendFile(DataFiles.builder(spec_a)
+        .withPath("/path/to/data/a.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("a=1")
+        .withRecordCount(1)
+        .build()).commit();
+
+    table.updateSpec().addField("b").removeField("a").commit();
+    table.newFastAppend().appendFile(DataFiles.builder(table.spec())
+        .withPath("/path/to/data/b.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("b=1")
+        .withRecordCount(1)
+        .build()).commit();
+
+    table.updateSpec().addField("a").commit();
+    table.newFastAppend().appendFile(DataFiles.builder(table.spec())
+        .withPath("/path/to/data/ab.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("b=1/a=1")
+        .withRecordCount(1)
+        .build()).commit();
+
+    table.newFastAppend().appendFile(DataFiles.builder(table.spec())
+        .withPath("/path/to/data/a2b.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("b=1/a=2")
+        .withRecordCount(1)
+        .build()).commit();
+
+    TableScan scan1 = table.newScan().filter(Expressions.equal("b", "1"));
+    try (CloseableIterable<CombinedScanTask> tasks = scan1.planTasks()) {
+      Assert.assertTrue("There should be 1 combined task", Iterables.size(tasks) == 1);
+      for (CombinedScanTask combinedScanTask : tasks) {
+        Assert.assertEquals("All 4 files should match b=1 filter", 4, combinedScanTask.files().size());
+      }
+    }
+
+    TableScan scan2 = table.newScan().filter(Expressions.equal("a", 2));
+    try (CloseableIterable<CombinedScanTask> tasks = scan2.planTasks()) {
+      Assert.assertTrue("There should be 1 combined task", Iterables.size(tasks) == 1);
+      for (CombinedScanTask combinedScanTask : tasks) {
+        Assert.assertEquals("a=2 and file without a in spec should match", 2, combinedScanTask.files().size());
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -137,18 +137,18 @@ public abstract class ScanTestBase<T extends Scan<T>> extends TableTestBase {
   }
 
   @Test
-  public void testReaddingPartitionField() throws Exception {
+  public void testReAddingPartitionField() throws Exception {
     Assume.assumeTrue(formatVersion == 2);
     Schema schema = new Schema(
         required(1, "a", Types.IntegerType.get()),
         required(2, "b", Types.StringType.get()),
         required(3, "data", Types.IntegerType.get())
     );
-    PartitionSpec spec_a = PartitionSpec.builderFor(schema).identity("a").build();
+    PartitionSpec initialSpec = PartitionSpec.builderFor(schema).identity("a").build();
     File dir = temp.newFolder();
     dir.delete();
-    this.table = TestTables.create(dir, "test_part_evolution", schema, spec_a, formatVersion);
-    table.newFastAppend().appendFile(DataFiles.builder(spec_a)
+    this.table = TestTables.create(dir, "test_part_evolution", schema, initialSpec, formatVersion);
+    table.newFastAppend().appendFile(DataFiles.builder(initialSpec)
         .withPath("/path/to/data/a.parquet")
         .withFileSizeInBytes(10)
         .withPartitionPath("a=1")

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -514,7 +514,11 @@ public class TestMetadataTableScans extends TableTestBase {
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
 
-    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    // Here we need to specify target name as 'data_bucket_16'. If unspecified a default name will be generated. As per
+    // https://github.com/apache/iceberg/pull/4868 there's an inconsistency of doing this: in V2, the above removed
+    // data_bucket would be recycled in favor of data_bucket_16. By specifying the target name, we explicitly require
+    // data_bucket not to be recycled.
+    table.updateSpec().addField("data_bucket_16", Expressions.bucket("data", 16)).commit();
     table.refresh();
 
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -45,7 +45,6 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -482,11 +481,6 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
   @Test
   public void testPartitionsTableSwitchFields() throws Exception {
-    // Re-added partition fields currently not re-associated: https://github.com/apache/iceberg/issues/4292
-    // In V1, dropped partition fields show separately when field is re-added
-    // In V2, re-added field currently conflicts with its deleted form
-    Assume.assumeTrue(formatVersion == 1);
-
     sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg", tableName);
     initTable();
     Table table = validationCatalog.loadTable(tableIdent);


### PR DESCRIPTION
First go at fixing #4661.
The proposed solution described at https://github.com/apache/iceberg/pull/3411#discussion_r823692312 seems very hardly feasible, so this would be a quick fix to just avoid `Invalid schema` errors thrown in any metadata query where the a partition col was reused.