### PR TITLE
[WIP] AWS: Add partition info to Glue

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -65,7 +65,7 @@ public class GlueTestBase {
   static GlueCatalog glueCatalogWithSkip;
 
   static Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
-  static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
+  static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).identity("c1").build();
 
   // table location properties
   static final Map<String, String> tableLocationProperties = ImmutableMap.of(

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -78,6 +78,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Assert.assertEquals("additionalLocations should match",
         tableLocationProperties.values().stream().sorted().collect(Collectors.toList()),
         response.table().storageDescriptor().additionalLocations().stream().sorted().collect(Collectors.toList()));
+    Assert.assertEquals(partitionSpec.fields().size(), response.table().partitionKeys().size());
     // verify metadata file exists in S3
     String metaLocation = response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
     String key = metaLocation.split(testBucketName, -1)[1].substring(1);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -49,7 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.DatabaseInput;
-import software.amazon.awssdk.services.glue.model.Order;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.TableInput;
 
@@ -211,7 +209,6 @@ class IcebergToGlueConverter {
           .storageDescriptor(storageDescriptor
               .location(metadata.location())
               .columns(toColumns(metadata))
-              .sortColumns(toSortOrder(metadata))
               .build())
           .partitionKeys(toPartitionColumns(metadata));
     } catch (RuntimeException e) {
@@ -310,17 +307,9 @@ class IcebergToGlueConverter {
   private static List<Column> toPartitionColumns(TableMetadata metadata) {
     return metadata.spec().fields().stream()
         .map(f -> Column.builder()
-            .name(f.toString())
+            .name(f.transform() + "(" + f.name() + ")")
             .type(toTypeString(f.transform().getResultType(metadata.schema().findField(f.sourceId()).type())))
-            .build())
-        .collect(Collectors.toList());
-  }
-
-  private static List<Order> toSortOrder(TableMetadata metadata) {
-    return metadata.sortOrder().fields().stream()
-        .map(sortField -> Order.builder()
-            .sortOrder(sortField.direction() == SortDirection.ASC ? 1 : 0)
-            .column(sortField.toString())
+            .comment("fieldId: " + f.fieldId() + ", sourceId: " + f.sourceId() + ", transform: " + f.transform())
             .build())
         .collect(Collectors.toList());
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -38,7 +37,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.DatabaseInput;
-import software.amazon.awssdk.services.glue.model.Order;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.TableInput;
 
@@ -132,10 +130,8 @@ public class TestIcebergToGlueConverter {
         .withSpecId(1000)
         .build();
 
-    SortOrder sortOrder = SortOrder.builderFor(schema).asc("x").build();
-
     TableMetadata tableMetadata = TableMetadata
-        .newTableMetadata(schema, partitionSpec, sortOrder, "s3://test", tableLocationProperties);
+        .newTableMetadata(schema, partitionSpec, "s3://test", tableLocationProperties);
     IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
     TableInput actualTableInput = actualTableInputBuilder.build();
 
@@ -165,17 +161,12 @@ public class TestIcebergToGlueConverter {
                         IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
                     ))
                     .build()))
-            .sortColumns(ImmutableList.of(
-                Order.builder()
-                    .column("identity(1) ASC NULLS FIRST")
-                    .sortOrder(1)
-                    .build()
-            ))
             .build())
         .partitionKeys(ImmutableList.of(
             Column.builder()
-                .name("1000: x: identity(1)")
+                .name("identity(x)")
                 .type("string")
+                .comment("fieldId: 1000, sourceId: 1, transform: identity")
                 .build()
         ))
         .build();
@@ -196,11 +187,6 @@ public class TestIcebergToGlueConverter {
         "Partition keys should match",
         expectedTableInput.partitionKeys(),
         actualTableInput.partitionKeys());
-
-    Assert.assertEquals(
-        "SortOrders should match",
-        expectedTableInput.storageDescriptor().sortColumns(),
-        actualTableInput.storageDescriptor().sortColumns());
   }
 
   @Test


### PR DESCRIPTION
At present partition info is not being populated to the Glue. 

From checking past discussions, it looks like we decided to re-visit how to model these.
-  https://github.com/apache/iceberg/pull/3887

In this PR, the partition column's name are derived from `{tranform}({colName})`,  I am open to other ways to representing this as well. 

TODO : check if this works well with LF

---

cc @jackye1995 @rajarshisarkar @amogh-jahagirdar @arminnajafi @xiaoxuandev @yyanyy @flyrain @szehon-ho @natsukawa-kanou 
