### PR TITLE
Flink: Get the CatalogTable directly instead of reflecting

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -39,7 +39,6 @@ import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -71,14 +70,6 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
           .noDefaultValue()
           .withDescription("Table name managed in the underlying iceberg catalog and database.");
 
-  // Flink 1.13.x change the return type from CatalogTable interface to ResolvedCatalogTable which extends the
-  // CatalogTable. Here we use the dynamic method loading approach to avoid adding explicit CatalogTable or
-  // ResolvedCatalogTable class into the iceberg-flink-runtime jar for compatibility purpose.
-  private static final DynMethods.UnboundMethod GET_CATALOG_TABLE = DynMethods.builder("getCatalogTable")
-      .impl(Context.class, "getCatalogTable")
-      .orNoop()
-      .build();
-
   private final FlinkCatalog catalog;
 
   public FlinkDynamicTableFactory() {
@@ -89,14 +80,10 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
     this.catalog = catalog;
   }
 
-  private static CatalogTable loadCatalogTable(Context context) {
-    return GET_CATALOG_TABLE.invoke(context);
-  }
-
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    CatalogTable catalogTable = loadCatalogTable(context);
+    CatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> tableProps = catalogTable.getOptions();
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
 
@@ -114,7 +101,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    CatalogTable catalogTable = loadCatalogTable(context);
+    CatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> tableProps = catalogTable.getOptions();
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
 


### PR DESCRIPTION
Get the `CatalogTable` directly instead of reflecting
It was originally part of #4246, but I take it out separately this time, because it has no correlation with #4246 and is easier to solve.

cc @kbendick 