### PR TITLE
Format: Add reserved field id to data_file

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -446,6 +446,7 @@ Notes:
 1. Single-value serialization for lower and upper bounds is detailed in Appendix D.
 2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate. NaNs are not permitted as lower or upper bounds.
 3. If sort order ID is missing or unknown, then the order is assumed to be unsorted. Only data files and equality delete files should be written with a non-null order id. [Position deletes](#position-delete-files) are required to be sorted by file and position, not a table order, and should set sort order id to null. Readers must ignore sort order id for position delete files.
+4. The following field ids are reserved on `data_file`: 141.
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.
 


### PR DESCRIPTION
The generated field spec_id is added to data_file metadata table in https://github.com/apache/iceberg/pull/3015

As per https://github.com/apache/iceberg/pull/3015#discussion_r735838832 , this is a late follow up to mark the field id as reserved.