### PR TITLE
API: Optionally ignore position deletes in rewrite validation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -84,4 +84,16 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Set the snapshot ID used in any reads for this operation.
+   * <p>
+   * Validations will check changes after this snapshot ID. If this is not called, all ancestor snapshots through the
+   * table's initial snapshot are validated.
+   *
+   * @param snapshotId a snapshot ID
+   * @param ignorePosDeletes whether to ignore position delete in validation
+   * @return this for method chaining
+   */
+  RewriteFiles validateFromSnapshot(long snapshotId, boolean ignorePosDeletes);
 }

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -86,14 +86,10 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   RewriteFiles validateFromSnapshot(long snapshotId);
 
   /**
-   * Set the snapshot ID used in any reads for this operation.
-   * <p>
-   * Validations will check changes after this snapshot ID. If this is not called, all ancestor snapshots through the
-   * table's initial snapshot are validated.
+   * Ignore the position deletes in rewrite validation. Flink upsert job only generates position deletes in the
+   * ongoing transaction, so it is not necessary to validate position deletes when rewriting.
    *
-   * @param snapshotId a snapshot ID
-   * @param ignorePosDeletes whether to ignore position delete in validation
    * @return this for method chaining
    */
-  RewriteFiles validateFromSnapshot(long snapshotId, boolean ignorePosDeletes);
+  RewriteFiles ignorePosDeletesInValidation();
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   private final Set<DataFile> replacedDataFiles = Sets.newHashSet();
   private Long startingSnapshotId = null;
+  private boolean ignorePosDeletes = false;
 
   BaseRewriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -102,10 +103,17 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles validateFromSnapshot(long snapshotId, boolean ignorePositionDeletes) {
+    this.startingSnapshotId = snapshotId;
+    this.ignorePosDeletes = ignorePositionDeletes;
+    return this;
+  }
+
+  @Override
   protected void validate(TableMetadata base) {
     if (replacedDataFiles.size() > 0) {
       // if there are replaced data files, there cannot be any new row-level deletes for those data files
-      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles);
+      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles, ignorePosDeletes);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -1309,7 +1309,8 @@ public class TestRowDelta extends V2TableTestBase {
 
     RewriteFiles rewriteFiles = table.newRewrite()
         .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2), baseSnapshot.sequenceNumber())
-        .validateFromSnapshot(baseSnapshot.snapshotId(), true);
+        .ignorePosDeletesInValidation()
+        .validateFromSnapshot(baseSnapshot.snapshotId());
 
     rowDelta.commit();
     rewriteFiles.commit();

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -103,6 +103,7 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
   protected class RowDataDeltaWriter extends BaseEqualityDeltaWriter {
     RowDataDeltaWriter(PartitionKey partition) {
       super(partition, schema, deleteSchema);
+      ignorePosDeletesReferences();
     }
 
     @Override


### PR DESCRIPTION
This reduces conflicts when performing rewrite service for the fink upsert job.

When streaming change log to iceberg table, the flink task writers produce position deletes against the data files that were produced in the same transaction. The offline rewrite service thus is safe to commit the rewritten data files without caring about the position deletes.