### PR TITLE
API: Add default value API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -68,10 +68,12 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
         sameTypes = false; // signal that some types were altered
         if (field.isOptional()) {
           selectedFields.add(
-              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
+              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc(),
+              field.initialDefault(), field.writeDefault()));
         } else {
           selectedFields.add(
-              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
+              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc(),
+                  field.initialDefault(), field.writeDefault()));
         }
       }
     }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -415,27 +415,42 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type, null);
+      return new NestedField(true, id, name, type, null, null, null);
     }
 
     public static NestedField optional(int id, String name, Type type, String doc) {
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, null, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc,
+                                       Object initialDefault, Object writeDefault) {
+      return new NestedField(true, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type, null);
+      return new NestedField(false, id, name, type, null, null, null);
     }
 
     public static NestedField required(int id, String name, Type type, String doc) {
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, null, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc,
+                                       Object initialDefault, Object writeDefault) {
+      return new NestedField(false, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
-      return new NestedField(isOptional, id, name, type, null);
+      return new NestedField(isOptional, id, name, type, null, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
-      return new NestedField(isOptional, id, name, type, doc);
+      return new NestedField(isOptional, id, name, type, doc, null, null);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, String doc,
+                                 Object initialDefault, Object writeDefault) {
+      return new NestedField(isOptional, id, name, type, doc, initialDefault, writeDefault);
     }
 
     private final boolean isOptional;
@@ -443,8 +458,12 @@ public class Types {
     private final String name;
     private final Type type;
     private final String doc;
+    private final Object initialDefault;
+    private final Object writeDefault;
 
-    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+    private NestedField(
+        boolean isOptional, int id, String name, Type type, String doc,
+        Object initialDefault, Object writeDefault) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
       this.isOptional = isOptional;
@@ -452,6 +471,8 @@ public class Types {
       this.name = name;
       this.type = type;
       this.doc = doc;
+      this.initialDefault = initialDefault;
+      this.writeDefault = writeDefault;
     }
 
     public boolean isOptional() {
@@ -462,7 +483,7 @@ public class Types {
       if (isOptional) {
         return this;
       }
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, initialDefault, writeDefault);
     }
 
     public boolean isRequired() {
@@ -473,7 +494,11 @@ public class Types {
       if (!isOptional) {
         return this;
       }
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, initialDefault, writeDefault);
+    }
+
+    public NestedField withWriteDefault(Object newWriteDefault) {
+      return new NestedField(isOptional, id, name, type, doc, initialDefault, newWriteDefault);
     }
 
     public int fieldId() {
@@ -490,6 +515,14 @@ public class Types {
 
     public String doc() {
       return doc;
+    }
+
+    public Object initialDefault() {
+      return initialDefault;
+    }
+
+    public Object writeDefault() {
+      return writeDefault;
     }
 
     @Override


### PR DESCRIPTION
This PR enhances the API of `NestedField` to include default values, they are represented as Java `Object` in memory, this PR is the first PR to implement the spec PR #4301 .

The API changes will be the basis for subsequent PRs to implement the java in-mem to/from json round trip serialization and deserialization, and to support different engines to read/write default values in various formats, according to the semantics in the spec.

@rdblue @wmoustafa