### PR TITLE
Add a skeleton for the BuildPositionAccessors visitor

### DIFF
--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -526,7 +526,7 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[int, "Accessor"]]):
         return self._index
 
 
-def build_position_accessors(schema_or_type) -> Dict[int, "Accessor"]:
+def build_position_accessors(schema_or_type: Schema | IcebergType) -> Dict[int, Accessor]:
     """Generate an index of field IDs to schema position accessors
 
     Args:

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 import sys
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Iterable, List, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Iterable, List, TypeVar
+
+if TYPE_CHECKING:
+    from iceberg.expressions.base import Accessor
 
 if sys.version_info >= (3, 8):
     from functools import singledispatch  # pragma: no cover
@@ -54,6 +57,7 @@ class Schema:
         self._name_to_id_lower: Dict[str, int] = {}  # Should be accessed through self._lazy_name_to_id_lower()
         self._id_to_field: Dict[int, NestedField] = {}  # Should be accessed through self._lazy_id_to_field()
         self._id_to_name: Dict[int, str] = {}  # Should be accessed through self._lazy_id_to_name()
+        self._id_to_accessor: Dict[int, "Accessor"] = {}  # Should be accessed through self._lazy_id_to_accessor()
 
     def __str__(self):
         return "table {\n" + "\n".join(["  " + str(field) for field in self.columns]) + "\n}"
@@ -104,6 +108,15 @@ class Schema:
             self._id_to_name = index_name_by_id(self)
         return self._id_to_name
 
+    def _lazy_id_to_accessor(self) -> Dict[int, "Accessor"]:
+        """Returns an index of field ID to accessor
+
+        This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
+        """
+        if not self._id_to_accessor:
+            self._id_to_accessor = build_position_accessors(self)
+        return self._id_to_accessor
+
     def as_struct(self) -> StructType:
         """Returns the underlying struct"""
         return self._struct
@@ -150,6 +163,17 @@ class Schema:
             str: The column name (or None if the column ID cannot be found)
         """
         return self._lazy_id_to_name().get(column_id)  # type: ignore
+
+    def accessor_for_field(self, column_id: int) -> "Accessor":
+        """Find a schema position accessor given a column ID
+
+        Args:
+            column_id (int): The ID of the column
+
+        Returns:
+            Accessor: An accessor for the column
+        """
+        return self._lazy_id_to_accessor().get(column_id)  # type: ignore
 
     def select(self, names: List[str], case_sensitive: bool = True) -> "Schema":
         """Return a new schema instance pruned to a subset of columns
@@ -471,3 +495,44 @@ def index_name_by_id(schema_or_type) -> Dict[int, str]:
     indexer = _IndexByName()
     visit(schema_or_type, indexer)
     return indexer.by_id()
+
+
+class _BuildPositionAccessors(SchemaVisitor[Dict[int, "Accessor"]]):
+    """A schema visitor for generating a field ID to accessor index"""
+
+    def __init__(self) -> None:
+        self._index: Dict[int, "Accessor"] = {}
+
+    def schema(self, schema, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+        return self._index
+
+    def struct(self, struct, result: List[Dict[int, "Accessor"]]) -> Dict[int, "Accessor"]:
+        # TODO: Populate the `self._index` dictionary where the key is the field ID and the value is an accessor for that field.
+        #   The equivalent java logic can be found here: https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/Accessors.java#L213-L230
+        return self._index
+
+    def field(self, field: NestedField, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+        return self._index
+
+    def list(self, list_type: ListType, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+        return self._index
+
+    def map(
+        self, map_type: MapType, key_result: Dict[int, "Accessor"], value_result: Dict[int, "Accessor"]
+    ) -> Dict[int, "Accessor"]:
+        return self._index
+
+    def primitive(self, primitive: PrimitiveType) -> Dict[int, "Accessor"]:
+        return self._index
+
+
+def build_position_accessors(schema_or_type) -> Dict[int, "Accessor"]:
+    """Generate an index of field IDs to schema position accessors
+
+    Args:
+        schema_or_type (Schema | IcebergType): A schema or type to index
+
+    Returns:
+        Dict[int, Accessor]: An index of field IDs to accessors
+    """
+    return visit(schema_or_type, _BuildPositionAccessors())

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -57,7 +57,7 @@ class Schema:
         self._name_to_id_lower: Dict[str, int] = {}  # Should be accessed through self._lazy_name_to_id_lower()
         self._id_to_field: Dict[int, NestedField] = {}  # Should be accessed through self._lazy_id_to_field()
         self._id_to_name: Dict[int, str] = {}  # Should be accessed through self._lazy_id_to_name()
-        self._id_to_accessor: Dict[int, "Accessor"] = {}  # Should be accessed through self._lazy_id_to_accessor()
+        self._id_to_accessor: Dict[int, Accessor] = {}  # Should be accessed through self._lazy_id_to_accessor()
 
     def __str__(self):
         return "table {\n" + "\n".join(["  " + str(field) for field in self.columns]) + "\n}"
@@ -108,7 +108,7 @@ class Schema:
             self._id_to_name = index_name_by_id(self)
         return self._id_to_name
 
-    def _lazy_id_to_accessor(self) -> Dict[int, "Accessor"]:
+    def _lazy_id_to_accessor(self) -> Dict[int, Accessor]:
         """Returns an index of field ID to accessor
 
         This is calculated once when called for the first time. Subsequent calls to this method will use a cached index.
@@ -164,7 +164,7 @@ class Schema:
         """
         return self._lazy_id_to_name().get(column_id)  # type: ignore
 
-    def accessor_for_field(self, field_id: int) -> "Accessor":
+    def accessor_for_field(self, field_id: int) -> Accessor:
         """Find a schema position accessor given a field ID
 
         Args:
@@ -501,28 +501,26 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[int, "Accessor"]]):
     """A schema visitor for generating a field ID to accessor index"""
 
     def __init__(self) -> None:
-        self._index: Dict[int, "Accessor"] = {}
+        self._index: Dict[int, Accessor] = {}
 
-    def schema(self, schema, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+    def schema(self, schema, result: Dict[int, Accessor]) -> Dict[int, Accessor]:
         return self._index
 
-    def struct(self, struct, result: List[Dict[int, "Accessor"]]) -> Dict[int, "Accessor"]:
+    def struct(self, struct, result: List[Dict[int, Accessor]]) -> Dict[int, Accessor]:
         # TODO: Populate the `self._index` dictionary where the key is the field ID and the value is an accessor for that field.
         #   The equivalent java logic can be found here: https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/Accessors.java#L213-L230
         return self._index
 
-    def field(self, field: NestedField, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+    def field(self, field: NestedField, result: Dict[int, Accessor]) -> Dict[int, Accessor]:
         return self._index
 
-    def list(self, list_type: ListType, result: Dict[int, "Accessor"]) -> Dict[int, "Accessor"]:
+    def list(self, list_type: ListType, result: Dict[int, Accessor]) -> Dict[int, Accessor]:
         return self._index
 
-    def map(
-        self, map_type: MapType, key_result: Dict[int, "Accessor"], value_result: Dict[int, "Accessor"]
-    ) -> Dict[int, "Accessor"]:
+    def map(self, map_type: MapType, key_result: Dict[int, Accessor], value_result: Dict[int, Accessor]) -> Dict[int, Accessor]:
         return self._index
 
-    def primitive(self, primitive: PrimitiveType) -> Dict[int, "Accessor"]:
+    def primitive(self, primitive: PrimitiveType) -> Dict[int, Accessor]:
         return self._index
 
 

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -164,14 +164,14 @@ class Schema:
         """
         return self._lazy_id_to_name().get(column_id)  # type: ignore
 
-    def accessor_for_field(self, column_id: int) -> "Accessor":
-        """Find a schema position accessor given a column ID
+    def accessor_for_field(self, field_id: int) -> "Accessor":
+        """Find a schema position accessor given a field ID
 
         Args:
-            column_id (int): The ID of the column
+            field_id (int): The ID of the field
 
         Returns:
-            Accessor: An accessor for the column
+            Accessor: An accessor for the given field ID
         """
         return self._lazy_id_to_accessor().get(column_id)  # type: ignore
 

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -173,7 +173,7 @@ class Schema:
         Returns:
             Accessor: An accessor for the given field ID
         """
-        return self._lazy_id_to_accessor().get(column_id)  # type: ignore
+        return self._lazy_id_to_accessor().get(field_id)  # type: ignore
 
     def select(self, names: List[str], case_sensitive: bool = True) -> "Schema":
         """Return a new schema instance pruned to a subset of columns


### PR DESCRIPTION
This adds a skeleton visitor for the `BuildPositionAccessors` visitor and the following `# TODO` in the struct component of the visitor:
```
# TODO: Populate the `self._index` dictionary where the key is the field ID and the value is an accessor for that field.
#   The equivalent java logic can be found here: https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/Accessors.java#L213-L230
```
The main reason for adding this now is to unblock the work on expressions visitors (for example PR #4679)

cc: @rdblue @emkornfield @dramaticlly @CircArgs @jun-he @dhruv-pratap