### PR TITLE
AWS: support overriding endpoint in DynamoDB

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -53,5 +54,17 @@ public class TestDefaultAwsClientFactory {
         S3Exception.class,
         "The AWS Access Key Id you provided does not exist in our records",
         () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
+  }
+
+  @Test
+  public void testDynamoDbEndpointOverride() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.DYNAMODB_ENDPOINT, "https://unknown:1234");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    DynamoDbClient dynamoDbClient = factory.dynamo();
+    AssertHelpers.assertThrowsCause("Should refuse connection to unknown endpoint",
+        SdkClientException.class,
+        "Unable to execute HTTP request: unknown",
+        dynamoDbClient::listTables);
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -46,6 +46,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private String region;
   private String s3Endpoint;
   private boolean s3UseArnRegionEnabled;
+  private String dynamoDbEndpoint;
   private String httpClientType;
 
   @Override
@@ -69,7 +70,10 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
   @Override
   public DynamoDbClient dynamo() {
-    return DynamoDbClient.builder().applyMutation(this::configure).build();
+    return DynamoDbClient.builder()
+        .applyMutation(this::configure)
+        .applyMutation(builder -> AwsClientFactories.configureEndpoint(builder, dynamoDbEndpoint))
+        .build();
   }
 
   @Override
@@ -88,6 +92,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     this.tags = toTags(properties);
     this.s3UseArnRegionEnabled = PropertyUtil.propertyAsBoolean(properties, AwsProperties.S3_ACCESS_POINTS_PREFIX,
         AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
+    this.dynamoDbEndpoint = properties.get(AwsProperties.DYNAMODB_ENDPOINT);
     this.httpClientType = PropertyUtil.propertyAsString(properties,
         AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_DEFAULT);
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -84,6 +84,7 @@ public class AwsClientFactories {
     private String s3SecretAccessKey;
     private String s3SessionToken;
     private Boolean s3UseArnRegionEnabled;
+    private String dynamoDbEndpoint;
     private String httpClientType;
 
     DefaultAwsClientFactory() {
@@ -111,7 +112,10 @@ public class AwsClientFactories {
 
     @Override
     public DynamoDbClient dynamo() {
-      return DynamoDbClient.builder().httpClientBuilder(configureHttpClientBuilder(httpClientType)).build();
+      return DynamoDbClient.builder()
+          .httpClientBuilder(configureHttpClientBuilder(httpClientType))
+          .applyMutation(builder -> configureEndpoint(builder, dynamoDbEndpoint))
+          .build();
     }
 
     @Override
@@ -126,6 +130,7 @@ public class AwsClientFactories {
       ValidationException.check((s3AccessKeyId == null && s3SecretAccessKey == null) ||
           (s3AccessKeyId != null && s3SecretAccessKey != null),
           "S3 client access key ID and secret access key must be set at the same time");
+      this.dynamoDbEndpoint = properties.get(AwsProperties.DYNAMODB_ENDPOINT);
       this.httpClientType = PropertyUtil.propertyAsString(properties,
           AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_DEFAULT);
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -223,6 +223,11 @@ public class AwsProperties implements Serializable {
   public static final int S3FILEIO_DELETE_BATCH_SIZE_MAX = 1000;
 
   /**
+   * Configure an alternative endpoint of the DynamoDB service to access.
+   */
+  public static final String DYNAMODB_ENDPOINT = "dynamodb.endpoint";
+
+  /**
    * DynamoDB table name for {@link DynamoDbCatalog}
    */
   public static final String DYNAMODB_TABLE_NAME = "dynamodb.table-name";


### PR DESCRIPTION
This makes testing DynamoDB integration easily with docker (https://hub.docker.com/r/amazon/dynamodb-local/). 