### PR TITLE
delete unnecessary switch case judgement

### DIFF
--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
@@ -62,6 +62,7 @@ public class RowDataConverter {
     List<Types.NestedField> fields = struct.fields();
     for (int i = 0; i < fields.size(); i += 1) {
       Types.NestedField field = fields.get(i);
+
       Type fieldType = field.type();
       rowData.setField(i, convert(fieldType, record.get(i)));
     }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/RowDataConverter.java
@@ -62,22 +62,8 @@ public class RowDataConverter {
     List<Types.NestedField> fields = struct.fields();
     for (int i = 0; i < fields.size(); i += 1) {
       Types.NestedField field = fields.get(i);
-
       Type fieldType = field.type();
-
-      switch (fieldType.typeId()) {
-        case STRUCT:
-          rowData.setField(i, convert(fieldType.asStructType(), record.get(i)));
-          break;
-        case LIST:
-          rowData.setField(i, convert(fieldType.asListType(), record.get(i)));
-          break;
-        case MAP:
-          rowData.setField(i, convert(fieldType.asMapType(), record.get(i)));
-          break;
-        default:
-          rowData.setField(i, convert(fieldType, record.get(i)));
-      }
+      rowData.setField(i, convert(fieldType, record.get(i)));
     }
     return rowData;
   }


### PR DESCRIPTION
private static RowData convert(Types.StructType struct, Record record) invoke private static Object convert(Type type, Object object), the latter has already use a switch case to handle STRUCT,LIST,MAP，so I just remove the unnecessary judgement  in the caller method.