### PR TITLE
Core: optimize planning for position delete matching

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -86,6 +86,12 @@ public class DataTableScan extends BaseTableScan {
         .specsById(table().specs())
         .ignoreDeleted();
 
+    if (PropertyUtil.propertyAsBoolean(table().properties(),
+        TableProperties.POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED,
+        TableProperties.POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED_DEFAULT)) {
+      manifestGroup.posDeleteHasSameSeqWithRefs();
+    }
+
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();
     }

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 
 class IncrementalDataTableScan extends DataTableScan {
@@ -90,6 +91,12 @@ class IncrementalDataTableScan extends DataTableScan {
                 manifestEntry.status() == ManifestEntry.Status.ADDED)
         .specsById(table().specs())
         .ignoreDeleted();
+
+    if (PropertyUtil.propertyAsBoolean(table().properties(),
+        TableProperties.POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED,
+        TableProperties.POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED_DEFAULT)) {
+      manifestGroup.posDeleteHasSameSeqWithRefs();
+    }
 
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -147,6 +147,11 @@ class ManifestGroup {
     return this;
   }
 
+  ManifestGroup posDeleteHasSameSeqWithRefs() {
+    deleteIndexBuilder.posDeleteHasSameSeqWithRefs();
+    return this;
+  }
+
   /**
    * Returns a iterable of scan tasks. It is safe to add entries of this iterable
    * to a collection as {@link DataFile} in each {@link FileScanTask} is defensively

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -340,4 +340,8 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED =
+      "write.pos-delete-has-same-seq-with-refs.enabled";
+  public static final boolean POS_DELETE_HAS_SAME_SEQ_WITH_REFS_ENABLED_DEFAULT = false;
 }


### PR DESCRIPTION
In the case of the Flink upsert job, the position delete contains the same sequence number as its referred data files. In terms of that, the planning could be optimized by checking the equality of sequence numbers.

The situation may not fit other cases, so this PR adds a table property.