### PR TITLE
Doc : Document time travel via SPARK SQL

### DIFF
--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -116,7 +116,19 @@ ignored. Do not use `table` when attempting to time-travel or use other options.
 in [Spark 3.1 - SPARK-32592](https://issues.apache.org/jira/browse/SPARK-32592).
 {{< /hint >}}
 
-Time travel is not yet supported by Spark's SQL syntax.
+Time travel is not yet fully supported by Spark's SQL syntax. (ref : [Spark 3.3 - SPARK-37219](https://issues.apache.org/jira/browse/SPARK-37219)
+for `AS OF` syntax support)
+
+As an alternative we can use `at_timestamp_`, `snapshot_id_` as prefix of timestamp, snapshot_id respectively along with
+the table name to time travel.
+
+```sql
+--  time travel to October 26, 1986 at 01:21:00
+SELECT * FROM prod.db.table.at_timestamp_499162860000;
+
+-- time travel to snapshot with ID 10963874102873L
+SELECT * FROM prod.db.table.snapshot_id_10963874102873;
+```
 
 ### Incremental read
 


### PR DESCRIPTION
At present `AS OF` grammar is not supported in SPARK-SQL (was added in Spark 3.3 via [SPARK-37219](https://issues.apache.org/jira/browse/SPARK-37219)).

On digging more in the code found that there was a work-around adopted by the community until this grammar is supported in SPARK itself, by using `at_timestamp_`, `snapshot_id_` 
https://github.com/apache/iceberg/blob/bf582ebf68ea05be26f38d786584d474aebe048b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java#L545-L555


Presently the docs stated `Time travel is not yet supported by Spark's SQL syntax.` which can be worked around with the functionalities present. This PR attempts to document that.

--- 

cc @rdblue @jackye1995  @RussellSpitzer