### PR TITLE
API: Add equals and hashCode to Schema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -484,4 +484,21 @@ public class Schema implements Serializable {
             .map(this::identifierFieldToString)
             .collect(Collectors.toList())));
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    return sameSchema((Schema) o);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 *  struct.hashCode() + Arrays.hashCode(identifierFieldIds);
+  }
 }


### PR DESCRIPTION
Add `equals` method to Schema. It leverages the existing `sameSchema` method.

This will make it easy to compare 2 schemas.

Currently `Schema.toString()` is used to compare 2 schemas at a few places.