### PR TITLE
Spark-3.2: Avoid duplicate computation of ALL_MANIFESTS metadata table for spark actions

### DIFF
--- a/docs/spark/spark-procedures.md
+++ b/docs/spark/spark-procedures.md
@@ -202,6 +202,7 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `retain_last` |    | int       | Number of ancestor snapshots to preserve regardless of `older_than` (defaults to 1) |
 | `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 | `stream_results` |    | boolean       | When true, deletion files will be sent to Spark driver by RDD partition (by default, all the files will be sent to Spark driver). This option is recommended to set to `true` to prevent Spark driver OOM from large file size |
+| `use_caching` | ️   | boolean | Use Spark caching during operation (defaults to true) |
 
 If `older_than` and `retain_last` are omitted, the table's [expiration properties](./configuration/#table-behavior-properties) will be used.
 
@@ -234,6 +235,7 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
 | `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
 | `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
+| `use_caching` | ️   | boolean | Use Spark caching during operation (defaults to true) |
 
 #### Output
 


### PR DESCRIPTION
ALL_MANIFESTS computation is a heavy operation when lot of snapshots exist as it involves reading of the the manifest list file for every snapshot.
We are currently having duplicate computation of the same in many places in spark actions.

This PR aims to improve the performance of spark actions and stored procedures by computing once and reusing it in other locations using dataset.persist().