### PR TITLE
Spark 3.x: Support rewrite data files with starting sequence number

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -82,6 +82,7 @@ abstract class BaseRewriteDataFilesSparkAction
       PARTIAL_PROGRESS_ENABLED,
       PARTIAL_PROGRESS_MAX_COMMITS,
       TARGET_FILE_SIZE_BYTES,
+      USE_STARTING_SEQUENCE_NUMBER,
       REWRITE_JOB_ORDER
   );
 
@@ -91,6 +92,7 @@ abstract class BaseRewriteDataFilesSparkAction
   private int maxConcurrentFileGroupRewrites;
   private int maxCommits;
   private boolean partialProgressEnabled;
+  private boolean useStartingSequenceNumber;
   private RewriteJobOrder rewriteJobOrder;
   private RewriteStrategy strategy = null;
 
@@ -248,7 +250,7 @@ abstract class BaseRewriteDataFilesSparkAction
 
   @VisibleForTesting
   RewriteDataFilesCommitManager commitManager(long startingSnapshotId) {
-    return new RewriteDataFilesCommitManager(table, startingSnapshotId);
+    return new RewriteDataFilesCommitManager(table, startingSnapshotId, useStartingSequenceNumber);
   }
 
   private Result doExecute(RewriteExecutionContext ctx, Stream<RewriteFileGroup> groupStream,
@@ -394,6 +396,10 @@ abstract class BaseRewriteDataFilesSparkAction
     partialProgressEnabled = PropertyUtil.propertyAsBoolean(options(),
         PARTIAL_PROGRESS_ENABLED,
         PARTIAL_PROGRESS_ENABLED_DEFAULT);
+
+    useStartingSequenceNumber = PropertyUtil.propertyAsBoolean(options(),
+        USE_STARTING_SEQUENCE_NUMBER,
+        USE_STARTING_SEQUENCE_NUMBER_DEFAULT);
 
     rewriteJobOrder = RewriteJobOrder.fromName(PropertyUtil.propertyAsString(options(),
         REWRITE_JOB_ORDER,


### PR DESCRIPTION
I noticed that `use-starting-sequence-number` option is missing while developing https://github.com/apache/iceberg/pull/4377 and https://github.com/apache/iceberg/pull/4579. Adding support for the same in this PR.

When `use-starting-sequence-number` is enabled then compaction should use the sequence number of the snapshot at compaction start time for new data files, instead of using the sequence number of the newly produced snapshot. This avoids commit conflicts with updates that add newer equality deletes at a higher sequence number.

---

cc: @RussellSpitzer @jackye1995 @szehon-ho 