### PR TITLE
[CORE] - Add remaining parsers for MetadataUpdate implementations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -233,16 +233,16 @@ public interface MetadataUpdate extends Serializable {
   }
 
   class SetSnapshotRef implements MetadataUpdate {
-    private final String name;
+    private final String refName;
     private final Long snapshotId;
     private final SnapshotRefType type;
     private Integer minSnapshotsToKeep;
     private Long maxSnapshotAgeMs;
     private Long maxRefAgeMs;
 
-    public SetSnapshotRef(String name, Long snapshotId, SnapshotRefType type, Integer minSnapshotsToKeep,
+    public SetSnapshotRef(String refName, Long snapshotId, SnapshotRefType type, Integer minSnapshotsToKeep,
                           Long maxSnapshotAgeMs, Long maxRefAgeMs) {
-      this.name = name;
+      this.refName = refName;
       this.snapshotId = snapshotId;
       this.type = type;
       this.minSnapshotsToKeep = minSnapshotsToKeep;
@@ -251,7 +251,7 @@ public interface MetadataUpdate extends Serializable {
     }
 
     public String name() {
-      return name;
+      return refName;
     }
 
     public String type() {
@@ -281,7 +281,7 @@ public interface MetadataUpdate extends Serializable {
           .maxSnapshotAgeMs(maxSnapshotAgeMs)
           .maxRefAgeMs(maxRefAgeMs)
           .build();
-      metadataBuilder.setRef(name, ref);
+      metadataBuilder.setRef(refName, ref);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -98,10 +98,17 @@ public class SnapshotParser {
   }
 
   public static String toJson(Snapshot snapshot) {
+    // Use true as default value of pretty for backwards compatibility
+    return toJson(snapshot, true);
+  }
+
+  public static String toJson(Snapshot snapshot, boolean pretty) {
     try {
       StringWriter writer = new StringWriter();
       JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      generator.useDefaultPrettyPrinter();
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
       toJson(snapshot, generator);
       generator.flush();
       return writer.toString();

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -148,6 +148,14 @@ public class JsonUtil {
         .build();
   }
 
+  public static Set<String> getStringSet(String property, JsonNode node) {
+    Preconditions.checkArgument(node.hasNonNull(property), "Cannot parse missing set %s", property);
+
+    return ImmutableSet.<String>builder()
+        .addAll(new JsonStringArrayIterator(property, node))
+        .build();
+  }
+
   public static List<String> getStringListOrNull(String property, JsonNode node) {
     if (!node.has(property) || node.get(property).isNull()) {
       return null;
@@ -165,6 +173,16 @@ public class JsonUtil {
 
     return ImmutableSet.<Integer>builder()
         .addAll(new JsonIntegerArrayIterator(property, node))
+        .build();
+  }
+
+  public static Set<Long> getLongSetOrNull(String property, JsonNode node) {
+    if (!node.hasNonNull(property)) {
+      return null;
+    }
+
+    return ImmutableSet.<Long>builder()
+        .addAll(new JsonLongArrayIterator(property, node))
         .build();
   }
 
@@ -241,6 +259,24 @@ public class JsonUtil {
     @Override
     void validate(JsonNode element) {
       Preconditions.checkArgument(element.isInt(), "Cannot parse integer from non-int value: %s", element);
+    }
+  }
+
+  static class JsonLongArrayIterator extends JsonArrayIterator<Long> {
+
+    JsonLongArrayIterator(String property, JsonNode node) {
+      super(property, node);
+    }
+
+    @Override
+    Long convert(JsonNode element) {
+      return element.asLong();
+    }
+
+    @Override
+    void validate(JsonNode element) {
+      Preconditions.checkArgument(element.isIntegralNumber() && element.canConvertToLong(),
+          "Cannot parse long from  non-long value: %s", element);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -20,13 +20,20 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.IntStream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.apache.iceberg.Files.localInput;
 
 public class TestMetadataUpdateParser {
 
@@ -50,6 +57,28 @@ public class TestMetadataUpdateParser {
     }
   }
 
+  /** AssignUUID **/
+
+  @Test
+  public void testAssignUUIDToJson() {
+    String action = MetadataUpdateParser.ASSIGN_UUID;
+    String uuid = "9510c070-5e6d-4b40-bf40-a8915bb76e5d";
+    String json = "{\"action\":\"assign-uuid\",\"uuid\":\"9510c070-5e6d-4b40-bf40-a8915bb76e5d\"}";
+    MetadataUpdate expected = new MetadataUpdate.AssignUUID(uuid);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testAssignUUIDFromJson() {
+    String uuid = "9510c070-5e6d-4b40-bf40-a8915bb76e5d";
+    String expected = "{\"action\":\"assign-uuid\",\"uuid\":\"9510c070-5e6d-4b40-bf40-a8915bb76e5d\"}";
+    MetadataUpdate actual = new MetadataUpdate.AssignUUID(uuid);
+    Assert.assertEquals("Assign UUID should convert to the correct JSON value",
+        expected, MetadataUpdateParser.toJson(actual));
+  }
+
+  /** UpgradeFormatVersion **/
+
   @Test
   public void testUpgradeFormatVersionToJson() {
     int formatVersion = 2;
@@ -67,6 +96,8 @@ public class TestMetadataUpdateParser {
     Assert.assertEquals("Upgrade format version should convert to the correct JSON value",
         expected, MetadataUpdateParser.toJson(actual));
   }
+
+  /** AddSchema **/
 
   @Test
   public void testAddSchemaFromJson() {
@@ -90,6 +121,8 @@ public class TestMetadataUpdateParser {
     Assert.assertEquals("Add schema should convert to the correct JSON value", expected, actual);
   }
 
+  /** SetCurrentSchema **/
+
   @Test
   public void testSetCurrentSchemaFromJson() {
     String action = MetadataUpdateParser.SET_CURRENT_SCHEMA;
@@ -108,6 +141,8 @@ public class TestMetadataUpdateParser {
     String actual = MetadataUpdateParser.toJson(update);
     Assert.assertEquals("Set current schema should convert to the correct JSON value", expected, actual);
   }
+
+  /** AddPartitionSpec **/
 
   @Test
   public void testAddPartitionSpecFromJsonWithFieldId() {
@@ -201,6 +236,8 @@ public class TestMetadataUpdateParser {
     Assert.assertEquals("Add partition spec should convert to the correct JSON value", expected, actual);
   }
 
+  /** SetDefaultPartitionSpec **/
+
   @Test
   public void testSetDefaultPartitionSpecToJson() {
     String action = MetadataUpdateParser.SET_DEFAULT_PARTITION_SPEC;
@@ -219,6 +256,8 @@ public class TestMetadataUpdateParser {
     MetadataUpdate.SetDefaultPartitionSpec expected = new MetadataUpdate.SetDefaultPartitionSpec(specId);
     assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
   }
+
+  /** AddSortOrder **/
 
   @Test
   public void testAddSortOrderToJson() {
@@ -251,11 +290,360 @@ public class TestMetadataUpdateParser {
     assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
   }
 
+  /** SetDefaultSortOrder **/
+
+  @Test
+  public void testSetDefaultSortOrderToJson() {
+    String action = MetadataUpdateParser.SET_DEFAULT_SORT_ORDER;
+    int sortOrderId = 2;
+    String expected = String.format("{\"action\":\"%s\",\"sort-order-id\":%d}", action, sortOrderId);
+    MetadataUpdate update = new MetadataUpdate.SetDefaultSortOrder(sortOrderId);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set default sort order should serialize to the correct JSON value", expected, actual);
+  }
+
+  @Test
+  public void testSetDefaultSortOrderFromJson() {
+    String action = MetadataUpdateParser.SET_DEFAULT_SORT_ORDER;
+    int sortOrderId = 2;
+    String json = String.format("{\"action\":\"%s\",\"sort-order-id\":%d}", action, sortOrderId);
+    MetadataUpdate expected = new MetadataUpdate.SetDefaultSortOrder(sortOrderId);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  /** AddSnapshot **/
+
+  @Test
+  public void testAddSnapshotToJson() {
+    String action = MetadataUpdateParser.ADD_SNAPSHOT;
+    long parentId = 1;
+    long snapshotId = 2;
+    int schemaId = 3;
+    List<ManifestFile> manifests = ImmutableList.of(
+        new GenericManifestFile(localInput("file:/tmp/manifest1.avro"), 0),
+        new GenericManifestFile(localInput("file:/tmp/manifest2.avro"), 0));
+
+    Snapshot snapshot = new BaseSnapshot(null, snapshotId, parentId, System.currentTimeMillis(),
+        DataOperations.REPLACE, ImmutableMap.of("files-added", "4", "files-deleted", "100"),
+        schemaId, manifests);
+    String snapshotJson = SnapshotParser.toJson(snapshot, /* pretty */ false);
+    String expected = String.format("{\"action\":\"%s\",\"snapshot\":%s}", action, snapshotJson);
+    MetadataUpdate update = new MetadataUpdate.AddSnapshot(snapshot);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Add snapshot should serialize to the correct JSON value", expected, actual);
+  }
+
+  @Test
+  public void testAddSnapshotFromJson() {
+    String action = MetadataUpdateParser.ADD_SNAPSHOT;
+    long parentId = 1;
+    long snapshotId = 2;
+    int schemaId = 3;
+    List<ManifestFile> manifests = ImmutableList.of(
+        new GenericManifestFile(localInput("file:/tmp/manifest1.avro"), 0),
+        new GenericManifestFile(localInput("file:/tmp/manifest2.avro"), 0));
+    Map<String, String> summary = ImmutableMap.of("files-added", "4", "files-deleted", "100");
+    Snapshot snapshot = new BaseSnapshot(null, snapshotId, parentId, System.currentTimeMillis(),
+        DataOperations.REPLACE, summary, schemaId, manifests);
+    String snapshotJson = SnapshotParser.toJson(snapshot, /* pretty */ false);
+    String json = String.format("{\"action\":\"%s\",\"snapshot\":%s}", action, snapshotJson);
+    MetadataUpdate expected = new MetadataUpdate.AddSnapshot(snapshot);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  /** RemoveSnapshots **/
+
+  @Test
+  public void testRemoveSnapshotsFromJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
+    long snapshotId = 2L;
+    String json = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testRemoveSnapshotsToJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOTS;
+    long snapshotId = 2L;
+    String expected = String.format("{\"action\":\"%s\",\"snapshot-ids\":[2]}", action);
+    MetadataUpdate update = new MetadataUpdate.RemoveSnapshot(snapshotId);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Remove snapshots should serialize to the correct JSON value", expected, actual);
+  }
+
+  /** SetSnapshotRef **/
+
+  @Test
+  public void testSetSnapshotRefTagFromJsonDefault_NullValuesMissing() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"tag\"}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefTagFromJsonDefault_ExplicitNullValues() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"tag\"," +
+        "\"min-snapshots-to-keep\":null,\"max-snapshot-age-ms\":null,\"max-ref-age-ms\":null}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefTagFromJsonAllFields_NullValuesMissing() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = 1L;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\"," +
+        "\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefTagFromJsonAllFields_ExplicitNullValues() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = 1L;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"tag\"," +
+        "\"max-ref-age-ms\":1,\"min-snapshots-to-keep\":null,\"max-snapshot-age-ms\":null}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefBranchFromJsonDefault_NullValuesMissing() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.BRANCH;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"bRaNch\"}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefBranchFromJsonDefault_ExplicitNullValues() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.BRANCH;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"bRaNch\"," +
+        "\"max-ref-age-ms\":null,\"min-snapshots-to-keep\":null,\"max-snapshot-age-ms\":null}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testBranchFromJsonAllFields() {
+    String action = MetadataUpdateParser.SET_SNAPSHOT_REF;
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.BRANCH;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = 2;
+    Long maxSnapshotAgeMs = 3L;
+    Long maxRefAgeMs = 4L;
+    String json = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"branch\"," +
+        "\"min-snapshots-to-keep\":2,\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    MetadataUpdate expected = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetSnapshotRefTagToJsonDefault() {
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String expected = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"tag\"}";
+    MetadataUpdate update = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set snapshot ref should serialize to the correct JSON value for tag with default fields",
+        expected, actual);
+  }
+
+  @Test
+  public void testSetSnapshotRefTagToJsonAllFields() {
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.TAG;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = 1L;
+    String expected = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\"," +
+        "\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    MetadataUpdate update = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set snapshot ref should serialize to the correct JSON value for tag with all fields",
+        expected, actual);
+  }
+
+  @Test
+  public void testSetSnapshotRefBranchToJsonDefault() {
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.BRANCH;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = null;
+    Long maxSnapshotAgeMs = null;
+    Long maxRefAgeMs = null;
+    String expected =
+        "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"branch\"}";
+    MetadataUpdate update = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set snapshot ref should serialize to the correct JSON value for branch with default fields",
+        expected, actual);
+  }
+
+  @Test
+  public void testSetSnapshotRefBranchToJsonAllFields() {
+    long snapshotId = 1L;
+    SnapshotRefType type = SnapshotRefType.BRANCH;
+    String refName = "hank";
+    Integer minSnapshotsToKeep = 2;
+    Long maxSnapshotAgeMs = 3L;
+    Long maxRefAgeMs = 4L;
+    String expected = "{\"action\":\"set-snapshot-ref\",\"ref-name\":\"hank\",\"snapshot-id\":1,\"type\":\"branch\"," +
+        "\"min-snapshots-to-keep\":2,\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    MetadataUpdate update = new MetadataUpdate.SetSnapshotRef(
+        refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set snapshot ref should serialize to the correct JSON value for branch with all fields",
+        expected, actual);
+  }
+
+  /** SetProperties */
+
+  @Test
+  public void testSetPropertiesFromJson() {
+    String action = MetadataUpdateParser.SET_PROPERTIES;
+    Map<String, String> props = ImmutableMap.of(
+        "prop1", "val1",
+        "prop2", "val2"
+    );
+    String propsMap = "{\"prop1\":\"val1\",\"prop2\":\"val2\"}";
+    String json = String.format("{\"action\":\"%s\",\"updated\":%s}", action, propsMap);
+    MetadataUpdate expected = new MetadataUpdate.SetProperties(props);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetPropertiesFromJsonFailsWhenDeserializingNullValues() {
+    String action = MetadataUpdateParser.SET_PROPERTIES;
+    Map<String, String> props = Maps.newHashMap();
+    props.put("prop1", "val1");
+    props.put("prop2", null);
+    String propsMap = "{\"prop1\":\"val1\",\"prop2\":null}";
+    String json = String.format("{\"action\":\"%s\",\"updated\":%s}", action, propsMap);
+    AssertHelpers.assertThrows(
+        "Parsing updates from SetProperties with a property set to null should throw",
+        IllegalArgumentException.class,
+        "Cannot parse prop2 to a string value: null",
+        () -> MetadataUpdateParser.fromJson(json)
+    );
+  }
+
+  @Test
+  public void testSetPropertiesToJson() {
+    String action = MetadataUpdateParser.SET_PROPERTIES;
+    Map<String, String> props = ImmutableMap.of(
+        "prop1", "val1",
+        "prop2", "val2"
+    );
+    String propsMap = "{\"prop1\":\"val1\",\"prop2\":\"val2\"}";
+    String expected = String.format("{\"action\":\"%s\",\"updated\":%s}", action, propsMap);
+    MetadataUpdate update = new MetadataUpdate.SetProperties(props);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Set properties should serialize to the correct JSON value", expected, actual);
+  }
+
+  /** RemoveProperties */
+
+  @Test
+  public void testRemovePropertiesFromJson() {
+    String action = MetadataUpdateParser.REMOVE_PROPERTIES;
+    Set<String> toRemove = ImmutableSet.of("prop1", "prop2");
+    String toRemoveAsJSON = "[\"prop1\",\"prop2\"]";
+    String json = String.format("{\"action\":\"%s\",\"removed\":%s}", action, toRemoveAsJSON);
+    MetadataUpdate expected = new MetadataUpdate.RemoveProperties(toRemove);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testRemovePropertiesToJson() {
+    String action = MetadataUpdateParser.REMOVE_PROPERTIES;
+    Set<String> toRemove = ImmutableSet.of("prop1", "prop2");
+    String toRemoveAsJSON = "[\"prop1\",\"prop2\"]";
+    String expected = String.format("{\"action\":\"%s\",\"removed\":%s}", action, toRemoveAsJSON);
+    MetadataUpdate update = new MetadataUpdate.RemoveProperties(toRemove);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Remove properties should serialize to the correct JSON value", expected, actual);
+  }
+
+  /** SetLocation */
+
+  @Test
+  public void testSetLocationFromJson() {
+    String action = MetadataUpdateParser.SET_LOCATION;
+    String location = "s3://bucket/warehouse/tbl_location";
+    String json = String.format("{\"action\":\"%s\",\"location\":\"%s\"}", action, location);
+    MetadataUpdate expected = new MetadataUpdate.SetLocation(location);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testSetLocationToJson() {
+    String action = MetadataUpdateParser.SET_LOCATION;
+    String location = "s3://bucket/warehouse/tbl_location";
+    String expected = String.format("{\"action\":\"%s\",\"location\":\"%s\"}", action, location);
+    MetadataUpdate update = new MetadataUpdate.SetLocation(location);
+    String actual = MetadataUpdateParser.toJson(update);
+    Assert.assertEquals("Remove properties should serialize to the correct JSON value", expected, actual);
+  }
 
   public void assertEquals(String action, MetadataUpdate expectedUpdate, MetadataUpdate actualUpdate) {
     switch (action) {
       case MetadataUpdateParser.ASSIGN_UUID:
-        Assert.fail(String.format("MetadataUpdateParser for %s is not implemented", action));
+        assertEqualsAssignUUID((MetadataUpdate.AssignUUID) expectedUpdate, (MetadataUpdate.AssignUUID) actualUpdate);
         break;
       case MetadataUpdateParser.UPGRADE_FORMAT_VERSION:
         assertEqualsUpgradeFormatVersion((MetadataUpdate.UpgradeFormatVersion) expectedUpdate,
@@ -281,17 +669,39 @@ public class TestMetadataUpdateParser {
             (MetadataUpdate.AddSortOrder) actualUpdate);
         break;
       case MetadataUpdateParser.SET_DEFAULT_SORT_ORDER:
+        assertEqualsSetDefaultSortOrder((MetadataUpdate.SetDefaultSortOrder) expectedUpdate,
+            (MetadataUpdate.SetDefaultSortOrder) actualUpdate);
+        break;
       case MetadataUpdateParser.ADD_SNAPSHOT:
+        assertEqualsAddSnapshot((MetadataUpdate.AddSnapshot) expectedUpdate, (MetadataUpdate.AddSnapshot) actualUpdate);
+        break;
       case MetadataUpdateParser.REMOVE_SNAPSHOTS:
+        assertEqualsRemoveSnapshots((MetadataUpdate.RemoveSnapshot) expectedUpdate,
+            (MetadataUpdate.RemoveSnapshot) actualUpdate);
+        break;
       case MetadataUpdateParser.SET_SNAPSHOT_REF:
+        assertEqualsSetSnapshotRef((MetadataUpdate.SetSnapshotRef) expectedUpdate,
+            (MetadataUpdate.SetSnapshotRef) actualUpdate);
+        break;
       case MetadataUpdateParser.SET_PROPERTIES:
+        assertEqualsSetProperties((MetadataUpdate.SetProperties) expectedUpdate,
+            (MetadataUpdate.SetProperties) actualUpdate);
+        break;
       case MetadataUpdateParser.REMOVE_PROPERTIES:
+        assertEqualsRemoveProperties((MetadataUpdate.RemoveProperties) expectedUpdate,
+            (MetadataUpdate.RemoveProperties) actualUpdate);
+        break;
       case MetadataUpdateParser.SET_LOCATION:
-        Assert.fail(String.format("MetadataUpdateParser for %s is not implemented yet", action));
+        assertEqualsSetLocation((MetadataUpdate.SetLocation) expectedUpdate,
+            (MetadataUpdate.SetLocation) actualUpdate);
         break;
       default:
         Assert.fail("Unrecognized metadata update action: " + action);
     }
+  }
+
+  private static void assertEqualsAssignUUID(MetadataUpdate.AssignUUID expected, MetadataUpdate.AssignUUID actual) {
+    Assert.assertEquals("UUIDs should be equal", expected.uuid(), actual.uuid());
   }
 
   private static void assertEqualsUpgradeFormatVersion(
@@ -336,8 +746,6 @@ public class TestMetadataUpdateParser {
 
   private static void assertEqualsAddSortOrder(
       MetadataUpdate.AddSortOrder expected, MetadataUpdate.AddSortOrder actual) {
-    UnboundSortOrder expectedSortOrder = expected.sortOrder();
-    UnboundSortOrder actualSortOrder = actual.sortOrder();
     Assert.assertEquals("Order id of the sort order should be the same",
         expected.sortOrder().orderId(), actual.sortOrder().orderId());
 
@@ -354,5 +762,73 @@ public class TestMetadataUpdateParser {
               expectedField.direction().equals(actualField.direction()) &&
               Objects.equals(expectedField.transformAsString(), actualField.transformAsString()));
         });
+  }
+
+  private static void assertEqualsSetDefaultSortOrder(
+      MetadataUpdate.SetDefaultSortOrder expected, MetadataUpdate.SetDefaultSortOrder actual) {
+    Assert.assertEquals("Sort order id should be the same", expected.sortOrderId(), actual.sortOrderId());
+  }
+
+  private static void assertEqualsAddSnapshot(
+      MetadataUpdate.AddSnapshot expected, MetadataUpdate.AddSnapshot actual) {
+    Assert.assertEquals("Snapshot ID should be equal",
+        expected.snapshot().snapshotId(), actual.snapshot().snapshotId());
+    Assert.assertEquals("Manifest list location should be equal",
+        expected.snapshot().manifestListLocation(), actual.snapshot().manifestListLocation());
+    Assertions.assertThat(actual.snapshot().summary())
+        .as("Snapshot summary should be equivalent")
+        .containsExactlyEntriesOf(expected.snapshot().summary());
+    Assert.assertEquals("Snapshot Parent ID should be equal",
+        expected.snapshot().parentId(), actual.snapshot().parentId());
+    Assert.assertEquals("Snapshot timestamp should be equal", expected.snapshot().timestampMillis(),
+        actual.snapshot().timestampMillis());
+    Assert.assertEquals("Snapshot schema id should be equal", expected.snapshot().schemaId(),
+        actual.snapshot().schemaId());
+  }
+
+  private static void assertEqualsRemoveSnapshots(
+      MetadataUpdate.RemoveSnapshot expected, MetadataUpdate.RemoveSnapshot actual) {
+    Assert.assertEquals("Snapshots to remove should be the same", expected.snapshotId(), actual.snapshotId());
+  }
+
+  private static void assertEqualsSetSnapshotRef(
+      MetadataUpdate.SetSnapshotRef expected, MetadataUpdate.SetSnapshotRef actual) {
+    // Non-null fields
+    Assert.assertNotNull("Snapshot ref name should not be null", actual.name());
+    Assert.assertEquals("Snapshot ref name should be equal", expected.name(), actual.name());
+    Assert.assertEquals("Snapshot ID should be equal", expected.snapshotId(), actual.snapshotId());
+    Assert.assertNotNull("Snapshot reference type should not be null", actual.type());
+    Assert.assertEquals("Snapshot reference type should be equal", expected.type(), actual.type());
+
+    // Nullable fields
+    Assert.assertEquals("Min snapshots to keep should be equal when present and null when missing or explicitly null",
+        expected.minSnapshotsToKeep(), actual.minSnapshotsToKeep());
+    Assert.assertEquals("Max snapshot age ms should be equal when present and null when missing or explicitly null",
+        expected.maxSnapshotAgeMs(), actual.maxSnapshotAgeMs());
+    Assert.assertEquals("Max ref age ms should be equal when present and null when missing or explicitly null",
+        expected.maxRefAgeMs(), actual.maxRefAgeMs());
+  }
+
+  private static void assertEqualsSetProperties(
+      MetadataUpdate.SetProperties expected, MetadataUpdate.SetProperties actual) {
+    Assertions.assertThat(actual.updated())
+        .as("Properties to set / update should not be null")
+        .isNotNull()
+        .as("Properties to set / update should be the same")
+        .containsExactlyInAnyOrderEntriesOf(expected.updated());
+  }
+
+  private static void assertEqualsRemoveProperties(
+      MetadataUpdate.RemoveProperties expected, MetadataUpdate.RemoveProperties actual) {
+    Assertions.assertThat(actual.removed())
+        .as("Properties to remove should not be null")
+        .isNotNull()
+        .as("Properties to remove should be equal")
+        .containsExactlyInAnyOrderElementsOf(expected.removed());
+  }
+
+  private static void assertEqualsSetLocation(
+      MetadataUpdate.SetLocation expected, MetadataUpdate.SetLocation actual) {
+    Assert.assertEquals("Location should be the same", expected.location(), actual.location());
   }
 }

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1074,10 +1074,13 @@ components:
           enum: ["tag", "branch"]
         snapshot-id:
           type: integer
+          format: int64
         max-ref-age-ms:
           type: integer
+          format: int64
         max-snapshot-age-ms:
           type: integer
+          format: int64
         min-snapshots-to-keep:
           type: integer
 
@@ -1261,9 +1264,9 @@ components:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
           required:
-            - order-id
+            - sort-order-id
           properties:
-            order-id:
+            sort-order-id:
               type: integer
               description: Sort order ID to set as the default, or -1 to set last added sort order
 
@@ -1283,9 +1286,9 @@ components:
         - $ref: '#/components/schemas/SnapshotReference'
         - type: object
           required:
-            - ref
+            - ref-name
           properties:
-            ref:
+            ref-name:
               type: string
 
     RemoveSnapshotsUpdate:
@@ -1299,6 +1302,7 @@ components:
               type: array
               items:
                 type: integer
+                format: int64
 
     SetLocationUpdate:
       allOf:


### PR DESCRIPTION
Adds the remaining parsers for metadata update subclasses.

Opening this as a draft so I can compare and because some field renaming in a tangentially related PR: https://github.com/apache/iceberg/pull/4693

I'll probably move the field renaming over here if they don't get merged in over there before.