### PR TITLE
Core: Add the API for multiple table locations.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -19,8 +19,10 @@
 
 package org.apache.iceberg;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -108,6 +110,15 @@ public interface Table {
    * @return this table's location
    */
   String location();
+
+  /**
+   * Return the table's base locations.
+   *
+   * @return this table's locations
+   */
+  default Set<String> locations() {
+    return Collections.singleton(location());
+  }
 
   /**
    * Get the current {@link Snapshot snapshot} for this table, or null if there are no snapshots.


### PR DESCRIPTION
This new API expose multiple locations so that the data writer can choose the location.
Writing data to multiple locations is desired in some cases, e.g.
- better data locality when data is ingested from multiple data centers 
- avoid hotspotting to underlying storage system


