### PR TITLE
Specify pip>=21.1 in tox dependencies

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -22,6 +22,7 @@ envlist = py37,py38,py39,linters
 usedevelop = true
 extras = arrow
 deps =
+    pip>=21.1
     coverage
     mock
     pytest


### PR DESCRIPTION
Since we recently removed `setup.py` and only include a `pyproject.toml` and `setup.cfg` file, pip versions less than 21.1 no longer work due to hitting this error:
```
ERROR: File "setup.py" not found. Directory cannot be installed in editable mode: /Users/sam/iceberg/python
(A "pyproject.toml" file was found, but editable mode currently requires a setup.py based build.)
WARNING: You are using pip version 21.0; however, version 22.0.4 is available.
You should consider upgrading via the '/Users/sam/iceberg/python/.tox/py37/bin/python -m pip install --upgrade pip' command.
```
Some bugfixes for installing in editable mode were introduced in [pip 21.1](https://pip.pypa.io/en/stable/news/#v21-1) and depending on how you setup your virtual environment, you can end up with an older version.

This PR sets `pip>=21.1` in the `deps` section of the `tox.ini` file which will force an upgrade of pip in the virtual environment if required.