### PR TITLE
Core: Fix invalid null handling in JsonUtils::getIntOrNull ::getLongOrNull

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -59,7 +59,7 @@ public class JsonUtil {
   }
 
   public static Integer getIntOrNull(String property, JsonNode node) {
-    if (!node.has(property)) {
+    if (!node.hasNonNull(property)) {
       return null;
     }
     JsonNode pNode = node.get(property);
@@ -69,7 +69,7 @@ public class JsonUtil {
   }
 
   public static Long getLongOrNull(String property, JsonNode node) {
-    if (!node.has(property)) {
+    if (!node.hasNonNull(property)) {
       return null;
     }
     JsonNode pNode = node.get(property);


### PR DESCRIPTION
Using `JsonUtils::getLongOrNull` in https://github.com/apache/iceberg/pull/4693, it seems that the functions `getIntOrNull` and `getLongOrNull` do not properly handle an explicit null.

As you can see in the `Preconditions` check, after getting the property, if the JsonNode of the nullable Integer or Long is explicitly `null`, the Precondition check will fail.

cc @rdblue @RussellSpitzer 