### PR TITLE
Core: Accept all API warnings in master

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,2 +1,87 @@
 versionOverrides:
   org.apache.iceberg:iceberg-api:release-base-0.13.0: "0.13.0"
+acceptedBreaks:
+  release-base-0.13.0:
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.PartitionSpec"
+      new: "class org.apache.iceberg.PartitionSpec"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.Schema"
+      new: "class org.apache.iceberg.Schema"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.SortOrder"
+      new: "class org.apache.iceberg.SortOrder"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.util.CharSequenceSet"
+      new: "class org.apache.iceberg.util.CharSequenceSet"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method T org.apache.iceberg.Scan<T extends org.apache.iceberg.Scan<T extends\
+        \ org.apache.iceberg.Scan<T>>>::planWith(java.util.concurrent.ExecutorService)\
+        \ @ org.apache.iceberg.TableScan"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method ThisT org.apache.iceberg.SnapshotUpdate<ThisT>::scanManifestsWith(java.util.concurrent.ExecutorService)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ExpireSnapshots org.apache.iceberg.ExpireSnapshots::planWith(java.util.concurrent.ExecutorService)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::createBranch(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::createTag(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::fastForwardBranch(java.lang.String,\
+        \ java.lang.String)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::removeBranch(java.lang.String)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::removeTag(java.lang.String)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::renameBranch(java.lang.String,\
+        \ java.lang.String)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::replaceBranch(java.lang.String,\
+        \ java.lang.String)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::replaceBranch(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::replaceTag(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::setMaxRefAgeMs(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::setMaxSnapshotAgeMs(java.lang.String,\
+        \ long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ManageSnapshots org.apache.iceberg.ManageSnapshots::setMinSnapshotsToKeep(java.lang.String,\
+        \ int)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ReplacePartitions org.apache.iceberg.ReplacePartitions::validateFromSnapshot(long)"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ReplacePartitions org.apache.iceberg.ReplacePartitions::validateNoConflictingData()"
+      justification: "Accept all changes prior to introductig API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.ReplacePartitions org.apache.iceberg.ReplacePartitions::validateNoConflictingDeletes()"
+      justification: "Accept all changes prior to introductig API compatibility checks"


### PR DESCRIPTION
Adds a blanket acceptance for all existing breaks that occurred prior to the introduction of the API / ABI compatibility guarantee checking tool, `revapi`, in https://github.com/apache/iceberg/pull/4638

cc @rdblue 