### PR TITLE
Core: Fix ConvertEqualityDeleteStrategy::options return type

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/ConvertEqualityDeleteStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/ConvertEqualityDeleteStrategy.java
@@ -49,7 +49,7 @@ public interface ConvertEqualityDeleteStrategy {
   /**
    * Sets options to be used with this strategy
    */
-  RewritePositionDeleteStrategy options(Map<String, String> options);
+  ConvertEqualityDeleteStrategy options(Map<String, String> options);
 
   /**
    * Select the delete files to convert.


### PR DESCRIPTION
After reading the [design doc](https://docs.google.com/document/d/1-EyKSfwd_W9iI5jrzAvomVw3w1mb_kayVNT7f2I-SUg) I think the `ConvertEqualityDeleteStrategy::options` should return `ConvertEqualityDeleteStrategy` instead of the `RewritePositionDeleteStrategy` type. I guess this was an omission unless I miss something.