### PR TITLE
Docs: To delete a table and its underlying data, use the `PURGE` keyword

### DIFF
--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -134,11 +134,15 @@ To delete a table, run:
 DROP TABLE prod.db.sample
 ```
 
-To delete an empty table use `PURGE`, run:
+To delete a table and its underlying data, use the `PURGE` keyword:
 
 ```sql
 DROP TABLE prod.db.sample PURGE
 ```
+
+{{< hint info >}}
+The `PURGE` flag can also be used to remove an empty table from its corresponding catalog if the table's metadata files have been removed by some other process and cannot be recovered.
+{{< /hint >}}
 
 ## `ALTER TABLE`
 

--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -134,6 +134,11 @@ To delete a table, run:
 DROP TABLE prod.db.sample
 ```
 
+To delete an empty table use `PURGE`, run:
+
+```sql
+DROP TABLE prod.db.sample PURGE
+```
 
 ## `ALTER TABLE`
 


### PR DESCRIPTION
Close #4735 

When `DROP TABLE prod.db.sample` Non empty table, the table directory can be deleted at the same time, but when the table is empty, the table directory left after being dropped, it shoule use `DROP TABLE prod.db.sample PURGE`，But the description is missing in spark-ddl/#drop-table.