### PR TITLE
WIP: Remove redundant sorts from copy on write deletes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.util.SnapshotUtil;
 public class DataTableScan extends BaseTableScan {
   static final ImmutableList<String> SCAN_COLUMNS = ImmutableList.of(
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
-      "file_size_in_bytes", "record_count", "partition", "key_metadata", "split_offsets"
+      "file_size_in_bytes", "record_count", "partition", "key_metadata", "split_offsets", "sort_order_id"
   );
   static final ImmutableList<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
       .addAll(SCAN_COLUMNS)

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -207,6 +207,9 @@ public class TableProperties {
   public static final String SPLIT_OPEN_FILE_COST = "read.split.open-file-cost";
   public static final long SPLIT_OPEN_FILE_COST_DEFAULT = 4 * 1024 * 1024; // 4MB
 
+  public static final String FILE_AS_SPLIT = "read.split.file-as-split";
+  public static final boolean FILE_AS_SPLIT_DEFAULT = false;
+
   public static final String PARQUET_VECTORIZATION_ENABLED = "read.parquet.vectorization.enabled";
   public static final boolean PARQUET_VECTORIZATION_ENABLED_DEFAULT = true;
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -19,9 +19,18 @@
 
 package org.apache.iceberg.spark.extensions;
 
+import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteDelete extends TestDelete {
 
@@ -32,6 +41,69 @@ public class TestCopyOnWriteDelete extends TestDelete {
 
   @Override
   protected Map<String, String> extraTableProperties() {
-    return ImmutableMap.of(TableProperties.DELETE_MODE, "copy-on-write");
+    return ImmutableMap.of(TableProperties.DELETE_MODE, "copy-on-write",
+        TableProperties.DELETE_DISTRIBUTION_MODE, "range");
+  }
+
+  @Test
+  public void testDeleteWithRangePartitioningOptimization() throws NoSuchTableException {
+    Assume.assumeTrue(fileFormat.equalsIgnoreCase("parquet"));
+
+    createAndInitPartitionedTable();
+    sql("ALTER TABLE %s WRITE ORDERED BY %s", tableName, "id");
+
+
+    append(
+        new Employee(1, "hr"),
+        new Employee(3, "hr"),
+        new Employee(4, "hr"),
+        new Employee(5, "hr"),
+        new Employee(6, "hr"),
+        new Employee(7, "hr"),
+        new Employee(8, "hr"),
+        new Employee(9, "hr"));
+    append(
+        new Employee(1, "hardware"),
+        new Employee(2, "hardware"),
+        new Employee(3, "hardware"),
+        new Employee(4, "hardware"),
+        new Employee(5, "hardware"),
+        new Employee(6, "hardware"),
+        new Employee(7, "hardware"),
+        new Employee(8, "hardware"),
+        new Employee(9, "hardware"),
+        new Employee(10, "hardware"));
+
+    List<Object[]> sortOrders = sql("SELECT sort_order_id from %s.files", tableName);
+    Assert.assertTrue(sortOrders.stream().allMatch(x -> (int) x[x.length - 1] == 1));
+
+    sql("DELETE FROM %s WHERE id = 2", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertEquals("Should have 3 snapshots", 3, Iterables.size(table.snapshots()));
+
+    Snapshot currentSnapshot = table.currentSnapshot();
+    validateCopyOnWrite(currentSnapshot, "1", "1", "1");
+
+    assertEquals("Should have expected rows",
+        ImmutableList.of(
+            row(1, "hardware"),
+            row(1, "hr"),
+            row(3, "hardware"),
+            row(3, "hr"),
+            row(4, "hardware"),
+            row(4, "hr"),
+            row(5, "hardware"),
+            row(5, "hr"),
+            row(6, "hardware"),
+            row(6, "hr"),
+            row(7, "hardware"),
+            row(7, "hr"),
+            row(8, "hardware"),
+            row(8, "hr"),
+            row(9, "hardware"),
+            row(9, "hr"),
+            row(10, "hardware")),
+        sql("SELECT * FROM %s ORDER BY id, dep", tableName));
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -42,7 +42,8 @@ public class TestCopyOnWriteDelete extends TestDelete {
   @Override
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(TableProperties.DELETE_MODE, "copy-on-write",
-        TableProperties.DELETE_DISTRIBUTION_MODE, "range");
+        TableProperties.DELETE_DISTRIBUTION_MODE, "range",
+        TableProperties.FILE_AS_SPLIT, "true");
   }
 
   @Test
@@ -51,7 +52,6 @@ public class TestCopyOnWriteDelete extends TestDelete {
 
     createAndInitPartitionedTable();
     sql("ALTER TABLE %s WRITE ORDERED BY %s", tableName, "id");
-
 
     append(
         new Employee(1, "hr"),

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -199,6 +199,14 @@ public class SparkReadConf {
         .parse();
   }
 
+  public boolean fileAsSplit() {
+    return confParser.booleanConf()
+        .option(SparkReadOptions.FILE_AS_SPLIT)
+        .tableProperty(TableProperties.FILE_AS_SPLIT)
+        .defaultValue(TableProperties.FILE_AS_SPLIT_DEFAULT)
+        .parse();
+  }
+
   /**
    * Enables reading a timestamp without time zone as a timestamp with time zone.
    * <p>

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -48,6 +48,9 @@ public class SparkReadOptions {
   // Overrides the table's read.split.open-file-cost
   public static final String FILE_OPEN_COST = "file-open-cost";
 
+  // Use input file as one split
+  public static final String FILE_AS_SPLIT = "file-as-split";
+
   // Overrides the table's read.split.open-file-cost
   public static final String VECTORIZATION_ENABLED = "vectorization-enabled";
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
@@ -51,6 +52,7 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
 
   private final TableScan scan;
   private final Snapshot snapshot;
+  private final SparkReadConf readConf;
 
   // lazy variables
   private List<FileScanTask> files = null; // lazy cache of files
@@ -69,6 +71,7 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
 
     this.scan = scan;
     this.snapshot = snapshot;
+    this.readConf = readConf;
 
     if (scan == null) {
       this.files = Collections.emptyList();
@@ -133,12 +136,19 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
   @Override
   protected synchronized List<CombinedScanTask> tasks() {
     if (tasks == null) {
-      CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(
-          CloseableIterable.withNoopClose(files()),
-          scan.targetSplitSize());
-      CloseableIterable<CombinedScanTask> scanTasks = TableScanUtil.planTasks(
-          splitFiles, scan.targetSplitSize(),
-          scan.splitLookback(), scan.splitOpenFileCost());
+      CloseableIterable<CombinedScanTask> scanTasks;
+      if (readConf.fileAsSplit()) {
+        scanTasks = CloseableIterable.transform(
+            CloseableIterable.withNoopClose(files()),
+            BaseCombinedScanTask::new);
+      } else {
+        CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(
+            CloseableIterable.withNoopClose(files()),
+            scan.targetSplitSize());
+        scanTasks = TableScanUtil.planTasks(
+            splitFiles, scan.targetSplitSize(),
+            scan.splitLookback(), scan.splitOpenFileCost());
+      }
       tasks = Lists.newArrayList(scanTasks);
     }
 
@@ -175,5 +185,9 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
     return String.format(
         "IcebergCopyOnWriteScan(table=%s, type=%s, filters=%s, caseSensitive=%s)",
         table(), expectedSchema().asStruct(), filterExpressions(), caseSensitive());
+  }
+
+  public boolean fileAsSplit() {
+    return readConf.fileAsSplit();
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -251,7 +251,8 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         .ignoreResiduals()
         .caseSensitive(caseSensitive)
         .filter(filterExpression())
-        .project(expectedSchema);
+        .project(expectedSchema)
+        .includeColumnStats();
 
     scan = configureSplitPlanning(scan);
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -581,8 +581,13 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     private final StructType dsSchema;
     private final boolean partitionedFanoutEnabled;
 
-    protected WriterFactory(Broadcast<Table> tableBroadcast, FileFormat format, long targetFileSize,
-                            Schema writeSchema, StructType dsSchema, boolean partitionedFanoutEnabled) {
+    protected WriterFactory(
+        Broadcast<Table> tableBroadcast,
+        FileFormat format,
+        long targetFileSize,
+        Schema writeSchema,
+        StructType dsSchema,
+        boolean partitionedFanoutEnabled) {
       this.tableBroadcast = tableBroadcast;
       this.format = format;
       this.targetFileSize = targetFileSize;
@@ -609,6 +614,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
           .dataFileFormat(format)
           .dataSchema(writeSchema)
           .dataSparkType(dsSchema)
+          .dataSortOrder(table.sortOrder())
           .build();
 
       if (spec.isUnpartitioned()) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -581,13 +581,8 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     private final StructType dsSchema;
     private final boolean partitionedFanoutEnabled;
 
-    protected WriterFactory(
-        Broadcast<Table> tableBroadcast,
-        FileFormat format,
-        long targetFileSize,
-        Schema writeSchema,
-        StructType dsSchema,
-        boolean partitionedFanoutEnabled) {
+    protected WriterFactory(Broadcast<Table> tableBroadcast, FileFormat format, long targetFileSize,
+                            Schema writeSchema, StructType dsSchema, boolean partitionedFanoutEnabled) {
       this.tableBroadcast = tableBroadcast;
       this.format = format;
       this.targetFileSize = targetFileSize;


### PR DESCRIPTION
This diff includes following changes.
1. Enables reading entire file as one split in copy-on-write operations.
2. Writes sort-order-id from spark writers into data files.
3. Enables reading sort-order-id when reading through spark readers.
4. Enables skipping distribution and ordering in case of copy-on-write operations to make these operations efficient.