### PR TITLE
Add UnboundReference class

### DIFF
--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -20,6 +20,7 @@ from functools import reduce
 from typing import Any, Generic, TypeVar
 
 from iceberg.files import StructProtocol
+from iceberg.schema import Schema
 from iceberg.types import NestedField, Singleton
 
 T = TypeVar("T")
@@ -328,3 +329,35 @@ class BoundReference:
             Any: The value at the referenced field's position in `struct`
         """
         return self._accessor.get(struct)
+
+
+class UnboundReference:
+    """A reference not yet bounded to a field in a schema
+
+    Args:
+        name (str): The name of the field
+    """
+
+    def __init__(self, name: str):
+        if not name:
+            raise ValueError(f"Name cannot be null: {name}")
+        self._name = name
+
+    def __str__(self):
+        return f"UnboundReference(name={repr(self.name)})"
+
+    def __repr__(self):
+        return f"UnboundReference(name={repr(self.name)})"
+
+    @property
+    def name(self):
+        return self._name
+
+    def bind(self, schema: Schema, case_sensitive: bool) -> BoundReference:
+        """ """
+        field = schema.find_field(name_or_id=self.name, case_sensitive=case_sensitive)
+
+        if not field:
+            raise ValueError(f"Cannot find field '{self.name}' in schema: {schema}")
+
+        return BoundReference(field=field, accessor=schema.accessor_for_field(field.field_id))

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -336,7 +336,7 @@ class UnboundReference:
 
     Args:
         name (str): The name of the field
-    
+
     Note:
         An unbound reference is sometimes referred to as a "named" reference
     """

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -332,10 +332,13 @@ class BoundReference:
 
 
 class UnboundReference:
-    """A reference not yet bounded to a field in a schema
+    """A reference not yet bound to a field in a schema
 
     Args:
         name (str): The name of the field
+    
+    Note:
+        An unbound reference is sometimes referred to as a "named" reference
     """
 
     def __init__(self, name: str):

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -343,18 +343,29 @@ class UnboundReference:
             raise ValueError(f"Name cannot be null: {name}")
         self._name = name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"UnboundReference(name={repr(self.name)})"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"UnboundReference(name={repr(self.name)})"
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self._name
 
     def bind(self, schema: Schema, case_sensitive: bool) -> BoundReference:
-        """ """
+        """Bind the reference to an Iceberg schema
+
+        Args:
+            schema (Schema): An Iceberg schema
+            case_sensitive (bool): Whether to consider case when binding the reference to the field
+
+        Raises:
+            ValueError: If an empty name is provided
+
+        Returns:
+            BoundReference: A reference bound to the specific field in the Iceberg schema
+        """
         field = schema.find_field(name_or_id=self.name, case_sensitive=case_sensitive)
 
         if not field:


### PR DESCRIPTION
This adds an `UnboundReference` class that has a `bind` method which returns a `BoundReference` class. Merging this relies on PR #4678 which adds the `Schema.accessor_for_field` method. For complete functionality, a subsequent PR needs to be opened that implements the `struct` method in the `BuildPositionAccessors` visitor (added in the other PR) that builds a map of field ID to schema position accessor (the same PR should probably include tests for `UnboundReference` and `BuildPositionAccessors`.

To summarize:
- [x] Review and merge PR #4678
- [ ] Rebase this PR (tests will then pass), review and merge
- [ ] Follow-up with an update to PR #4678 that adds the logic for building the field ID -> Accessor map
- [ ] Follow-up with tests for `BuildPositionAccessors` and `UnboundReference`

cc: @rdblue @emkornfield @dramaticlly @CircArgs @jun-he @dhruv-pratap