### PR TITLE
Spark: Fix unable to disable use-caching in RewriteManifestsProcedure

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -85,7 +85,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
       RewriteManifests action = actions().rewriteManifests(table);
 
       if (useCaching != null) {
-        action.option("use-caching", "true");
+        action.option("use-caching", useCaching.toString());
       }
 
       RewriteManifests.Result result = action.execute();

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -85,7 +85,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
       RewriteManifests action = actions().rewriteManifests(table);
 
       if (useCaching != null) {
-        action.option("use-caching", "true");
+        action.option("use-caching", useCaching.toString());
       }
 
       RewriteManifests.Result result = action.execute();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -85,7 +85,7 @@ class RewriteManifestsProcedure extends BaseProcedure {
       RewriteManifests action = actions().rewriteManifests(table);
 
       if (useCaching != null) {
-        action.option("use-caching", "true");
+        action.option("use-caching", useCaching.toString());
       }
 
       RewriteManifests.Result result = action.execute();


### PR DESCRIPTION
use-caching in RewriteManifestsProcedure is always hardcoded to true and default value is also true. So, unable to disable.