### PR TITLE
[SPEC] Fix typ in REST Catalog OpenAPI Spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1361,7 +1361,7 @@ components:
         uuid:
           type: string
         snapshot-id:
-          type: interger
+          type: integer
           format: int64
         last-assigned-field-id:
           type: integer


### PR DESCRIPTION
Small typo slipped into the REST OpenAPI spec, so it doesn't parse.

Just fixing `integer`.

I haven't added an openapi spec validator to our github actions because there doesn't seem to be a canonical one, and of the 6+ I've tried I get differing results amongst them.

But that will be prioritized given this as there are some that run fine.

After this change, we can use `openapi-spec-validator` as a starting point though I've found it misses some issues.

But I admittedly have gotten an `OK` response from `openapi-spec-validator` that gave errors elsewhere in other validators.  

The website editor.swagger.io seems to be the most correct in my experience.