### PR TITLE
Docs: Updated version description for Flink

### DIFF
--- a/docs/flink/flink-getting-started.md
+++ b/docs/flink/flink-getting-started.md
@@ -22,8 +22,7 @@ url: flink
 
 # Flink
 
-Apache Iceberg supports both [Apache Flink](https://flink.apache.org/)'s DataStream API and Table API. Currently,
-Iceberg integration for Apache Flink is available for Flink versions 1.12, 1.13, and 1.14. Previous versions of Iceberg also support Flink 1.11.
+Apache Iceberg supports both [Apache Flink](https://flink.apache.org/)'s DataStream API and Table API. See the [Multi-Engine Support#apache-flink](https://iceberg.apache.org/multi-engine-support/#apache-flink) page for the integration of Apache Flink.
 
 | Feature support                                             | Flink  | Notes                                                        |
 | ----------------------------------------------------------- | -----  | ------------------------------------------------------------ |


### PR DESCRIPTION
We added support for Flink 1.15 and removed 1.12, the purpose of this PR is to update the docs..
The specific version number is no longer described, but refers the user to multi-engine-support page, meanwhile, I also raised https://github.com/apache/iceberg-docs/pull/79  to update it.

cc @kbendick 