### PR TITLE
Make sort strategy an idempotent action

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -261,6 +261,14 @@ public abstract class BinPackStrategy implements RewriteStrategy {
     return (long) (targetFileSize + ((maxFileSize - targetFileSize) * 0.5));
   }
 
+  protected long maxGroupSize() {
+    return maxGroupSize;
+  }
+
+  protected boolean rewriteAll() {
+    return rewriteAll;
+  }
+
   private long sizeOfInputFiles(List<FileScanTask> group) {
     return group.stream().mapToLong(FileScanTask::length).sum();
   }

--- a/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
@@ -19,27 +19,57 @@
 
 package org.apache.iceberg.actions;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.util.BinPacking;
+import org.apache.iceberg.util.BinPacking.ListPacker;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.SortStrategyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * A rewrite strategy for data files which aims to reorder data with data files to optimally lay them out
  * in relation to a column. For example, if the Sort strategy is used on a set of files which is ordered
- * by column x and original has files File A (x: 0 - 50), File B ( x: 10 - 40) and File C ( x: 30 - 60),
- * this Strategy will attempt to rewrite those files into File A' (x: 0-20), File B' (x: 21 - 40),
- * File C' (x: 41 - 60).
+ * by column x and original has files File A (x: 0 - 50), File B ( x: 10 - 40), File C ( x: 30 - 60),
+ * File D ( x: 61 - 80), and File E ( x: 81 - 100), this Strategy will attempt to rewrite files A, B and C
+ * into File A' (x: 0-20), File B' (x: 21 - 40), File C' (x: 41 - 60) and keep File D and E unchanged.
  * <p>
- * Currently the there is no file overlap detection and we will rewrite all files if {@link SortStrategy#REWRITE_ALL}
- * is true (default: false). If this property is disabled any files that would be chosen by
- * {@link BinPackStrategy} will be rewrite candidates.
+ * When the {@link BinPackStrategy#REWRITE_ALL} flag is, all files are selected for rewrite. Otherwise,
+ * only unsorted files are selected. Rewrite will be applied to those selected files if
+ * 1. There are a certain number of mis-sized data files or
+ * 2. Those data files do not have sortedness score good enough.
  * <p>
- * In the future other algorithms for determining files to rewrite will be provided.
  */
 public abstract class SortStrategy extends BinPackStrategy {
+  private static final Logger LOG = LoggerFactory.getLogger(SortStrategy.class);
+  /**
+   * Rewrites if the ratio of mis-sized files to total files is over this threshold.
+   * The value should be between 0.0 and 1.0
+   */
+  public static final String MIS_SIZED_RATIO_THRESHOLD = "mis-sized-ratio-threshold";
+  public static final double MIS_SIZED_RATIO_THRESHOLD_DEFAULT = 0.05;
 
+  /**
+   * Rewrites if the sortedness score of given files is below this threshold.
+   * The value should be between 0.0 and 1.0
+   */
+  public static final String SORTEDNESS_SCORE_THRESHOLD = "sortedness-score-threshold";
+  public static final double SORTEDNESS_SCORE__THRESHOLD_DEFAULT = 0.95;
+
+  private double misSizedRatioThreshold;
+  private double sortednessScoreThreshold;
   private SortOrder sortOrder;
 
   /**
@@ -72,6 +102,14 @@ public abstract class SortStrategy extends BinPackStrategy {
   public RewriteStrategy options(Map<String, String> options) {
     super.options(options); // Also checks validity of BinPack options
 
+    misSizedRatioThreshold = PropertyUtil.propertyAsDouble(options,
+        MIS_SIZED_RATIO_THRESHOLD,
+        MIS_SIZED_RATIO_THRESHOLD_DEFAULT);
+
+    sortednessScoreThreshold = PropertyUtil.propertyAsDouble(options,
+        SORTEDNESS_SCORE_THRESHOLD,
+        SORTEDNESS_SCORE__THRESHOLD_DEFAULT);
+
     if (sortOrder == null) {
       sortOrder = table().sortOrder();
     }
@@ -80,12 +118,55 @@ public abstract class SortStrategy extends BinPackStrategy {
     return this;
   }
 
+  @Override
+  public Iterable<FileScanTask> selectFilesToRewrite(Iterable<FileScanTask> dataFiles) {
+    if (rewriteAll()) {
+      LOG.info("Table {} set to rewrite all data files", table().name());
+      return dataFiles;
+    } else {
+      // Remove files that are completely sorted.
+      // Example: File_A(1, 10), File_B(11, 25), File_C(15, 30), File_D(31, 40)
+      // Then only File_B and File_C are selected
+      Iterable<FileScanTask> selectedFiles = SortStrategyUtil.removeSortedFiles(dataFiles, sortOrder);
+      if (!haveGoodFileSizes(selectedFiles) || !areFilesSorted(selectedFiles)) {
+        // Rewrite all selected files if they are mis-sized or have bad sortedness score
+        return selectedFiles;
+      }
+      return ImmutableList.of();
+    }
+  }
+
+  @Override
+  public Iterable<List<FileScanTask>> planFileGroups(Iterable<FileScanTask> dataFiles) {
+    ListPacker<FileScanTask> packer = new BinPacking.ListPacker<>(maxGroupSize(), 1, false);
+    return packer.pack(dataFiles, FileScanTask::length);
+  }
+
   protected void validateOptions() {
+    Preconditions.checkArgument(misSizedRatioThreshold >= 0 && misSizedRatioThreshold <= 1,
+        "mis-sized-ratio-threshold value must be between 0.0 and 1.0");
+
+    Preconditions.checkArgument(sortednessScoreThreshold >= 0 && sortednessScoreThreshold <= 1,
+        "sortedness-score-threshold value must be between 0.0 and 1.0");
+
     Preconditions.checkArgument(!sortOrder.isUnsorted(),
         "Can't use %s when there is no sort order, either define table %s's sort order or set sort" +
             "order in the action",
         name(), table().name());
 
     SortOrder.checkCompatibility(sortOrder, table().schema());
+  }
+
+  boolean haveGoodFileSizes(Iterable<FileScanTask> dataFiles) {
+    int totalDataFiles = Iterables.size(dataFiles);
+    int misSizedDataFiles = Iterables.size(super.selectFilesToRewrite(dataFiles));
+    return (0.0 + misSizedDataFiles) / totalDataFiles <= misSizedRatioThreshold;
+  }
+
+  boolean areFilesSorted(Iterable<FileScanTask> dataFiles) {
+    List<DataFile> files = FluentIterable.from(dataFiles).stream()
+        .map(FileScanTask::file)
+        .collect(Collectors.toList());
+    return SortStrategyUtil.sortednessScore(files, sortOrder) >= sortednessScoreThreshold;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/SortStrategyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortStrategyUtil.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
+import org.apache.iceberg.expressions.StrictMetricsEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.iceberg.expressions.Expressions.equal;
+
+public class SortStrategyUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(SortStrategyUtil.class);
+
+  private SortStrategyUtil() {
+  }
+
+  /**
+   * Measures the sortedness score for a given list of {@link DataFile}s.
+   *
+   * @param files List of {@link DataFile}s
+   * @param sortOrder The sort order
+   * @return A score between 0.0 and 1.0 to represent how well those data files are sorted
+   * on the sort order.
+   */
+  public static double sortednessScore(List<DataFile> files, SortOrder sortOrder)  {
+    if (files.size() == 1) {
+      return 1.0;
+    }
+
+    List<Integer> sortColIndices = getSortColumnIndices(sortOrder);
+    if (sortColIndices.isEmpty()) {
+      // Cannot obtain indices of sort columns, will consider those files are completely unsorted
+      return 0.0;
+    }
+
+    double totalScore = 0;
+    // Compute and aggregate scores for all lowerBounds
+    List<List<ByteBuffer>> lowerBounds = getColumnValueBounds(files, sortColIndices, true);
+    for (List<ByteBuffer> point : lowerBounds) {
+      totalScore += overlapScore(point, files, sortColIndices, sortOrder.schema());
+    }
+    // Compute and aggregate scores for all upperBounds
+    List<List<ByteBuffer>> upperBounds = getColumnValueBounds(files, sortColIndices, false);
+    for (List<ByteBuffer> point : upperBounds) {
+      totalScore += overlapScore(point, files, sortColIndices, sortOrder.schema());
+    }
+    // Then normalize the result
+    return totalScore / (2 * files.size());
+  }
+
+  /**
+   * Removes files that are already sorted (having no overlap on sort column values with other files)
+   * from a collection of file scans.
+   *
+   * @param fileScans The original collection of file scans
+   * @param sortOrder The sort order
+   * @return A collection of file scans after removing sorted ones from the original collection
+   */
+  public static Iterable<FileScanTask> removeSortedFiles(Iterable<FileScanTask> fileScans, SortOrder sortOrder) {
+    List<Integer> sortColIndices = getSortColumnIndices(sortOrder);
+    List<DataFile> dataFiles = FluentIterable.from(fileScans).stream()
+        .map(FileScanTask::file)
+        .collect(Collectors.toList());
+    return FluentIterable.from(fileScans)
+        .filter(f -> hasOverLap(f.file(), dataFiles, sortColIndices, sortOrder.schema()));
+  }
+
+  private static boolean hasOverLap(
+      DataFile file,
+      List<DataFile> dataFiles,
+      List<Integer> sortColIndices,
+      Schema sortSchema) {
+    for (DataFile f : dataFiles) {
+      if (!f.equals(file) && isOverlap(f, file, sortColIndices, sortSchema)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static List<Integer> getSortColumnIndices(SortOrder sortOrder) {
+    List<Integer> sortColIndices = Lists.newArrayList();
+    for (SortField sortField : sortOrder.fields()) {
+      if (!sortField.transform().isIdentity()) {
+        LOG.info("Cannot measure sortedness score on derived sort column {}",
+            sortField.transform().dedupName());
+        return ImmutableList.of();
+      }
+      sortColIndices.add(sortField.sourceId());
+    }
+    return sortColIndices;
+  }
+
+  // Counts how many data files from a given list have overlaps with a given data point
+  static int overlapCount(
+      List<ByteBuffer> point,
+      List<DataFile> files,
+      List<Integer> sortColIndices,
+      Schema sortSchema) {
+    int overLapCount = 0;
+    for (DataFile file : files) {
+      if (isOverlap(point, file, sortColIndices, sortSchema)) {
+        overLapCount++;
+      }
+    }
+    return overLapCount;
+  }
+
+  private static double overlapScore(
+      List<ByteBuffer> point,
+      List<DataFile> files,
+      List<Integer> sortColIndices,
+      Schema sortSchema) {
+    double overlapScore = overlapCount(point, files, sortColIndices, sortSchema);
+    return 1.0 - (overlapScore - 1.0) / (files.size() - 1.0);
+  }
+
+  // Check if a data point (x[1], x[2],..., x[k]) has overlap with a data file that has lower bounds of
+  // (min[1], min[2],..., min[k]) and upper bounds of (max[1], max[2],..., max[k])
+  // An overlap happens if for j going from 1 to k:
+  // if x[j] < min[j] or x[j] > max[j] then return false
+  // else if min[j <= x[j] <= max[j] and min[j] != max[j] and  then return true
+  // else (meaning min[j] == x[j] == max[j]) continue with j + 1
+  private static boolean isOverlap(
+      List<ByteBuffer> point,
+      DataFile file,
+      List<Integer> sortColIndices,
+      Schema sortSchema) {
+    for (int j = 0; j < sortColIndices.size(); j++) {
+      Types.NestedField col = sortSchema.findField(sortColIndices.get(j));
+      if (point.get(j) == null || NaNUtil.isNaN(point.get(j))) {
+        // null or NaN is considered to have overlap with everything
+        return true;
+      }
+      Expression pred = equal(col.name(), Conversions.fromByteBuffer(col.type(), point.get(j)));
+      // Check if min[j <= x[j] <= max[j]
+      boolean inclusiveEvaluation = new InclusiveMetricsEvaluator(sortSchema, pred).eval(file);
+      // Check if  min[j] == x[j] == max[j]
+      boolean strictEvaluation = new StrictMetricsEvaluator(sortSchema, pred).eval(file);
+      if (!inclusiveEvaluation) {
+        // x[j] < min[j] or x[j] > max[j]
+        return false;
+      }
+      if (!strictEvaluation) {
+        // min[j <= x[j] <= max[j] and min[j] != max[j]
+        return true;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isOverlap(
+      DataFile file1,
+      DataFile file2,
+      List<Integer> sortColIndices,
+      Schema sortSchema) {
+    List<ByteBuffer> lowerEnd1 = getColumnValueBound(file1, sortColIndices, true);
+    List<ByteBuffer> upperEnd1 = getColumnValueBound(file1, sortColIndices, false);
+    List<ByteBuffer> lowerEnd2 = getColumnValueBound(file2, sortColIndices, true);
+    List<ByteBuffer> upperEnd2 = getColumnValueBound(file2, sortColIndices, false);
+    return isOverlap(lowerEnd1, file2, sortColIndices, sortSchema) ||
+        isOverlap(upperEnd1, file2, sortColIndices, sortSchema) ||
+        isOverlap(lowerEnd2, file1, sortColIndices, sortSchema) ||
+        isOverlap(upperEnd2, file1, sortColIndices, sortSchema);
+  }
+
+  private static List<List<ByteBuffer>> getColumnValueBounds(
+      List<DataFile> dataFiles,
+      List<Integer> sortColIndices,
+      boolean isLowerBound) {
+    List<List<ByteBuffer>> results = Lists.newArrayList();
+    for (DataFile file : dataFiles) {
+      List<ByteBuffer> valueBound = getColumnValueBound(file, sortColIndices, isLowerBound);
+      results.add(getColumnValueBound(file, sortColIndices, isLowerBound));
+    }
+    return results;
+  }
+
+  private static List<ByteBuffer> getColumnValueBound(
+      DataFile dataFile,
+      List<Integer> sortColIndices,
+      boolean isLowerBound) {
+    List<ByteBuffer> valueBound = Lists.newArrayList();
+    for (Integer index : sortColIndices) {
+      Map<Integer, ByteBuffer> valueMap = isLowerBound ? dataFile.lowerBounds() : dataFile.upperBounds();
+      valueBound.add(valueMap != null ? valueMap.get(index) : null);
+    }
+    return valueBound;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestSortStrategyUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSortStrategyUtil.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MockFileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Conversions.toByteBuffer;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestSortStrategyUtil {
+  private static final double FLOATING_POINT_DELTA = 0.001;
+  private static final Schema SCHEMA = new Schema(
+      required(1, "id", Types.LongType.get()),
+      optional(2, "strCol", Types.StringType.get()),
+      required(3, "intCol", Types.IntegerType.get())
+  );
+
+  private static final SortOrder SORT_ORDER1 = SortOrder.builderFor(SCHEMA.select("intCol"))
+      .asc("intCol")
+      .build();
+  private static final SortOrder SORT_ORDER2 = SortOrder.builderFor(SCHEMA.select("intCol", "strCol"))
+      .asc("intCol")
+      .asc("strCol")
+      .build();
+
+  private static DataFile buildDataFile(int minInt, int maxInt) {
+    return buildDataFile(minInt, maxInt, "", "");
+  }
+
+  private static DataFile buildDataFile(int minInt, int maxInt, String minStr, String maxStr) {
+    return new TestHelpers.TestDataFile("test_file", TestHelpers.Row.of(), 100,
+        // any value counts, including nulls
+        ImmutableMap.of(),
+        // null value counts
+        ImmutableMap.of(),
+        // nan value counts
+        ImmutableMap.of(),
+        // lower bounds
+        ImmutableMap.of(
+            2, toByteBuffer(Types.StringType.get(), minStr),
+            3, toByteBuffer(Types.IntegerType.get(), minInt)
+        ),
+        // upper bounds
+        ImmutableMap.of(
+            2, toByteBuffer(Types.StringType.get(), maxStr),
+            3, toByteBuffer(Types.IntegerType.get(), maxInt)
+        )
+    );
+  }
+
+  private static FileScanTask buildFileScanTask(int minInt, int maxInt) {
+    return new MockFileScanTask(buildDataFile(minInt, maxInt));
+  }
+
+  private List<ByteBuffer> getDataPoint(int intVal) {
+    return ImmutableList.of(toByteBuffer(Types.IntegerType.get(), intVal));
+  }
+
+  private List<ByteBuffer> getDataPoint(int intVal, String strVal) {
+    return ImmutableList.of(
+        toByteBuffer(Types.IntegerType.get(), intVal),
+        toByteBuffer(Types.StringType.get(), strVal)
+    );
+  }
+
+  private void testOverlapCountHelper(List<DataFile> files, int intVal, int expected) {
+    int actual = SortStrategyUtil.overlapCount(
+        getDataPoint(intVal),
+        files,
+        SortStrategyUtil.getSortColumnIndices(SORT_ORDER1),
+        SORT_ORDER1.schema()
+    );
+    Assert.assertEquals(expected, actual, FLOATING_POINT_DELTA);
+  }
+
+  private void testOverlapCountHelper(List<DataFile> files, int intVal, String strVal, int expected) {
+    int actual = SortStrategyUtil.overlapCount(
+        getDataPoint(intVal, strVal),
+        files,
+        SortStrategyUtil.getSortColumnIndices(SORT_ORDER2),
+        SORT_ORDER2.schema()
+    );
+    Assert.assertEquals(expected, actual, FLOATING_POINT_DELTA);
+  }
+
+  @Test
+  public void testOverlapCount() {
+    List<DataFile> files1 = ImmutableList.of(
+        buildDataFile(1, 100),
+        buildDataFile(3, 98),
+        buildDataFile(5, 96),
+        buildDataFile(7, 94),
+        buildDataFile(9, 92)
+    );
+    testOverlapCountHelper(files1, 0, 0);
+    testOverlapCountHelper(files1, 101, 0);
+    testOverlapCountHelper(files1, 2, 1);
+    testOverlapCountHelper(files1, 3, 2);
+    testOverlapCountHelper(files1, 95, 3);
+    testOverlapCountHelper(files1, 94, 4);
+    testOverlapCountHelper(files1, 9, 5);
+    testOverlapCountHelper(files1, 10, 5);
+    testOverlapCountHelper(files1, 92, 5);
+    testOverlapCountHelper(files1, 91, 5);
+
+    List<DataFile> files2 = ImmutableList.of(
+        buildDataFile(5, 5, "aa", "z"),
+        buildDataFile(5, 5, "bb", "y"),
+        buildDataFile(5, 5, "cc", "x"),
+        buildDataFile(1, 94, "dd", "w"),
+        buildDataFile(3, 92, "ee", "v")
+    );
+    testOverlapCountHelper(files2, 0, "h", 0);
+    testOverlapCountHelper(files2, 95, "g", 0);
+    testOverlapCountHelper(files2, 3, "g", 2);
+    testOverlapCountHelper(files2, 5, "a", 2);
+    testOverlapCountHelper(files2, 5, "b", 3);
+    testOverlapCountHelper(files2, 5, "bb", 4);
+    testOverlapCountHelper(files2, 5, "xx", 4);
+    testOverlapCountHelper(files2, 5, "h", 5);
+  }
+
+  private void testSortednessScoreHelper1(List<DataFile> files, double expected) {
+    double actual = SortStrategyUtil.sortednessScore(files, SORT_ORDER1);
+    Assert.assertEquals(expected, actual, FLOATING_POINT_DELTA);
+  }
+
+  private void testSortednessScoreHelper2(List<DataFile> files, double expected) {
+    double actual = SortStrategyUtil.sortednessScore(files, SORT_ORDER2);
+    Assert.assertEquals(expected, actual, FLOATING_POINT_DELTA);
+  }
+
+  @Test
+  public void testSortednessScore() {
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 3)
+        ),
+        1.0
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 3)
+        ),
+        0.0
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 3),
+            buildDataFile(1, 5)
+        ),
+        0.1
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 10),
+            buildDataFile(2, 9),
+            buildDataFile(3, 8),
+            buildDataFile(4, 7),
+            buildDataFile(5, 6)
+        ),
+        0.5
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 2),
+            buildDataFile(3, 4),
+            buildDataFile(5, 6),
+            buildDataFile(7, 8),
+            buildDataFile(1, 8)
+        ),
+        0.75
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 3),
+            buildDataFile(2, 5),
+            buildDataFile(4, 7),
+            buildDataFile(6, 9),
+            buildDataFile(8, 10)
+        ),
+        0.8
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 3),
+            buildDataFile(2, 4),
+            buildDataFile(5, 6),
+            buildDataFile(7, 8),
+            buildDataFile(9, 10)
+        ),
+        0.95
+    );
+
+    testSortednessScoreHelper1(
+        ImmutableList.of(
+            buildDataFile(1, 2),
+            buildDataFile(3, 4),
+            buildDataFile(5, 6),
+            buildDataFile(7, 8),
+            buildDataFile(9, 10)
+        ),
+        1.0
+    );
+
+    testSortednessScoreHelper2(
+        ImmutableList.of(
+            buildDataFile(1, 2, "a", "b"),
+            buildDataFile(3, 4, "a", "b"),
+            buildDataFile(5, 6, "a", "b"),
+            buildDataFile(7, 8, "a", "b"),
+            buildDataFile(9, 10, "a", "b")
+        ),
+        1.0
+    );
+
+    testSortednessScoreHelper2(
+        ImmutableList.of(
+            buildDataFile(1, 1, "a", "bb"),
+            buildDataFile(1, 1, "b", "c"),
+            buildDataFile(1, 1, "d", "e"),
+            buildDataFile(1, 1, "f", "g"),
+            buildDataFile(1, 1, "h", "i")
+        ),
+        0.95
+    );
+
+    testSortednessScoreHelper2(
+        ImmutableList.of(
+            buildDataFile(1, 1, "aa", "z"),
+            buildDataFile(1, 1, "bb", "y"),
+            buildDataFile(1, 1, "cc", "x"),
+            buildDataFile(1, 1, "dd", "w"),
+            buildDataFile(1, 1, "ee", "v")
+        ),
+        0.5
+    );
+
+    testSortednessScoreHelper2(
+        ImmutableList.of(
+            buildDataFile(1, 1, "a", "b"),
+            buildDataFile(1, 1, "a", "b"),
+            buildDataFile(1, 1, "a", "b"),
+            buildDataFile(1, 1, "a", "b"),
+            buildDataFile(1, 1, "a", "b")
+        ),
+        0.0
+    );
+  }
+
+  private void testRemoveSortedFilesHelper(List<FileScanTask> files, int expectedResultCount) {
+    int actual = Iterables.size(SortStrategyUtil.removeSortedFiles(files, SORT_ORDER1));
+    Assert.assertEquals(expectedResultCount, actual);
+  }
+
+  @Test
+  public void testRemoveSortedFiles() {
+    testRemoveSortedFilesHelper(
+        ImmutableList.of(
+            buildFileScanTask(1, 2),
+            buildFileScanTask(3, 4),
+            buildFileScanTask(5, 6),
+            buildFileScanTask(7, 8),
+            buildFileScanTask(9, 10)
+        ),
+        0
+    );
+
+    testRemoveSortedFilesHelper(
+        ImmutableList.of(
+            buildFileScanTask(1, 3),
+            buildFileScanTask(2, 4),
+            buildFileScanTask(5, 6),
+            buildFileScanTask(7, 8),
+            buildFileScanTask(9, 10)
+        ),
+        2
+    );
+
+    testRemoveSortedFilesHelper(
+        ImmutableList.of(
+            buildFileScanTask(1, 2),
+            buildFileScanTask(3, 4),
+            buildFileScanTask(5, 6),
+            buildFileScanTask(3, 8),
+            buildFileScanTask(9, 10)
+        ),
+        3
+    );
+
+    testRemoveSortedFilesHelper(
+        ImmutableList.of(
+            buildFileScanTask(1, 2),
+            buildFileScanTask(3, 4),
+            buildFileScanTask(5, 6),
+            buildFileScanTask(7, 8),
+            buildFileScanTask(1, 10)
+        ),
+        5
+    );
+  }
+}


### PR DESCRIPTION
This PR will make sort rewrite action an idempotent operation, meaning we will skip sorting data if the data files are somewhat already sorted.

First we remove all files that have no overlap with other files as these files are considered as sorted. For the remaining files, rewrite will be applied if
1. There are a certain number of mis-sized data files or
2. Those data files do not have sortedness score (defined in this the below doc) good enough

We use threshold params to control these conditions.

Example: if the Sort strategy is used on a set of files which is ordered by column x and original has files File A (x: 0 - 50), File B ( x: 10 - 40), File C ( x: 30 - 60), File D ( x: 61 - 80), and File E ( x: 81 - 100), this Strategy will attempt to rewrite files A, B and C into File A' (x: 0-20), File B' (x: 21 - 40), File C' (x: 41 - 60) and keep File D and E unchanged.

Proposal doc for the feature:
https://docs.google.com/document/d/1rZUHljNsLn8JqsO5lYElst3F800T8OBnQ5fasUB-fp8/