### PR TITLE
Flink 1.15 - Fix flaky test that has implicit order dependency in TestFlinkTableSource

### DIFF
--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -98,13 +99,6 @@ public class TestFlinkTableSource extends FlinkTestBase {
 
   @Test
   public void testLimitPushDown() {
-    String querySql = String.format("SELECT * FROM %s LIMIT 1", TABLE_NAME);
-    String explain = getTableEnv().explainSql(querySql);
-    String expectedExplain = "limit=[1]";
-    Assert.assertTrue("Explain should contain LimitPushDown", explain.contains(expectedExplain));
-    List<Row> result = sql(querySql);
-    Assert.assertEquals("Should have 1 record", 1, result.size());
-    Assert.assertEquals("Should produce the expected records", Row.of(1, "iceberg", 10.0), result.get(0));
 
     AssertHelpers.assertThrows("Invalid limit number: -1 ", SqlParserException.class,
         () -> sql("SELECT * FROM %s LIMIT -1", TABLE_NAME));
@@ -120,6 +114,16 @@ public class TestFlinkTableSource extends FlinkTestBase {
         Row.of(3, null, 30.0)
     );
     assertSameElements(expectedList, resultExceed);
+
+    String querySql = String.format("SELECT * FROM %s LIMIT 1", TABLE_NAME);
+    String explain = getTableEnv().explainSql(querySql);
+    String expectedExplain = "limit=[1]";
+    Assert.assertTrue("Explain should contain LimitPushDown", explain.contains(expectedExplain));
+    List<Row> result = sql(querySql);
+    Assert.assertEquals("Should have 1 record", 1, result.size());
+    Assertions.assertThat(result)
+        .containsAnyElementsOf(expectedList)
+        .size().isEqualTo(1);
 
     String sqlMixed = String.format("SELECT * FROM %s WHERE id = 1 LIMIT 2", TABLE_NAME);
     List<Row> mixedResult = sql(sqlMixed);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -122,8 +122,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Row> result = sql(querySql);
     Assert.assertEquals("Should have 1 record", 1, result.size());
     Assertions.assertThat(result)
-        .containsAnyElementsOf(expectedList)
-        .size().isEqualTo(1);
+        .containsAnyElementsOf(expectedList);
 
     String sqlMixed = String.format("SELECT * FROM %s WHERE id = 1 LIMIT 2", TABLE_NAME);
     List<Row> mixedResult = sql(sqlMixed);


### PR DESCRIPTION
Some tests in Flink's `TestFlinkTableSource` have been found to be order dependent.

As the order of results on read is not defined (without an order by clause), most of the tests were fixed in https://github.com/apache/iceberg/commit/c726b2222f491aac02f0f1910898b4a8dfda2b14

However, there is one test that has a `LIMIT 1` that then asserts on the row, which could be any of 3 possible rows.

As Flink happened to be returning the records in a stable manner prior to Flink 1.15, this test was passing. But in PR https://github.com/apache/iceberg/pull/4693, this test was discovered to occasionally fail, as `SELECT * .... LIMIT 1` on a table with 3 results has no guarantee of which record will be returned.

Failed execution output:
```
org.apache.iceberg.flink.TestFlinkTableSource > testLimitPushDown FAILED
    java.lang.AssertionError: Should produce the expected records expected:<+I[1, iceberg, 10.0]> but was:<+I[2, b, 20.0]>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.apache.iceberg.flink.TestFlinkTableSource.testLimitPushDown(TestFlinkTableSource.java:107)
```

I've updated the test to assert that there is only one record, and that it is one of the 3 records in the table (which is assured by the previous query, which issues `SELECT * .. LIMIT 4` with no filter and gets 3 records back).