### PR TITLE
Flink: add job level upsert config for table sink

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
 public class FlinkConfigOptions {
+  public static final Boolean SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT = false;
 
   private FlinkConfigOptions() {
   }
@@ -46,4 +47,10 @@ public class FlinkConfigOptions {
           .booleanType()
           .noDefaultValue()
           .withDescription("Expose split host information to use Flink's locality aware split assigner.");
+
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED =
+      ConfigOptions.key("table.exec.iceberg.write-upsert-enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to transform all INSERT/UPDATE_AFTER events to UPSERT.");
 }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.PropertyUtil;
 
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
   static final String FACTORY_IDENTIFIER = "iceberg";
@@ -113,7 +114,11 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
           objectPath.getObjectName());
     }
 
-    return new IcebergTableSink(tableLoader, tableSchema);
+    boolean upsert = PropertyUtil.propertyAsBoolean(tableProps,
+        FlinkConfigOptions.TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED.key(),
+        FlinkConfigOptions.SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT);
+
+    return new IcebergTableSink(tableLoader, tableSchema, upsert);
   }
 
   @Override

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -38,16 +38,23 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
   private final TableSchema tableSchema;
 
   private boolean overwrite = false;
+  private boolean upsertEnabled = false;
 
   private IcebergTableSink(IcebergTableSink toCopy) {
     this.tableLoader = toCopy.tableLoader;
     this.tableSchema = toCopy.tableSchema;
     this.overwrite = toCopy.overwrite;
+    this.upsertEnabled = toCopy.upsertEnabled;
   }
 
   public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema) {
+    this(tableLoader, tableSchema, false);
+  }
+
+  public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema, boolean upsertEnabled) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
+    this.upsertEnabled = upsertEnabled;
   }
 
   @Override
@@ -64,6 +71,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
         .tableSchema(tableSchema)
         .equalityFieldColumns(equalityColumns)
         .overwrite(overwrite)
+        .upsert(upsertEnabled)
         .append();
   }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.flink.types.Row;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Snapshot;
@@ -133,7 +134,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
     );
 
     testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), inputRowsPerCheckpoint,
-        expectedRecordsPerCheckpoint);
+        expectedRecordsPerCheckpoint, false);
   }
 
   @Test
@@ -164,7 +165,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         ImmutableList.of(insertRow(1, "aaa"), insertRow(1, "ccc"), insertRow(2, "aaa"), insertRow(2, "ccc"))
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords, false);
   }
 
   @Test
@@ -194,7 +195,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         ImmutableList.of(insertRow(1, "aaa"), insertRow(1, "ccc"), insertRow(2, "aaa"), insertRow(2, "bbb"))
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data", "id"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data", "id"), elementsPerCheckpoint, expectedRecords, false);
   }
 
   @Test
@@ -235,17 +236,59 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         )
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords, false);
+  }
+
+  @Test
+  public void testUpsertOnIdKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            insertRow(1, "aaa")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "aaa"),
+            updateAfterRow(1, "bbb")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "bbb"),
+            updateAfterRow(1, "ccc")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "ccc"),
+            updateAfterRow(1, "ddd"),
+            updateBeforeRow(1, "ddd"),
+            updateAfterRow(1, "eee")
+        )
+    );
+
+    List<List<Row>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(insertRow(1, "aaa")),
+        ImmutableList.of(insertRow(1, "bbb")),
+        ImmutableList.of(insertRow(1, "ccc")),
+        ImmutableList.of(insertRow(1, "eee"))
+    );
+
+    if (!partitioned) {
+      testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), elementsPerCheckpoint, expectedRecords, true);
+    } else {
+      AssertHelpers.assertThrows("Should be error because equality field columns don't include all partition keys",
+          IllegalStateException.class, "should be included in equality fields",
+          () -> {
+            testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), elementsPerCheckpoint, expectedRecords, true);
+            return null;
+          });
+    }
   }
 
   private static Record record(int id, String data) {
     return SimpleDataUtil.createRecord(id, data);
   }
 
-  private Table createTable(String tableName, List<String> key, boolean isPartitioned) {
+  private Table createTable(String tableName, List<String> key, boolean isPartitioned, boolean upsert) {
     String partitionByCause = isPartitioned ? "PARTITIONED BY (data)" : "";
-    sql("CREATE TABLE %s(id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s",
-        tableName, Joiner.on(',').join(key), partitionByCause);
+    sql("CREATE TABLE %s(id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s" +
+            "WITH ('table.exec.iceberg.write-upsert-enabled'='%s')",
+        tableName, Joiner.on(',').join(key), partitionByCause, upsert ? "true" : "false");
 
     // Upgrade the iceberg table to format v2.
     CatalogLoader loader = CatalogLoader.hadoop("my_catalog", CONF, ImmutableMap.of(
@@ -262,7 +305,8 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   private void testSqlChangeLog(String tableName,
                                 List<String> key,
                                 List<List<Row>> inputRowsPerCheckpoint,
-                                List<List<Row>> expectedRecordsPerCheckpoint) throws Exception {
+                                List<List<Row>> expectedRecordsPerCheckpoint,
+                                boolean insertAsUpsert) throws Exception {
     String dataId = BoundedTableFactory.registerDataSet(inputRowsPerCheckpoint);
     sql("CREATE TABLE %s(id INT NOT NULL, data STRING NOT NULL)" +
         " WITH ('connector'='BoundedSource', 'data-id'='%s')", SOURCE_TABLE, dataId);
@@ -271,7 +315,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         listJoin(inputRowsPerCheckpoint),
         sql("SELECT * FROM %s", SOURCE_TABLE));
 
-    Table table = createTable(tableName, key, partitioned);
+    Table table = createTable(tableName, key, partitioned, insertAsUpsert);
     sql("INSERT INTO %s SELECT * FROM %s", tableName, SOURCE_TABLE);
 
     table.refresh();

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.util.ThreadPools;
  * </pre>
  */
 public class FlinkConfigOptions {
+  public static final Boolean SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT = false;
 
   private FlinkConfigOptions() {
   }
@@ -81,4 +82,10 @@ public class FlinkConfigOptions {
           .intType()
           .defaultValue(ThreadPools.WORKER_THREAD_POOL_SIZE)
           .withDescription("The size of workers pool used to plan or scan manifests.");
+
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED =
+      ConfigOptions.key("table.exec.iceberg.write-upsert-enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to transform all INSERT/UPDATE_AFTER events to UPSERT.");
 }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.PropertyUtil;
 
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
   static final String FACTORY_IDENTIFIER = "iceberg";
@@ -113,7 +114,11 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
           objectPath.getObjectName());
     }
 
-    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration());
+    boolean upsert = PropertyUtil.propertyAsBoolean(tableProps,
+        FlinkConfigOptions.TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED.key(),
+        FlinkConfigOptions.SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT);
+
+    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration(), upsert);
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -38,6 +38,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
   private final TableLoader tableLoader;
   private final TableSchema tableSchema;
   private final ReadableConfig readableConfig;
+  private final boolean upsert;
 
   private boolean overwrite = false;
 
@@ -46,12 +47,19 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
     this.tableSchema = toCopy.tableSchema;
     this.overwrite = toCopy.overwrite;
     this.readableConfig = toCopy.readableConfig;
+    this.upsert = toCopy.upsert;
   }
 
   public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema, ReadableConfig readableConfig) {
+    this(tableLoader, tableSchema, readableConfig, false);
+  }
+
+  public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema, ReadableConfig readableConfig,
+                          boolean upsert) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
     this.readableConfig = readableConfig;
+    this.upsert = upsert;
   }
 
   @Override
@@ -69,6 +77,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
         .equalityFieldColumns(equalityColumns)
         .overwrite(overwrite)
         .flinkConf(readableConfig)
+        .upsert(upsert)
         .append();
   }
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.flink.types.Row;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Snapshot;
@@ -133,7 +134,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
     );
 
     testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), inputRowsPerCheckpoint,
-        expectedRecordsPerCheckpoint);
+        expectedRecordsPerCheckpoint, false);
   }
 
   @Test
@@ -164,7 +165,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         ImmutableList.of(insertRow(1, "aaa"), insertRow(1, "ccc"), insertRow(2, "aaa"), insertRow(2, "ccc"))
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords, false);
   }
 
   @Test
@@ -194,7 +195,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         ImmutableList.of(insertRow(1, "aaa"), insertRow(1, "ccc"), insertRow(2, "aaa"), insertRow(2, "bbb"))
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data", "id"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data", "id"), elementsPerCheckpoint, expectedRecords, false);
   }
 
   @Test
@@ -235,17 +236,59 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         )
     );
 
-    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords, false);
+  }
+
+  @Test
+  public void testUpsertOnIdKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            insertRow(1, "aaa")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "aaa"),
+            updateAfterRow(1, "bbb")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "bbb"),
+            updateAfterRow(1, "ccc")
+        ),
+        ImmutableList.of(
+            updateBeforeRow(1, "ccc"),
+            updateAfterRow(1, "ddd"),
+            updateBeforeRow(1, "ddd"),
+            updateAfterRow(1, "eee")
+        )
+    );
+
+    List<List<Row>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(insertRow(1, "aaa")),
+        ImmutableList.of(insertRow(1, "bbb")),
+        ImmutableList.of(insertRow(1, "ccc")),
+        ImmutableList.of(insertRow(1, "eee"))
+    );
+
+    if (!partitioned) {
+      testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), elementsPerCheckpoint, expectedRecords, true);
+    } else {
+      AssertHelpers.assertThrows("Should be error because equality field columns don't include all partition keys",
+          IllegalStateException.class, "should be included in equality fields",
+          () -> {
+            testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), elementsPerCheckpoint, expectedRecords, true);
+            return null;
+          });
+    }
   }
 
   private static Record record(int id, String data) {
     return SimpleDataUtil.createRecord(id, data);
   }
 
-  private Table createTable(String tableName, List<String> key, boolean isPartitioned) {
+  private Table createTable(String tableName, List<String> key, boolean isPartitioned, boolean upsertEnabled) {
     String partitionByCause = isPartitioned ? "PARTITIONED BY (data)" : "";
-    sql("CREATE TABLE %s(id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s",
-        tableName, Joiner.on(',').join(key), partitionByCause);
+    sql("CREATE TABLE %s(id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s " +
+            "WITH ('table.exec.iceberg.write-upsert-enabled'='%s')",
+        tableName, Joiner.on(',').join(key), partitionByCause, upsertEnabled ? "true" : "false");
 
     // Upgrade the iceberg table to format v2.
     CatalogLoader loader = CatalogLoader.hadoop("my_catalog", CONF, ImmutableMap.of(
@@ -262,7 +305,8 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   private void testSqlChangeLog(String tableName,
                                 List<String> key,
                                 List<List<Row>> inputRowsPerCheckpoint,
-                                List<List<Row>> expectedRecordsPerCheckpoint) throws Exception {
+                                List<List<Row>> expectedRecordsPerCheckpoint,
+                                boolean insertAsUpsert) throws Exception {
     String dataId = BoundedTableFactory.registerDataSet(inputRowsPerCheckpoint);
     sql("CREATE TABLE %s(id INT NOT NULL, data STRING NOT NULL)" +
         " WITH ('connector'='BoundedSource', 'data-id'='%s')", SOURCE_TABLE, dataId);
@@ -271,7 +315,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
         listJoin(inputRowsPerCheckpoint),
         sql("SELECT * FROM %s", SOURCE_TABLE));
 
-    Table table = createTable(tableName, key, partitioned);
+    Table table = createTable(tableName, key, partitioned, insertAsUpsert);
     sql("INSERT INTO %s SELECT * FROM %s", tableName, SOURCE_TABLE);
 
     table.refresh();

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -51,6 +51,8 @@ public class FlinkConfigOptions {
   private FlinkConfigOptions() {
   }
 
+  public static final Boolean SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT = false;
+
   public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM =
       ConfigOptions.key("table.exec.iceberg.infer-source-parallelism")
           .booleanType()
@@ -81,4 +83,10 @@ public class FlinkConfigOptions {
           .intType()
           .defaultValue(ThreadPools.WORKER_THREAD_POOL_SIZE)
           .withDescription("The size of workers pool used to plan or scan manifests.");
+
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED =
+      ConfigOptions.key("table.exec.iceberg.write-upsert-enabled")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to transform all INSERT/UPDATE_AFTER events to UPSERT.");
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.PropertyUtil;
 
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
   static final String FACTORY_IDENTIFIER = "iceberg";
@@ -113,7 +114,11 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
           objectPath.getObjectName());
     }
 
-    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration());
+    boolean upsertEnabled = PropertyUtil.propertyAsBoolean(tableProps,
+        FlinkConfigOptions.TABLE_EXEC_ICEBERG_WRITE_UPSERT_ENABLED.key(),
+        FlinkConfigOptions.SINK_TABLE_WRITE_UPSERT_ENABLED_DEFAULT);
+
+    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration(), upsertEnabled);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -40,18 +40,26 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
   private final ReadableConfig readableConfig;
 
   private boolean overwrite = false;
+  private boolean upsertEnabled = false;
 
   private IcebergTableSink(IcebergTableSink toCopy) {
     this.tableLoader = toCopy.tableLoader;
     this.tableSchema = toCopy.tableSchema;
     this.overwrite = toCopy.overwrite;
     this.readableConfig = toCopy.readableConfig;
+    this.upsertEnabled = toCopy.upsertEnabled;
   }
 
   public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema, ReadableConfig readableConfig) {
+    this(tableLoader, tableSchema, readableConfig, false);
+  }
+
+  public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema, ReadableConfig readableConfig,
+                          boolean upsertEnabled) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
     this.readableConfig = readableConfig;
+    this.upsertEnabled = upsertEnabled;
   }
 
   @Override
@@ -68,6 +76,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
         .tableSchema(tableSchema)
         .equalityFieldColumns(equalityColumns)
         .overwrite(overwrite)
+        .upsert(upsertEnabled)
         .flinkConf(readableConfig)
         .append();
   }


### PR DESCRIPTION
This adds the option to the Flink SQL job so that users could specify the write mode. 

We have a table property to indicate the upsert mode for table level, while I think that is not the exact case since we have rewrite jobs in most cases. Also, we might have multiple writers to write in different branches/partitions.  So I would suggest removing that property as well.