### PR TITLE
[python legacy] use process pool instead of thread pool for files planning

### DIFF
--- a/python_legacy/iceberg/core/data_table_scan.py
+++ b/python_legacy/iceberg/core/data_table_scan.py
@@ -18,7 +18,7 @@
 import itertools
 import logging
 from multiprocessing import cpu_count
-from multiprocessing.dummy import Pool
+from multiprocessing import Pool
 
 from iceberg.api.expressions import (InclusiveManifestEvaluator,
                                      ResidualEvaluator)


### PR DESCRIPTION
Based on analysis, `plan_files()` spent most of the time on doing copy and file reading which are both CPU bounded operations. However, current implementation is using thread pool instead of process pool which does not speed up the operation at all.

This diff proposes switch to process pool instead of thread pool.

Frame graph
![profile](https://user-images.githubusercontent.com/8072956/167751644-bb69eef7-051e-4514-afcb-7e163519cb48.svg)

Command
`py-spy record -o profile.svg -- python myprogram.py`

Code
```
from iceberg.hive import HiveTables

conf = {"hive.metastore.uris": 'xxxx', 'iceberg.scan.plan-in-worker-pool': True, 'iceberg.worker.num-threads': 4}
tables = HiveTables(conf)
table = tables.load('abc.xyz')
scan = table.new_scan()
files = scan.plan_files()
```