### PR TITLE
Core: Fix query failure when using projection on top of partitions metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -152,7 +152,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
     LoadingCache<Integer, ManifestEvaluator> evalCache = Caffeine.newBuilder().build(specId -> {
       PartitionSpec spec = table.specs().get(specId);
-      PartitionSpec transformedSpec = transformSpec(scan.schema(), spec);
+      PartitionSpec transformedSpec = transformSpec(scan.tableSchema(), spec);
       return ManifestEvaluator.forRowFilter(scan.filter(), transformedSpec, caseSensitive);
     });
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -171,6 +171,13 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
     TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expectedDataFiles.get(0), actualDataFiles.get(0));
 
+    List<Row> actualPartitionsWithProjection =
+        spark.sql("SELECT file_count FROM " + tableName + ".partitions ").collectAsList();
+    Assert.assertEquals("Metadata table should return two partitions record", 2, actualPartitionsWithProjection.size());
+    for (int i = 0; i < 2; ++i) {
+      Assert.assertEquals(1, actualPartitionsWithProjection.get(i).get(0));
+    }
+
     // Check files table
     List<Record> expectedFiles = Stream.concat(expectedDataFiles.stream(), expectedDeleteFiles.stream())
         .collect(Collectors.toList());


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/4718

As per my understanding, we should use scan.tableSchema() rather than scan.schema() for transformSpec when planFiles() for partitions metaData table. 

Hence we faced :
> 22/05/06 16:12:25 ERROR SparkSQLDriver: Failed in [select file_count from spark_catalog.monitoring.test.partitions]
java.lang.IllegalArgumentException: Cannot find source column: partition.date

as present in reported ticket

Though in master we will get : 

>Cannot find source column: 1000
java.lang.NullPointerException: Cannot find source column: 1000

---

Testing Done : 
Added UT fails without the change

cc @szehon-ho @RussellSpitzer 