### PR TITLE
Flink 1.15: Migrate back to use ReusableArrayData

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -24,12 +24,10 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
@@ -484,10 +482,8 @@ public class FlinkParquetReaders {
 
     @Override
     protected ArrayData buildList(ReusableArrayData list) {
-      // Since ReusableArrayData is not accepted by Flink, use GenericArrayData temporarily to walk around it.
-      // Revert this to use ReusableArrayData once it is fixed in Flink.
-      // For your reference, https://issues.apache.org/jira/browse/FLINK-25238.
-      return new GenericArrayData(Arrays.copyOf(list.values, writePos));
+      list.setNumElements(writePos);
+      return list;
     }
   }
 


### PR DESCRIPTION
Migrate back to use ReusableArrayData for Flink 1.15

part of #4624

This change is already covered by the existing test: `TestFlinkScan#testCustomizedFlinkDataTypes`, for detail:
https://github.com/apache/iceberg/blob/f79da868f48c3364762eae25ee13f31d6f620eb7/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java#L310-L321