### PR TITLE
Core: Add all_delete_files and all_files tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.io.CloseableIterable;
+
+/**
+ * A {@link Table} implementation that exposes a table's valid delete files as rows.
+ * <p>
+ * A valid delete file is one that is readable from any snapshot currently tracked by the table.
+ * <p>
+ * This table may return duplicate rows.
+ */
+public class AllDeleteFilesTable extends BaseFilesTable {
+
+  AllDeleteFilesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".all_delete_files");
+  }
+
+  AllDeleteFilesTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new AllDataFilesTableScan(operations(), table(), schema());
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.ALL_DELETE_FILES;
+  }
+
+  public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
+
+    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES);
+    }
+
+    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema,
+                                  TableScanContext context) {
+      super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new AllDataFilesTableScan(ops, table, schema, context);
+    }
+
+    @Override
+    protected CloseableIterable<ManifestFile> manifests() {
+      return reachableManifests(Snapshot::deleteManifests);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
@@ -22,7 +22,7 @@ package org.apache.iceberg;
 import org.apache.iceberg.io.CloseableIterable;
 
 /**
- * A {@link Table} implementation that exposes a table's valid delete files as rows.
+ * A {@link Table} implementation that exposes its valid delete files as rows.
  * <p>
  * A valid delete file is one that is readable from any snapshot currently tracked by the table.
  * <p>
@@ -40,7 +40,7 @@ public class AllDeleteFilesTable extends BaseFilesTable {
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(operations(), table(), schema());
+    return new AllDeleteFilesTableScan(operations(), table(), schema());
   }
 
   @Override
@@ -48,20 +48,20 @@ public class AllDeleteFilesTable extends BaseFilesTable {
     return MetadataTableType.ALL_DELETE_FILES;
   }
 
-  public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
+  public static class AllDeleteFilesTableScan extends BaseAllFilesTableScan {
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+    AllDeleteFilesTableScan(TableOperations ops, Table table, Schema schema) {
       super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES);
     }
 
-    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema,
-                                  TableScanContext context) {
+    private AllDeleteFilesTableScan(TableOperations ops, Table table, Schema schema,
+                                    TableScanContext context) {
       super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, context);
+      return new AllDeleteFilesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllFilesTable.java
@@ -22,7 +22,7 @@ package org.apache.iceberg;
 import org.apache.iceberg.io.CloseableIterable;
 
 /**
- * A {@link Table} implementation that exposes a table's valid files as rows.
+ * A {@link Table} implementation that exposes its valid files as rows.
  * <p>
  * A valid file is one that is readable from any snapshot currently tracked by the table.
  * <p>
@@ -40,7 +40,7 @@ public class AllFilesTable extends BaseFilesTable {
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(operations(), table(), schema());
+    return new AllFilesTableScan(operations(), table(), schema());
   }
 
   @Override
@@ -48,20 +48,20 @@ public class AllFilesTable extends BaseFilesTable {
     return MetadataTableType.ALL_FILES;
   }
 
-  public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
+  public static class AllFilesTableScan extends BaseAllFilesTableScan {
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+    AllFilesTableScan(TableOperations ops, Table table, Schema schema) {
       super(ops, table, schema, MetadataTableType.ALL_FILES);
     }
 
-    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema,
-                                  TableScanContext context) {
+    private AllFilesTableScan(TableOperations ops, Table table, Schema schema,
+                              TableScanContext context) {
       super(ops, table, schema, MetadataTableType.ALL_FILES, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, context);
+      return new AllFilesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllFilesTable.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.io.CloseableIterable;
+
+/**
+ * A {@link Table} implementation that exposes a table's valid files as rows.
+ * <p>
+ * A valid file is one that is readable from any snapshot currently tracked by the table.
+ * <p>
+ * This table may return duplicate rows.
+ */
+public class AllFilesTable extends BaseFilesTable {
+
+  AllFilesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".all_files");
+  }
+
+  AllFilesTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new AllDataFilesTableScan(operations(), table(), schema());
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.ALL_FILES;
+  }
+
+  public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
+
+    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema, MetadataTableType.ALL_FILES);
+    }
+
+    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema,
+                                  TableScanContext context) {
+      super(ops, table, schema, MetadataTableType.ALL_FILES, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new AllDataFilesTableScan(ops, table, schema, context);
+    }
+
+    @Override
+    protected CloseableIterable<ManifestFile> manifests() {
+      return reachableManifests(Snapshot::allManifests);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -31,6 +31,8 @@ public enum MetadataTableType {
   MANIFESTS,
   PARTITIONS,
   ALL_DATA_FILES,
+  ALL_DELETE_FILES,
+  ALL_FILES,
   ALL_MANIFESTS,
   ALL_ENTRIES;
 

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -69,6 +69,10 @@ public class MetadataTableUtils {
         return new PartitionsTable(ops, baseTable, metadataTableName);
       case ALL_DATA_FILES:
         return new AllDataFilesTable(ops, baseTable, metadataTableName);
+      case ALL_DELETE_FILES:
+        return new AllDeleteFilesTable(ops, baseTable, metadataTableName);
+      case ALL_FILES:
+        return new AllFilesTable(ops, baseTable, metadataTableName);
       case ALL_MANIFESTS:
         return new AllManifestsTable(ops, baseTable, metadataTableName);
       case ALL_ENTRIES:

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.Set;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.BaseFilesTable.ManifestReadTask;
 import org.apache.iceberg.expressions.Expression;
@@ -40,6 +41,10 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 @RunWith(Parameterized.class)
 public class TestMetadataTableFilters extends TableTestBase {
+
+  private static final Set<MetadataTableType> aggFileTables = Sets.newHashSet(MetadataTableType.ALL_DATA_FILES,
+      MetadataTableType.ALL_DATA_FILES,
+      MetadataTableType.ALL_FILES);
 
   private final MetadataTableType type;
 
@@ -99,7 +104,7 @@ public class TestMetadataTableFilters extends TableTestBase {
           .commit();
     }
 
-    if (allFileTableTest(type)) {
+    if (isAggFileTable(type)) {
       // Clear all files from current snapshot to test whether 'all' Files tables scans previous files
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Moves file entries to DELETED state
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Removes all entries
@@ -152,11 +157,8 @@ public class TestMetadataTableFilters extends TableTestBase {
     }
   }
 
-  private boolean allFileTableTest(MetadataTableType tableType) {
-    return Sets.newHashSet(MetadataTableType.ALL_DATA_FILES,
-            MetadataTableType.ALL_DATA_FILES,
-            MetadataTableType.ALL_FILES)
-        .contains(tableType);
+  private boolean isAggFileTable(MetadataTableType tableType) {
+    return aggFileTables.contains(tableType);
   }
 
   @Test
@@ -310,7 +312,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
-    if (allFileTableTest(type)) {
+    if (isAggFileTable(type)) {
       // Clear all files from current snapshot to test whether 'all' Files tables scans previous files
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Moves file entries to DELETED state
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Removes all entries
@@ -385,7 +387,7 @@ public class TestMetadataTableFilters extends TableTestBase {
       table.newRowDelta().addDeletes(delete11).commit();
     }
 
-    if (allFileTableTest(type)) {
+    if (isAggFileTable(type)) {
       // Clear all files from current snapshot to test whether 'all' Files tables scans previous files
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Moves file entries to DELETED state
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Removes all entries
@@ -446,7 +448,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
-    if (allFileTableTest(type)) {
+    if (isAggFileTable(type)) {
       // Clear all files from current snapshot to test whether 'all' Files tables scans previous files
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Moves file entries to DELETED state
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Removes all entries
@@ -521,7 +523,7 @@ public class TestMetadataTableFilters extends TableTestBase {
       table.newRowDelta().addDeletes(delete11).commit();
     }
 
-    if (allFileTableTest(type)) {
+    if (isAggFileTable(type)) {
       // Clear all files from current snapshot to test whether 'all' Files tables scans previous files
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Moves file entries to DELETED state
       table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();  // Removes all entries

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -77,6 +78,10 @@ import static scala.collection.JavaConverters.seqAsJavaListConverter;
 public class TestHelpers {
 
   private TestHelpers() {
+  }
+
+  public static void assertEqualsSafe(Types.StructType struct, List<Record> recs, List<Row> rows) {
+    Streams.forEachPair(recs.stream(), rows.stream(), (rec, row) -> assertEqualsSafe(struct, rec, row));
   }
 
   public static void assertEqualsSafe(Types.StructType struct, Record rec, Row row) {


### PR DESCRIPTION
This will be the final set of changes for https://github.com/apache/iceberg/issues/4139, adding the new metadata tables 'all_delete_files' and 'all_files' to include delete files.

This adds both in one change list as it's easier to write a unified test, although they can be split up if we prefer that.