### PR TITLE
AWS : Use strongly consistent read while acquiring lock via DDBLockManager

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -200,6 +200,7 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
   void acquireOnce(String entityId, String ownerId) {
     GetItemResponse response = dynamo.getItem(GetItemRequest.builder()
         .tableName(lockTableName)
+        .consistentRead(true)
         .key(toKey(entityId))
         .build());
 


### PR DESCRIPTION
### About the change
At present DDB get request uses eventually consistent reads by default unless specified to use strongly consistent read.

ref : https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html

As per my understanding we should always read most up to date data with strong consistency as with eventually consistent read we can read stale data, when read in very short interval of write.

This PR attempts to make GET's of DDB strongly consistent, as by default GET's are eventually consistent.

---

### Testing Done :

Ran integration tests locally (passes)

```shell
./gradlew :iceberg-aws:integrationTest --tests "org.apache.iceberg.aws.dynamodb.TestDynamoDbLockManager"
```

----
cc @jackye1995 @rajarshisarkar @amogh-jahagirdar @arminnajafi  @xiaoxuandev @yyanyy