### PR TITLE
Docs: Add StarRocks to Documentation

### DIFF
--- a/docs/starrocks/_index.md
+++ b/docs/starrocks/_index.md
@@ -1,0 +1,23 @@
+---
+title: "StarRocks"
+bookIconImage: ../img/starrocks-logo.png
+bookFlatSection: true
+weight: 430
+bookExternalUrlNewWindow: https://docs.starrocks.com/en-us/main/introduction/StarRocks_intro
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->

--- a/docs/starrocks/_index.md
+++ b/docs/starrocks/_index.md
@@ -3,7 +3,7 @@ title: "StarRocks"
 bookIconImage: ../img/starrocks-logo.png
 bookFlatSection: true
 weight: 430
-bookExternalUrlNewWindow: https://docs.starrocks.com/en-us/main/introduction/StarRocks_intro
+bookExternalUrlNewWindow: https://docs.starrocks.com/en-us/main/using_starrocks/External_table#apache-iceberg-external-table
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more


### PR DESCRIPTION
This PR adds a link to the documentation for StarRocks querying for Iceberg tables.