### PR TITLE
Spark: Add explicit deps to parquet-column and parquet-hadoop deps in spark …

### DIFF
--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -64,8 +64,12 @@ project(':iceberg-spark:iceberg-spark-3.0_2.12') {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       exclude group: 'org.roaringbitmap'
     }
+
+    implementation("org.apache.parquet:parquet-column")
+    implementation("org.apache.parquet:parquet-hadoop")
 
     implementation("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
@@ -136,6 +140,7 @@ project(":iceberg-spark:iceberg-spark-extensions-3.0_2.12") {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       exclude group: 'org.roaringbitmap'
     }
 

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -64,8 +64,12 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       exclude group: 'org.roaringbitmap'
     }
+
+    implementation("org.apache.parquet:parquet-column")
+    implementation("org.apache.parquet:parquet-hadoop")
 
     implementation("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
@@ -136,6 +140,7 @@ project(":iceberg-spark:iceberg-spark-extensions-3.1_2.12") {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       exclude group: 'org.roaringbitmap'
     }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -65,10 +65,14 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
       exclude group: 'org.roaringbitmap'
     }
+
+    implementation("org.apache.parquet:parquet-column")
+    implementation("org.apache.parquet:parquet-hadoop")
 
     implementation("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
@@ -141,6 +145,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'org.apache.parquet'
       // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
       exclude group: 'org.roaringbitmap'


### PR DESCRIPTION
…3.x modules and exclude transitive parquet deps from spark-hive. This way it is easier for have consistent parquet versions across iceberg modules.

I am excluding 2.4 for this deps cleanup.