### PR TITLE
Python: Skip missing tox interpreters

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -17,6 +17,7 @@
 
 [tox]
 envlist = py37,py38,py39,linters
+skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
I have only Python 3.9 installed locally. And for fast turnaround
I'm not super interested to test everything against each version
locally. Therefore I would suggest to skip the missing interpreters.

Otherwise I have all the red lines with the errors that python 3.7 and 3.8
failed in the terminal all the time, which makes me uncomfortable.

Before:
```
______________________________________________________________________________________________ summary
_______________________________________________________________________________________________
ERROR:  py37: InterpreterNotFound: python3.7
ERROR:  py38: InterpreterNotFound: python3.8
  py39: commands succeeded
  linters: commands succeeded
```

After:
```
______________________________________________________________________________________________ summary
_______________________________________________________________________________________________
SKIPPED:  py37: InterpreterNotFound: python3.7
SKIPPED:  py38: InterpreterNotFound: python3.8
  py39: commands succeeded
  linters: commands succeeded
  congratulations :)
```