### PR TITLE
Python: Add PartitionSpec

### DIFF
--- a/python/spellcheck-dictionary.txt
+++ b/python/spellcheck-dictionary.txt
@@ -37,6 +37,7 @@ NaN
 nan
 NestedField
 nullability
+PartitionField
 pragma
 PrimitiveType
 pyarrow

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Dict, List, Tuple
+
+from iceberg.schema import Schema
 from iceberg.transforms import Transform
 
 
@@ -64,3 +67,100 @@ class PartitionField:
 
     def __repr__(self):
         return f"PartitionField(field_id={self.field_id}, name={self.name}, transform={repr(self.transform)}, source_id={self.source_id})"
+
+    def __hash__(self):
+        return hash((self.source_id, self.field_id, self.name, self.transform))
+
+
+class PartitionSpec:
+    """
+    PartitionSpec capture the transformation from table data to partition values
+
+    Attributes:
+        schema(Schema): the schema of data table
+        spec_id(int): any change to PartitionSpec will produce a new specId
+        fields(List[PartitionField): list of partition fields to produce partition values
+        last_assigned_field_id(int): auto-increment partition field id starting from PARTITION_DATA_ID_START
+    """
+
+    PARTITION_DATA_ID_START: int = 1000
+
+    def __init__(self, schema: Schema, spec_id: int, fields: Tuple[PartitionField], last_assigned_field_id: int):
+        self._schema = schema
+        self._spec_id = spec_id
+        self._fields = fields
+        self._last_assigned_field_id = last_assigned_field_id
+        # derived
+        self.fields_by_source_id: Dict[int, List[PartitionField]] = {}
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    @property
+    def spec_id(self) -> int:
+        return self._spec_id
+
+    @property
+    def fields(self) -> Tuple[PartitionField]:
+        return self._fields
+
+    @property
+    def last_assigned_field_id(self) -> int:
+        return self._last_assigned_field_id
+
+    def __eq__(self, other):
+        return self.spec_id == other.spec_id and self.fields == other.fields
+
+    def __str__(self):
+        if self.is_unpartitioned():
+            return "[]"
+        else:
+            delimiter = "\n  "
+            partition_fields_in_str = (str(partition_field) for partition_field in self.fields)
+            head = f"[{delimiter}"
+            tail = f"\n]"
+            return f"{head}{delimiter.join(partition_fields_in_str)}{tail}"
+
+    def __repr__(self):
+        return f"PartitionSpec: {str(self)}"
+
+    def __hash__(self):
+        return hash((self.spec_id, self.fields))
+
+    def is_unpartitioned(self) -> bool:
+        return len(self.fields) < 1
+
+    def get_fields_by_source_id(self, filed_id: int) -> List[PartitionField]:
+        if not self.fields_by_source_id:
+            for partition_field in self.fields:
+                source_column = self.schema.find_column_name(partition_field.source_id)
+                if not source_column:
+                    raise ValueError(f"Cannot find source column: {partition_field.source_id}")
+                existing = self.fields_by_source_id.get(partition_field.source_id, [])
+                existing.append(partition_field)
+                self.fields_by_source_id[partition_field.source_id] = existing
+        return self.fields_by_source_id.get(filed_id)  # type: ignore
+
+    def compatible_with(self, other) -> bool:
+        """
+        Returns true if this partition spec is equivalent to the other, with partition field_id ignored.
+        That is, if both specs have the same number of fields, field order, field name, source column ids, and transforms.
+        """
+        if self.__eq__(other):
+            return True
+
+        if len(self.fields) != len(other.fields):
+            return False
+
+        for index in range(len(self.fields)):
+            this_field = self.fields[index]
+            that_field = other.fields[index]
+            if (
+                this_field.source_id != that_field.source_id
+                or this_field.transform != that_field.transform
+                or this_field.name != that_field.name
+            ):
+                return False
+
+        return True

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -135,7 +135,7 @@ class PartitionSpec:
                 self._fields_by_source_id[partition_field.source_id] = existing
         return self._fields_by_source_id[field_id]
 
-    def compatible_with(self, other) -> bool:
+    def compatible_with(self, other: "PartitionSpec") -> bool:
         """
         Returns true if this partition spec is equivalent to the other, with partition field_id ignored.
         That is, if both specs have the same number of fields, field order, field name, source column ids, and transforms.

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -59,7 +59,7 @@ class PartitionSpec:
 
     schema: Schema
     spec_id: int
-    fields: Tuple[PartitionField]
+    fields: Tuple[PartitionField, ...]
     last_assigned_field_id: int
     source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False, repr=False)
 
@@ -76,8 +76,13 @@ class PartitionSpec:
 
     def __eq__(self, other):
         """
-        Equality check on spec_id and partition fields only
+        Produce a boolean to return True if two objects are considered equal
+
+        Note:
+            Equality of PartitionSpec is determined by spec_id and partition fields only
         """
+        if not isinstance(other, PartitionSpec):
+            return False
         return self.spec_id == other.spec_id and self.fields == other.fields
 
     def __str__(self):
@@ -101,8 +106,7 @@ class PartitionSpec:
 
     def compatible_with(self, other: "PartitionSpec") -> bool:
         """
-        Returns true if this partition spec is equivalent to the other, with partition field_id ignored.
-        That is, if both specs have the same number of fields, field order, field name, source column ids, and transforms.
+        Produce a boolean to return True if two PartitionSpec are considered compatible
         """
         return all(
             this_field.source_id == that_field.source_id

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -99,7 +99,7 @@ class PartitionSpec:
         return result_str
 
     def is_unpartitioned(self) -> bool:
-        return len(self.fields) < 1
+        return not self.fields
 
     def fields_by_source_id(self, field_id: int) -> List[PartitionField]:
         return self.source_id_to_fields_map[field_id]
@@ -108,6 +108,10 @@ class PartitionSpec:
         """
         Produce a boolean to return True if two PartitionSpec are considered compatible
         """
+        if self == other:
+            return True
+        if len(self.fields) != len(other.fields):
+            return False
         return all(
             this_field.source_id == that_field.source_id
             and this_field.transform == that_field.transform

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -45,7 +45,7 @@ class PartitionField:
         return f"{self.field_id}: {self.name}: {self.transform}({self.source_id})"
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, frozen=True)
 class PartitionSpec:
     """
     PartitionSpec capture the transformation from table data to partition values
@@ -64,14 +64,15 @@ class PartitionSpec:
     source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False)
 
     def __post_init__(self):
-        self.source_id_to_fields_map = dict()
+        source_id_to_fields_map = dict()
         for partition_field in self.fields:
             source_column = self.schema.find_column_name(partition_field.source_id)
             if not source_column:
                 raise ValueError(f"Cannot find source column: {partition_field.source_id}")
-            existing = self.source_id_to_fields_map.get(partition_field.source_id, [])
+            existing = source_id_to_fields_map.get(partition_field.source_id, [])
             existing.append(partition_field)
-            self.source_id_to_fields_map[partition_field.source_id] = existing
+            source_id_to_fields_map[partition_field.source_id] = existing
+        object.__setattr__(self, "source_id_to_fields_map", source_id_to_fields_map)
 
     def __eq__(self, other):
         """

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -88,10 +88,8 @@ class PartitionSpec:
             Only include list of partition fields in the PartitionSpec's string representation
         """
         result_str = "["
-        for partition_field in self.fields:
-            result_str += f"\n  {str(partition_field)}"
-        if len(self.fields) > 0:
-            result_str += "\n"
+        if self.fields:
+            result_str += "\n  " + "\n  ".join([str(field) for field in self.fields]) + "\n"
         result_str += "]"
         return result_str
 

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -61,7 +61,7 @@ class PartitionSpec:
     spec_id: int
     fields: Tuple[PartitionField]
     last_assigned_field_id: int
-    source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False)
+    source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False, repr=False)
 
     def __post_init__(self):
         source_id_to_fields_map = dict()
@@ -82,7 +82,10 @@ class PartitionSpec:
 
     def __str__(self):
         """
-        PartitionSpec str method highlight the partition field only
+        Produce a human-readable string representation of PartitionSpec
+
+        Note:
+            Only include list of partition fields in the PartitionSpec's string representation
         """
         result_str = "["
         for partition_field in self.fields:

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -21,7 +21,6 @@ from iceberg.transforms import Transform
 
 _PARTITION_DATA_ID_START: int = 1000
 
-
 class PartitionField:
     """
     PartitionField is a single element with name and unique id,
@@ -140,17 +139,8 @@ class PartitionSpec:
         Returns true if this partition spec is equivalent to the other, with partition field_id ignored.
         That is, if both specs have the same number of fields, field order, field name, source column ids, and transforms.
         """
-        if self == other:
-            return True
-        if len(self.fields) != len(other.fields):
-            return False
-        for index in range(len(self.fields)):
-            this_field = self.fields[index]
-            that_field = other.fields[index]
-            if (
-                this_field.source_id != that_field.source_id
-                or this_field.transform != that_field.transform
-                or this_field.name != that_field.name
-            ):
-                return False
-        return True
+        return all(
+            this_field.source_id == that_field.source_id and this_field.transform == that_field.transform and this_field.name == that_field.name
+            for this_field, that_field
+            in zip(self.fields, other.fields)
+        )

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -48,7 +48,7 @@ class PartitionField:
 @dataclass(eq=False, frozen=True)
 class PartitionSpec:
     """
-    PartitionSpec capture the transformation from table data to partition values
+    PartitionSpec captures the transformation from table data to partition values
 
     Attributes:
         schema(Schema): the schema of data table

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -70,9 +70,6 @@ class PartitionField:
     def __repr__(self):
         return f"PartitionField(field_id={self.field_id}, name={self.name}, transform={repr(self.transform)}, source_id={self.source_id})"
 
-    def __hash__(self):
-        return hash((self.source_id, self.field_id, self.name, self.transform))
-
 
 class PartitionSpec:
     """
@@ -113,20 +110,16 @@ class PartitionSpec:
         return self.spec_id == other.spec_id and self.fields == other.fields
 
     def __str__(self):
-        if self.is_unpartitioned():
-            return "[]"
-        else:
-            delimiter = "\n  "
-            partition_fields_in_str = (str(partition_field) for partition_field in self.fields)
-            head = f"[{delimiter}"
-            tail = f"\n]"
-            return f"{head}{delimiter.join(partition_fields_in_str)}{tail}"
+        result_str = "["
+        for partition_field in self.fields:
+            result_str += f"\n  {str(partition_field)}"
+        if len(self.fields) > 0:
+            result_str += "\n"
+        result_str += "]"
+        return result_str
 
     def __repr__(self):
         return f"PartitionSpec: {str(self)}"
-
-    def __hash__(self):
-        return hash((self.spec_id, self.fields))
 
     def is_unpartitioned(self) -> bool:
         return len(self.fields) < 1

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -30,10 +30,13 @@ def test_partition_field_init():
     assert partition_field.transform == bucket_transform
     assert partition_field.name == "id"
     assert partition_field == partition_field
+    print(str(partition_field))
+    print("repr")
+    print(repr(partition_field))
     assert str(partition_field) == "1000: id: bucket[100](3)"
     assert (
         repr(partition_field)
-        == "PartitionField(field_id=1000, name=id, transform=transforms.bucket(source_type=IntegerType(), num_buckets=100), source_id=3)"
+        == "PartitionField(source_id=3, field_id=1000, transform=transforms.bucket(source_type=IntegerType(), num_buckets=100), name='id')"
     )
 
 

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -35,7 +35,6 @@ def test_partition_field_init():
         repr(partition_field)
         == "PartitionField(field_id=1000, name=id, transform=transforms.bucket(source_type=IntegerType(), num_buckets=100), source_id=3)"
     )
-    assert hash(partition_field) == hash(partition_field)
 
 
 def test_partition_spec_init(table_schema_simple: Schema):
@@ -51,7 +50,6 @@ def test_partition_spec_init(table_schema_simple: Schema):
     # only differ by PartitionField field_id
     id_field2 = PartitionField(3, 1002, bucket_transform, "id")
     partition_spec2 = PartitionSpec(table_schema_simple, 0, (id_field2,), 1001)
-    assert hash(partition_spec1) != hash(partition_spec2)
     assert partition_spec1.compatible_with(partition_spec2)
     assert partition_spec1.fields_by_source_id(3) == [id_field1]
 

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -56,6 +56,15 @@ def test_partition_spec_init(table_schema_simple: Schema):
     assert partition_spec1.fields_by_source_id(3) == [id_field1]
 
 
+def test_partition_compatible_with(table_schema_simple: Schema):
+    bucket_transform = bucket(IntegerType(), 4)
+    field1 = PartitionField(3, 100, bucket_transform, "id")
+    field2 = PartitionField(3, 102, bucket_transform, "id")
+    lhs = PartitionSpec(table_schema_simple, 0, (field1,), 1001)
+    rhs = PartitionSpec(table_schema_simple, 0, (field1, field2), 1001)
+    assert not lhs.compatible_with(rhs)
+
+
 def test_unpartitioned(table_schema_simple: Schema):
     unpartitioned = PartitionSpec(table_schema_simple, 1, tuple(), 1000)
 

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -45,6 +45,7 @@ def test_partition_spec_init(table_schema_simple: Schema):
     assert partition_spec1.spec_id == 0
     assert partition_spec1.schema == table_schema_simple
     assert partition_spec1 == partition_spec1
+    assert partition_spec1 != id_field1
     assert str(partition_spec1) == f"[\n  {str(id_field1)}\n]"
     assert not partition_spec1.is_unpartitioned()
     # only differ by PartitionField field_id
@@ -56,7 +57,7 @@ def test_partition_spec_init(table_schema_simple: Schema):
 
 
 def test_unpartitioned(table_schema_simple: Schema):
-    unpartitioned = PartitionSpec(table_schema_simple, 1, (), 1000)
+    unpartitioned = PartitionSpec(table_schema_simple, 1, tuple(), 1000)
 
     assert not unpartitioned.fields
     assert unpartitioned.is_unpartitioned()

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -53,7 +53,7 @@ def test_partition_spec_init(table_schema_simple: Schema):
     partition_spec2 = PartitionSpec(table_schema_simple, 0, (id_field2,), 1001)
     assert hash(partition_spec1) != hash(partition_spec2)
     assert partition_spec1.compatible_with(partition_spec2)
-    assert partition_spec1.get_fields_by_source_id(3) == [id_field1]
+    assert partition_spec1.fields_by_source_id(3) == [id_field1]
 
 
 def test_unpartitioned(table_schema_simple: Schema):

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -50,6 +50,7 @@ def test_partition_spec_init(table_schema_simple: Schema):
     # only differ by PartitionField field_id
     id_field2 = PartitionField(3, 1002, bucket_transform, "id")
     partition_spec2 = PartitionSpec(table_schema_simple, 0, (id_field2,), 1001)
+    assert partition_spec1 != partition_spec2
     assert partition_spec1.compatible_with(partition_spec2)
     assert partition_spec1.fields_by_source_id(3) == [id_field1]
 

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from iceberg.table.partitioning import PartitionField
+from iceberg.schema import Schema
+from iceberg.table.partitioning import PartitionField, PartitionSpec
 from iceberg.transforms import bucket
 from iceberg.types import IntegerType
 
@@ -34,3 +35,30 @@ def test_partition_field_init():
         repr(partition_field)
         == "PartitionField(field_id=1000, name=id, transform=transforms.bucket(source_type=IntegerType(), num_buckets=100), source_id=3)"
     )
+    assert hash(partition_field) == hash(partition_field)
+
+
+def test_partition_spec_init(table_schema_simple: Schema):
+    bucket_transform = bucket(IntegerType(), 4)
+    id_field1 = PartitionField(3, 1001, bucket_transform, "id")
+    partition_spec1 = PartitionSpec(table_schema_simple, 0, (id_field1,), 1001)
+
+    assert partition_spec1.spec_id == 0
+    assert partition_spec1.schema == table_schema_simple
+    assert partition_spec1 == partition_spec1
+    assert str(partition_spec1) == f"[\n  {str(id_field1)}\n]"
+    assert not partition_spec1.is_unpartitioned()
+    # only differ by PartitionField field_id
+    id_field2 = PartitionField(3, 1002, bucket_transform, "id")
+    partition_spec2 = PartitionSpec(table_schema_simple, 0, (id_field2,), 1001)
+    assert hash(partition_spec1) != hash(partition_spec2)
+    assert partition_spec1.compatible_with(partition_spec2)
+    assert partition_spec1.get_fields_by_source_id(3) == [id_field1]
+
+
+def test_unpartitioned(table_schema_simple: Schema):
+    unpartitioned = PartitionSpec(table_schema_simple, 1, (), 1000)
+
+    assert not unpartitioned.fields
+    assert unpartitioned.is_unpartitioned()
+    assert str(unpartitioned) == "[]"

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -30,9 +30,6 @@ def test_partition_field_init():
     assert partition_field.transform == bucket_transform
     assert partition_field.name == "id"
     assert partition_field == partition_field
-    print(str(partition_field))
-    print("repr")
-    print(repr(partition_field))
     assert str(partition_field) == "1000: id: bucket[100](3)"
     assert (
         repr(partition_field)


### PR DESCRIPTION
2nd step of complete the https://github.com/apache/iceberg/issues/3228

This change include the PartitionSpec but not include its builder part as I want to keep the changelist as small as possible. As suggested in https://github.com/apache/iceberg/issues/4631, the construction of PartitionSpec shall rely on its Builder class with proper checks and such logic shall not be duplicated in its dunder init methods.

```python
from iceberg.schema import Schema
from iceberg.transforms import bucket
from iceberg.types import BooleanType, IntegerType, NestedField, StringType
from iceberg.table.partitioning import PartitionSpec, PartitionField

table_schema = Schema(
        NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
        NestedField(field_id=2, name="bar", field_type=IntegerType(), is_optional=True),
        NestedField(field_id=3, name="baz", field_type=BooleanType(), is_optional=False),
        schema_id=1,
        identifier_field_ids=[1],
    )
bucket_transform = bucket(IntegerType(), 100)
foo_field = PartitionField(source_id=1, field_id=1001, transform=bucket_transform, name="foo_bucket")
partition_spec = PartitionSpec(schema=table_schema, spec_id=0, fields=(foo_field,), last_assigned_field_id=1001)

>>> partition_spec
PartitionSpec: [
  1001: foo_bucket: bucket[100](1)
]
``` 

I will come up with follow up on PartitionSpecBuilder class

CC @samredai @rdblue @dhruv-pratap