### PR TITLE
API: Add an action to generate table change set

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -74,4 +74,11 @@ public interface ActionsProvider {
   default DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /**
+   * Instantiates an action to generate a change data set.
+   */
+  default GenerateChangeSet generateChangeSet(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement generateChangeSet");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/GenerateChangeSet.java
+++ b/api/src/main/java/org/apache/iceberg/actions/GenerateChangeSet.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public interface GenerateChangeSet extends Action<GenerateChangeSet, GenerateChangeSet.Result> {
+  /**
+   * Emit changed data set by a snapshot id.
+   *
+   * @param snapshotId id of the snapshot to generate changed data
+   * @return this for method chaining
+   */
+  GenerateChangeSet forSnapshot(long snapshotId);
+
+  /**
+   * Emit changed data set for the current snapshot.
+   *
+   * @return this for method chaining
+   */
+  GenerateChangeSet forCurrentSnapshot();
+
+  /**
+   * Emit changed data from a particular snapshot(exclusive).
+   *
+   * @param fromSnapshotId id of the start snapshot
+   * @return this for method chaining
+   */
+  GenerateChangeSet afterSnapshot(long fromSnapshotId);
+
+  /**
+   * Emit change data set from the start snapshot (exclusive) to the end snapshot (inclusive).
+   *
+   * @param fromSnapshotId id of the start snapshot
+   * @param toSnapshotId   id of the end snapshot
+   * @return this for method chaining
+   */
+  GenerateChangeSet betweenSnapshots(long fromSnapshotId, long toSnapshotId);
+
+  /**
+   * The action result that contains a dataset of changed rows.
+   */
+  interface Result<T> {
+    /**
+     * Returns the change set.
+     */
+    T changeSet();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/GenerateChangeSet.java
+++ b/api/src/main/java/org/apache/iceberg/actions/GenerateChangeSet.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.actions;
 
+/**
+ * An action that generates a change data set from snapshots.
+ */
 public interface GenerateChangeSet extends Action<GenerateChangeSet, GenerateChangeSet.Result> {
   /**
    * Emit changed data set by a snapshot id.
@@ -29,28 +32,36 @@ public interface GenerateChangeSet extends Action<GenerateChangeSet, GenerateCha
   GenerateChangeSet forSnapshot(long snapshotId);
 
   /**
-   * Emit changed data set for the current snapshot.
+   * Emit change data set from the start snapshot (inclusive).
+   * <p>
+   * If neither {@link #fromSnapshotInclusive(long)} or {@link #fromSnapshotExclusive(long)} is provided,
+   * the start snapshot (inclusive) is defaulted to the oldest ancestor of the snapshot history.
    *
+   * @param fromSnapshotId id of the start snapshot (inclusive)
    * @return this for method chaining
    */
-  GenerateChangeSet forCurrentSnapshot();
+  GenerateChangeSet fromSnapshotInclusive(long fromSnapshotId);
 
   /**
-   * Emit changed data from a particular snapshot(exclusive).
+   * Emit change data set from the start snapshot (exclusive).
+   * <p>
+   * If neither {@link #fromSnapshotInclusive(long)} or {@link #fromSnapshotExclusive(long)} is provided,
+   * the start snapshot (inclusive) is defaulted to the oldest ancestor of the snapshot history.
    *
-   * @param fromSnapshotId id of the start snapshot
+   * @param fromSnapshotId id of the start snapshot (exclusive)
    * @return this for method chaining
    */
-  GenerateChangeSet afterSnapshot(long fromSnapshotId);
+  GenerateChangeSet fromSnapshotExclusive(long fromSnapshotId);
 
   /**
-   * Emit change data set from the start snapshot (exclusive) to the end snapshot (inclusive).
+   * Emit changed data to a particular snapshot (inclusive).
+   * <p>
+   * If not provided, end snapshot is defaulted to the table's current snapshot.
    *
-   * @param fromSnapshotId id of the start snapshot
-   * @param toSnapshotId   id of the end snapshot
+   * @param toSnapshotId id of the end snapshot (inclusive)
    * @return this for method chaining
    */
-  GenerateChangeSet betweenSnapshots(long fromSnapshotId, long toSnapshotId);
+  GenerateChangeSet toSnapshot(long toSnapshotId);
 
   /**
    * The action result that contains a dataset of changed rows.

--- a/core/src/main/java/org/apache/iceberg/actions/BaseGenerateChangeSetActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseGenerateChangeSetActionResult.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class BaseGenerateChangeSetActionResult<T> implements GenerateChangeSet.Result<T> {
+  private final T changeSet;
+
+  public BaseGenerateChangeSetActionResult(T changeSet) {
+    this.changeSet = changeSet;
+  }
+
+  @Override
+  public T changeSet() {
+    return changeSet;
+  }
+}


### PR DESCRIPTION
Extracted the interface change from the draft PR #4539. According the MVP design and recent community discussion, we are going to create an action interface first for Change Data Capture(CDC).

cc @aokolnychyi @RussellSpitzer @szehon-ho @jackye1995 @kbendick @karuppayya @chenjunjiedada @stevenzwu @rdblue @Reo-LEI @hameizi @singhpk234 @rajarshisarkar 