### PR TITLE
Fix `META-INF/services` in shaded jars

### DIFF
--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -166,6 +166,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -164,6 +164,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -77,6 +77,8 @@ project(':iceberg-hive-runtime') {
     // relocate OrcSplit in order to avoid the conflict from Hive's OrcSplit
     relocate 'org.apache.hadoop.hive.ql.io.orc.OrcSplit', 'org.apache.iceberg.shaded.org.apache.hadoop.hive.ql.io.orc.OrcSplit'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/hive3-orc-bundle/build.gradle
+++ b/hive3-orc-bundle/build.gradle
@@ -74,6 +74,8 @@ project(':iceberg-hive3-orc-bundle') {
       exclude 'shaded/parquet/**/*'
     }
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -168,6 +168,8 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -255,6 +255,8 @@ project(':iceberg-spark:iceberg-spark-runtime-3.0_2.12') {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -255,6 +255,8 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -260,6 +260,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 


### PR DESCRIPTION
None of the shaded jars properly relocates the file names nor the contents of the services files.

For example, the file `META-INF/services/com.fasterxml.jackson.core.ObjectCodec` in a Spark runtime jar should have the name `META-INF/services/org.apache.iceberg.shaded.com.fasterxml.jackson.core.ObjectCodec` and the contents should contain `org.apache.iceberg.shaded.com.fasterxml.jackson.databind.ObjectMapper`, not
`com.fasterxml.jackson.databind.ObjectMapper`.

The Gradle shadow plugin has a builtin functionality to handle this - just need to be enabled.