### PR TITLE
Core: remove reference files for BaseEqualityDeltaWriter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.StructLikeMap;
 import org.apache.iceberg.util.StructProjection;
 import org.apache.iceberg.util.Tasks;
@@ -44,7 +43,6 @@ import org.apache.iceberg.util.Tasks;
 public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private final List<DataFile> completedDataFiles = Lists.newArrayList();
   private final List<DeleteFile> completedDeleteFiles = Lists.newArrayList();
-  private final CharSequenceSet referencedDataFiles = CharSequenceSet.empty();
 
   private final PartitionSpec spec;
   private final FileFormat format;
@@ -85,7 +83,6 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     return WriteResult.builder()
         .addDataFiles(completedDataFiles)
         .addDeleteFiles(completedDeleteFiles)
-        .addReferencedDataFiles(referencedDataFiles)
         .build();
   }
 
@@ -199,7 +196,6 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
       // Add the completed pos-delete files.
       if (posDeleteWriter != null) {
         completedDeleteFiles.addAll(posDeleteWriter.complete());
-        referencedDataFiles.addAll(posDeleteWriter.referencedDataFiles());
         posDeleteWriter = null;
       }
     }

--- a/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
@@ -162,7 +162,6 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     Assert.assertEquals("Should have a pos-delete file", 1, result.deleteFiles().length);
     DeleteFile posDeleteFile = result.deleteFiles()[0];
     Assert.assertEquals("Should be a pos-delete file", FileContent.POSITION_DELETES, posDeleteFile.content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
     Assert.assertEquals("Should have expected records", expectedRowSet(ImmutableList.of(
         createRecord(4, "eee"),
         createRecord(3, "fff"),
@@ -249,7 +248,6 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     Assert.assertEquals("Should have a data file", 1, result.dataFiles().length);
     Assert.assertEquals("Should have a pos-delete file for deduplication purpose", 1, result.deleteFiles().length);
     Assert.assertEquals("Should be pos-delete file", FileContent.POSITION_DELETES, result.deleteFiles()[0].content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
     commitTransaction(result);
 
     Assert.assertEquals("Should have expected records", expectedRowSet(ImmutableList.of(
@@ -332,7 +330,6 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     Assert.assertEquals("Should have a data file", 1, result.dataFiles().length);
     Assert.assertEquals("Should have a pos-delete file for deduplication purpose", 1, result.deleteFiles().length);
     Assert.assertEquals("Should be pos-delete file", FileContent.POSITION_DELETES, result.deleteFiles()[0].content());
-    Assert.assertEquals(1, result.referencedDataFiles().length);
     commitTransaction(result);
 
     Assert.assertEquals("Should have expected records", expectedRowSet(ImmutableList.of(
@@ -363,7 +360,6 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     result = deltaWriter.complete();
     Assert.assertEquals(1, result.dataFiles().length);
     Assert.assertEquals(2, result.deleteFiles().length);
-    Assert.assertEquals(1, result.referencedDataFiles().length);
     commitTransaction(result);
 
     Assert.assertEquals("Should have expected records", expectedRowSet(ImmutableList.of(


### PR DESCRIPTION
Flink upsert commit doesn't validate the conflict of data files that position deletes referred, thus it doesn't have to keep referred data files of position deletes in memory anymore. 