### PR TITLE
[Flink][Iceberg 0.13.2 Backport] - Log an error message about correctness issue when using upsert mode in Flink 1.12

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -366,6 +366,24 @@ public class FlinkSink {
       boolean upsertMode = upsert || PropertyUtil.propertyAsBoolean(table.properties(),
           UPSERT_ENABLED, UPSERT_ENABLED_DEFAULT);
 
+      // `upsert` mode should not be used in Flink 1.12 due to correctness issues.
+      // As part of a patch release, apache-iceberg-flink-runtime_1.12:0.13.2,
+      // it has been decided the best course of action would be to log a warning
+      // asking people to upgrade, as Flink 1.12 has been deprecated in upstream Apache Flink
+      // for some time as well as will be removed in the next major Iceberg release, Iceberg 0.14.0.
+      //
+      // But we allow the configuration given that it's a patch release and the change would be otherwise
+      // too breaking for a patch release.
+      //
+      // See https://github.com/apache/iceberg/pull/4364 for more information.
+      if (upsertMode) {
+        LOG.error(
+            "This table sink is running in upsert mode. Upsert mode should not be used with Flink 1.12 because " +
+            "it will write incorrect delete file metadata, which could prevent deletes from being correctly" +
+            "applied. Upgrading to Flink 1.13+ is recommended. " +
+            "To safely use Flink 1.12, set manifest metrics to counts only.");
+      }
+
       // Validate the equality fields and partition fields if we enable the upsert mode.
       if (upsertMode) {
         Preconditions.checkState(!overwrite,


### PR DESCRIPTION
Updating https://github.com/apache/iceberg/pull/4519/files to target 0.13.x branch, as Flink 1.12 support has been removed from master and changing that PR that targeted master was very messy.