### PR TITLE
Spark: add delete info to rewrite job description

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -68,7 +68,7 @@ public class RewriteFileGroup {
         .count();
   }
 
-  public int referencedPositionalDeletes() {
+  public int referencedPosDeletes() {
     return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
         .filter(d -> d.content().equals(FileContent.POSITION_DELETES))
         .distinct()

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -61,14 +61,14 @@ public class RewriteFileGroup {
     return fileScans().stream().map(FileScanTask::file).collect(Collectors.toSet());
   }
 
-  public int referencedEqDeletes() {
+  public int referencedEqDeleteNumber() {
     return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
         .filter(d -> d.content().equals(FileContent.EQUALITY_DELETES))
         .distinct()
         .count();
   }
 
-  public int referencedPosDeletes() {
+  public int referencedPosDeleteNumber() {
     return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
         .filter(d -> d.content().equals(FileContent.POSITION_DELETES))
         .distinct()

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupInfo;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -58,6 +59,18 @@ public class RewriteFileGroup {
 
   public Set<DataFile> rewrittenFiles() {
     return fileScans().stream().map(FileScanTask::file).collect(Collectors.toSet());
+  }
+
+  public int rewrittenEqDeletes() {
+    return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
+        .filter(d -> d.content().equals(FileContent.EQUALITY_DELETES))
+        .count();
+  }
+
+  public int rewrittenPosDeletes() {
+    return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
+        .filter(d -> d.content().equals(FileContent.POSITION_DELETES))
+        .count();
   }
 
   public Set<DataFile> addedFiles() {

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -61,15 +61,17 @@ public class RewriteFileGroup {
     return fileScans().stream().map(FileScanTask::file).collect(Collectors.toSet());
   }
 
-  public int rewrittenEqDeletes() {
+  public int referencedEqDeletes() {
     return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
         .filter(d -> d.content().equals(FileContent.EQUALITY_DELETES))
+        .distinct()
         .count();
   }
 
-  public int rewrittenPosDeletes() {
+  public int referencedPositionalDeletes() {
     return (int) fileScans().stream().flatMap(f -> f.deletes().stream())
         .filter(d -> d.content().equals(FileContent.POSITION_DELETES))
+        .distinct()
         .count();
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -414,14 +414,14 @@ public class BaseRewriteDataFilesSparkAction
   private String jobDesc(RewriteFileGroup group, RewriteExecutionContext ctx) {
     StructLike partition = group.info().partition();
     if (partition.size() > 0) {
-      return String.format("Rewriting %d files (%s, file group %d/%d, %s (%d/%d)) in %s",
-          group.rewrittenFiles().size(),
+      return String.format("Rewriting %d files %d eq deletes %d pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
+          group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenEqDeletes(),
           strategy.name(), group.info().globalIndex(),
           ctx.totalGroupCount(), partition, group.info().partitionIndex(), ctx.groupsInPartition(partition),
           table.name());
     } else {
-      return String.format("Rewriting %d files (%s, file group %d/%d) in %s",
-          group.rewrittenFiles().size(),
+      return String.format("Rewriting %d files %d eq deletes %d pos deletes (%s, file group %d/%d) in %s",
+          group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenPosDeletes(),
           strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
           table.name());
     }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -414,13 +414,13 @@ public class BaseRewriteDataFilesSparkAction
   private String jobDesc(RewriteFileGroup group, RewriteExecutionContext ctx) {
     StructLike partition = group.info().partition();
     if (partition.size() > 0) {
-      return String.format("Rewriting %d files %d eq deletes %d pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
+      return String.format("Rewriting %d files %d, eq deletes %d, pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
           group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenEqDeletes(),
           strategy.name(), group.info().globalIndex(),
           ctx.totalGroupCount(), partition, group.info().partitionIndex(), ctx.groupsInPartition(partition),
           table.name());
     } else {
-      return String.format("Rewriting %d files %d eq deletes %d pos deletes (%s, file group %d/%d) in %s",
+      return String.format("Rewriting %d files %d, eq deletes %d, pos deletes (%s, file group %d/%d) in %s",
           group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenPosDeletes(),
           strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
           table.name());

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -414,16 +414,14 @@ public class BaseRewriteDataFilesSparkAction
   private String jobDesc(RewriteFileGroup group, RewriteExecutionContext ctx) {
     StructLike partition = group.info().partition();
     if (partition.size() > 0) {
-      return String.format("Rewriting %d files, %d eq deletes, %d pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
-          group.rewrittenFiles().size(), group.referencedEqDeletes(), group.referencedPositionalDeletes(),
-          strategy.name(), group.info().globalIndex(),
-          ctx.totalGroupCount(), partition, group.info().partitionIndex(), ctx.groupsInPartition(partition),
-          table.name());
+      return String.format("Rewriting %d files (%s, file group %d/%d, %s (%d/%d), %d eq deletes, %d pos deletes) in %s",
+          group.rewrittenFiles().size(), strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(), partition,
+          group.info().partitionIndex(), ctx.groupsInPartition(partition), group.referencedEqDeletes(),
+          group.referencedPosDeletes(), table.name());
     } else {
-      return String.format("Rewriting %d files, %d eq deletes, %d pos deletes (%s, file group %d/%d) in %s",
-          group.rewrittenFiles().size(), group.referencedEqDeletes(), group.referencedPositionalDeletes(),
-          strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
-          table.name());
+      return String.format("Rewriting %d files (%s, file group %d/%d, %d eq deletes, %d pos deletes) in %s",
+          group.rewrittenFiles().size(), strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
+          group.referencedEqDeletes(), group.referencedPosDeletes(), table.name());
     }
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -414,14 +414,14 @@ public class BaseRewriteDataFilesSparkAction
   private String jobDesc(RewriteFileGroup group, RewriteExecutionContext ctx) {
     StructLike partition = group.info().partition();
     if (partition.size() > 0) {
-      return String.format("Rewriting %d files %d, eq deletes %d, pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
-          group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenEqDeletes(),
+      return String.format("Rewriting %d files, %d eq deletes, %d pos deletes (%s, file group %d/%d, %s (%d/%d)) in %s",
+          group.rewrittenFiles().size(), group.referencedEqDeletes(), group.referencedPositionalDeletes(),
           strategy.name(), group.info().globalIndex(),
           ctx.totalGroupCount(), partition, group.info().partitionIndex(), ctx.groupsInPartition(partition),
           table.name());
     } else {
-      return String.format("Rewriting %d files %d, eq deletes %d, pos deletes (%s, file group %d/%d) in %s",
-          group.rewrittenFiles().size(), group.rewrittenEqDeletes(), group.rewrittenPosDeletes(),
+      return String.format("Rewriting %d files, %d eq deletes, %d pos deletes (%s, file group %d/%d) in %s",
+          group.rewrittenFiles().size(), group.referencedEqDeletes(), group.referencedPositionalDeletes(),
           strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
           table.name());
     }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -416,12 +416,12 @@ public class BaseRewriteDataFilesSparkAction
     if (partition.size() > 0) {
       return String.format("Rewriting %d files (%s, file group %d/%d, %s (%d/%d), %d eq deletes, %d pos deletes) in %s",
           group.rewrittenFiles().size(), strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(), partition,
-          group.info().partitionIndex(), ctx.groupsInPartition(partition), group.referencedEqDeletes(),
-          group.referencedPosDeletes(), table.name());
+          group.info().partitionIndex(), ctx.groupsInPartition(partition), group.referencedEqDeleteNumber(),
+          group.referencedPosDeleteNumber(), table.name());
     } else {
       return String.format("Rewriting %d files (%s, file group %d/%d, %d eq deletes, %d pos deletes) in %s",
           group.rewrittenFiles().size(), strategy.name(), group.info().globalIndex(), ctx.totalGroupCount(),
-          group.referencedEqDeletes(), group.referencedPosDeletes(), table.name());
+          group.referencedEqDeleteNumber(), group.referencedPosDeleteNumber(), table.name());
     }
   }
 


### PR DESCRIPTION
This adds deletes info to spark job desc so that people could see the rewrite effect more conveniently. 