### PR TITLE
Static Analysis: Mixed Mutability Return Type

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/MultiBufferInputStream.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -178,7 +179,7 @@ class MultiBufferInputStream extends ByteBufferInputStream {
 
   public List<ByteBuffer> sliceBuffers(long len) throws EOFException {
     if (len <= 0) {
-      return Collections.emptyList();
+      return ImmutableList.of();
     }
 
     if (current == null) {


### PR DESCRIPTION
This method returns both mutable and immutable collections or maps from different paths, I think it should `return ImmutableList.of();`