### PR TITLE
Core: Align snapshot summary property names for delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -31,10 +31,10 @@ public class SnapshotSummary {
   public static final String DELETED_FILES_PROP = "deleted-data-files";
   public static final String TOTAL_DATA_FILES_PROP = "total-data-files";
   public static final String ADDED_DELETE_FILES_PROP = "added-delete-files";
-  public static final String ADD_EQ_DELETE_FILES_PROP = "added-eq-delete-files";
-  public static final String REMOVED_EQ_DELETE_FILES_PROP = "removed-eq-delete-files";
-  public static final String ADD_POS_DELETE_FILES_PROP = "added-pos-delete-files";
-  public static final String REMOVED_POS_DELETE_FILES_PROP = "removed-pos-delete-files";
+  public static final String ADD_EQ_DELETE_FILES_PROP = "added-equality-delete-files";
+  public static final String REMOVED_EQ_DELETE_FILES_PROP = "removed-equality-delete-files";
+  public static final String ADD_POS_DELETE_FILES_PROP = "added-position-delete-files";
+  public static final String REMOVED_POS_DELETE_FILES_PROP = "removed-position-delete-files";
   public static final String REMOVED_DELETE_FILES_PROP = "removed-delete-files";
   public static final String TOTAL_DELETE_FILES_PROP = "total-delete-files";
   public static final String ADDED_RECORDS_PROP = "added-records";


### PR DESCRIPTION
This PR renames recently added and unreleased snapshot summary properties for equality and position delete files to match other recent public constants/methods.

Specifically, all other snapshot properties use full words for `equality` and `position`.

```
// SnapshotSummary
public static final String ADDED_POS_DELETES_PROP = "added-position-deletes";
public static final String REMOVED_POS_DELETES_PROP = "removed-position-deletes";
public static final String TOTAL_POS_DELETES_PROP = "total-position-deletes";
public static final String ADDED_EQ_DELETES_PROP = "added-equality-deletes";

// ConvertEqualityDeleteFiles
int convertedEqualityDeleteFilesCount();
int addedPositionDeleteFilesCount();

// FileWriterFactory
EqualityDeleteWriter<T> newEqualityDeleteWriter(...);
PositionDeleteWriter<T> newPositionDeleteWriter(...);

etc
```

Since the new snapshot summary properties haven't been released yet and were added recently, I'd consider renaming them for consistency.