### PR TITLE
Core: Add request headers to REST client

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -29,13 +29,15 @@ import org.apache.iceberg.rest.responses.ErrorResponse;
  */
 public interface RESTClient extends Closeable {
 
-  void head(String path, Consumer<ErrorResponse> errorHandler);
+  void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler);
 
-  <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
+  <T extends RESTResponse> T delete(String path, Class<T> responseType, Map<String, String> headers,
+                                    Consumer<ErrorResponse> errorHandler);
 
-  <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
+  <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers,
+                                 Consumer<ErrorResponse> errorHandler);
 
-  <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
+  <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType, Map<String, String> headers,
                                   Consumer<ErrorResponse> errorHandler);
 
   <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.rest;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 import org.apache.iceberg.LocationProviders;
@@ -48,20 +49,22 @@ class RESTTableOperations implements TableOperations {
 
   private final RESTClient client;
   private final String path;
+  private final Map<String, String> headers;
   private final FileIO io;
   private final List<MetadataUpdate> createChanges;
   private final TableMetadata replaceBase;
   private UpdateType updateType;
   private TableMetadata current;
 
-  RESTTableOperations(RESTClient client, String path, FileIO io, TableMetadata current) {
-    this(client, path, io, UpdateType.SIMPLE, Lists.newArrayList(), current);
+  RESTTableOperations(RESTClient client, String path, Map<String, String> headers, FileIO io, TableMetadata current) {
+    this(client, path, headers, io, UpdateType.SIMPLE, Lists.newArrayList(), current);
   }
 
-  RESTTableOperations(RESTClient client, String path, FileIO io, UpdateType updateType,
+  RESTTableOperations(RESTClient client, String path, Map<String, String> headers, FileIO io, UpdateType updateType,
                       List<MetadataUpdate> createChanges, TableMetadata current) {
     this.client = client;
     this.path = path;
+    this.headers = headers;
     this.io = io;
     this.updateType = updateType;
     this.createChanges = createChanges;
@@ -80,7 +83,7 @@ class RESTTableOperations implements TableOperations {
 
   @Override
   public TableMetadata refresh() {
-    return updateCurrentMetadata(client.get(path, LoadTableResponse.class, ErrorHandlers.tableErrorHandler()));
+    return updateCurrentMetadata(client.get(path, LoadTableResponse.class, headers, ErrorHandlers.tableErrorHandler()));
   }
 
   @Override
@@ -121,7 +124,7 @@ class RESTTableOperations implements TableOperations {
 
     // the error handler will throw necessary exceptions like CommitFailedException and UnknownCommitStateException
     // TODO: ensure that the HTTP client lib passes HTTP client errors to the error handler
-    LoadTableResponse response = client.post(path, request, LoadTableResponse.class, errorHandler);
+    LoadTableResponse response = client.post(path, request, LoadTableResponse.class, headers, errorHandler);
 
     // all future commits should be simple commits
     this.updateType = UpdateType.SIMPLE;

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -63,4 +63,8 @@ public class ResourcePaths {
         "v1", prefix, "namespaces", RESTUtil.encodeNamespace(ident.namespace()), "tables",
         RESTUtil.encodeString(ident.name()));
   }
+
+  public String rename() {
+    return SLASH.join("v1", prefix, "tables", "rename");
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -81,7 +81,7 @@ public class RESTCatalogAdapter implements RESTClient {
     this.asNamespaceCatalog = catalog instanceof SupportsNamespaces ? (SupportsNamespaces) catalog : null;
   }
 
-  private enum HTTPMethod {
+  enum HTTPMethod {
     GET,
     HEAD,
     POST,
@@ -240,7 +240,7 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   public <T extends RESTResponse> T execute(HTTPMethod method, String path, Object body, Class<T> responseType,
-                                            Consumer<ErrorResponse> errorHandler) {
+                                            Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
     ErrorResponse.Builder errorBuilder = ErrorResponse.builder();
     Pair<Route, Map<String, String>> routeAndVars = Route.from(method, path);
     if (routeAndVars != null) {
@@ -266,30 +266,32 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   @Override
-  public <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
-    return execute(HTTPMethod.DELETE, path, null, responseType, errorHandler);
+  public <T extends RESTResponse> T delete(String path, Class<T> responseType, Map<String, String> headers,
+                                           Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.DELETE, path, null, responseType, headers, errorHandler);
   }
 
   @Override
   public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
-                                         Consumer<ErrorResponse> errorHandler) {
-    return execute(HTTPMethod.POST, path, body, responseType, errorHandler);
+                                         Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.POST, path, body, responseType, headers, errorHandler);
   }
 
   @Override
-  public <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
-    return execute(HTTPMethod.GET, path, null, responseType, errorHandler);
+  public <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers,
+                                        Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.GET, path, null, responseType, headers, errorHandler);
   }
 
   @Override
-  public void head(String path, Consumer<ErrorResponse> errorHandler) {
-    execute(HTTPMethod.HEAD, path, null, null, errorHandler);
+  public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+    execute(HTTPMethod.HEAD, path, null, null, headers, errorHandler);
   }
 
   @Override
   public <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType,
                                              Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
-    return execute(HTTPMethod.POST, path, formData, responseType, errorHandler);
+    return execute(HTTPMethod.POST, path, formData, responseType, headers, errorHandler);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
 import org.junit.AfterClass;
@@ -198,14 +199,14 @@ public class TestHTTPClient {
   private static Item doExecuteRequest(HttpMethod method, String path, Item body, Consumer<ErrorResponse> onError) {
     switch (method) {
       case POST:
-        return restClient.post(path, body, Item.class, onError);
+        return restClient.post(path, body, Item.class, ImmutableMap.of(), onError);
       case GET:
-        return restClient.get(path, Item.class, onError);
+        return restClient.get(path, Item.class, ImmutableMap.of(), onError);
       case HEAD:
-        restClient.head(path, onError);
+        restClient.head(path, ImmutableMap.of(), onError);
         return null;
       case DELETE:
-        return restClient.delete(path, Item.class, onError);
+        return restClient.delete(path, Item.class, ImmutableMap.of(), onError);
       default:
         throw new IllegalArgumentException(String.format("Invalid method: %s", method));
     }


### PR DESCRIPTION
This adds a parameter to `RESTClient` to pass headers when making a request. This was originally part of #4575, but we can get it in more easily on its own.