### PR TITLE
Docs: Update compression codec enum supported by Avro in configuration.md

### DIFF
--- a/docs/tables/configuration.md
+++ b/docs/tables/configuration.md
@@ -50,7 +50,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.parquet.dict-size-bytes      | 2097152 (2 MB)     | Parquet dictionary page size                       |
 | write.parquet.compression-codec    | gzip               | Parquet compression codec: zstd, brotli, lz4, gzip, snappy, uncompressed |
 | write.parquet.compression-level    | null               | Parquet compression level                          |
-| write.avro.compression-codec       | gzip               | Avro compression codec: gzip(deflate with 9 level), gzip, snappy, uncompressed |
+| write.avro.compression-codec       | gzip               | Avro compression codec: gzip(deflate with 9 level), zstd, snappy, uncompressed |
 | write.avro.compression-level       | null               | Avro compression level                             |
 | write.orc.stripe-size-bytes        | 67108864 (64 MB)   | Define the default ORC stripe size, in bytes       |
 | write.orc.block-size-bytes         | 268435456 (256 MB) | Define the default file system block size for ORC files |


### PR DESCRIPTION
## What is the purpose of the change

Update the doc for compression codec enum supported by Avro 

## Brief change log

Based on：
https://github.com/apache/iceberg/blob/932ede696cbb07c266a15505a5d49083f624608e/core/src/main/java/org/apache/iceberg/avro/Avro.java#L74-L82

the codec should be：

- gzip(deflate with 9 level)
- zstd
- snappy
- uncompressed