### PR TITLE
Spark: Add actions for disaster recovery.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -74,4 +74,25 @@ public interface ActionsProvider {
   default DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /**
+   * Instantiates an action to copy table.
+   */
+  default CopyTable copyTable(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement copyTable");
+  }
+
+  /**
+   * Instantiates an action to check snapshot integrity.
+   */
+  default CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement checkSnapshotIntegrity");
+  }
+
+  /**
+   * Instantiates an action to remove expired files.
+   */
+  default RemoveExpiredFiles removeExpiredFiles(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement removeExpiredFiles");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/CheckSnapshotIntegrity.java
+++ b/api/src/main/java/org/apache/iceberg/actions/CheckSnapshotIntegrity.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.concurrent.ExecutorService;
+
+public interface CheckSnapshotIntegrity extends Action<CheckSnapshotIntegrity, CheckSnapshotIntegrity.Result> {
+
+  /**
+   * Passes an alternative executor service that will be used for snapshot integrity checking. If this method is not
+   * called, snapshot integrity checker will still be running by a single threaded executor service.
+   *
+   * @param executorService an executor service to parallelize tasks to check snapshot integrity
+   * @return this for method chaining
+   */
+  CheckSnapshotIntegrity executeWith(ExecutorService executorService);
+
+  /**
+   * Pass the target version to check. The action checks the snapshots in the target version, not in the current version
+   * of the table.
+   *
+   * @param targetVersion the target version file to be checked. Either a file name or a file path is acceptable. For
+   *                      example, it could be either "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json" or
+   *                      "/path/to/00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CheckSnapshotIntegrity targetVersion(String targetVersion);
+
+  /**
+   * The action result that contains a summary of the execution.
+   */
+  interface Result {
+    /**
+     * Returns locations of missing metadata/data files.
+     */
+    Iterable<String> missingFileLocations();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/CopyTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/CopyTable.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.Table;
+
+public interface CopyTable extends Action<CopyTable, CopyTable.Result> {
+
+  /**
+   * Passes the source and target prefixes that will be used to replace the source prefix with the target one.
+   *
+   * @param sourcePrefix the source prefix to be replaced
+   * @param targetPrefix the target prefix
+   * @return this for method chaining
+   */
+  CopyTable rewriteLocationPrefix(String sourcePrefix, String targetPrefix);
+
+  /**
+   * Pass the version copied last time. It is optional if the target table is provided. The default value is the target
+   * table's current version. User needs to make sure whether the start version is valid if target table is not
+   * provided.
+   *
+   * @param lastCopiedVersion only version file name is needed, not the metadata json file path. For example, the
+   *                          version file would be "v2.metadata.json" for a Hadoop table. For metastore tables, the
+   *                          version file would be like "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CopyTable lastCopiedVersion(String lastCopiedVersion);
+
+  /**
+   * The latest version of the table to copy. It is optional, the default value is the source table's current version.
+   *
+   * @param endVersion only version file name is needed, not the metadata json file path. For example, the version
+   *                   file would be "v2.metadata.json" for a Hadoop table. For metastore tables, the version file
+   *                   would be like "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  CopyTable endVersion(String endVersion);
+
+  /**
+   * Set the customized staging location. It is optional. By default, staging location is a sub directory under table's
+   * metadata directory.
+   *
+   * @param stagingLocation the staging location
+   * @return this for method chaining
+   */
+  CopyTable stagingLocation(String stagingLocation);
+
+  /**
+   * Set the target table. It is optional if the start version is provided.
+   *
+   * @param targetTable the target table
+   * @return this for method chaining
+   */
+  CopyTable targetTable(Table targetTable);
+
+  /**
+   * The action result that contains a summary of the execution.
+   */
+  interface Result {
+    /**
+     * Return directory of data files list.
+     */
+    String dataFileListLocation();
+
+    /**
+     * Return directory of metadata files list.
+     */
+    String metadataFileListLocation();
+
+    /**
+     * Return the latest version
+     */
+    String latestVersion();
+  }
+}
+

--- a/api/src/main/java/org/apache/iceberg/actions/RemoveExpiredFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RemoveExpiredFiles.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.concurrent.ExecutorService;
+
+public interface RemoveExpiredFiles extends Action<RemoveExpiredFiles, RemoveExpiredFiles.Result> {
+
+  /**
+   * Passes an alternative executor service that will be used for snapshot integrity checking. If this method is not
+   * called, snapshot integrity checker will still be running by a single threaded executor service.
+   *
+   * @param executorService an executor service to parallelize tasks to check snapshot integrity
+   * @return this for method chaining
+   */
+  RemoveExpiredFiles executeWith(ExecutorService executorService);
+
+  /**
+   * Pass the target version to check. The action checks the snapshots in the target version, not in the current version
+   * of the table.
+   *
+   * @param targetVersion the target version file to be checked. Either a file name or a file path is acceptable. For
+   *                      example, it could be either "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json" or
+   *                      "/path/to/00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
+   * @return this for method chaining
+   */
+  RemoveExpiredFiles targetVersion(String targetVersion);
+
+  /**
+   * The action result that contains a summary of the execution.
+   */
+  interface Result {
+    /**
+     * Returns the number of deleted data files.
+     */
+    long deletedDataFilesCount();
+
+    /**
+     * Returns the number of deleted manifests.
+     */
+    long deletedManifestsCount();
+
+    /**
+     * Returns the number of deleted manifest lists.
+     */
+    long deletedManifestListsCount();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.types.Types.StructType;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-interface ManifestEntry<F extends ContentFile<F>> {
+public interface ManifestEntry<F extends ContentFile<F>> {
   enum Status {
     EXISTING(0),
     ADDED(1),

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.Pair;
 
 public class ManifestFiles {
   private ManifestFiles() {
@@ -54,6 +55,12 @@ public class ManifestFiles {
     return CloseableIterable.transform(
         read(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
         entry -> entry.file().path().toString());
+  }
+
+  public static CloseableIterable<Pair<String, Long>> readPathsWithSnapshotId(ManifestFile manifest, FileIO io) {
+    return CloseableIterable.transform(
+        read(manifest, io, null).select(ImmutableList.of("file_path", "snapshot_id")).liveEntries(),
+        entry -> Pair.of(entry.file().path().toString(), entry.snapshotId()));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -29,11 +29,11 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
-class ManifestLists {
+public class ManifestLists {
   private ManifestLists() {
   }
 
-  static List<ManifestFile> read(InputFile manifestList) {
+  public static List<ManifestFile> read(InputFile manifestList) {
     try (CloseableIterable<ManifestFile> files = Avro.read(manifestList)
         .rename("manifest_file", GenericManifestFile.class.getName())
         .rename("partitions", GenericPartitionFieldSummary.class.getName())
@@ -50,8 +50,8 @@ class ManifestLists {
     }
   }
 
-  static ManifestListWriter write(int formatVersion, OutputFile manifestListFile,
-                                  long snapshotId, Long parentSnapshotId, long sequenceNumber) {
+  public static ManifestListWriter write(int formatVersion, OutputFile manifestListFile,
+                                         long snapshotId, Long parentSnapshotId, long sequenceNumber) {
     switch (formatVersion) {
       case 1:
         Preconditions.checkArgument(sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -175,7 +175,7 @@ public class ManifestReader<F extends ContentFile<F>>
     return this;
   }
 
-  CloseableIterable<ManifestEntry<F>> entries() {
+  public CloseableIterable<ManifestEntry<F>> entries() {
     if ((rowFilter != null && rowFilter != Expressions.alwaysTrue()) ||
         (partFilter != null && partFilter != Expressions.alwaysTrue()) ||
         (partitionSet != null)) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadataUtil.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class TableMetadataUtil {
+  private TableMetadataUtil() {
+  }
+
+  public static TableMetadata replacePaths(TableMetadata metadata,
+                                           String sourcePrefix,
+                                           String targetPrefix,
+                                           FileIO io) {
+    String newLocation = newPath(metadata.location(), sourcePrefix, targetPrefix);
+    List<Snapshot> newSnapshots = updatePathInSnapshots(metadata, sourcePrefix, targetPrefix, io);
+    List<MetadataLogEntry> metadataLogEntries = updatePathInMetadataLogs(metadata, sourcePrefix, targetPrefix);
+    long snapshotId = metadata.currentSnapshot() == null ? -1 : metadata.currentSnapshot().snapshotId();
+    Map<String, String> properties = updateProperties(metadata.properties(), sourcePrefix, targetPrefix);
+
+    return new TableMetadata(null, metadata.formatVersion(), metadata.uuid(),
+        newLocation, metadata.lastSequenceNumber(), metadata.lastUpdatedMillis(), metadata.lastColumnId(),
+        metadata.currentSchemaId(), metadata.schemas(), metadata.defaultSpecId(), metadata.specs(),
+        metadata.lastAssignedPartitionId(), metadata.defaultSortOrderId(), metadata.sortOrders(),
+        properties, snapshotId, newSnapshots, metadata.snapshotLog(), metadataLogEntries, metadata.refs(),
+        metadata.changes());
+  }
+
+  private static Map<String, String> updateProperties(Map<String, String> tableProperties,
+                                                      String sourcePrefix,
+                                                      String targetPrefix) {
+    Map properties = Maps.newHashMap(tableProperties);
+    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.OBJECT_STORE_PATH);
+    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
+    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.WRITE_DATA_LOCATION);
+    updatePathInProperty(properties, sourcePrefix, targetPrefix, TableProperties.WRITE_METADATA_LOCATION);
+
+    return properties;
+  }
+
+  private static void updatePathInProperty(Map<String, String> properties, String sourcePrefix, String targetPrefix,
+                                           String propertyName) {
+    if (properties.containsKey(propertyName)) {
+      properties.put(propertyName, newPath(properties.get(propertyName), sourcePrefix, targetPrefix));
+    }
+  }
+
+  private static List<MetadataLogEntry> updatePathInMetadataLogs(TableMetadata metadata,
+                                                                 String sourcePrefix,
+                                                                 String targetPrefix) {
+    List<MetadataLogEntry> metadataLogEntries = Lists.newArrayListWithCapacity(metadata.previousFiles().size());
+    for (MetadataLogEntry metadataLog : metadata.previousFiles()) {
+      MetadataLogEntry newMetadataLog = new MetadataLogEntry(metadataLog.timestampMillis(), newPath(metadataLog.file(),
+          sourcePrefix, targetPrefix));
+      metadataLogEntries.add(newMetadataLog);
+    }
+    return metadataLogEntries;
+  }
+
+  private static List<Snapshot> updatePathInSnapshots(TableMetadata metadata,
+                                                      String sourcePrefix,
+                                                      String targetPrefix,
+                                                      FileIO io) {
+    List<Snapshot> newSnapshots = Lists.newArrayListWithCapacity(metadata.snapshots().size());
+    for (Snapshot snapshot : metadata.snapshots()) {
+      String newManifestListLocation = newPath(snapshot.manifestListLocation(), sourcePrefix, targetPrefix);
+      Snapshot newSnapshot = new BaseSnapshot(io, snapshot.sequenceNumber(), snapshot.snapshotId(),
+          snapshot.parentId(), snapshot.timestampMillis(), snapshot.operation(), snapshot.summary(),
+          snapshot.schemaId(), newManifestListLocation);
+      newSnapshots.add(newSnapshot);
+    }
+    return newSnapshots;
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return path.replaceFirst(sourcePrefix, targetPrefix);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCheckSnapshotIntegrityResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCheckSnapshotIntegrityResult.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class BaseCheckSnapshotIntegrityResult implements CheckSnapshotIntegrity.Result {
+  private final Iterable<String> missingFileLocations;
+
+  public BaseCheckSnapshotIntegrityResult(Iterable<String> missingFileLocations) {
+    this.missingFileLocations = missingFileLocations;
+  }
+
+  @Override
+  public Iterable<String> missingFileLocations() {
+    return missingFileLocations;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseCopyTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCopyTableActionResult.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class BaseCopyTableActionResult implements CopyTable.Result {
+  private final String latestVersion;
+  private final String dataFileListPath;
+  private final String metadataFileListPath;
+
+  public BaseCopyTableActionResult(String dataFileListPath, String metadataFileListPath, String latestVersion) {
+    this.dataFileListPath = dataFileListPath;
+    this.metadataFileListPath = metadataFileListPath;
+    this.latestVersion = latestVersion;
+  }
+
+  @Override
+  public String dataFileListLocation() {
+    return dataFileListPath;
+  }
+
+  @Override
+  public String metadataFileListLocation() {
+    return metadataFileListPath;
+  }
+
+  @Override
+  public String latestVersion() {
+    return latestVersion;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRemoveExpiredFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRemoveExpiredFilesActionResult.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class BaseRemoveExpiredFilesActionResult implements RemoveExpiredFiles.Result {
+  private final long deletedDataFilesCount;
+  private final long deletedManifestsCount;
+  private final long deletedManifestListsCount;
+
+  public BaseRemoveExpiredFilesActionResult(long deletedDataFilesCount, long deletedManifestsCount,
+      long deletedManifestListsCount) {
+    this.deletedDataFilesCount = deletedDataFilesCount;
+    this.deletedManifestsCount = deletedManifestsCount;
+    this.deletedManifestListsCount = deletedManifestListsCount;
+  }
+
+  @Override
+  public long deletedDataFilesCount() {
+    return deletedDataFilesCount;
+  }
+
+  @Override
+  public long deletedManifestsCount() {
+    return deletedManifestsCount;
+  }
+
+  @Override
+  public long deletedManifestListsCount() {
+    return deletedManifestListsCount;
+  }
+}

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
@@ -21,12 +21,9 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
-import org.apache.iceberg.actions.CheckSnapshotIntegrity;
-import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
-import org.apache.iceberg.actions.RemoveExpiredFiles;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.spark.sql.SparkSession;
 
@@ -60,20 +57,5 @@ abstract class BaseSparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
-  }
-
-  @Override
-  public CopyTable copyTable(Table table) {
-    return new BaseCopyTableSparkAction(spark, table);
-  }
-
-  @Override
-  public CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
-    return new BaseCheckSnapshotIntegritySparkAction(spark, table);
-  }
-
-  @Override
-  public RemoveExpiredFiles removeExpiredFiles(Table table) {
-    return new BaseRemoveExpiredFilesSparkAction(spark, table);
   }
 }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
@@ -21,9 +21,12 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CheckSnapshotIntegrity;
+import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
+import org.apache.iceberg.actions.RemoveExpiredFiles;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.spark.sql.SparkSession;
 
@@ -57,5 +60,20 @@ abstract class BaseSparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
+  }
+
+  @Override
+  public CopyTable copyTable(Table table) {
+    return new BaseCopyTableSparkAction(spark, table);
+  }
+
+  @Override
+  public CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
+    return new BaseCheckSnapshotIntegritySparkAction(spark, table);
+  }
+
+  @Override
+  public RemoveExpiredFiles removeExpiredFiles(Table table) {
+    return new BaseRemoveExpiredFilesSparkAction(spark, table);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCheckSnapshotIntegritySparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCheckSnapshotIntegritySparkAction.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.BaseCheckSnapshotIntegrityResult;
+import org.apache.iceberg.actions.CheckSnapshotIntegrity;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.util.Tasks;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseCheckSnapshotIntegritySparkAction
+    extends BaseSparkAction<CheckSnapshotIntegrity, CheckSnapshotIntegrity.Result> implements CheckSnapshotIntegrity {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCheckSnapshotIntegritySparkAction.class);
+  private static final ExecutorService DEFAULT_EXECUTOR_SERVICE = null;
+
+  private final Table table;
+  private final Set<String> missingFiles = Collections.synchronizedSet(Sets.newHashSet());
+  private ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
+  private String targetVersion;
+  private Table targetTable;
+
+  private Consumer<String> validateFunc = new Consumer<String>() {
+    @Override
+    public void accept(String file) {
+      try {
+        if (!table.io().newInputFile(file).exists()) {
+          missingFiles.add(file);
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to check the existence of file: {}. Marking it as missing.", file, e);
+        missingFiles.add(file);
+      }
+    }
+  };
+
+  public BaseCheckSnapshotIntegritySparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+  }
+
+  @Override
+  protected CheckSnapshotIntegrity self() {
+    return this;
+  }
+
+  @Override
+  public CheckSnapshotIntegrity executeWith(ExecutorService service) {
+    this.executorService = service;
+    return this;
+  }
+
+  @Override
+  public CheckSnapshotIntegrity targetVersion(String tVersion) {
+    Preconditions.checkArgument(tVersion != null && !tVersion.isEmpty(), "Target version file('%s') cannot be empty.",
+        tVersion);
+
+    String tVersionFile = tVersion;
+    if (!tVersionFile.contains(File.separator)) {
+      tVersionFile = ((HasTableOperations) table).operations().metadataFileLocation(tVersionFile);
+    }
+
+    Preconditions.checkArgument(fileExist(tVersionFile), "Version file('%s') doesn't exist.", tVersionFile);
+    this.targetVersion = tVersionFile;
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    JobGroupInfo info = newJobGroupInfo("CHECK-SNAPSHOT-INTEGRITY", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private String jobDesc() {
+    return String.format("Checking integrity of version '%s' of table %s.", targetVersion, table.name());
+  }
+
+  private CheckSnapshotIntegrity.Result doExecute() {
+    targetTable = newStaticTable(targetVersion, table.io());
+
+    List<String> filesToCheck = filesToCheck();
+
+    Tasks.foreach(filesToCheck)
+        .noRetry()
+        .suppressFailureWhenFinished()
+        .executeWith(executorService)
+        .run(validateFunc::accept);
+
+    return new BaseCheckSnapshotIntegrityResult(missingFiles);
+  }
+
+  private List<String> filesToCheck() {
+    Dataset<Row> targetFileDF = fileDF(targetTable);
+    Dataset<Row> currentFileDF = fileDF(table);
+    return targetFileDF.except(currentFileDF).as(Encoders.STRING()).collectAsList();
+  }
+
+  private Dataset<Row> fileDF(Table tbl) {
+    Dataset<Row> validDataFileDF = buildValidDataFileDF(tbl);
+    Dataset<Row> validMetadataFileDF = buildValidMetadataFileDF(tbl);
+    return validDataFileDF.union(validMetadataFileDF);
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseCopyTableSparkAction.java
@@ -1,0 +1,552 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestEntry;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestLists;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadata.MetadataLogEntry;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableMetadataUtil;
+import org.apache.iceberg.actions.BaseCopyTableActionResult;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.spark.SparkUtil;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseCopyTableSparkAction
+    extends BaseSparkAction<CopyTable, CopyTable.Result> implements CopyTable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseCopyTableSparkAction.class);
+  private static final String DATA_FILE_LIST_DIR = "data-file-list-to-move";
+  private static final String METADATA_FILE_LIST_DIR = "metadata-file-list-to-move";
+
+  private final Table table;
+  private final Set<String> metadataFilesToMove = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<String> manifestFilePaths = Collections.synchronizedSet(Sets.newHashSet());
+  private final Set<ManifestFile> manifestFilesToRewrite = Collections.synchronizedSet(Sets.newHashSet());
+  private String dataFileListPath = null;
+  private String metadataFileListPath = null;
+  private final boolean enabledPME;
+
+  private String sourcePrefix = "";
+  private String targetPrefix = "";
+  private String startVersion = "";
+  private String endVersion = "";
+  private String stagingDir = "";
+  private Table targetTable = null;
+
+  private Table startStaticTable = null;
+  private Table endStaticTable = null;
+
+  public BaseCopyTableSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    enabledPME = table.properties().containsKey("parquet.encryption.footer.key");
+  }
+
+  @Override
+  public CopyTable rewriteLocationPrefix(String sPrefix, String tPrefix) {
+    Preconditions.checkArgument(sPrefix != null && !sPrefix.isEmpty(), "Source prefix('%s') cannot be empty.", sPrefix);
+    this.sourcePrefix = sPrefix;
+
+    if (tPrefix != null) {
+      this.targetPrefix = tPrefix;
+    }
+    return this;
+  }
+
+  @Override
+  public CopyTable lastCopiedVersion(String sVersion) {
+    Preconditions.checkArgument(sVersion != null && !sVersion.trim().isEmpty(),
+        "Last copied version('%s') cannot be empty.", sVersion);
+    this.startVersion = sVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable endVersion(String eVersion) {
+    Preconditions.checkArgument(eVersion != null && !eVersion.trim().isEmpty(),
+        "End version('%s') cannot be empty.", eVersion);
+    this.endVersion = eVersion;
+    return this;
+  }
+
+  @Override
+  public CopyTable stagingLocation(String stagingLocation) {
+    Preconditions.checkArgument(stagingLocation != null && !stagingLocation.isEmpty(),
+        "Staging location('%s') cannot be empty.", stagingLocation);
+    this.stagingDir = stagingLocation;
+    return this;
+  }
+
+  @Override
+  public CopyTable targetTable(Table tgtTable) {
+    this.targetTable = tgtTable;
+    return this;
+  }
+
+  @Override
+  protected CopyTable self() {
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    validateInputs();
+    JobGroupInfo info = newJobGroupInfo("COPY-TABLE", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private CopyTable.Result doExecute() {
+    rebuildMetaData();
+    return new BaseCopyTableActionResult(dataFileListPath, metadataFileListPath, fileName(endVersion));
+  }
+
+  private void validateInputs() {
+    Preconditions.checkArgument(sourcePrefix != null && !sourcePrefix.isEmpty(),
+        "Source prefix('%s') cannot be empty.", sourcePrefix);
+
+    validateAndSetEndVersion();
+
+    endStaticTable = newStaticTable(endVersion, table.io());
+
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+    Preconditions.checkArgument(tableMetadata.formatVersion() == 1, "Support Iceberg format version 1 only.");
+
+    validateAndSetStartVersion(tableMetadata);
+
+    if (fileExist(startVersion)) {
+      startStaticTable = newStaticTable(startVersion, table.io());
+    }
+
+    if (stagingDir.isEmpty()) {
+      stagingDir = getMetadataLocation(table) + "copy-table-staging-" + UUID.randomUUID() + "/";
+    } else if (!stagingDir.endsWith("/")) {
+      stagingDir = stagingDir + "/";
+    }
+  }
+
+  private void validateAndSetEndVersion() {
+    if (endVersion.isEmpty()) {
+      endVersion = currentMetadataPath(table);
+    } else {
+      TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+      if (versionInFilePath(tableMetadata.metadataFileLocation(), endVersion)) {
+        endVersion = tableMetadata.metadataFileLocation();
+      }
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), endVersion)) {
+          endVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(fileExist(endVersion), "Cannot find the end version('%s') in the current version " +
+          "files", endVersion);
+    }
+  }
+
+  private void validateAndSetStartVersion(TableMetadata tableMetadata) {
+    if (startVersion.isEmpty()) {
+      if (targetTable == null) {
+        LOG.warn("No input of the start version. Will do a full copy.");
+      } else {
+        String tgtTableCurrentVersion = fileName(currentMetadataPath(targetTable));
+
+        for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+          if (metadataLogEntry.file().endsWith(tgtTableCurrentVersion)) {
+            startVersion = metadataLogEntry.file();
+            break;
+          }
+        }
+
+        if (fileNotExist(startVersion)) {
+          throw new IllegalArgumentException("Cannot find the current version of target table in the source table. " +
+              "Please make sure the target table is a subset of source table.");
+        }
+      }
+    } else {
+      for (MetadataLogEntry metadataLogEntry : tableMetadata.previousFiles()) {
+        if (versionInFilePath(metadataLogEntry.file(), startVersion)) {
+          startVersion = metadataLogEntry.file();
+          break;
+        }
+      }
+
+      Preconditions.checkArgument(fileExist(startVersion), "Start version('%s') is NOT valid.", startVersion);
+
+      if (targetTable != null && !fileName(startVersion).equals(fileName(currentMetadataPath(targetTable)))) {
+        throw new IllegalArgumentException("The start version isn't the current version of the target table. " +
+            "Please make sure the target table is a subset of source table.");
+      }
+    }
+  }
+
+  private boolean versionInFilePath(String path, String version) {
+    return fileName(path).equals(version);
+  }
+
+  private String jobDesc() {
+    if (startVersion.isEmpty()) {
+      return String.format("Replacing path prefixes '%s' with '%s' in the metadata files of table %s," +
+          "up to version '%s'.", sourcePrefix, targetPrefix, table.name(), endVersion);
+    } else {
+      return String.format("Replacing path prefixes '%s' with '%s' in the metadata files of table %s," +
+          "from version '%s' to '%s'.", sourcePrefix, targetPrefix, table.name(), startVersion, endVersion);
+    }
+  }
+
+  /**
+   * Here are steps: 1. rebuild version files 2. rebuild manifest list files 3. rebuild manifest files 4. get all data
+   * files need to move
+   */
+  private void rebuildMetaData() {
+    TableMetadata tableMetadata = ((HasTableOperations) endStaticTable).operations().current();
+
+    // rebuild version files
+    Set<Long> allSnapshotIds = rewriteVersionFiles(tableMetadata);
+
+    Set<Long> diffSnapshotIds = getDiffSnapshotIds(allSnapshotIds);
+
+    // get all manifest file paths need to rewrite
+    List<String> manifestFilePathToMove = manifestFilesToMove(diffSnapshotIds);
+    manifestFilePaths.addAll(manifestFilePathToMove);
+
+    // rebuild manifest-list files
+    Set<Snapshot> validSnapshots = Sets.difference(snapshotSet(endVersion), snapshotSet(startVersion));
+    validSnapshots.forEach(snapshot -> rewriteManifestList(snapshot, tableMetadata));
+
+    // rebuild manifest files
+    List<ManifestFile> newManifests = rewriteManifests(tableMetadata);
+    newManifests.forEach(manifestFile -> addToRebuiltFiles(manifestFile.path()));
+    saveMetadataFileList();
+
+    Dataset<Row> dataFiles = getDiffDataFiles(diffSnapshotIds);
+    saveDataFileList(dataFiles);
+  }
+
+  private void saveMetadataFileList() {
+    List<String> fileList = Lists.newArrayList();
+    fileList.addAll(metadataFilesToMove);
+    Dataset<String> metadataFileList = spark().createDataset(fileList, Encoders.STRING());
+    metadataFileListPath = stagingDir + METADATA_FILE_LIST_DIR;
+    metadataFileList.repartition(1).write().mode(SaveMode.Overwrite).format("text").save(metadataFileListPath);
+  }
+
+  private void saveDataFileList(Dataset<Row> dataFiles) {
+    dataFileListPath = stagingDir + DATA_FILE_LIST_DIR;
+
+    try {
+      dataFiles.repartition(1).write().mode(SaveMode.Overwrite).format("text").save(dataFileListPath);
+    } catch (Exception e) {
+      throw new UnsupportedOperationException("Failed to build the data files dataframe, the end version you are " +
+          "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid " +
+          "snapshots", e);
+    }
+  }
+
+  private Set<Long> getDiffSnapshotIds(Set<Long> allSnapshotIds) {
+    Set<Long> snapshotIdsInStartVersion = Sets.newHashSet();
+    if (startStaticTable != null) {
+      startStaticTable.snapshots().forEach(snapshot -> snapshotIdsInStartVersion.add(snapshot.snapshotId()));
+    }
+    return Sets.difference(allSnapshotIds, snapshotIdsInStartVersion);
+  }
+
+  private Set<Long> rewriteVersionFiles(TableMetadata metadata) {
+    Set<Long> allSnapshotIds = Sets.newHashSet();
+
+    String stagingPath = stagingPath(endVersion, stagingDir);
+    metadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+    rewriteVersionFile(metadata, stagingPath);
+
+    List<MetadataLogEntry> versions = metadata.previousFiles();
+    for (int i = versions.size() - 1; i >= 0; i--) {
+      String versionFilePath = versions.get(i).file();
+      if (versionFilePath.equals(startVersion)) {
+        break;
+      }
+
+      Preconditions.checkArgument(
+          fileExist(versionFilePath),
+          String.format("Version file %s doesn't exist", versionFilePath));
+      String newPath = stagingPath(versionFilePath, stagingDir);
+      TableMetadata tableMetadata = new StaticTableOperations(versionFilePath, table.io()).current();
+
+      tableMetadata.snapshots().forEach(snapshot -> allSnapshotIds.add(snapshot.snapshotId()));
+
+      rewriteVersionFile(tableMetadata, newPath);
+    }
+
+    return allSnapshotIds;
+  }
+
+  private Set<Snapshot> snapshotSet(String metadataPath) {
+    Set<Snapshot> snapshots = Sets.newHashSet();
+    if (!metadataPath.isEmpty()) {
+      StaticTableOperations ops = new StaticTableOperations(metadataPath, table.io());
+      TableMetadata metadata = ops.current();
+      snapshots.addAll(metadata.snapshots());
+    }
+    return snapshots;
+  }
+
+  private void rewriteVersionFile(TableMetadata metadata, String stagingPath) {
+    TableMetadata newTableMetadata = TableMetadataUtil.replacePaths(metadata, sourcePrefix, targetPrefix, table.io());
+    TableMetadataParser.overwrite(newTableMetadata, table.io().newOutputFile(stagingPath));
+    addToRebuiltFiles(stagingPath);
+  }
+
+  private void rewriteManifestList(Snapshot snapshot, TableMetadata tableMetadata) {
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(snapshot);
+    String path = snapshot.manifestListLocation();
+    String stagingPath = stagingPath(path, stagingDir);
+    OutputFile outputFile = table.io().newOutputFile(stagingPath);
+    try (FileAppender<ManifestFile> writer = ManifestLists.write(tableMetadata.formatVersion(), outputFile,
+        snapshot.snapshotId(), snapshot.parentId(), snapshot.sequenceNumber())) {
+
+      for (ManifestFile file : manifestFiles) {
+        // need to get the ManifestFile object for manifest file rewriting
+        if (manifestFilePaths.contains(file.path())) {
+          manifestFilesToRewrite.add(file);
+        }
+
+        ManifestFile newFile = file.copy();
+        if (newFile.path().startsWith(sourcePrefix)) {
+          ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        }
+        writer.add(newFile);
+      }
+
+      addToRebuiltFiles(stagingPath);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to rewrite the manifest list file " + path, e);
+    }
+  }
+
+  private List<ManifestFile> manifestFilesInSnapshot(Snapshot snapshot) {
+    String path = snapshot.manifestListLocation();
+    List<ManifestFile> manifestFiles = Lists.newLinkedList();
+    try {
+      manifestFiles = ManifestLists.read(table.io().newInputFile(path));
+    } catch (RuntimeIOException e) {
+      LOG.warn("Failed to read manifest list {}", path, e);
+    }
+    return manifestFiles;
+  }
+
+  private List<String> manifestFilesToMove(Set<Long> diffSnapshotIds) {
+    try {
+      Dataset<Row> lastVersionFiles = buildManifestFileDF(endStaticTable);
+      if (startStaticTable == null) {
+        return lastVersionFiles.distinct()
+            .as(Encoders.STRING())
+            .collectAsList();
+      } else {
+        return lastVersionFiles.distinct()
+            .filter(functions.column("added_snapshot_id").isInCollection(diffSnapshotIds))
+            .as(Encoders.STRING())
+            .collectAsList();
+      }
+    } catch (Exception e) {
+      throw new UnsupportedOperationException("Failed to build the manifest files dataframe, the end version you are " +
+          "trying to copy may contain invalid snapshots, please use the younger version which doesn't have invalid " +
+          "snapshots", e);
+    }
+  }
+
+  /**
+   * Rewrite manifest files in a distributed manner.
+   */
+  private List<ManifestFile> rewriteManifests(TableMetadata tableMetadata) {
+    if (manifestFilesToRewrite.isEmpty()) {
+      return Lists.newArrayList();
+    }
+
+    Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
+    Dataset<ManifestFile> manifestDS =
+        spark().createDataset(Lists.newArrayList(manifestFilesToRewrite), manifestFileEncoder);
+
+    Broadcast<FileIO> io = sparkContext().broadcast(SparkUtil.serializableFileIO(table));
+    Broadcast<Map<Integer, PartitionSpec>> specsById = sparkContext().broadcast(tableMetadata.specsById());
+
+    return manifestDS
+        .repartition(manifestFilesToRewrite.size())
+        .mapPartitions(
+            toManifests(io, stagingDir, tableMetadata.formatVersion(), specsById, sourcePrefix, targetPrefix),
+            manifestFileEncoder
+        )
+        .collectAsList();
+  }
+
+  private static MapPartitionsFunction<ManifestFile, ManifestFile> toManifests(
+      Broadcast<FileIO> io, String stagingLocation, int format, Broadcast<Map<Integer, PartitionSpec>> specsById,
+      String sourcePrefix, String targetPrefix) {
+
+    return rows -> {
+      List<ManifestFile> manifests = Lists.newArrayList();
+      while (rows.hasNext()) {
+        manifests.add(writeManifest(rows.next(), io, stagingLocation, format, specsById, sourcePrefix, targetPrefix));
+      }
+
+      return manifests.iterator();
+    };
+  }
+
+  private static ManifestFile writeManifest(
+      ManifestFile manifestFile, Broadcast<FileIO> io, String stagingLocation, int format,
+      Broadcast<Map<Integer, PartitionSpec>> specsById, String sourcePrefix, String targetPrefix) throws IOException {
+
+    String stagingPath = stagingPath(manifestFile.path(), stagingLocation);
+    OutputFile outputFile = io.value().newOutputFile(stagingPath);
+    PartitionSpec spec = specsById.getValue().get(manifestFile.partitionSpecId());
+    ManifestWriter<DataFile> writer = ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifestFile, io.getValue(), specsById.getValue())
+        .select(Arrays.asList("*"))) {
+      reader.entries().forEach(entry -> appendEntry(entry, writer, spec, sourcePrefix, targetPrefix));
+    } finally {
+      writer.close();
+    }
+
+    return writer.toManifestFile();
+  }
+
+  private static void appendEntry(
+      ManifestEntry<DataFile> entry, ManifestWriter<DataFile> writer, PartitionSpec spec,
+      String sourcePrefix, String targetPrefix) {
+    DataFile dataFile = entry.file();
+    String dataFilePath = dataFile.path().toString();
+    if (dataFilePath.startsWith(sourcePrefix)) {
+      dataFilePath = newPath(dataFilePath, sourcePrefix, targetPrefix);
+      dataFile = DataFiles.builder(spec).copy(entry.file()).withPath(dataFilePath).build();
+    }
+
+    switch (entry.status()) {
+      case ADDED:
+        writer.add(dataFile);
+        break;
+      case EXISTING:
+        writer.existing(dataFile, entry.snapshotId(), entry.sequenceNumber());
+        break;
+      case DELETED:
+        writer.delete(dataFile);
+        break;
+    }
+  }
+
+  private Dataset<Row> getDiffDataFiles(Set<Long> diffSnapshotIds) {
+    Dataset<Row> lastVersionFiles = buildValidDataFileDFWithSnapshotId(endStaticTable);
+    if (startStaticTable == null) {
+      return lastVersionFiles.distinct().select("file_path");
+    } else {
+      return lastVersionFiles.distinct()
+          .filter(functions.column("snapshot_id").isInCollection(diffSnapshotIds))
+          .select("file_path");
+    }
+  }
+
+  private boolean fileNotExist(String path) {
+    return !fileExist(path);
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+
+  private static String newPath(String path, String sourcePrefix, String targetPrefix) {
+    return path.replaceFirst(sourcePrefix, targetPrefix);
+  }
+
+  private void addToRebuiltFiles(String path) {
+    metadataFilesToMove.add(path);
+  }
+
+  private static String stagingPath(String originalPath, String stagingLocation) {
+    return stagingLocation + fileName(originalPath);
+  }
+
+  private String currentMetadataPath(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+
+  private String getMetadataLocation(Table tbl) {
+    String currentMetadataPath = ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+    int lastIndex = currentMetadataPath.lastIndexOf(File.separator);
+    String metadataDir = "";
+    if (lastIndex != -1) {
+      metadataDir = currentMetadataPath.substring(0, lastIndex + 1);
+    }
+
+    Preconditions.checkArgument(!metadataDir.isEmpty(), "Failed to get the metadata file root directory");
+    return metadataDir;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveExpiredFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveExpiredFilesSparkAction.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.actions.BaseRemoveExpiredFilesActionResult;
+import org.apache.iceberg.actions.RemoveExpiredFiles;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.util.Tasks;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseRemoveExpiredFilesSparkAction extends BaseSparkAction<RemoveExpiredFiles, RemoveExpiredFiles.Result>
+    implements RemoveExpiredFiles {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseRemoveExpiredFilesSparkAction.class);
+  private static final ExecutorService DEFAULT_EXECUTOR_SERVICE = null;
+  private static final String DATA_FILE = "Data File";
+  private static final String MANIFEST = "Manifest";
+  private static final String MANIFEST_LIST = "Manifest List";
+
+  private final Table table;
+  private ExecutorService executorService = DEFAULT_EXECUTOR_SERVICE;
+  private String targetVersion;
+  private Table targetTable;
+
+  private AtomicLong dataFileCount = new AtomicLong(0L);
+  private AtomicLong manifestCount = new AtomicLong(0L);
+  private AtomicLong manifestListCount = new AtomicLong(0L);
+
+  private final Consumer<String> deleteFunc = new Consumer<String>() {
+    @Override
+    public void accept(String file) {
+      table.io().deleteFile(file);
+    }
+  };
+
+  public BaseRemoveExpiredFilesSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+  }
+
+  @Override
+  protected RemoveExpiredFiles self() {
+    return this;
+  }
+
+  @Override
+  public RemoveExpiredFiles executeWith(ExecutorService service) {
+    this.executorService = service;
+    return this;
+  }
+
+  @Override
+  public RemoveExpiredFiles targetVersion(String tVersion) {
+    Preconditions.checkArgument(tVersion != null && !tVersion.isEmpty(), "Target version file('%s') cannot be empty.",
+        tVersion);
+
+    String tVersionFile = tVersion;
+    if (!tVersionFile.contains(File.separator)) {
+      tVersionFile = ((HasTableOperations) table).operations().metadataFileLocation(tVersionFile);
+    }
+
+    Preconditions.checkArgument(fileExist(tVersionFile), "Version file('%s') doesn't exist.", tVersionFile);
+    this.targetVersion = tVersionFile;
+    return this;
+  }
+
+  @Override
+  public RemoveExpiredFiles.Result execute() {
+    JobGroupInfo info = newJobGroupInfo("REMOVE-EXPIRED-FILES", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private String jobDesc() {
+    return String.format("Remove expired files in version '%s' of table %s.", targetVersion, table.name());
+  }
+
+  private RemoveExpiredFiles.Result doExecute() {
+    targetTable = newStaticTable(targetVersion, table.io());
+
+    deleteFiles(expiredFiles().collectAsList().iterator());
+
+    return new BaseRemoveExpiredFilesActionResult(dataFileCount.get(), manifestCount.get(), manifestListCount.get());
+  }
+
+  private Dataset<Row> expiredFiles() {
+    Dataset<Row> originalFiles = buildValidFileDF(currentMetadata(table));
+    Dataset<Row> validFiles = buildValidFileDF(currentMetadata(targetTable));
+    return originalFiles.except(validFiles);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  private Dataset<Row> buildValidFileDF(TableMetadata metadata) {
+    Table staticTable = newStaticTable(metadata, this.table.io());
+    return appendTypeString(buildValidDataFileDF(staticTable), DATA_FILE)
+        .union(appendTypeString(buildManifestFileDF(staticTable), MANIFEST))
+        .union(appendTypeString(buildManifestListDF(staticTable), MANIFEST_LIST));
+  }
+
+  private Dataset<Row> appendTypeString(Dataset<Row> ds, String type) {
+    return ds.select(new Column("file_path"), functions.lit(type).as("file_type"));
+  }
+
+  private void deleteFiles(Iterator<Row> filesToDelete) {
+    Tasks.foreach(filesToDelete)
+        .retry(3).stopRetryOn(NotFoundException.class).suppressFailureWhenFinished()
+        .executeWith(executorService)
+        .onFailure((fileInfo, exc) -> {
+          String file = fileInfo.getString(0);
+          String type = fileInfo.getString(1);
+          LOG.warn("Delete failed for {}: {}", type, file, exc);
+        })
+        .run(fileInfo -> {
+          String file = fileInfo.getString(0);
+          String type = fileInfo.getString(1);
+          deleteFunc.accept(file);
+          switch (type) {
+            case DATA_FILE:
+              dataFileCount.incrementAndGet();
+              LOG.trace("Deleted Data File: {}", file);
+              break;
+            case MANIFEST:
+              manifestCount.incrementAndGet();
+              LOG.debug("Deleted Manifest: {}", file);
+              break;
+            case MANIFEST_LIST:
+              manifestListCount.incrementAndGet();
+              LOG.debug("Deleted Manifest List: {}", file);
+              break;
+          }
+        });
+
+    LOG.info("Deleted {} total files", dataFileCount.get() + manifestCount.get() + manifestListCount.get());
+  }
+
+  private boolean fileExist(String path) {
+    if (path == null || path.trim().isEmpty()) {
+      return false;
+    }
+    return table.io().newInputFile(path).exists();
+  }
+}
+

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -21,10 +21,13 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CheckSnapshotIntegrity;
+import org.apache.iceberg.actions.CopyTable;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.actions.MigrateTable;
+import org.apache.iceberg.actions.RemoveExpiredFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.actions.SnapshotTable;
@@ -94,5 +97,20 @@ public class SparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
+  }
+
+  @Override
+  public CopyTable copyTable(Table table) {
+    return new BaseCopyTableSparkAction(spark, table);
+  }
+
+  @Override
+  public CheckSnapshotIntegrity checkSnapshotIntegrity(Table table) {
+    return new BaseCheckSnapshotIntegritySparkAction(spark, table);
+  }
+
+  @Override
+  public RemoveExpiredFiles removeExpiredFiles(Table table) {
+    return new BaseRemoveExpiredFilesSparkAction(spark, table);
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCheckSnapshotIntegrityAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCheckSnapshotIntegrityAction.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CheckSnapshotIntegrity;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestCheckSnapshotIntegrityAction extends SparkTestBase {
+  private ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA = new Schema(
+      optional(1, "c1", Types.IntegerType.get()),
+      optional(2, "c2", Types.StringType.get()),
+      optional(3, "c3", Types.StringType.get())
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createTableWith2Snapshots();
+  }
+
+  @Test
+  public void testCheckSnapshotIntegrity() {
+    List<String> validFiles = validFiles();
+
+    String metadataPath = ((HasTableOperations) table).operations().current().metadataFileLocation();
+    String startVersionFile = tableLocation + "metadata/v1.metadata.json";
+    Table startTable = newStaticTable(startVersionFile, table.io());
+    CheckSnapshotIntegrity.Result result =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(0, result);
+
+    // delete one file
+    table.io().deleteFile(validFiles.get(0));
+    CheckSnapshotIntegrity.Result result1 =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(1, result1);
+
+    // delete another file
+    table.io().deleteFile(validFiles.get(1));
+    CheckSnapshotIntegrity.Result result2 =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(2, result2);
+  }
+
+  @Test
+  public void testStartFromFirstSnapshot() {
+    List<String> validFiles = validFiles();
+
+    String metadataPath = ((HasTableOperations) table).operations().current().metadataFileLocation();
+
+    String startVersionFile = tableLocation + "metadata/v2.metadata.json";
+    Table startTable = newStaticTable(startVersionFile, table.io());
+    CheckSnapshotIntegrity.Result result =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(0, result);
+
+    // delete the file added by the first snapshot
+    table.io().deleteFile(validFiles.get(1));
+    CheckSnapshotIntegrity.Result result1 =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(0, result1);
+
+    // delete the file added by the first snapshot
+    table.io().deleteFile(validFiles.get(0));
+    CheckSnapshotIntegrity.Result result2 =
+        actions().checkSnapshotIntegrity(startTable).targetVersion(metadataPath).execute();
+    checkMissingFiles(1, result2);
+  }
+
+  @Test
+  public void testInputs() {
+    CheckSnapshotIntegrity actions = actions().checkSnapshotIntegrity(table);
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion(""));
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion(null));
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion("invalid"));
+
+    // either version file name or path are valid
+    String versionFilePath = currentMetadata(table).metadataFileLocation();
+    actions.targetVersion(versionFilePath);
+    String versionFilename = fileName(versionFilePath);
+    actions.targetVersion(versionFilename);
+  }
+
+  private void checkMissingFiles(int num, CheckSnapshotIntegrity.Result result) {
+    Assert.assertEquals("Missing file count should be", num, ((Set) result.missingFileLocations()).size());
+  }
+
+  private Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  private List<String> validFiles() {
+    return validFiles(tableLocation);
+  }
+
+  private List<String> validFiles(String location) {
+    return spark.read().format("iceberg")
+        .load(location + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+  }
+
+  private Table createTableWith2Snapshots() {
+    return createTableWith2Snapshots(tableLocation);
+  }
+
+  private Table createTableWith2Snapshots(String tblLocation) {
+    return createTableWithSnapshots(tblLocation, 2);
+  }
+
+  private Table createTableWithSnapshots(String tblLocation, int snapshotNumber) {
+    Table tbl = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tblLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(tblLocation);
+    }
+
+    tbl.refresh();
+
+    return tbl;
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCopyTableAction.java
@@ -1,0 +1,785 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestCopyTableAction extends SparkTestBase {
+  protected ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA = new Schema(
+      optional(1, "c1", Types.IntegerType.get()),
+      optional(2, "c2", Types.StringType.get()),
+      optional(3, "c3", Types.StringType.get())
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createATableWith2Snapshots(tableLocation);
+  }
+
+  private Table createATableWith2Snapshots(String location) {
+    return createTableWithSnapshots(location, 2);
+  }
+
+  private Table createTableWithSnapshots(String location, int snapshotNumber) {
+    return createTableWithSnapshots(location, snapshotNumber, Maps.newHashMap());
+  }
+
+  protected Table createTableWithSnapshots(String location, int snapshotNumber, Map<String, String> properties) {
+    Table newTable = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, location);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(location);
+    }
+
+    return newTable;
+  }
+
+  @Test
+  public void testCopyTable() throws Exception {
+    String targetTableLocation = newTableLocation();
+
+    // check the data file location before the rebuild
+    List<String> validDataFiles = spark.read().format("iceberg")
+        .load(tableLocation + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFiles.size());
+
+    CopyTable.Result result = actions().copyTable(table)
+        .rewriteLocationPrefix(tableLocation, targetTableLocation)
+        .endVersion("v3.metadata.json")
+        .execute();
+
+    Assert.assertEquals("The latest version should be", "v3.metadata.json", result.latestVersion());
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(tableLocation, targetTableLocation, stagingDir(result));
+
+    // verify the data file path after the rebuild
+    List<String> validDataFilesAfterRebuilt = spark.read().format("iceberg")
+        .load(targetTableLocation + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+    Assert.assertEquals("Should be 2 valid data files", 2, validDataFilesAfterRebuilt.size());
+    for (String item : validDataFilesAfterRebuilt) {
+      Assert.assertTrue("Data file should point to the new location", item.startsWith(targetTableLocation));
+    }
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2", "c3")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    expectedRecords.add(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testDataFilesDiff() throws Exception {
+    CopyTable.Result result = actions().copyTable(table)
+        .rewriteLocationPrefix(tableLocation, newTableLocation())
+        .lastCopiedVersion("v2.metadata.json")
+        .execute();
+
+    checkDataFileNum(1, result);
+
+    List<String> rebuiltFiles =
+        spark.read().format("text").load(result.metadataFileListLocation()).as(Encoders.STRING()).collectAsList();
+
+    // v3.metadata.json, one manifest-list file, one manifest file
+    checkMetadataFileNum(3, result);
+
+    String currentSnapshotId = String.valueOf(table.currentSnapshot().snapshotId());
+    Assert.assertTrue(
+        "Should have the current snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(currentSnapshotId)).count() == 1);
+
+    String parentSnapshotId = String.valueOf(table.currentSnapshot().parentId());
+    Assert.assertTrue(
+        "Should NOT have the parent snapshot file",
+        rebuiltFiles.stream().filter(c -> c.contains(parentSnapshotId)).count() == 0);
+  }
+
+  @Test
+  public void testTableWith3Snapshots() throws Exception {
+    String location = newTableLocation();
+    Table tableWith3Snaps = createTableWithSnapshots(location, 3);
+    CopyTable.Result result = actions().copyTable(tableWith3Snaps)
+        .rewriteLocationPrefix(location, newTableLocation())
+        .lastCopiedVersion("v2.metadata.json")
+        .execute();
+
+    checkMetadataFileNum(2, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // start from the first version
+    CopyTable.Result result1 = actions().copyTable(tableWith3Snaps)
+        .rewriteLocationPrefix(location, newTableLocation())
+        .lastCopiedVersion("v1.metadata.json")
+        .execute();
+
+    checkMetadataFileNum(3, 3, 3, result1);
+    checkDataFileNum(3, result1);
+  }
+
+  @Test
+  public void testFullTableCopy() throws Exception {
+    CopyTable.Result result = actions().copyTable(table)
+        .rewriteLocationPrefix(tableLocation, newTableLocation())
+        .execute();
+
+    checkMetadataFileNum(3, 2, 2, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testDeleteDataFile() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(location);
+    List<String> validDataFiles = spark.read().format("iceberg")
+        .load(location + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+
+    sourceTable.newDelete().deleteFile(validDataFiles.stream().findFirst().get()).commit();
+
+    String targetLocation = newTableLocation();
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(location, targetLocation)
+        .execute();
+
+    checkMetadataFileNum(4, 3, 3, result);
+    checkDataFileNum(2, result);
+
+    // copy the metadata files and data files
+    moveTableFiles(location, targetLocation, stagingDir(result));
+
+    // verify data rows
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(targetLocation);
+    Assert.assertEquals("There are only one row left since we deleted a data file", 1, resultDF
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .count());
+  }
+
+  @Test
+  public void testFullTableCopyWithDeletedVersionFiles() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 2);
+    // expire the first snapshot
+    Table staticTable = newStaticTable(location + "metadata/v2.metadata.json", table.io());
+    actions().expireSnapshots(sourceTable)
+        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+        .execute();
+
+    // create 100 more snapshots
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    for (int i = 0; i < 100; i++) {
+      df.select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(location);
+    }
+    sourceTable.refresh();
+
+    // v1/v2/v3.metadata.json has been deleted in v104.metadata.json, and there is no way to find the first snapshot
+    // from the version file history
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(location, newTableLocation())
+        .execute();
+
+    // you can only find 101 snapshots but the manifest file and data file count should be 102.
+    checkMetadataFileNum(101, 101, 101, result);
+    checkDataFileNum(102, result);
+  }
+
+  protected Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  @Test
+  public void testRewriteTableWithoutSnapshot() throws Exception {
+    CopyTable.Result result = actions().copyTable(table)
+        .rewriteLocationPrefix(tableLocation, newTableLocation())
+        .endVersion("v1.metadata.json")
+        .execute();
+
+    // the only rebuilt file is v1.metadata.json since it contains no snapshot
+    checkMetadataFileNum(1, result);
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testExpireSnapshotBeforeRewrite() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions().expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    checkMetadataFileNum(4, 1, 2, result);
+
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testStartSnapshotWithoutValidSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions().expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    Assert.assertEquals("1 out 2 snapshot has been removed", 1, ((List) sourceTable.snapshots()).size());
+
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .lastCopiedVersion("v2.metadata.json")
+        .execute();
+
+    // 2 metadata.json, 1 manifest list file, 1 manifest files
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+  }
+
+  @Test
+  public void testMoveTheVersionExpireSnapshot() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions().expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    // only move version v4, which is the version generated by snapshot expiration
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .lastCopiedVersion("v3.metadata.json")
+        .execute();
+
+    // only v4.metadata.json needs to move
+    checkMetadataFileNum(1, result);
+    // no data file needs to move
+    checkDataFileNum(0, result);
+  }
+
+  @Test
+  public void testMoveVersionWithInvalidSnapshots() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // expire one snapshot
+    actions().expireSnapshots(sourceTable)
+        .expireSnapshotId(sourceTable.currentSnapshot().parentId())
+        .execute();
+
+    AssertHelpers.assertThrows(
+        "Copy a version with invalid snapshots aren't allowed",
+        UnsupportedOperationException.class,
+        () -> actions().copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+            .endVersion("v3.metadata.json")
+            .execute());
+  }
+
+  @Test
+  public void testRollBack() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+    Long secondSnapshotId = sourceTable.currentSnapshot().snapshotId();
+
+    // roll back to the first snapshot(v2)
+    sourceTable.rollback().toSnapshotId(sourceTable.currentSnapshot().parentId()).commit();
+
+    // add a new snapshot
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // roll back to the second snapshot(v3)
+    sourceTable.rollback().toSnapshotId(secondSnapshotId).commit();
+
+    // copy table
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    // check the result
+    checkMetadataFileNum(6, 3, 3, result);
+  }
+
+  @Test
+  public void testWriteAuditPublish() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // enable WAP
+    sourceTable.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
+    spark.conf().set("spark.wap.id", "1");
+
+    // add a new snapshot without changing the current snapshot of the table
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceTableLocation);
+
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    // check the result. There are 3 snapshots in total, although the current snapshot is the second one.
+    checkMetadataFileNum(5, 3, 3, result);
+  }
+
+  @Test
+  public void testSchemaChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createATableWith2Snapshots(sourceTableLocation);
+
+    // change the schema
+    sourceTable.updateSchema().addColumn("c4", Types.StringType.get()).commit();
+
+    // copy table
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    // check the result
+    checkMetadataFileNum(4, 2, 2, result);
+  }
+
+  @Test
+  public void testWithTargetTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+        .targetTable(targetTable)
+        .execute();
+
+    Assert.assertEquals("The latest version should be", "v4.metadata.json", result.latestVersion());
+
+    // 3 files rebuilt from v3 to v4: v4.metadata.json, one manifest list, one manifest file
+    checkMetadataFileNum(3, result);
+  }
+
+  @Test
+  public void testInvalidStartVersion() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 3);
+    String targetTableLocation = newTableLocation();
+    Table targetTable = createATableWith2Snapshots(targetTableLocation);
+
+    AssertHelpers.assertThrows("The valid start version should be v3", IllegalArgumentException.class,
+        "The start version isn't the current version of the target table.",
+        () -> actions().copyTable(sourceTable)
+            .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+            .targetTable(targetTable)
+            .lastCopiedVersion("v2.metadata.json")
+            .execute());
+  }
+
+  @Test
+  public void testSnapshotIdInheritanceEnabled() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true");
+
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    checkMetadataFileNum(7, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testMetadataCompression() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable = createTableWithSnapshots(sourceTableLocation, 2, properties);
+
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .endVersion("v2.gz.metadata.json")
+        .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .lastCopiedVersion("v1.gz.metadata.json")
+        .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  @Test
+  public void testInvalidArgs() {
+    CopyTable actions = actions().copyTable(table);
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, "Source prefix('') cannot be empty",
+        () -> actions.rewriteLocationPrefix("", null));
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, "Source prefix('null') cannot be empty",
+        () -> actions.rewriteLocationPrefix(null, null));
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, "Staging location('') cannot be empty",
+        () -> actions.stagingLocation(""));
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, "Staging location('null') cannot be empty",
+        () -> actions.stagingLocation(null));
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, "Last copied version('null') cannot be empty",
+        () -> actions.lastCopiedVersion(null));
+
+    AssertHelpers.assertThrows("Last copied version cannot be empty", IllegalArgumentException.class,
+        () -> actions.lastCopiedVersion(" "));
+
+    AssertHelpers.assertThrows("End version cannot be empty", IllegalArgumentException.class,
+        () -> actions.endVersion(" "));
+
+    AssertHelpers.assertThrows("End version cannot be empty", IllegalArgumentException.class,
+        () -> actions.endVersion(null));
+  }
+
+  protected void checkDataFileNum(long count, CopyTable.Result result) {
+    List<String> filesToMove  =
+        spark.read().format("text").load(result.dataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    Assert.assertEquals("The rebuilt data file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(int count, CopyTable.Result result) {
+    List<String> filesToMove  =
+        spark.read().format("text").load(result.metadataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    Assert.assertEquals("The rebuilt metadata file number should be", count, filesToMove.size());
+  }
+
+  protected void checkMetadataFileNum(
+      int versionFileCount, int manifestListCount,
+      int manifestFileCount, CopyTable.Result result) {
+    List<String> filesToMove  =
+            spark.read().format("text").load(result.metadataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    Assert.assertEquals("The rebuilt version file number should be", versionFileCount,
+        filesToMove.stream().filter(f -> f.endsWith(".metadata.json")).count());
+    Assert.assertEquals("The rebuilt Manifest list file number should be", manifestListCount,
+        filesToMove.stream().filter(f -> f.contains("snap-")).count());
+    Assert.assertEquals("The rebuilt Manifest file number should be", manifestFileCount,
+        filesToMove.stream().filter(f -> f.endsWith("-m0.avro")).count());
+  }
+
+  private String stagingDir(CopyTable.Result result) {
+    String metadataFileListPath = result.metadataFileListLocation();
+    return metadataFileListPath.substring(0, metadataFileListPath.lastIndexOf(File.separator));
+  }
+
+  protected String newTableLocation() throws IOException {
+    return temp.newFolder().toURI().toString();
+  }
+
+  private void moveTableFiles(String sourceDir, String targetDir, String stagingDir) throws Exception {
+    FileUtils.copyDirectory(new File(removePrefix(sourceDir) + "data/"), new File(removePrefix(targetDir) + "/data/"));
+    FileUtils.copyDirectory(new File(removePrefix(stagingDir)), new File(removePrefix(targetDir) + "/metadata/"));
+  }
+
+  private String removePrefix(String path) {
+    return path.substring(path.lastIndexOf(":") + 1);
+  }
+
+  // Metastore table tests
+  @Test
+  public void testMetadataLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-metadata-dir";
+    sourceTable.updateProperties().set(
+        TableProperties.WRITE_METADATA_LOCATION,
+        sourceTableLocation + newMetadataDir).commit();
+
+    spark.sql("insert into hive.default.tbl values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version from the old metadata dir as the end version
+    CopyTable.Result result1 = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .endVersion(fileName(metadataFilePath))
+        .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+
+    // pick up a version from the old metadata dir as the last copied version
+    CopyTable.Result result2 = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .lastCopiedVersion(fileName(metadataFilePath))
+        .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+  }
+
+  @Test
+  public void testMetadataCompressionWithMetastoreTable() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(TableProperties.METADATA_COMPRESSION, "gzip");
+    Table sourceTable = createMetastoreTable(sourceTableLocation, properties, "testMetadataCompression", 2);
+
+    TableMetadata currentMetadata = currentMetadata(sourceTable);
+
+    // set the second version as the endVersion
+    String endVersion = fileName(currentMetadata.previousFiles().get(1).file());
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .endVersion(endVersion)
+        .execute();
+
+    checkMetadataFileNum(4, result);
+    checkDataFileNum(1, result);
+
+    // set the first version as the lastCopiedVersion
+    String firstVersion = fileName(currentMetadata.previousFiles().get(0).file());
+    result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .lastCopiedVersion(firstVersion)
+        .execute();
+
+    checkMetadataFileNum(6, result);
+    checkDataFileNum(2, result);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  @Test
+  public void testDataFileLocationChange() throws Exception {
+    String sourceTableLocation = newTableLocation();
+    Table sourceTable = createMetastoreTable(sourceTableLocation, Maps.newHashMap(), "tbl1", 1);
+    String metadataFilePath = currentMetadata(sourceTable).metadataFileLocation();
+
+    String newMetadataDir = "new-data-dir";
+    sourceTable.updateProperties()
+        .set(TableProperties.OBJECT_STORE_PATH, sourceTableLocation + newMetadataDir)
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    spark.sql("insert into hive.default.tbl1 values (1, 'AAAAAAAAAA', 'AAAA')");
+    sourceTable.refresh();
+
+    // copy table
+    CopyTable.Result result = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, newTableLocation())
+        .execute();
+
+    checkMetadataFileNum(4, 2, 2, result);
+    checkDataFileNum(2, result);
+
+    // pick up a version with the data file in the old data directory as the end version
+    String targetTableLocation = newTableLocation();
+    CopyTable.Result result1 = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+        .endVersion(fileName(metadataFilePath))
+        .execute();
+
+    checkMetadataFileNum(2, 1, 1, result1);
+    checkDataFileNum(1, result1);
+    List<String> filesToMove1 =
+        spark.read().format("text").load(result1.dataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    Assert.assertTrue("The data file should be in the old data directory.",
+        filesToMove1.stream().findFirst().get().startsWith(sourceTableLocation + "data"));
+
+    // pick up a version with the data file in the new data directory as the last copied version
+    CopyTable.Result result2 = actions().copyTable(sourceTable)
+        .rewriteLocationPrefix(sourceTableLocation, targetTableLocation)
+        .lastCopiedVersion(fileName(metadataFilePath))
+        .execute();
+
+    checkMetadataFileNum(2, 1, 1, result2);
+    checkDataFileNum(1, result2);
+    List<String> filesToMove2 =
+        spark.read().format("text").load(result2.dataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    Assert.assertTrue(
+        "The data file should be in the new data directory.",
+        filesToMove2.stream().findFirst().get().startsWith(sourceTableLocation + newMetadataDir));
+
+    // check if table properties have been modified
+    List<String> metadataFilesToMove =
+        spark.read().format("text").load(result2.metadataFileListLocation()).as(Encoders.STRING()).collectAsList();
+    metadataFilesToMove.stream().filter(f -> f.endsWith(".metadata.json")).forEach(
+        metadataFile -> {
+          StaticTableOperations ops = new StaticTableOperations(metadataFile, sourceTable.io());
+          Table targetStaticTable = new BaseTable(ops, metadataFile);
+          if (targetStaticTable.properties().containsKey(TableProperties.OBJECT_STORE_PATH)) {
+            Assert.assertTrue("The write.object-storage.path should be modified with the target table location.",
+                targetStaticTable.properties().get(TableProperties.OBJECT_STORE_PATH).startsWith(targetTableLocation));
+          }
+        }
+    );
+  }
+
+  private Table createMetastoreTable(
+      String location, Map<String, String> properties, String tableName,
+      int snapshotNumber) {
+    spark.conf().set("spark.sql.catalog.hive", SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog.hive.type", "hive");
+    spark.conf().set("spark.sql.catalog.hive.default-namespace", "default");
+    spark.conf().set("spark.sql.catalog.hive.cache-enabled", "false");
+
+    StringBuilder propertiesStr = new StringBuilder();
+    properties.forEach((k, v) -> propertiesStr.append("'" + k + "'='" + v + "',"));
+    String tblProperties = propertiesStr.substring(0, propertiesStr.length() > 0 ? propertiesStr.length() - 1 : 0);
+
+    if (tblProperties.isEmpty()) {
+      sql("CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s'",
+          tableName, location);
+    } else {
+      sql("CREATE TABLE hive.default.%s (c1 bigint, c2 string, c3 string) USING iceberg LOCATION '%s' TBLPROPERTIES " +
+          "(%s)", tableName, location, tblProperties);
+    }
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      sql("insert into hive.default.%s values (1, 'AAAAAAAAAA', 'AAAA')", tableName);
+    }
+    return catalog.loadTable(TableIdentifier.of("default", tableName));
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveExpiredFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveExpiredFilesAction.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.CheckSnapshotIntegrity;
+import org.apache.iceberg.actions.CopyTable;
+import org.apache.iceberg.actions.RemoveExpiredFiles;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestRemoveExpiredFilesAction extends SparkTestBase {
+  private ActionsProvider actions() {
+    return SparkActions.get();
+  }
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA = new Schema(
+      optional(1, "c1", Types.IntegerType.get()),
+      optional(2, "c2", Types.StringType.get()),
+      optional(3, "c3", Types.StringType.get())
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+  private Table table = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+    this.table = createTableWith2Snapshots();
+  }
+
+  @Test
+  public void testRemoveExpiredFiles() throws Exception {
+    String tblLocation = newTableLocation();
+    Table tbl = createTableWith2Snapshots(tblLocation);
+    String targetLocation = newTableLocation();
+
+    // copy it to a new place, we have two identical tables after this
+    CopyTable.Result result = actions().copyTable(tbl).rewriteLocationPrefix(tblLocation, targetLocation).execute();
+    moveTableFiles(tblLocation, targetLocation, stagingDir(result));
+    String tgtMetadataLoc = targetLocation + "metadata/" + result.latestVersion();
+    Table targetTable = newStaticTable(tgtMetadataLoc, tbl.io());
+
+    // expire the first snapshot in the source table
+    Table staticTable = newStaticTable(tblLocation + "metadata/v2.metadata.json", tbl.io());
+    actions().expireSnapshots(tbl)
+        .expireSnapshotId(staticTable.currentSnapshot().snapshotId())
+        .execute();
+
+    // copy it again
+    CopyTable.Result result2 = actions().copyTable(tbl)
+        .targetTable(targetTable)
+        .rewriteLocationPrefix(tblLocation, targetLocation)
+        .execute();
+    moveTableFiles(tblLocation, targetLocation, stagingDir(result2));
+    String tgtMetadataLocNew = targetLocation + "metadata/" + result2.latestVersion();
+
+    // remove expired files
+    RemoveExpiredFiles.Result integrityResult =
+        actions().removeExpiredFiles(targetTable).targetVersion(tgtMetadataLocNew).execute();
+
+    // one manifest list file is deleted
+    Assert.assertEquals("Deleted manifest list file count should be", 1L, integrityResult.deletedManifestListsCount());
+    Assert.assertEquals("Deleted data file count should be", 0L, integrityResult.deletedDataFilesCount());
+    Assert.assertEquals("Deleted manifest file count should be", 0L, integrityResult.deletedManifestsCount());
+
+    // check file count
+    Assert.assertEquals("Source table file count should equal to target table one", validFiles(tblLocation).size(),
+        validFiles(targetLocation).size());
+
+    // verify data rows
+    Assert.assertEquals("Rows must match", records(tblLocation), records(targetLocation));
+  }
+
+  @Test
+  public void testInputs() {
+    CheckSnapshotIntegrity actions = actions().checkSnapshotIntegrity(table);
+
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion(""));
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion(null));
+    AssertHelpers.assertThrows("", IllegalArgumentException.class, () -> actions.targetVersion("invalid"));
+
+    // either version file name or path are valid
+    String versionFilePath = currentMetadata(table).metadataFileLocation();
+    actions.targetVersion(versionFilePath);
+    String versionFilename = fileName(versionFilePath);
+    actions.targetVersion(versionFilename);
+  }
+
+  private TableMetadata currentMetadata(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current();
+  }
+
+  private static String fileName(String path) {
+    String filename = path;
+    int lastIndex = path.lastIndexOf(File.separator);
+    if (lastIndex != -1) {
+      filename = path.substring(lastIndex + 1);
+    }
+    return filename;
+  }
+
+  private List<ThreeColumnRecord> records(String location) {
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(location);
+    return resultDF.sort("c1", "c2", "c3")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+  }
+
+  private String stagingDir(CopyTable.Result result) {
+    String metadataFileListPath = result.metadataFileListLocation();
+    return metadataFileListPath.substring(0, metadataFileListPath.lastIndexOf(File.separator));
+  }
+
+  private void moveTableFiles(String sourceDir, String targetDir, String stagingDir) throws Exception {
+    FileUtils.copyDirectory(new File(removePrefix(sourceDir) + "data/"), new File(removePrefix(targetDir) + "/data/"));
+    FileUtils.copyDirectory(new File(removePrefix(stagingDir)), new File(removePrefix(targetDir) + "/metadata/"));
+  }
+
+  private String removePrefix(String path) {
+    return path.substring(path.lastIndexOf(":") + 1);
+  }
+
+  private Table newStaticTable(String metadataFileLocation, FileIO io) {
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    return new BaseTable(ops, metadataFileLocation);
+  }
+
+  private List<String> validFiles(String location) {
+    return spark.read().format("iceberg")
+        .load(location + "#files")
+        .select("file_path")
+        .as(Encoders.STRING())
+        .collectAsList();
+  }
+
+  private Table createTableWith2Snapshots() {
+    return createTableWith2Snapshots(tableLocation);
+  }
+
+  private Table createTableWith2Snapshots(String tblLocation) {
+    return createTableWithSnapshots(tblLocation, 2);
+  }
+
+  private Table createTableWithSnapshots(String tblLocation, int snapshotNumber) {
+    Table tbl = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tblLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList(
+        new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    for (int i = 0; i < snapshotNumber; i++) {
+      df.select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(tblLocation);
+    }
+
+    tbl.refresh();
+
+    return tbl;
+  }
+
+  protected String newTableLocation() throws IOException {
+    return temp.newFolder().toURI().toString();
+  }
+}


### PR DESCRIPTION
Multiple people asked me to share the tool to rewrite the metadata files when moving tables from one location to another. Here you are. Three Spark actions are added. 
1. Action copy-table is for the source tables to rewrite metadata files
2. Action checkSnapshotIntegrity and action removeExpiredFiles are for the target tables to apply changes, integrity check, and cleanup. 