### PR TITLE
Core - Add Parser for UpdateRequirement

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -42,6 +42,8 @@ import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.rest.requests.UpdateRequirementParser;
+import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.apache.iceberg.util.JsonUtil;
@@ -69,8 +71,27 @@ public class RESTSerializers {
         .addSerializer(MetadataUpdate.class, new MetadataUpdateSerializer())
         .addDeserializer(MetadataUpdate.class, new MetadataUpdateDeserializer())
         .addSerializer(TableMetadata.class, new TableMetadataSerializer())
-        .addDeserializer(TableMetadata.class, new TableMetadataDeserializer());
+        .addDeserializer(TableMetadata.class, new TableMetadataDeserializer())
+        .addSerializer(UpdateRequirement.class, new UpdateRequirementSerializer())
+        .addDeserializer(UpdateRequirement.class, new UpdateRequirementDeserializer());
     mapper.registerModule(module);
+  }
+
+  public static class UpdateRequirementDeserializer extends JsonDeserializer<UpdateRequirement> {
+    @Override
+    public UpdateRequirement deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+      JsonNode node = p.getCodec().readTree(p);
+      return UpdateRequirementParser.fromJson(node);
+    }
+  }
+
+  public static class UpdateRequirementSerializer extends JsonSerializer<UpdateRequirement> {
+    @Override
+    public void serialize(UpdateRequirement value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      UpdateRequirementParser.toJson(value, gen);
+    }
   }
 
   public static class TableMetadataDeserializer extends JsonDeserializer<TableMetadata> {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -46,9 +46,9 @@ public class UpdateRequirementParser {
   // AssertTableUUID
   private static final String UUID = "uuid";
 
-  // AssertRefSnapshotID  // field `name` is ref in the spec
-  private static final String REF = "ref";  // renamed from `name` to match spec
-  private static final String SNAPSHOT_ID = "snapshot-id";  // Long
+  // AssertRefSnapshotID
+  private static final String REF = "ref";
+  private static final String SNAPSHOT_ID = "snapshot-id";
 
   // AssertLastAssignedFieldId
   private static final String LAST_ASSIGNED_FIELD_ID = "last-assigned-field-id";  // int

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
+import org.apache.iceberg.util.JsonUtil;
+
+public class UpdateRequirementParser {
+
+  private UpdateRequirementParser() {
+  }
+
+  private static final String TYPE = "type";
+
+  // assertion types
+  static final String ASSERT_TABLE_UUID = "assert-table-uuid";
+  static final String ASSERT_TABLE_DOES_NOT_EXIST = "assert-create";
+  static final String ASSERT_REF_SNAPSHOT_ID = "assert-ref-snapshot-id";
+  static final String ASSERT_LAST_ASSIGNED_FIELD_ID = "assert-last-assigned-field-id";
+  static final String ASSERT_CURRENT_SCHEMA_ID = "assert-current-schema-id";
+  static final String ASSERT_LAST_ASSIGNED_PARTITION_ID = "assert-last-assigned-partition-id";
+  static final String ASSERT_DEFAULT_SPEC_ID = "assert-default-spec-id`";
+  static final String ASSERT_DEFAULT_SORT_ORDER_ID = "assert-default-write-order-id";
+
+  // AssertTableUUID
+  private static final String UUID = "uuid";  // String
+
+  // AssertTableDoesNotExist - Doesn't have any fields - just checks for null of current TableMetadata.
+  //                           Maybe `base`
+
+  // AssertRefSnapshotID  // field `name` is ref in the spec
+  private static final String REF = "ref";  // renamed from `name` to match spec
+  private static final String SNAPSHOT_ID = "snapshot-id";  // Long
+
+  // AssertLastAssignedFieldId
+  private static final String LAST_ASSIGNED_FIELD_ID = "last-assigned-field-id";  // int
+
+  // AssertCurrentSchemaID  // field is current-schema-id in spec
+  private static final String SCHEMA_ID = "schema-id";  // int
+
+  // AssertLastAssignedPartitionId
+  private static final String LAST_ASSIGNED_PARTITION_ID = "last-assigned-partition-id"; // int
+
+  // AssertDefaultSpecID  // field is default-spec-id in spec
+  private static final String SPEC_ID = "spec-id";  // int
+
+  // AssertDefaultSortOrderID  // field is default-write-order-id in spec
+  private static final String SORT_ORDER_ID = "sort-order-id";  // int - some of these should be long though?
+
+  private static final Map<Class<? extends UpdateTableRequest.UpdateRequirement>, String> TYPES = ImmutableMap
+      .<Class<? extends UpdateTableRequest.UpdateRequirement>, String>builder()
+      .put(UpdateRequirement.AssertTableUUID.class, ASSERT_TABLE_UUID)
+      .put(UpdateRequirement.AssertTableDoesNotExist.class, ASSERT_TABLE_DOES_NOT_EXIST)
+      .put(UpdateRequirement.AssertRefSnapshotID.class, ASSERT_REF_SNAPSHOT_ID)
+      .put(UpdateRequirement.AssertLastAssignedFieldId.class, ASSERT_LAST_ASSIGNED_FIELD_ID)
+      .put(UpdateRequirement.AssertCurrentSchemaID.class, ASSERT_CURRENT_SCHEMA_ID)
+      .put(UpdateRequirement.AssertLastAssignedPartitionId.class, ASSERT_LAST_ASSIGNED_PARTITION_ID)
+      .put(UpdateRequirement.AssertDefaultSpecID.class, ASSERT_DEFAULT_SPEC_ID)
+      .put(UpdateRequirement.AssertDefaultSortOrderID.class, ASSERT_DEFAULT_SORT_ORDER_ID)
+      .build();
+
+  public static String toJson(UpdateRequirement updateRequirement) {
+    return toJson(updateRequirement, false);
+  }
+
+  public static String toJson(UpdateRequirement updateRequirement, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+      toJson(updateRequirement, generator);
+      generator.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(
+          String.format("Failed to write update requirement json for: %s", updateRequirement), e);
+    }
+  }
+
+  public static void toJson(UpdateRequirement updateRequirement, JsonGenerator generator) throws IOException {
+    String requirementType = TYPES.get(updateRequirement.getClass());
+
+    generator.writeStartObject();
+    generator.writeStringField(TYPE, requirementType);
+
+    switch (requirementType) {
+      case ASSERT_TABLE_DOES_NOT_EXIST:
+        throw new UnsupportedOperationException("Not Implemented: UpdateRequirement::toJson for " + requirementType);
+      case ASSERT_TABLE_UUID:
+        writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
+        break;
+      case ASSERT_REF_SNAPSHOT_ID:
+        writeAssertRefSnapshotId((UpdateRequirement.AssertRefSnapshotID) updateRequirement, generator);
+        break;
+      case ASSERT_LAST_ASSIGNED_FIELD_ID:
+        writeAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
+        break;
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
+        writeAssertLastAssignedPartitionId((UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
+        break;
+      case ASSERT_CURRENT_SCHEMA_ID:
+        writeAssertCurrentSchemaId((UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
+        break;
+      case ASSERT_DEFAULT_SPEC_ID:
+        writeAssertDefaultSpecId((UpdateRequirement.AssertDefaultSpecID) updateRequirement, generator);
+        break;
+      case ASSERT_DEFAULT_SORT_ORDER_ID:
+        writeAssertDefaultSortOrderId((UpdateRequirement.AssertDefaultSortOrderID) updateRequirement, generator);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Cannot convert update requirement to json. Unrecognized type: %s", requirementType));
+    }
+
+    generator.writeEndObject();
+  }
+
+  /**
+   * Read MetadataUpdate from a JSON string.
+   *
+   * @param json a JSON string of a MetadataUpdate
+   * @return a MetadataUpdate object
+   */
+  public static UpdateRequirement fromJson(String json) {
+    try {
+      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read JSON string: " + json, e);
+    }
+  }
+
+  public static UpdateRequirement fromJson(JsonNode jsonNode) {
+    Preconditions.checkArgument(jsonNode != null && jsonNode.isObject(),
+        "Cannot parse metadata update from non-object value: %s", jsonNode);
+    Preconditions.checkArgument(jsonNode.hasNonNull(TYPE), "Cannot parse metadata update. Missing field: type");
+    String type = JsonUtil.getString(TYPE, jsonNode).toLowerCase(Locale.ROOT);
+
+    switch (type) {
+      case ASSERT_TABLE_DOES_NOT_EXIST:
+        throw new UnsupportedOperationException("Not implemented: AssignUUID");
+      case ASSERT_TABLE_UUID:
+        return readAssertTableUUID(jsonNode);
+      case ASSERT_REF_SNAPSHOT_ID:
+        return readAssertRefSnapshotId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_FIELD_ID:
+        return readAssertLastAssignedFieldId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
+        return readAssertLastAssignedPartitionId(jsonNode);
+      case ASSERT_CURRENT_SCHEMA_ID:
+        return readAssertCurrentSchemaId(jsonNode);
+      case ASSERT_DEFAULT_SPEC_ID:
+        return readAssertDefaultSpecId(jsonNode);
+      case ASSERT_DEFAULT_SORT_ORDER_ID:
+        return readAssertDefaultSortOrderId(jsonNode);
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Unrecognized update requirement. Cannot convert to json: %s", type));
+    }
+  }
+
+  private static void writeAssertTableUUID(UpdateRequirement.AssertTableUUID requirement, JsonGenerator gen)
+      throws IOException {
+    gen.writeStringField(UUID, requirement.uuid());
+  }
+
+  private static void writeAssertRefSnapshotId(UpdateRequirement.AssertRefSnapshotID requirement, JsonGenerator gen)
+      throws IOException {
+    gen.writeStringField(REF, requirement.refName());
+    gen.writeNumberField(SNAPSHOT_ID, requirement.snapshotId());
+  }
+
+  private static void writeAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId update,
+      JsonGenerator gen) throws IOException {
+    // gen.writeNumberField(LAST_ASSIGNED_FIELD_ID, update.schemaId());
+  }
+
+  private static void writeAssertLastAssignedPartitionId(UpdateRequirement.AssertLastAssignedPartitionId update,
+      JsonGenerator gen) throws IOException {
+    // gen.writeNumberField(SPEC_ID, update.specId());
+  }
+
+  private static void writeAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID updateRequirement,
+      JsonGenerator gen) throws IOException {
+
+  }
+
+  private static void writeAssertDefaultSpecId(UpdateRequirement.AssertDefaultSpecID updateRequirement,
+      JsonGenerator gen) throws IOException {
+
+  }
+
+  private static void writeAssertDefaultSortOrderId(
+      UpdateRequirement.AssertDefaultSortOrderID updateRequirement, JsonGenerator gen) throws IOException {
+
+  }
+
+  private static UpdateRequirement readAssertTableUUID(JsonNode node) {
+    String uuid = JsonUtil.getString(UUID, node);
+    return new UpdateRequirement.AssertTableUUID(uuid);
+  }
+
+  private static UpdateRequirement readAssertRefSnapshotId(JsonNode node) {
+    String ref = JsonUtil.getStringOrNull(REF, node);
+    Long snapshotId = JsonUtil.getLongOrNull(SNAPSHOT_ID, node);
+    return new UpdateRequirement.AssertRefSnapshotID(ref, snapshotId);
+  }
+
+  private static UpdateRequirement readAssertLastAssignedFieldId(JsonNode node) {
+    int lastAssignedFieldId = JsonUtil.getInt(LAST_ASSIGNED_FIELD_ID, node);
+    return new UpdateRequirement.AssertLastAssignedFieldId(lastAssignedFieldId);
+  }
+
+  private static UpdateRequirement readAssertCurrentSchemaId(JsonNode node) {
+    int schemaId = JsonUtil.getInt(SCHEMA_ID, node);
+    return new UpdateRequirement.AssertCurrentSchemaID(schemaId);
+  }
+
+  private static UpdateRequirement readAssertLastAssignedPartitionId(JsonNode node) {
+    int lastAssignedPartitionId = JsonUtil.getInt(LAST_ASSIGNED_PARTITION_ID, node);
+    return new UpdateRequirement.AssertLastAssignedPartitionId(lastAssignedPartitionId);
+  }
+
+  private static UpdateRequirement readAssertDefaultSpecId(JsonNode node) {
+    int specId = JsonUtil.getInt(SPEC_ID, node);
+    return new UpdateRequirement.AssertDefaultSpecID(specId);
+  }
+
+  private static UpdateRequirement readAssertDefaultSortOrderId(JsonNode node) {
+    int sortOrderId = JsonUtil.getInt(SORT_ORDER_ID, node);
+    return new UpdateRequirement.AssertDefaultSortOrderID(sortOrderId);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -51,7 +51,7 @@ public class UpdateRequirementParser {
   private static final String SNAPSHOT_ID = "snapshot-id";
 
   // AssertLastAssignedFieldId
-  private static final String LAST_ASSIGNED_FIELD_ID = "last-assigned-field-id";  // int
+  private static final String LAST_ASSIGNED_FIELD_ID = "last-assigned-field-id";
 
   // AssertCurrentSchemaID  // field is current-schema-id in spec
   private static final String SCHEMA_ID = "schema-id";  // int

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -193,7 +193,11 @@ public class UpdateRequirementParser {
   private static void writeAssertRefSnapshotId(UpdateRequirement.AssertRefSnapshotID requirement, JsonGenerator gen)
       throws IOException {
     gen.writeStringField(NAME, requirement.refName());
-    gen.writeNumberField(SNAPSHOT_ID, requirement.snapshotId());
+    if (requirement.snapshotId() != null) {
+      gen.writeNumberField(SNAPSHOT_ID, requirement.snapshotId());
+    } else {
+      gen.writeNullField(SNAPSHOT_ID);
+    }
   }
 
   private static void writeAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId requirement,

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -63,7 +63,8 @@ public class UpdateRequirementParser {
   private static final String SPEC_ID = "default-spec-id";
 
   // AssertDefaultSortOrderID
-  // TODO - Is currently referred to as sort-order-id. Need to update it in class or in spec
+  // TODO - Is currently referred to as default-write-order-id in spec but class and comments use sort-order. Need to
+  //  update it in class or in spec
   private static final String SORT_ORDER_ID = "default-write-order-id";
 
   private static final Map<Class<? extends UpdateTableRequest.UpdateRequirement>, String> TYPES = ImmutableMap

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -60,7 +60,7 @@ public class UpdateRequirementParser {
   private static final String LAST_ASSIGNED_PARTITION_ID = "last-assigned-partition-id"; // int
 
   // AssertDefaultSpecID  // field is default-spec-id in spec
-  private static final String SPEC_ID = "spec-id";  // int
+  private static final String SPEC_ID = "default-spec-id";  // int
 
   // AssertDefaultSortOrderID  // field is default-write-order-id in spec
   private static final String SORT_ORDER_ID = "sort-order-id";  // int - some of these should be long though?

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -232,7 +232,7 @@ public class UpdateRequirementParser {
   }
 
   private static UpdateRequirement readAssertRefSnapshotId(JsonNode node) {
-    String name = JsonUtil.getStringOrNull(NAME, node);
+    String name = JsonUtil.getString(NAME, node);
     Long snapshotId = JsonUtil.getLongOrNull(SNAPSHOT_ID, node);
     return new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
   }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -44,10 +44,7 @@ public class UpdateRequirementParser {
   static final String ASSERT_DEFAULT_SORT_ORDER_ID = "assert-default-write-order-id";
 
   // AssertTableUUID
-  private static final String UUID = "uuid";  // String
-
-  // AssertTableDoesNotExist - Doesn't have any fields - just checks for null of current TableMetadata.
-  //                           Maybe `base`
+  private static final String UUID = "uuid";
 
   // AssertRefSnapshotID  // field `name` is ref in the spec
   private static final String REF = "ref";  // renamed from `name` to match spec

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -47,7 +47,9 @@ public class UpdateRequirementParser {
   private static final String UUID = "uuid";
 
   // AssertRefSnapshotID
-  private static final String REF = "ref";
+  // TODO - This is called `ref` in the spec.
+  //   https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1359-L1360
+  private static final String NAME = "name";
   private static final String SNAPSHOT_ID = "snapshot-id";
 
   // AssertLastAssignedFieldId
@@ -190,7 +192,7 @@ public class UpdateRequirementParser {
   // TODO - Also, looking at SnapshotRefParser it seems that `ref` is
   private static void writeAssertRefSnapshotId(UpdateRequirement.AssertRefSnapshotID requirement, JsonGenerator gen)
       throws IOException {
-    gen.writeStringField(REF, requirement.refName());
+    gen.writeStringField(NAME, requirement.refName());
     gen.writeNumberField(SNAPSHOT_ID, requirement.snapshotId());
   }
 
@@ -229,11 +231,10 @@ public class UpdateRequirementParser {
     return new UpdateRequirement.AssertTableUUID(uuid);
   }
 
-  // TODO - Should we fail if both are null? The logic will eventually cause it to fail.
   private static UpdateRequirement readAssertRefSnapshotId(JsonNode node) {
-    String ref = JsonUtil.getStringOrNull(REF, node);
+    String name = JsonUtil.getStringOrNull(NAME, node);
     Long snapshotId = JsonUtil.getLongOrNull(SNAPSHOT_ID, node);
-    return new UpdateRequirement.AssertRefSnapshotID(ref, snapshotId);
+    return new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
   }
 
   private static UpdateRequirement readAssertLastAssignedFieldId(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -158,7 +158,7 @@ public class UpdateRequirementParser {
 
     switch (type) {
       case ASSERT_TABLE_DOES_NOT_EXIST:
-        throw new UnsupportedOperationException("Not implemented: AssignUUID");
+        return readAssertTableDoesNotExist(jsonNode);
       case ASSERT_TABLE_UUID:
         return readAssertTableUUID(jsonNode);
       case ASSERT_REF_SNAPSHOT_ID:
@@ -213,6 +213,11 @@ public class UpdateRequirementParser {
   private static void writeAssertDefaultSortOrderId(UpdateRequirement.AssertDefaultSortOrderID requirement,
       JsonGenerator gen) throws IOException {
     gen.writeNumberField(SORT_ORDER_ID, requirement.sortOrderId());
+  }
+
+  @SuppressWarnings("unused")  // Keep same signature in case this requirement class evolves and gets fields
+  private static UpdateRequirement readAssertTableDoesNotExist(JsonNode node) {
+    return new UpdateRequirement.AssertTableDoesNotExist();
   }
 
   private static UpdateRequirement readAssertTableUUID(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -53,8 +53,8 @@ public class UpdateRequirementParser {
   // AssertLastAssignedFieldId
   private static final String LAST_ASSIGNED_FIELD_ID = "last-assigned-field-id";
 
-  // AssertCurrentSchemaID  // field is current-schema-id in spec
-  private static final String SCHEMA_ID = "schema-id";  // int
+  // AssertCurrentSchemaID
+  private static final String SCHEMA_ID = "current-schema-id";
 
   // AssertLastAssignedPartitionId
   private static final String LAST_ASSIGNED_PARTITION_ID = "last-assigned-partition-id"; // int

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -46,7 +46,7 @@ public class UpdateRequirementParser {
   static final String ASSERT_CURRENT_SCHEMA_ID = "assert-current-schema-id";
   static final String ASSERT_LAST_ASSIGNED_PARTITION_ID = "assert-last-assigned-partition-id";
   static final String ASSERT_DEFAULT_SPEC_ID = "assert-default-spec-id";
-  static final String ASSERT_DEFAULT_SORT_ORDER_ID = "assert-default-write-order-id";
+  static final String ASSERT_DEFAULT_SORT_ORDER_ID = "assert-default-sort-order-id";
 
   // AssertTableUUID
   private static final String UUID = "uuid";
@@ -68,7 +68,7 @@ public class UpdateRequirementParser {
   private static final String SPEC_ID = "default-spec-id";
 
   // AssertDefaultSortOrderID
-  private static final String SORT_ORDER_ID = "default-write-order-id";
+  private static final String SORT_ORDER_ID = "default-sort-order-id";
 
   private static final Map<Class<? extends UpdateTableRequest.UpdateRequirement>, String> TYPES = ImmutableMap
       .<Class<? extends UpdateTableRequest.UpdateRequirement>, String>builder()

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -108,7 +108,8 @@ public class UpdateRequirementParser {
 
     switch (requirementType) {
       case ASSERT_TABLE_DOES_NOT_EXIST:
-        throw new UnsupportedOperationException("Not Implemented: UpdateRequirement::toJson for " + requirementType);
+        // No fields beyond the requirement itself
+        break;
       case ASSERT_TABLE_UUID:
         writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
         break;
@@ -192,29 +193,29 @@ public class UpdateRequirementParser {
     gen.writeNumberField(SNAPSHOT_ID, requirement.snapshotId());
   }
 
-  private static void writeAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId update,
+  private static void writeAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId requirement,
       JsonGenerator gen) throws IOException {
-    // gen.writeNumberField(LAST_ASSIGNED_FIELD_ID, update.schemaId());
+    gen.writeNumberField(LAST_ASSIGNED_FIELD_ID, requirement.lastAssignedFieldId());
   }
 
-  private static void writeAssertLastAssignedPartitionId(UpdateRequirement.AssertLastAssignedPartitionId update,
+  private static void writeAssertLastAssignedPartitionId(UpdateRequirement.AssertLastAssignedPartitionId requirement,
       JsonGenerator gen) throws IOException {
-    // gen.writeNumberField(SPEC_ID, update.specId());
+    gen.writeNumberField(LAST_ASSIGNED_PARTITION_ID, requirement.lastAssignedPartitionId());
   }
 
-  private static void writeAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID updateRequirement,
+  private static void writeAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID requirement,
       JsonGenerator gen) throws IOException {
-
+    gen.writeNumberField(SCHEMA_ID, requirement.schemaId());
   }
 
-  private static void writeAssertDefaultSpecId(UpdateRequirement.AssertDefaultSpecID updateRequirement,
-      JsonGenerator gen) throws IOException {
-
+  private static void writeAssertDefaultSpecId(UpdateRequirement.AssertDefaultSpecID requirement, JsonGenerator gen)
+      throws IOException {
+    gen.writeNumberField(SPEC_ID, requirement.specId());
   }
 
-  private static void writeAssertDefaultSortOrderId(
-      UpdateRequirement.AssertDefaultSortOrderID updateRequirement, JsonGenerator gen) throws IOException {
-
+  private static void writeAssertDefaultSortOrderId(UpdateRequirement.AssertDefaultSortOrderID requirement,
+      JsonGenerator gen) throws IOException {
+    gen.writeNumberField(SORT_ORDER_ID, requirement.sortOrderId());
   }
 
   private static UpdateRequirement readAssertTableUUID(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -52,7 +52,7 @@ public class UpdateRequirementParser {
   private static final String UUID = "uuid";
 
   // AssertRefSnapshotID
-  private static final String NAME = "name";
+  private static final String NAME = "ref";
   private static final String SNAPSHOT_ID = "snapshot-id";
 
   // AssertLastAssignedFieldId

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -155,8 +155,8 @@ public class UpdateRequirementParser {
 
   public static UpdateRequirement fromJson(JsonNode jsonNode) {
     Preconditions.checkArgument(jsonNode != null && jsonNode.isObject(),
-        "Cannot parse metadata update from non-object value: %s", jsonNode);
-    Preconditions.checkArgument(jsonNode.hasNonNull(TYPE), "Cannot parse metadata update. Missing field: type");
+        "Cannot parse update requirement from non-object value: %s", jsonNode);
+    Preconditions.checkArgument(jsonNode.hasNonNull(TYPE), "Cannot parse update requirement. Missing field: type");
     String type = JsonUtil.getString(TYPE, jsonNode).toLowerCase(Locale.ROOT);
 
     switch (type) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.rest.requests;
@@ -40,15 +45,13 @@ public class UpdateRequirementParser {
   static final String ASSERT_LAST_ASSIGNED_FIELD_ID = "assert-last-assigned-field-id";
   static final String ASSERT_CURRENT_SCHEMA_ID = "assert-current-schema-id";
   static final String ASSERT_LAST_ASSIGNED_PARTITION_ID = "assert-last-assigned-partition-id";
-  static final String ASSERT_DEFAULT_SPEC_ID = "assert-default-spec-id`";
+  static final String ASSERT_DEFAULT_SPEC_ID = "assert-default-spec-id";
   static final String ASSERT_DEFAULT_SORT_ORDER_ID = "assert-default-write-order-id";
 
   // AssertTableUUID
   private static final String UUID = "uuid";
 
   // AssertRefSnapshotID
-  // TODO - This is called `ref` in the spec.
-  //   https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1359-L1360
   private static final String NAME = "name";
   private static final String SNAPSHOT_ID = "snapshot-id";
 
@@ -65,8 +68,6 @@ public class UpdateRequirementParser {
   private static final String SPEC_ID = "default-spec-id";
 
   // AssertDefaultSortOrderID
-  // TODO - Is currently referred to as default-write-order-id in spec but class and comments use sort-order. Need to
-  //  update it in class or in spec
   private static final String SORT_ORDER_ID = "default-write-order-id";
 
   private static final Map<Class<? extends UpdateTableRequest.UpdateRequirement>, String> TYPES = ImmutableMap
@@ -121,7 +122,8 @@ public class UpdateRequirementParser {
         writeAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
         break;
       case ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        writeAssertLastAssignedPartitionId((UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
+        writeAssertLastAssignedPartitionId(
+            (UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
         break;
       case ASSERT_CURRENT_SCHEMA_ID:
         writeAssertCurrentSchemaId((UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
@@ -188,8 +190,6 @@ public class UpdateRequirementParser {
     gen.writeStringField(UUID, requirement.uuid());
   }
 
-  // TODO - Should we fail if both are null or if ref is non-null and snapshotId is null? validate will fail here.
-  // TODO - Also, looking at SnapshotRefParser it seems that `ref` is
   private static void writeAssertRefSnapshotId(UpdateRequirement.AssertRefSnapshotID requirement, JsonGenerator gen)
       throws IOException {
     gen.writeStringField(NAME, requirement.refName());

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -184,6 +184,8 @@ public class UpdateRequirementParser {
     gen.writeStringField(UUID, requirement.uuid());
   }
 
+  // TODO - Should we fail if both are null or if ref is non-null and snapshotId is null? validate will fail here.
+  // TODO - Also, looking at SnapshotRefParser it seems that `ref` is
   private static void writeAssertRefSnapshotId(UpdateRequirement.AssertRefSnapshotID requirement, JsonGenerator gen)
       throws IOException {
     gen.writeStringField(REF, requirement.refName());
@@ -225,6 +227,7 @@ public class UpdateRequirementParser {
     return new UpdateRequirement.AssertTableUUID(uuid);
   }
 
+  // TODO - Should we fail if both are null? The logic will eventually cause it to fail.
   private static UpdateRequirement readAssertRefSnapshotId(JsonNode node) {
     String ref = JsonUtil.getStringOrNull(REF, node);
     Long snapshotId = JsonUtil.getLongOrNull(SNAPSHOT_ID, node);

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -57,13 +57,14 @@ public class UpdateRequirementParser {
   private static final String SCHEMA_ID = "current-schema-id";
 
   // AssertLastAssignedPartitionId
-  private static final String LAST_ASSIGNED_PARTITION_ID = "last-assigned-partition-id"; // int
+  private static final String LAST_ASSIGNED_PARTITION_ID = "last-assigned-partition-id";
 
-  // AssertDefaultSpecID  // field is default-spec-id in spec
-  private static final String SPEC_ID = "default-spec-id";  // int
+  // AssertDefaultSpecID
+  private static final String SPEC_ID = "default-spec-id";
 
-  // AssertDefaultSortOrderID  // field is default-write-order-id in spec
-  private static final String SORT_ORDER_ID = "sort-order-id";  // int - some of these should be long though?
+  // AssertDefaultSortOrderID
+  // TODO - Is currently referred to as sort-order-id. Need to update it in class or in spec
+  private static final String SORT_ORDER_ID = "default-write-order-id";
 
   private static final Map<Class<? extends UpdateTableRequest.UpdateRequirement>, String> TYPES = ImmutableMap
       .<Class<? extends UpdateTableRequest.UpdateRequirement>, String>builder()

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -258,6 +258,7 @@ public class UpdateTableRequest implements RESTRequest {
     }
 
     class AssertRefSnapshotID implements UpdateRequirement {
+      // This might be called name to not conflict with `ref` from TableMetadata (the enum of SnapshotRefType).
       private final String ref;
       private final Long snapshotId;
 

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -240,6 +240,7 @@ public class UpdateTableRequest implements RESTRequest {
 
     class AssertTableUUID implements UpdateRequirement {
       private final String uuid;
+
       AssertTableUUID(String uuid) {
         this.uuid = uuid;
       }
@@ -258,8 +259,6 @@ public class UpdateTableRequest implements RESTRequest {
     }
 
     class AssertRefSnapshotID implements UpdateRequirement {
-      // TODO - This is called `ref` in the spec.
-      // https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1359-L1360
       private final String name;
       private final Long snapshotId;
 
@@ -278,21 +277,21 @@ public class UpdateTableRequest implements RESTRequest {
 
       @Override
       public void validate(TableMetadata base) {
-        SnapshotRef ref = base.ref(this.name);
+        SnapshotRef ref = base.ref(name);
         if (ref != null) {
           String type = ref.isBranch() ? "branch" : "tag";
           if (snapshotId == null) {
             // a null snapshot ID means the ref should not exist already
             throw new CommitFailedException(
-                "Requirement failed: %s %s was created concurrently", type, this.name);
+                "Requirement failed: %s %s was created concurrently", type, name);
           } else if (snapshotId != ref.snapshotId()) {
             throw new CommitFailedException(
                 "Requirement failed: %s %s has changed: expected id %s != %s",
-                type, this.name, snapshotId, ref.snapshotId());
+                type, name, snapshotId, ref.snapshotId());
           }
         } else if (snapshotId != null) {
           throw new CommitFailedException(
-              "Requirement failed: branch or tag %s is missing, expected %s", this.name, snapshotId);
+              "Requirement failed: branch or tag %s is missing, expected %s", name, snapshotId);
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -241,7 +241,7 @@ public class UpdateTableRequest implements RESTRequest {
     class AssertTableUUID implements UpdateRequirement {
       private final String uuid;
 
-      private AssertTableUUID(String uuid) {
+      AssertTableUUID(String uuid) {
         this.uuid = uuid;
       }
 
@@ -259,16 +259,16 @@ public class UpdateTableRequest implements RESTRequest {
     }
 
     class AssertRefSnapshotID implements UpdateRequirement {
-      private final String name;
+      private final String ref;
       private final Long snapshotId;
 
-      private AssertRefSnapshotID(String name, Long snapshotId) {
-        this.name = name;
+      AssertRefSnapshotID(String ref, Long snapshotId) {
+        this.ref = ref;
         this.snapshotId = snapshotId;
       }
 
       public String refName() {
-        return name;
+        return ref;
       }
 
       public Long snapshotId() {
@@ -277,21 +277,21 @@ public class UpdateTableRequest implements RESTRequest {
 
       @Override
       public void validate(TableMetadata base) {
-        SnapshotRef ref = base.ref(name);
+        SnapshotRef ref = base.ref(this.ref);
         if (ref != null) {
           String type = ref.isBranch() ? "branch" : "tag";
           if (snapshotId == null) {
             // a null snapshot ID means the ref should not exist already
             throw new CommitFailedException(
-                "Requirement failed: %s %s was created concurrently", type, name);
+                "Requirement failed: %s %s was created concurrently", type, this.ref);
           } else if (snapshotId != ref.snapshotId()) {
             throw new CommitFailedException(
                 "Requirement failed: %s %s has changed: expected id %s != %s",
-                type, name, snapshotId, ref.snapshotId());
+                type, this.ref, snapshotId, ref.snapshotId());
           }
         } else if (snapshotId != null) {
           throw new CommitFailedException(
-              "Requirement failed: branch or tag %s is missing, expected %s", name, snapshotId);
+              "Requirement failed: branch or tag %s is missing, expected %s", this.ref, snapshotId);
         }
       }
     }
@@ -320,7 +320,7 @@ public class UpdateTableRequest implements RESTRequest {
     class AssertCurrentSchemaID implements UpdateRequirement {
       private final int schemaId;
 
-      private AssertCurrentSchemaID(int schemaId) {
+      AssertCurrentSchemaID(int schemaId) {
         this.schemaId = schemaId;
       }
 
@@ -362,7 +362,7 @@ public class UpdateTableRequest implements RESTRequest {
     class AssertDefaultSpecID implements UpdateRequirement {
       private final int specId;
 
-      private AssertDefaultSpecID(int specId) {
+      AssertDefaultSpecID(int specId) {
         this.specId = specId;
       }
 
@@ -383,7 +383,7 @@ public class UpdateTableRequest implements RESTRequest {
     class AssertDefaultSortOrderID implements UpdateRequirement {
       private final int sortOrderId;
 
-      private AssertDefaultSortOrderID(int sortOrderId) {
+      AssertDefaultSortOrderID(int sortOrderId) {
         this.sortOrderId = sortOrderId;
       }
 

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -258,17 +258,18 @@ public class UpdateTableRequest implements RESTRequest {
     }
 
     class AssertRefSnapshotID implements UpdateRequirement {
-      // This might be called name to not conflict with `ref` from TableMetadata (the enum of SnapshotRefType).
-      private final String ref;
+      // TODO - This is called `ref` in the spec.
+      // https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1359-L1360
+      private final String name;
       private final Long snapshotId;
 
-      AssertRefSnapshotID(String ref, Long snapshotId) {
-        this.ref = ref;
+      AssertRefSnapshotID(String name, Long snapshotId) {
+        this.name = name;
         this.snapshotId = snapshotId;
       }
 
       public String refName() {
-        return ref;
+        return name;
       }
 
       public Long snapshotId() {
@@ -277,21 +278,21 @@ public class UpdateTableRequest implements RESTRequest {
 
       @Override
       public void validate(TableMetadata base) {
-        SnapshotRef ref = base.ref(this.ref);
+        SnapshotRef ref = base.ref(this.name);
         if (ref != null) {
           String type = ref.isBranch() ? "branch" : "tag";
           if (snapshotId == null) {
             // a null snapshot ID means the ref should not exist already
             throw new CommitFailedException(
-                "Requirement failed: %s %s was created concurrently", type, this.ref);
+                "Requirement failed: %s %s was created concurrently", type, this.name);
           } else if (snapshotId != ref.snapshotId()) {
             throw new CommitFailedException(
                 "Requirement failed: %s %s has changed: expected id %s != %s",
-                type, this.ref, snapshotId, ref.snapshotId());
+                type, this.name, snapshotId, ref.snapshotId());
           }
         } else if (snapshotId != null) {
           throw new CommitFailedException(
-              "Requirement failed: branch or tag %s is missing, expected %s", this.ref, snapshotId);
+              "Requirement failed: branch or tag %s is missing, expected %s", this.name, snapshotId);
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -227,7 +227,7 @@ public class UpdateTableRequest implements RESTRequest {
     void validate(TableMetadata base);
 
     class AssertTableDoesNotExist implements UpdateRequirement {
-      private AssertTableDoesNotExist() {
+      AssertTableDoesNotExist() {
       }
 
       @Override
@@ -240,7 +240,6 @@ public class UpdateTableRequest implements RESTRequest {
 
     class AssertTableUUID implements UpdateRequirement {
       private final String uuid;
-
       AssertTableUUID(String uuid) {
         this.uuid = uuid;
       }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -79,6 +79,25 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  @Test
+  public void testAssertRefSnapshotIdToJson() {
+    String action = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
+    String ref = ""
+    String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+    UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
+    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertRefSnapshotIdFromJson() {
+    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+    String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+    UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
+    Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
+
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -63,6 +63,14 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  @Test
+  public void testAssertTableDoesNotExistToJson() {
+    String action = UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST;
+    String json = "{\"type\":\"assert-create\"}";
+    UpdateRequirement.AssertTableDoesNotExist expected = new UpdateRequirement.AssertTableDoesNotExist();
+    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+  }
+
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:
@@ -71,9 +79,7 @@ public class TestUpdateRequirementParser {
         break;
       case UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST:
         // Don't cast here as the function tests that the types are correct, given that the generated JSON
-        // for ASSERT_TABLE_DOES_NOT_EXIST does not have any fields outside of requirementType.
-        //
-        // There's no Assert.pass() method.
+        // for ASSERT_TABLE_DOES_NOT_EXIST does not have any fields other than the requirement type.
         assertEqualsAssertTableDoesNotExist(expected, actual);
         break;
       case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -158,77 +158,117 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  @Test
+  public void testAssertDefaultSpecIdFromJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID;
+    int specId = 5;
+    String json = String.format("{\"type\":\"%s\",\"default-spec-id\":%d}", requirementType, specId);
+    UpdateRequirement expected = new UpdateRequirement.AssertDefaultSpecID(specId);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertDefaultSpecIdToJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID;
+    int specId = 5;
+    String expected = String.format("{\"type\":\"%s\",\"default-spec-id\":%d}", requirementType, specId);
+    UpdateRequirement actual = new UpdateRequirement.AssertDefaultSpecID(specId);
+    Assert.assertEquals("AssertDefaultSpecId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:
-        assertEqualsAssertTableUUID((UpdateRequirement.AssertTableUUID) expected,
+        compareAssertTableUUID((UpdateRequirement.AssertTableUUID) expected,
             (UpdateRequirement.AssertTableUUID) actual);
         break;
       case UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST:
         // Don't cast here as the function explicitly tests that the types are correct, given that the generated JSON
         // for ASSERT_TABLE_DOES_NOT_EXIST does not have any fields other than the requirement type.
-        assertEqualsAssertTableDoesNotExist(expected, actual);
+        compareAssertTableDoesNotExist(expected, actual);
         break;
       case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:
         Assert.fail(String.format("UpdateRequirementParser equality comparison for %s is not implemented yet",
             requirementType));
         break;
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
-        assertEqualsAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) expected,
+        compareAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) expected,
             (UpdateRequirement.AssertLastAssignedFieldId) actual);
         break;
       case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
-        assertEqualsAssertCurrentSchemaId((UpdateRequirement.AssertCurrentSchemaID) expected,
+        compareAssertCurrentSchemaId((UpdateRequirement.AssertCurrentSchemaID) expected,
             (UpdateRequirement.AssertCurrentSchemaID) actual);
         break;
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        assertEqualsAssertLastAssignedPartitionId((UpdateRequirement.AssertLastAssignedPartitionId) expected,
+        compareAssertLastAssignedPartitionId((UpdateRequirement.AssertLastAssignedPartitionId) expected,
             (UpdateRequirement.AssertLastAssignedPartitionId) actual);
         break;
       case UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID:
+        compareAssertDefaultSpecId(
+            (UpdateRequirement.AssertDefaultSpecID) expected,
+            (UpdateRequirement.AssertDefaultSpecID) actual);
+        break;
       case UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID:
-        Assert.fail(String.format("UpdateRequirementParser equality comparison for %s is not implemented yet",
-            requirementType));
+        compareAssertDefaultSortOrderId(
+            (UpdateRequirement.AssertDefaultSortOrderID) expected,
+            (UpdateRequirement.AssertDefaultSortOrderID) actual);
         break;
       default:
         Assert.fail("Unrecognized update requirement type: " + requirementType);
     }
   }
 
-  private static void assertEqualsAssertTableUUID(
+  private static void compareAssertTableUUID(
       UpdateRequirement.AssertTableUUID expected, UpdateRequirement.AssertTableUUID actual) {
     Assertions.assertThat(actual.uuid())
         .as("UUID from JSON should not be null").isNotNull()
-        .as("UUID from JSON should parse correctly").isEqualTo(expected.uuid());
+        .as("UUID should parse correctly from JSON").isEqualTo(expected.uuid());
   }
 
   // AssertTableDoesNotExist does not have any fields beyond the requirement type, so just check that the classes
   // are the same and as expected.
-  private static void assertEqualsAssertTableDoesNotExist(UpdateRequirement expected, UpdateRequirement actual) {
+  private static void compareAssertTableDoesNotExist(UpdateRequirement expected, UpdateRequirement actual) {
     Assertions.assertThat(actual)
         .isOfAnyClassIn(UpdateRequirement.AssertTableDoesNotExist.class)
         .hasSameClassAs(expected);
   }
 
-  private static void assertEqualsAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId expected,
+  private static void compareAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId expected,
       UpdateRequirement.AssertLastAssignedFieldId actual) {
     Assertions.assertThat(actual.lastAssignedFieldId())
-        .as("Last assigned field id from JSON should parse correctly")
+        .as("Last assigned field id should parse correctly from JSON")
         .isEqualTo(expected.lastAssignedFieldId());
   }
 
-  private static void assertEqualsAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID expected,
+  private static void compareAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID expected,
       UpdateRequirement.AssertCurrentSchemaID actual) {
     Assertions.assertThat(actual.schemaId())
-        .as("Current schema id from JSON should parse correctly")
+        .as("Current schema id should parse correctly from JSON")
         .isEqualTo(expected.schemaId());
   }
 
-  private static void assertEqualsAssertLastAssignedPartitionId(
+  private static void compareAssertLastAssignedPartitionId(
       UpdateRequirement.AssertLastAssignedPartitionId expected,
       UpdateRequirement.AssertLastAssignedPartitionId actual) {
     Assertions.assertThat(actual.lastAssignedPartitionId())
         .as("Last assigned partition id should parse correctly from JSON")
         .isEqualTo(expected.lastAssignedPartitionId());
+  }
+
+  private static void compareAssertDefaultSpecId(
+      UpdateRequirement.AssertDefaultSpecID expected,
+      UpdateRequirement.AssertDefaultSpecID actual) {
+   Assertions.assertThat(actual.specId())
+       .as("Default spec id should parse correctly from JSON")
+       .isEqualTo(expected.specId());
+  }
+
+  private static void compareAssertDefaultSortOrderId(
+      UpdateRequirement.AssertDefaultSortOrderID expected,
+      UpdateRequirement.AssertDefaultSortOrderID actual) {
+   Assertions.assertThat(actual.sortOrderId())
+       .as("Default sort order id should parse correctly from JSON")
+       .isEqualTo(expected.sortOrderId());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -47,11 +47,11 @@ public class TestUpdateRequirementParser {
 
   @Test
   public void testAssertUUIDFromJson() {
-    String action = UpdateRequirementParser.ASSERT_TABLE_UUID;
+    String requirementType = UpdateRequirementParser.ASSERT_TABLE_UUID;
     String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
     String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
     UpdateRequirement expected = new UpdateRequirement.AssertTableUUID(uuid);
-    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
@@ -65,17 +65,17 @@ public class TestUpdateRequirementParser {
 
   @Test
   public void testAssertTableDoesNotExistFromJson() {
-    String action = UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST;
+    String requirementType = UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST;
     String json = "{\"type\":\"assert-create\"}";
     UpdateRequirement expected = new UpdateRequirement.AssertTableDoesNotExist();
-    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
   public void testAssertTableDoesNotExistToJson() {
     String expected  = "{\"type\":\"assert-create\"}";
     UpdateRequirement actual = new UpdateRequirement.AssertTableDoesNotExist();
-    Assert.assertEquals("AssertTableDoesNotExis should convert to the correct JSON value",
+    Assert.assertEquals("AssertTableDoesNotExist should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
 
@@ -101,23 +101,41 @@ public class TestUpdateRequirementParser {
 
   @Test
   public void testAssertLastAssignedFieldIdFromJson() {
-    String action = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
+    String requirementType = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
     int lastAssignedFieldId = 12;
-    String json = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", action, lastAssignedFieldId);
+    String json = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", requirementType, lastAssignedFieldId);
     UpdateRequirement expected = new UpdateRequirement.AssertLastAssignedFieldId(lastAssignedFieldId);
-    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
   public void testAssertLastAssignedFieldIdToJson() {
-    String action = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
+    String requirementType = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
     int lastAssignedFieldId = 12;
-    String expected = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", action, lastAssignedFieldId);
+    String expected = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", requirementType, lastAssignedFieldId);
     UpdateRequirement actual = new UpdateRequirement.AssertLastAssignedFieldId(lastAssignedFieldId);
     Assert.assertEquals("AssertLastAssignedFieldId should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  @Test
+  public void testAssertCurrentSchemaIdFromJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID;
+    int schemaId = 4;
+    String json = String.format("{\"type\":\"%s\",\"current-schema-id\":%d}", requirementType, schemaId);
+    UpdateRequirement expected = new UpdateRequirement.AssertCurrentSchemaID(schemaId);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertCurrentSchemaIdToJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID;
+    int schemaId = 4;
+    String expected = String.format("{\"type\":\"%s\",\"current-schema-id\":%d}", requirementType, schemaId);
+    UpdateRequirement actual = new UpdateRequirement.AssertCurrentSchemaID(schemaId);
+    Assert.assertEquals("AssertCurrentSchemaId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
 
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
@@ -139,6 +157,9 @@ public class TestUpdateRequirementParser {
             (UpdateRequirement.AssertLastAssignedFieldId) actual);
         break;
       case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
+        assertEqualsAssertCurrentSchemaId((UpdateRequirement.AssertCurrentSchemaID) expected,
+            (UpdateRequirement.AssertCurrentSchemaID) actual);
+        break;
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
       case UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID:
       case UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID:
@@ -170,5 +191,12 @@ public class TestUpdateRequirementParser {
     Assertions.assertThat(actual.lastAssignedFieldId())
         .as("Last assigned field id from JSON should parse correctly")
         .isEqualTo(expected.lastAssignedFieldId());
+  }
+
+  private static void assertEqualsAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID expected,
+      UpdateRequirement.AssertCurrentSchemaID actual) {
+    Assertions.assertThat(actual.schemaId())
+        .as("Current schema id from JSON should parse correctly")
+        .isEqualTo(expected.schemaId());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -137,6 +137,27 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  @Test
+  public void testAssertLastAssignedPartitionIdFromJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID;
+    int lastAssignedPartitionId = 1004;
+    String json = String.format("{\"type\":\"%s\",\"last-assigned-partition-id\":%d}",
+        requirementType, lastAssignedPartitionId);
+    UpdateRequirement expected = new UpdateRequirement.AssertLastAssignedPartitionId(lastAssignedPartitionId);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertLastAssignedPartitionIdToJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID;
+    int lastAssignedPartitionId = 1004;
+    String expected = String.format("{\"type\":\"%s\",\"last-assigned-partition-id\":%d}",
+        requirementType, lastAssignedPartitionId);
+    UpdateRequirement actual = new UpdateRequirement.AssertLastAssignedPartitionId(lastAssignedPartitionId);
+    Assert.assertEquals("AssertLastAssignedPartitionId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:
@@ -161,6 +182,9 @@ public class TestUpdateRequirementParser {
             (UpdateRequirement.AssertCurrentSchemaID) actual);
         break;
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
+        assertEqualsAssertLastAssignedPartitionId((UpdateRequirement.AssertLastAssignedPartitionId) expected,
+            (UpdateRequirement.AssertLastAssignedPartitionId) actual);
+        break;
       case UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID:
       case UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID:
         Assert.fail(String.format("UpdateRequirementParser equality comparison for %s is not implemented yet",
@@ -198,5 +222,13 @@ public class TestUpdateRequirementParser {
     Assertions.assertThat(actual.schemaId())
         .as("Current schema id from JSON should parse correctly")
         .isEqualTo(expected.schemaId());
+  }
+
+  private static void assertEqualsAssertLastAssignedPartitionId(
+      UpdateRequirement.AssertLastAssignedPartitionId expected,
+      UpdateRequirement.AssertLastAssignedPartitionId actual) {
+    Assertions.assertThat(actual.lastAssignedPartitionId())
+        .as("Last assigned partition id should parse correctly from JSON")
+        .isEqualTo(expected.lastAssignedPartitionId());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -209,7 +209,7 @@ public class TestUpdateRequirementParser {
   public void testAssertDefaultSortOrderIdFromJson() {
     String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID;
     int sortOrderId = 10;
-    String json = String.format("{\"type\":\"%s\",\"default-write-order-id\":%d}", requirementType, sortOrderId);
+    String json = String.format("{\"type\":\"%s\",\"default-sort-order-id\":%d}", requirementType, sortOrderId);
     UpdateRequirement expected = new UpdateRequirement.AssertDefaultSortOrderID(sortOrderId);
     assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
@@ -218,7 +218,7 @@ public class TestUpdateRequirementParser {
   public void testAssertDefaultSortOrderIdToJson() {
     String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID;
     int sortOrderId = 10;
-    String expected = String.format("{\"type\":\"%s\",\"default-write-order-id\":%d}", requirementType, sortOrderId);
+    String expected = String.format("{\"type\":\"%s\",\"default-sort-order-id\":%d}", requirementType, sortOrderId);
     UpdateRequirement actual = new UpdateRequirement.AssertDefaultSortOrderID(sortOrderId);
     Assert.assertEquals("AssertDefaultSortOrderId should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -82,33 +82,33 @@ public class TestUpdateRequirementParser {
   @Test
   public void testAssertRefSnapshotIdToJson() {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-    String name = "snapshot-name";
+    String refName = "snapshot-name";
     Long snapshotId = 1L;
-    String json = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
-        requirementType, name, snapshotId);
-    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    String json = String.format("{\"type\":\"%s\",\"ref\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, refName, snapshotId);
+    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(refName, snapshotId);
     assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
   public void testAssertRefSnapshotIdToJsonWithNullSnapshotId() {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-    String name = "snapshot-name";
+    String refName = "snapshot-name";
     Long snapshotId = null;
-    String json = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
-        requirementType, name, snapshotId);
-    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    String json = String.format("{\"type\":\"%s\",\"ref\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, refName, snapshotId);
+    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(refName, snapshotId);
     assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
   public void testAssertRefSnapshotIdFromJson() {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-    String name = "snapshot-name";
+    String refName = "snapshot-name";
     Long snapshotId = 1L;
-    String expected = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
-        requirementType, name, snapshotId);
-    UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    String expected = String.format("{\"type\":\"%s\",\"ref\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, refName, snapshotId);
+    UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(refName, snapshotId);
     Assert.assertEquals("AssertRefSnapshotId should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
@@ -116,11 +116,11 @@ public class TestUpdateRequirementParser {
   @Test
   public void testAssertRefSnapshotIdFromJsonWithNullSnapshotId() {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-    String name = "snapshot-name";
+    String refName = "snapshot-name";
     Long snapshotId = null;
-    String expected = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
-        requirementType, name, snapshotId);
-    UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    String expected = String.format("{\"type\":\"%s\",\"ref\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, refName, snapshotId);
+    UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(refName, snapshotId);
     Assert.assertEquals("AssertRefSnapshotId should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
@@ -286,7 +286,7 @@ public class TestUpdateRequirementParser {
       UpdateRequirement.AssertRefSnapshotID expected,
       UpdateRequirement.AssertRefSnapshotID actual) {
     Assertions.assertThat(actual.refName())
-        .as("Ref Name should parse correctly from JSON")
+        .as("Ref name should parse correctly from JSON")
         .isEqualTo(expected.refName());
     Assertions.assertThat(actual.snapshotId())
         .as("Snapshot ID should parse correctly from JSON")

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.MetadataUpdateParser;
+import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUpdateRequirementParser {
+
+  private static final Schema ID_DATA_SCHEMA = new Schema(
+      Types.NestedField.required(1, "id", Types.IntegerType.get()),
+      Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  @Test
+  public void testUpdateRequirementWithoutRequirementTypeCannotParse() {
+    List<String> invalidJson = ImmutableList.of(
+        "{\"type\":null,\"uuid\":\"2cc52516-5e73-41f2-b139-545d41a4e151\"}",
+        "{\"uuid\":\"2cc52516-5e73-41f2-b139-545d41a4e151\"}"
+    );
+
+    for (String json : invalidJson) {
+      AssertHelpers.assertThrows(
+          "UpdateRequirement without a recognized requirement type should fail to deserialize",
+          IllegalArgumentException.class,
+          "Cannot parse update requirement. Missing field: type",
+          () -> UpdateRequirementParser.fromJson(json));
+    }
+  }
+
+  @Test
+  public void testAssertUUIDToJson() {
+    String action = UpdateRequirementParser.ASSERT_TABLE_UUID;
+    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+    String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+    UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
+    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertUUIDFromJson() {
+    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+    String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+    UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
+    Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
+  // @Test
+  // public void testAddSchemaFromJson() {
+  //   String action = "add-schema";
+  //   Schema schema = ID_DATA_SCHEMA;
+  //   int lastColumnId = schema.highestFieldId();
+  //   String json = String.format("{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":%d}",
+  //       SchemaParser.toJson(schema), lastColumnId);
+  //   MetadataUpdate actualUpdate = new MetadataUpdate.AddSchema(schema, lastColumnId);
+  //   assertEquals(action, actualUpdate, MetadataUpdateParser.fromJson(json));
+  // }
+  //
+  // @Test
+  // public void testAddSchemaToJson() {
+  //   Schema schema = ID_DATA_SCHEMA;
+  //   int lastColumnId = schema.highestFieldId();
+  //   String expected = String.format("{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":%d}",
+  //       SchemaParser.toJson(schema), lastColumnId);
+  //   MetadataUpdate update = new MetadataUpdate.AddSchema(schema, lastColumnId);
+  //   String actual = MetadataUpdateParser.toJson(update);
+  //   Assert.assertEquals("Add schema should convert to the correct JSON value", expected, actual);
+  // }
+  //
+  // @Test
+  // public void testSetCurrentSchemaFromJson() {
+  //   String action = SET_CURRENT_SCHEMA;
+  //   int schemaId = 6;
+  //   String json = String.format("{\"action\":\"%s\",\"schema-id\":%d}", action, schemaId);
+  //   MetadataUpdate.SetCurrentSchema expected = new MetadataUpdate.SetCurrentSchema(schemaId);
+  //   assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  // }
+  //
+  // @Test
+  // public void testSetCurrentSchemaToJson() {
+  //   String action = SET_CURRENT_SCHEMA;
+  //   int schemaId = 6;
+  //   String expected = String.format("{\"action\":\"%s\",\"schema-id\":%d}", action, schemaId);
+  //   MetadataUpdate update = new MetadataUpdate.SetCurrentSchema(schemaId);
+  //   String actual = MetadataUpdateParser.toJson(update);
+  //   Assert.assertEquals("Set current schema should convert to the correct JSON value", expected, actual);
+  // }
+  //
+  // @Test
+  // public void testSetDefaultPartitionSpecToJson() {
+  //   String action = SET_DEFAULT_PARTITION_SPEC;
+  //   int specId = 4;
+  //   String expected = String.format("{\"action\":\"%s\",\"spec-id\":%d}", action, specId);
+  //   MetadataUpdate update = new MetadataUpdate.SetDefaultPartitionSpec(specId);
+  //   String actual = MetadataUpdateParser.toJson(update);
+  //   Assert.assertEquals("Set default partition spec should serialize to the correct JSON value", expected, actual);
+  // }
+  //
+  // @Test
+  // public void testSetDefaultPartitionSpecFromJson() {
+  //   String action = SET_DEFAULT_PARTITION_SPEC;
+  //   int specId = 4;
+  //   String json = String.format("{\"action\":\"%s\",\"spec-id\":%d}", action, specId);
+  //   MetadataUpdate.SetDefaultPartitionSpec expected = new MetadataUpdate.SetDefaultPartitionSpec(specId);
+  //   assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  // }
+
+  public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
+    switch (requirementType) {
+      case UpdateRequirementParser.ASSERT_TABLE_UUID:
+        assertEqualsAssertTableUUID((UpdateRequirement.AssertTableUUID) expected,
+            (UpdateRequirement.AssertTableUUID) actual);
+        break;
+      case UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST:
+      case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:
+      case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
+      case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
+      case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
+      case UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID:
+      case UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID:
+        Assert.fail(String.format("UpdateRequirementParser equals for %s is not implemented yet", requirementType));
+        break;
+      default:
+        Assert.fail("Unrecognized update requirement type: " + requirementType);
+    }
+  }
+
+  private static void assertEqualsAssertTableUUID(
+      UpdateRequirement.AssertTableUUID expected, UpdateRequirement.AssertTableUUID actual) {
+    Assertions.assertThat(actual.uuid()).isNotNull()
+        .as("UUID from JSON should be equal").isEqualTo(expected.uuid());
+  }
+
+  // private static void assertEqualsUpgradeFormatVersion(
+  //     MetadataUpdate.UpgradeFormatVersion expected, MetadataUpdate.UpgradeFormatVersion actual) {
+  //   Assert.assertEquals("Format version should be equal", expected.formatVersion(), actual.formatVersion());
+  // }
+  //
+  // private static void assertEqualsAddSchema(MetadataUpdate.AddSchema expected, MetadataUpdate.AddSchema actual) {
+  //   Assert.assertTrue("Schemas should be the same", expected.schema().sameSchema(actual.schema()));
+  //   Assert.assertEquals("Last column id should be equal", expected.lastColumnId(), actual.lastColumnId());
+  // }
+  //
+  // private static void assertEqualsSetCurrentSchema(
+  //     MetadataUpdate.SetCurrentSchema expected, MetadataUpdate.SetCurrentSchema actual) {
+  //   Assert.assertEquals("Schema id should be equal", expected.schemaId(), actual.schemaId());
+  // }
+  //
+  // private static void assertEqualsSetDefaultPartitionSpec(
+  //     MetadataUpdate.SetDefaultPartitionSpec expected, MetadataUpdate.SetDefaultPartitionSpec actual) {
+  //   Assertions.assertThat(actual.specId()).isEqualTo(expected.specId());
+  // }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -21,20 +21,13 @@ package org.apache.iceberg.rest.requests;
 
 import java.util.List;
 import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.MetadataUpdateParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestUpdateRequirementParser {
-
-  private static final Schema ID_DATA_SCHEMA = new Schema(
-      Types.NestedField.required(1, "id", Types.IntegerType.get()),
-      Types.NestedField.optional(2, "data", Types.StringType.get()));
 
   @Test
   public void testUpdateRequirementWithoutRequirementTypeCannotParse() {
@@ -70,66 +63,6 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
-  // @Test
-  // public void testAddSchemaFromJson() {
-  //   String action = "add-schema";
-  //   Schema schema = ID_DATA_SCHEMA;
-  //   int lastColumnId = schema.highestFieldId();
-  //   String json = String.format("{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":%d}",
-  //       SchemaParser.toJson(schema), lastColumnId);
-  //   MetadataUpdate actualUpdate = new MetadataUpdate.AddSchema(schema, lastColumnId);
-  //   assertEquals(action, actualUpdate, MetadataUpdateParser.fromJson(json));
-  // }
-  //
-  // @Test
-  // public void testAddSchemaToJson() {
-  //   Schema schema = ID_DATA_SCHEMA;
-  //   int lastColumnId = schema.highestFieldId();
-  //   String expected = String.format("{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":%d}",
-  //       SchemaParser.toJson(schema), lastColumnId);
-  //   MetadataUpdate update = new MetadataUpdate.AddSchema(schema, lastColumnId);
-  //   String actual = MetadataUpdateParser.toJson(update);
-  //   Assert.assertEquals("Add schema should convert to the correct JSON value", expected, actual);
-  // }
-  //
-  // @Test
-  // public void testSetCurrentSchemaFromJson() {
-  //   String action = SET_CURRENT_SCHEMA;
-  //   int schemaId = 6;
-  //   String json = String.format("{\"action\":\"%s\",\"schema-id\":%d}", action, schemaId);
-  //   MetadataUpdate.SetCurrentSchema expected = new MetadataUpdate.SetCurrentSchema(schemaId);
-  //   assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
-  // }
-  //
-  // @Test
-  // public void testSetCurrentSchemaToJson() {
-  //   String action = SET_CURRENT_SCHEMA;
-  //   int schemaId = 6;
-  //   String expected = String.format("{\"action\":\"%s\",\"schema-id\":%d}", action, schemaId);
-  //   MetadataUpdate update = new MetadataUpdate.SetCurrentSchema(schemaId);
-  //   String actual = MetadataUpdateParser.toJson(update);
-  //   Assert.assertEquals("Set current schema should convert to the correct JSON value", expected, actual);
-  // }
-  //
-  // @Test
-  // public void testSetDefaultPartitionSpecToJson() {
-  //   String action = SET_DEFAULT_PARTITION_SPEC;
-  //   int specId = 4;
-  //   String expected = String.format("{\"action\":\"%s\",\"spec-id\":%d}", action, specId);
-  //   MetadataUpdate update = new MetadataUpdate.SetDefaultPartitionSpec(specId);
-  //   String actual = MetadataUpdateParser.toJson(update);
-  //   Assert.assertEquals("Set default partition spec should serialize to the correct JSON value", expected, actual);
-  // }
-  //
-  // @Test
-  // public void testSetDefaultPartitionSpecFromJson() {
-  //   String action = SET_DEFAULT_PARTITION_SPEC;
-  //   int specId = 4;
-  //   String json = String.format("{\"action\":\"%s\",\"spec-id\":%d}", action, specId);
-  //   MetadataUpdate.SetDefaultPartitionSpec expected = new MetadataUpdate.SetDefaultPartitionSpec(specId);
-  //   assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
-  // }
-
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:
@@ -155,24 +88,4 @@ public class TestUpdateRequirementParser {
     Assertions.assertThat(actual.uuid()).isNotNull()
         .as("UUID from JSON should be equal").isEqualTo(expected.uuid());
   }
-
-  // private static void assertEqualsUpgradeFormatVersion(
-  //     MetadataUpdate.UpgradeFormatVersion expected, MetadataUpdate.UpgradeFormatVersion actual) {
-  //   Assert.assertEquals("Format version should be equal", expected.formatVersion(), actual.formatVersion());
-  // }
-  //
-  // private static void assertEqualsAddSchema(MetadataUpdate.AddSchema expected, MetadataUpdate.AddSchema actual) {
-  //   Assert.assertTrue("Schemas should be the same", expected.schema().sameSchema(actual.schema()));
-  //   Assert.assertEquals("Last column id should be equal", expected.lastColumnId(), actual.lastColumnId());
-  // }
-  //
-  // private static void assertEqualsSetCurrentSchema(
-  //     MetadataUpdate.SetCurrentSchema expected, MetadataUpdate.SetCurrentSchema actual) {
-  //   Assert.assertEquals("Schema id should be equal", expected.schemaId(), actual.schemaId());
-  // }
-  //
-  // private static void assertEqualsSetDefaultPartitionSpec(
-  //     MetadataUpdate.SetDefaultPartitionSpec expected, MetadataUpdate.SetDefaultPartitionSpec actual) {
-  //   Assertions.assertThat(actual.specId()).isEqualTo(expected.specId());
-  // }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -95,8 +95,8 @@ public class TestUpdateRequirementParser {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
     String name = "snapshot-name";
     Long snapshotId = null;
-    String json = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":null}",
-        requirementType, name);
+    String json = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, name, snapshotId);
     UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
     assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
   }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -79,25 +79,23 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
-  // TODO - Come back to these after verifying the rename of field `name` to `ref`.
-  // TODO - Also verify what combinations of null / missing are we allowed to have.
-  // @Test
-  // public void testAssertRefSnapshotIdToJson() {
-  //   String action = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-  //   String ref = "";
-  //   String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-  //   UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
-  //   assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
-  // }
-  //
-  // @Test
-  // public void testAssertRefSnapshotIdFromJson() {
-  //   String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
-  //   String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-  //   UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
-  //   Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
-  //       expected, UpdateRequirementParser.toJson(actual));
-  // }
+  @Test
+  public void testAssertRefSnapshotIdToJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
+    String name = "";
+    String json = String.format("{\"type\":\"assert-ref-snapshot-id\",\"ref\":\"%s\"}", name);
+    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(name);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertRefSnapshotIdFromJson() {
+    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+    String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+    UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
+    Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
 
   @Test
   public void testAssertLastAssignedFieldIdFromJson() {

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -91,10 +91,33 @@ public class TestUpdateRequirementParser {
   }
 
   @Test
+  public void testAssertRefSnapshotIdToJsonWithNullSnapshotId() {
+    String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
+    String name = "snapshot-name";
+    Long snapshotId = null;
+    String json = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":null}",
+        requirementType, name);
+    UpdateRequirement expected = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
   public void testAssertRefSnapshotIdFromJson() {
     String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
     String name = "snapshot-name";
     Long snapshotId = 1L;
+    String expected = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
+        requirementType, name, snapshotId);
+    UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);
+    Assert.assertEquals("AssertRefSnapshotId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
+  @Test
+  public void testAssertRefSnapshotIdFromJsonWithNullSnapshotId() {
+    String requirementType = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
+    String name = "snapshot-name";
+    Long snapshotId = null;
     String expected = String.format("{\"type\":\"%s\",\"name\":\"%s\",\"snapshot-id\":%d}",
         requirementType, name, snapshotId);
     UpdateRequirement actual = new UpdateRequirement.AssertRefSnapshotID(name, snapshotId);

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -70,6 +70,12 @@ public class TestUpdateRequirementParser {
             (UpdateRequirement.AssertTableUUID) actual);
         break;
       case UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST:
+        // Don't cast here as the function tests that the types are correct, given that the generated JSON
+        // for ASSERT_TABLE_DOES_NOT_EXIST does not have any fields outside of requirementType.
+        //
+        // There's no Assert.pass() method.
+        assertEqualsAssertTableDoesNotExist(expected, actual);
+        break;
       case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
       case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
@@ -87,5 +93,13 @@ public class TestUpdateRequirementParser {
       UpdateRequirement.AssertTableUUID expected, UpdateRequirement.AssertTableUUID actual) {
     Assertions.assertThat(actual.uuid()).isNotNull()
         .as("UUID from JSON should be equal").isEqualTo(expected.uuid());
+  }
+
+  // AssertTableDoesNotExist does not have any fields beyond the requirement type, so just check that the classes
+  // are the same and as expected.
+  private static void assertEqualsAssertTableDoesNotExist(UpdateRequirement expected, UpdateRequirement actual) {
+    Assertions.assertThat(actual)
+        .isOfAnyClassIn(UpdateRequirement.AssertTableDoesNotExist.class)
+        .hasSameClassAs(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -220,7 +220,8 @@ public class TestUpdateRequirementParser {
   }
 
   private static void compareAssertTableUUID(
-      UpdateRequirement.AssertTableUUID expected, UpdateRequirement.AssertTableUUID actual) {
+      UpdateRequirement.AssertTableUUID expected,
+      UpdateRequirement.AssertTableUUID actual) {
     Assertions.assertThat(actual.uuid())
         .as("UUID from JSON should not be null").isNotNull()
         .as("UUID should parse correctly from JSON").isEqualTo(expected.uuid());
@@ -234,14 +235,16 @@ public class TestUpdateRequirementParser {
         .hasSameClassAs(expected);
   }
 
-  private static void compareAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId expected,
+  private static void compareAssertLastAssignedFieldId(
+      UpdateRequirement.AssertLastAssignedFieldId expected,
       UpdateRequirement.AssertLastAssignedFieldId actual) {
     Assertions.assertThat(actual.lastAssignedFieldId())
         .as("Last assigned field id should parse correctly from JSON")
         .isEqualTo(expected.lastAssignedFieldId());
   }
 
-  private static void compareAssertCurrentSchemaId(UpdateRequirement.AssertCurrentSchemaID expected,
+  private static void compareAssertCurrentSchemaId(
+      UpdateRequirement.AssertCurrentSchemaID expected,
       UpdateRequirement.AssertCurrentSchemaID actual) {
     Assertions.assertThat(actual.schemaId())
         .as("Current schema id should parse correctly from JSON")

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -71,6 +71,14 @@ public class TestUpdateRequirementParser {
     assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
   }
 
+  @Test
+  public void testAssertTableDoesNotExistFromJson() {
+    String expected  = "{\"type\":\"assert-create\"}";
+    UpdateRequirement.AssertTableDoesNotExist actual = new UpdateRequirement.AssertTableDoesNotExist();
+    Assert.assertEquals("AssertTableDoesNotExis should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
       case UpdateRequirementParser.ASSERT_TABLE_UUID:
@@ -78,11 +86,14 @@ public class TestUpdateRequirementParser {
             (UpdateRequirement.AssertTableUUID) actual);
         break;
       case UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST:
-        // Don't cast here as the function tests that the types are correct, given that the generated JSON
+        // Don't cast here as the function explicitly tests that the types are correct, given that the generated JSON
         // for ASSERT_TABLE_DOES_NOT_EXIST does not have any fields other than the requirement type.
         assertEqualsAssertTableDoesNotExist(expected, actual);
         break;
       case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:
+        assertEqualsAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) expected,
+            (UpdateRequirement.AssertLastAssignedFieldId) actual);
+        break;
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
       case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
@@ -97,8 +108,9 @@ public class TestUpdateRequirementParser {
 
   private static void assertEqualsAssertTableUUID(
       UpdateRequirement.AssertTableUUID expected, UpdateRequirement.AssertTableUUID actual) {
-    Assertions.assertThat(actual.uuid()).isNotNull()
-        .as("UUID from JSON should be equal").isEqualTo(expected.uuid());
+    Assertions.assertThat(actual.uuid())
+        .as("UUID from JSON should not be null").isNotNull()
+        .as("UUID from JSON should parse correctly").isEqualTo(expected.uuid());
   }
 
   // AssertTableDoesNotExist does not have any fields beyond the requirement type, so just check that the classes
@@ -107,5 +119,12 @@ public class TestUpdateRequirementParser {
     Assertions.assertThat(actual)
         .isOfAnyClassIn(UpdateRequirement.AssertTableDoesNotExist.class)
         .hasSameClassAs(expected);
+  }
+
+  private static void assertEqualsAssertLastAssignedFieldId(UpdateRequirement.AssertLastAssignedFieldId expected,
+      UpdateRequirement.AssertLastAssignedFieldId actual) {
+    Assertions.assertThat(actual.lastAssignedFieldId())
+        .as("Last assigned field id from JSON should parse correctly")
+        .isEqualTo(expected.lastAssignedFieldId());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -172,8 +172,27 @@ public class TestUpdateRequirementParser {
     String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID;
     int specId = 5;
     String expected = String.format("{\"type\":\"%s\",\"default-spec-id\":%d}", requirementType, specId);
-    UpdateRequirement actual = new UpdateRequirement.AssertDefaultSpecID(specId);
+    UpdateRequirement actual = new UpdateRequirement.AssertDefaultSortOrderID(specId);
     Assert.assertEquals("AssertDefaultSpecId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
+  @Test
+  public void testAssertDefaultSortOrderIdFromJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID;
+    int sortOrderId = 10;
+    String json = String.format("{\"type\":\"%s\",\"default-write-order-id\":%d}", requirementType, sortOrderId);
+    UpdateRequirement expected = new UpdateRequirement.AssertDefaultSortOrderID(sortOrderId);
+    assertEquals(requirementType, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertDefaultSortOrderIdToJson() {
+    String requirementType = UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID;
+    int specId = 10;
+    String expected = String.format("{\"type\":\"%s\",\"default-spec-id\":%d}", requirementType, specId);
+    UpdateRequirement actual = new UpdateRequirement.AssertDefaultSpecID(specId);
+    Assert.assertEquals("AssertDefaultSortOrderId should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -46,39 +46,41 @@ public class TestUpdateRequirementParser {
   }
 
   @Test
-  public void testAssertUUIDToJson() {
+  public void testAssertUUIDFromJson() {
     String action = UpdateRequirementParser.ASSERT_TABLE_UUID;
     String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
     String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-    UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
+    UpdateRequirement expected = new UpdateRequirement.AssertTableUUID(uuid);
     assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
-  public void testAssertUUIDFromJson() {
+  public void testAssertUUIDToJson() {
     String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
     String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-    UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
+    UpdateRequirement actual = new UpdateRequirement.AssertTableUUID(uuid);
     Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
 
   @Test
-  public void testAssertTableDoesNotExistToJson() {
+  public void testAssertTableDoesNotExistFromJson() {
     String action = UpdateRequirementParser.ASSERT_TABLE_DOES_NOT_EXIST;
     String json = "{\"type\":\"assert-create\"}";
-    UpdateRequirement.AssertTableDoesNotExist expected = new UpdateRequirement.AssertTableDoesNotExist();
+    UpdateRequirement expected = new UpdateRequirement.AssertTableDoesNotExist();
     assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
   }
 
   @Test
-  public void testAssertTableDoesNotExistFromJson() {
+  public void testAssertTableDoesNotExistToJson() {
     String expected  = "{\"type\":\"assert-create\"}";
-    UpdateRequirement.AssertTableDoesNotExist actual = new UpdateRequirement.AssertTableDoesNotExist();
+    UpdateRequirement actual = new UpdateRequirement.AssertTableDoesNotExist();
     Assert.assertEquals("AssertTableDoesNotExis should convert to the correct JSON value",
         expected, UpdateRequirementParser.toJson(actual));
   }
 
+  // TODO - Come back to these after verifying the rename of field `name` to `ref`.
+  // TODO - Also verify what combinations of null / missing are we allowed to have.
   // @Test
   // public void testAssertRefSnapshotIdToJson() {
   //   String action = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
@@ -97,6 +99,25 @@ public class TestUpdateRequirementParser {
   //       expected, UpdateRequirementParser.toJson(actual));
   // }
 
+  @Test
+  public void testAssertLastAssignedFieldIdFromJson() {
+    String action = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
+    int lastAssignedFieldId = 12;
+    String json = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", action, lastAssignedFieldId);
+    UpdateRequirement expected = new UpdateRequirement.AssertLastAssignedFieldId(lastAssignedFieldId);
+    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssertLastAssignedFieldIdToJson() {
+    String action = UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID;
+    int lastAssignedFieldId = 12;
+    String expected = String.format("{\"type\":\"%s\",\"last-assigned-field-id\":%d}", action, lastAssignedFieldId);
+    UpdateRequirement actual = new UpdateRequirement.AssertLastAssignedFieldId(lastAssignedFieldId);
+    Assert.assertEquals("AssertLastAssignedFieldId should convert to the correct JSON value",
+        expected, UpdateRequirementParser.toJson(actual));
+  }
+
 
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {
     switch (requirementType) {
@@ -110,15 +131,19 @@ public class TestUpdateRequirementParser {
         assertEqualsAssertTableDoesNotExist(expected, actual);
         break;
       case UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID:
+        Assert.fail(String.format("UpdateRequirementParser equality comparison for %s is not implemented yet",
+            requirementType));
+        break;
+      case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
         assertEqualsAssertLastAssignedFieldId((UpdateRequirement.AssertLastAssignedFieldId) expected,
             (UpdateRequirement.AssertLastAssignedFieldId) actual);
         break;
-      case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_FIELD_ID:
       case UpdateRequirementParser.ASSERT_CURRENT_SCHEMA_ID:
       case UpdateRequirementParser.ASSERT_LAST_ASSIGNED_PARTITION_ID:
       case UpdateRequirementParser.ASSERT_DEFAULT_SPEC_ID:
       case UpdateRequirementParser.ASSERT_DEFAULT_SORT_ORDER_ID:
-        Assert.fail(String.format("UpdateRequirementParser equals for %s is not implemented yet", requirementType));
+        Assert.fail(String.format("UpdateRequirementParser equality comparison for %s is not implemented yet",
+            requirementType));
         break;
       default:
         Assert.fail("Unrecognized update requirement type: " + requirementType);

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -79,23 +79,23 @@ public class TestUpdateRequirementParser {
         expected, UpdateRequirementParser.toJson(actual));
   }
 
-  @Test
-  public void testAssertRefSnapshotIdToJson() {
-    String action = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
-    String ref = ""
-    String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-    UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
-    assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
-  }
-
-  @Test
-  public void testAssertRefSnapshotIdFromJson() {
-    String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
-    String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
-    UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
-    Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
-        expected, UpdateRequirementParser.toJson(actual));
-  }
+  // @Test
+  // public void testAssertRefSnapshotIdToJson() {
+  //   String action = UpdateRequirementParser.ASSERT_REF_SNAPSHOT_ID;
+  //   String ref = "";
+  //   String json = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+  //   UpdateRequirement.AssertTableUUID expected = new UpdateRequirement.AssertTableUUID(uuid);
+  //   assertEquals(action, expected, UpdateRequirementParser.fromJson(json));
+  // }
+  //
+  // @Test
+  // public void testAssertRefSnapshotIdFromJson() {
+  //   String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
+  //   String expected = String.format("{\"type\":\"assert-table-uuid\",\"uuid\":\"%s\"}", uuid);
+  //   UpdateRequirement.AssertTableUUID actual = new UpdateRequirement.AssertTableUUID(uuid);
+  //   Assert.assertEquals("AssertTableUUID should convert to the correct JSON value",
+  //       expected, UpdateRequirementParser.toJson(actual));
+  // }
 
 
   public void assertEquals(String requirementType, UpdateRequirement expected, UpdateRequirement actual) {

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1244,7 +1244,6 @@ components:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
           required:
-          required:
             - snapshot
           properties:
             snapshot:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1233,7 +1233,7 @@ components:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
           required:
-            - order-id
+            - sort-order-id
           properties:
             order-id:
               type: integer
@@ -1355,7 +1355,7 @@ components:
             - assert-current-schema-id
             - assert-last-assigned-partition-id
             - assert-default-spec-id
-            - assert-default-write-order-id
+            - assert-default-sort-order-id
         ref:
           type: string
         uuid:
@@ -1371,7 +1371,7 @@ components:
           type: integer
         default-spec-id:
           type: integer
-        default-write-order-id:
+        default-sort-order-id:
           type: integer
 
     LoadTableResult:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1233,9 +1233,9 @@ components:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
           required:
-            - sort-order-id
+            - order-id
           properties:
-            sort-order-id:
+            order-id:
               type: integer
               description: Sort order ID to set as the default, or -1 to set last added sort order
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1362,6 +1362,7 @@ components:
           type: string
         snapshot-id:
           type: interger
+          format: int64
         last-assigned-field-id:
           type: integer
         current-schema-id:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1361,7 +1361,7 @@ components:
         uuid:
           type: string
         snapshot-id:
-          type: integer
+          type: interger
         last-assigned-field-id:
           type: integer
         current-schema-id:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1235,7 +1235,7 @@ components:
           required:
             - sort-order-id
           properties:
-            order-id:
+            sort-order-id:
               type: integer
               description: Sort order ID to set as the default, or -1 to set last added sort order
 
@@ -1243,6 +1243,7 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
           required:
             - snapshot
           properties:
@@ -1340,7 +1341,7 @@ components:
         
         - `assert-default-spec-id` - the table's default spec id must match the requirement's `default-spec-id`
         
-        - `assert-default-write-order-id` - the table's default sort order id must match the requirement's `default-write-order-id`
+        - `assert-default-sort-order-id` - the table's default sort order id must match the requirement's `default-sort-order-id`
       type: object
       required:
         - requirement


### PR DESCRIPTION
We need a parser for `UpdateTableRequest.UpdateRequirement` class.

- Adds `UpdateRequirementParser`
- Adds json serializer / deserializer to the RESTSerializers class
- Adds tests for all of the individual implementations of `UpdateRequirement`, similar to `MetadataUpdate` tests.

Open questions:
- Some of the field names don't necessarily line up with the spec.
  - I've noted them on the PR. I was initially going to change them, but they are intertwined with some other classes (namely `MetadataUpdate`) and would also possibly cause shadowing issues in some cases.
  - The biggest source of confusion is `sortOrderId` vs `default-write-order-id`, though looking at the spec, the corresponding `MetadataUpdate` field is just called `order-id` so maybe it's not a concern.

EDIT:
For the naming, we've decided to keep the specs field name of `ref`, but update `default-write-order-id` and all references in `UpdateRequirement` to use `sort-order-id` instead of `write-order-id`.

There's an associated field in `MetadataUpdate` that's just called `order-id` which I will update in a different PR.