### PR TITLE
Change types into dataclasses

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -45,6 +45,7 @@ python_requires = >=3.7
 install_requires =
     mmh3
     singledispatch
+    cached-property; python_version <= '3.7'
 [options.extras_require]
 arrow =
     pyarrow

--- a/python/spellcheck-dictionary.txt
+++ b/python/spellcheck-dictionary.txt
@@ -26,10 +26,13 @@ FileInfo
 filesystem
 fs
 func
+IcebergType
 io
 NativeFile
+NestedField
 nullability
 pragma
+PrimitiveType
 pyarrow
 repr
 schemas
@@ -43,3 +46,4 @@ Timestamptz
 Timestamptzs
 unscaled
 URI
+

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -151,7 +151,7 @@ class Schema:
             NestedField: The type of the matched NestedField
         """
         field = self.find_field(name_or_id=name_or_id, case_sensitive=case_sensitive)
-        return field.type  # type: ignore
+        return field.field_type
 
     def find_column_name(self, column_id: int) -> str:
         """Find a column name given a column ID
@@ -323,7 +323,7 @@ def _(obj: StructType, visitor: SchemaVisitor[T]) -> T:
 
     for field in obj.fields:
         visitor.before_field(field)
-        result = visit(field.type, visitor)
+        result = visit(field.field_type, visitor)
         visitor.after_field(field)
         results.append(visitor.field(field, result))
 
@@ -335,7 +335,7 @@ def _(obj: ListType, visitor: SchemaVisitor[T]) -> T:
     """Visit a ListType with a concrete SchemaVisitor"""
 
     visitor.before_list_element(obj.element)
-    result = visit(obj.element.type, visitor)
+    result = visit(obj.element.field_type, visitor)
     visitor.after_list_element(obj.element)
 
     return visitor.list(obj, result)
@@ -345,11 +345,11 @@ def _(obj: ListType, visitor: SchemaVisitor[T]) -> T:
 def _(obj: MapType, visitor: SchemaVisitor[T]) -> T:
     """Visit a MapType with a concrete SchemaVisitor"""
     visitor.before_map_key(obj.key)
-    key_result = visit(obj.key.type, visitor)
+    key_result = visit(obj.key.field_type, visitor)
     visitor.after_map_key(obj.key)
 
     visitor.before_map_value(obj.value)
-    value_result = visit(obj.value.type, visitor)
+    value_result = visit(obj.value.field_type, visitor)
     visitor.after_list_element(obj.value)
 
     return visitor.map(obj, key_result, value_result)
@@ -417,12 +417,12 @@ class _IndexByName(SchemaVisitor[Dict[str, int]]):
 
     def before_list_element(self, element: NestedField) -> None:
         """Short field names omit element when the element is a StructType"""
-        if not isinstance(element.type, StructType):
+        if not isinstance(element.field_type, StructType):
             self._short_field_names.append(element.name)
         self._field_names.append(element.name)
 
     def after_list_element(self, element: NestedField) -> None:
-        if not isinstance(element.type, StructType):
+        if not isinstance(element.field_type, StructType):
             self._short_field_names.pop()
         self._field_names.pop()
 

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -203,13 +203,13 @@ class StructType(IcebergType):
     _instances: ClassVar[Dict[Tuple[NestedField, ...], "StructType"]] = {}
 
     def __new__(cls, *fields: NestedField, **kwargs):
-        if "fields" in kwargs:
+        if not fields and "fields" in kwargs:
             fields = kwargs["fields"]
         cls._instances[fields] = cls._instances.get(fields) or object.__new__(cls)
         return cls._instances[fields]
 
     def __init__(self, *fields: NestedField, **kwargs):
-        if "fields" in kwargs:
+        if not fields and "fields" in kwargs:
             fields = kwargs["fields"]
         object.__setattr__(self, "fields", fields)
 

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -42,7 +42,7 @@ class Singleton:
         return cls._instance
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class IcebergType:
     """Base type for all Iceberg Types
 
@@ -75,7 +75,7 @@ class PrimitiveType(IcebergType):
     """
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class FixedType(PrimitiveType):
     """A fixed data type in Iceberg.
 
@@ -123,7 +123,7 @@ class DecimalType(PrimitiveType):
         object.__setattr__(self, "type_string", f"decimal({self.precision}, {self.scale})")
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class NestedField(IcebergType):
     """Represents a field of a struct, a map key, a map value, or a list element.
 
@@ -180,7 +180,7 @@ class NestedField(IcebergType):
         return self.field_type
 
 
-@dataclass(frozen=True, eq=True, repr=True, init=False)
+@dataclass(frozen=True, init=False)
 class StructType(IcebergType):
     """A struct type in Iceberg
 
@@ -209,7 +209,7 @@ class StructType(IcebergType):
         object.__setattr__(self, "type_string", f"struct<{', '.join(map(str, self.fields))}>")
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class ListType(IcebergType):
     """A list type in Iceberg
 
@@ -249,7 +249,7 @@ class ListType(IcebergType):
         )
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class MapType(IcebergType):
     """A map type in Iceberg
 
@@ -297,7 +297,7 @@ class MapType(IcebergType):
         )
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class BooleanType(PrimitiveType, Singleton):
     """A boolean data type in Iceberg can be represented using an instance of this class.
 
@@ -312,7 +312,7 @@ class BooleanType(PrimitiveType, Singleton):
     type_string = "boolean"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class IntegerType(PrimitiveType, Singleton):
     """An Integer data type in Iceberg can be represented using an instance of this class. Integers in Iceberg are
     32-bit signed and can be promoted to Longs.
@@ -335,7 +335,7 @@ class IntegerType(PrimitiveType, Singleton):
     min: ClassVar[int] = -2147483648
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class LongType(PrimitiveType, Singleton):
     """A Long data type in Iceberg can be represented using an instance of this class. Longs in Iceberg are
     64-bit signed integers.
@@ -362,7 +362,7 @@ class LongType(PrimitiveType, Singleton):
     min: ClassVar[int] = -9223372036854775808
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class FloatType(PrimitiveType, Singleton):
     """A Float data type in Iceberg can be represented using an instance of this class. Floats in Iceberg are
     32-bit IEEE 754 floating points and can be promoted to Doubles.
@@ -387,7 +387,7 @@ class FloatType(PrimitiveType, Singleton):
     min: ClassVar[float] = -3.4028235e38
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class DoubleType(PrimitiveType, Singleton):
     """A Double data type in Iceberg can be represented using an instance of this class. Doubles in Iceberg are
     64-bit IEEE 754 floating points.
@@ -403,7 +403,7 @@ class DoubleType(PrimitiveType, Singleton):
     type_string = "double"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class DateType(PrimitiveType, Singleton):
     """A Date data type in Iceberg can be represented using an instance of this class. Dates in Iceberg are
     calendar dates without a timezone or time.
@@ -419,7 +419,7 @@ class DateType(PrimitiveType, Singleton):
     type_string = "date"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class TimeType(PrimitiveType, Singleton):
     """A Time data type in Iceberg can be represented using an instance of this class. Times in Iceberg
     have microsecond precision and are a time of day without a date or timezone.
@@ -435,7 +435,7 @@ class TimeType(PrimitiveType, Singleton):
     type_string = "time"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class TimestampType(PrimitiveType, Singleton):
     """A Timestamp data type in Iceberg can be represented using an instance of this class. Timestamps in
     Iceberg have microsecond precision and include a date and a time of day without a timezone.
@@ -452,7 +452,7 @@ class TimestampType(PrimitiveType, Singleton):
     repr_string = "TimestampType()"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class TimestamptzType(PrimitiveType, Singleton):
     """A Timestamptz data type in Iceberg can be represented using an instance of this class. Timestamptzs in
     Iceberg are stored as UTC and include a date and a time of day with a timezone.
@@ -468,7 +468,7 @@ class TimestamptzType(PrimitiveType, Singleton):
     type_string = "timestamptz"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class StringType(PrimitiveType, Singleton):
     """A String data type in Iceberg can be represented using an instance of this class. Strings in
     Iceberg are arbitrary-length character sequences and are encoded with UTF-8.
@@ -484,7 +484,7 @@ class StringType(PrimitiveType, Singleton):
     type_string = "string"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class UUIDType(PrimitiveType, Singleton):
     """A UUID data type in Iceberg can be represented using an instance of this class. UUIDs in
     Iceberg are universally unique identifiers.
@@ -500,7 +500,7 @@ class UUIDType(PrimitiveType, Singleton):
     type_string = "uuid"
 
 
-@dataclass(frozen=True, eq=True, repr=True)
+@dataclass(frozen=True)
 class BinaryType(PrimitiveType, Singleton):
     """A Binary data type in Iceberg can be represented using an instance of this class. Binaries in
     Iceberg are arbitrary-length byte arrays.

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -175,15 +175,10 @@ class NestedField(IcebergType):
     @property
     def string_type(self) -> str:
         return (
-            f"{self.field_id}: {self.name}: {'optional' if self.is_optional else 'required'} {self.type}"
+            f"{self.field_id}: {self.name}: {'optional' if self.is_optional else 'required'} {self.field_type}"
             if self.doc is None
             else f" ({self.doc})"
         )
-
-    # Alias for field_type
-    @property
-    def type(self) -> IcebergType:
-        return self.field_type
 
 
 @dataclass(frozen=True, init=False)

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -221,19 +221,19 @@ def test_schema_find_field_by_id(table_schema_simple):
     column1 = index[1]
     assert isinstance(column1, NestedField)
     assert column1.field_id == 1
-    assert column1.type == StringType()
+    assert column1.field_type == StringType()
     assert column1.is_optional == False
 
     column2 = index[2]
     assert isinstance(column2, NestedField)
     assert column2.field_id == 2
-    assert column2.type == IntegerType()
+    assert column2.field_type == IntegerType()
     assert column2.is_optional == True
 
     column3 = index[3]
     assert isinstance(column3, NestedField)
     assert column3.field_id == 3
-    assert column3.type == BooleanType()
+    assert column3.field_type == BooleanType()
     assert column3.is_optional == False
 
 

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -145,8 +145,8 @@ def test_list_type():
         ),
         False,
     )
-    assert isinstance(type_var.element.type, StructType)
-    assert len(type_var.element.type.fields) == 2
+    assert isinstance(type_var.element.field_type, StructType)
+    assert len(type_var.element.field_type.fields) == 2
     assert type_var.element.field_id == 1
     assert str(type_var) == str(eval(repr(type_var)))
     assert type_var == eval(repr(type_var))
@@ -161,9 +161,9 @@ def test_list_type():
 
 def test_map_type():
     type_var = MapType(1, DoubleType(), 2, UUIDType(), False)
-    assert isinstance(type_var.key.type, DoubleType)
+    assert isinstance(type_var.key.field_type, DoubleType)
     assert type_var.key.field_id == 1
-    assert isinstance(type_var.value.type, UUIDType)
+    assert isinstance(type_var.value.field_type, UUIDType)
     assert type_var.value.field_id == 2
     assert str(type_var) == str(eval(repr(type_var)))
     assert type_var == eval(repr(type_var))
@@ -192,7 +192,7 @@ def test_nested_field():
     assert field_var.is_optional
     assert not field_var.is_required
     assert field_var.field_id == 1
-    assert isinstance(field_var.type, StructType)
+    assert isinstance(field_var.field_type, StructType)
     assert str(field_var) == str(eval(repr(field_var)))
 
 


### PR DESCRIPTION
Proposal to change the types into dataclasses.

This has several improvments:

- We can use the dataclasss field(repr=True) to include the fields in the representation, instead of building our own strings
- We can assign the types in the post_init when they are dynamic (List, Maps, Structs etc) , or just override them when they are static (Primitives)
- We don't have to implement any eq methods because they come for free
- The types are frozen, which is kind of nice since we re-use them
- The code is much more consise
- We can assign the min/max of the int/long/float as Final as of 3.8: https://peps.python.org/pep-0591/

My inspiration was the comment by Kyle:
https://github.com/apache/iceberg/pull/4742#discussion_r869494393

This would entail implementing eq, but why not use the generated one since we're comparing all the attributes :)

Would love to get you input