### PR TITLE
Python: Test for warning of PyLint

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -1,0 +1,609 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold to be exceeded before program exits with error.
+fail-under=10.0
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the ignore-list. The
+# regex matches against paths and can be in Posix or Windows format.
+ignore-paths=
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths. The default value ignores emacs file
+# locks
+ignore-patterns=^\.#
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.9
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=all
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=spelling,W
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: af (aspell), am (aspell),
+# ar (aspell), ast (aspell), az (aspell), be (aspell), be_BY (aspell), be_SU
+# (aspell), bg (aspell), bn (aspell), br (aspell), ca (aspell), cs (aspell),
+# csb (aspell), cy (aspell), da (aspell), de (aspell), de_AT (aspell), de_CH
+# (aspell), de_DE (aspell), el (aspell), en (aspell), en_AU (aspell), en_CA
+# (aspell), en_GB (aspell), en_US (aspell), eo (aspell), es (aspell), es_ES
+# (AppleSpell), et (aspell), fa (aspell), fi (aspell), fo (aspell), fr
+# (aspell), fr_CH (aspell), fr_FR (aspell), fy (aspell), ga (aspell), gd
+# (aspell), gl (aspell), gr (aspell), grc (aspell), gu (aspell), gv (aspell),
+# he (aspell), hi (aspell), hil (aspell), hr (aspell), hsb (aspell), hu
+# (aspell), hu_HU (AppleSpell), hus (aspell), hy (aspell), ia (aspell), id
+# (aspell), it (aspell), it_IT (AppleSpell), kn (aspell), ku (aspell), ky
+# (aspell), la (aspell), lt (aspell), lv (aspell), mg (aspell), mi (aspell), mk
+# (aspell), ml (aspell), mn (aspell), mr (aspell), ms (aspell), mt (aspell),
+# nds (aspell), nl (aspell), nl_NL (AppleSpell), nn (aspell), ny (aspell), or
+# (aspell), pa (aspell), pl (aspell), pt_BR (aspell), pt_PT (aspell), qu
+# (aspell), ro (aspell), ru (aspell), rw (aspell), sc (aspell), sk (aspell),
+# sk_SK (aspell), sl (aspell), sr (aspell), srd (aspell), sv (aspell), sv_SE
+# (AppleSpell), sw (aspell), ta (aspell), te (aspell), tet (aspell), tk
+# (aspell), tl (aspell), tn (aspell), tr (aspell), uk (aspell), uz (aspell), vi
+# (aspell), wa (aspell), yi (aspell), zu (aspell).
+spelling-dict=en_US
+
+# List of comma separated words that should be considered directives if they
+# appear and the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=spellcheck-dictionary.txt
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# class is considered mixin if its name matches the mixin-class-rgx option.
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins ignore-mixin-
+# members is set to 'yes'
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=130
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=no
+
+# Signatures are removed from the similarity computation
+ignore-signatures=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -99,7 +99,7 @@ def _(primitive_type, value_str: str) -> int:
     Raises:
         ValueError: If the scale/exponent is not 0
     """
-    _, digits, exponent = Decimal(value_str).as_tuple()
+    _, _, exponent = Decimal(value_str).as_tuple()
     if exponent != 0:  # Raise if there are digits to the right of the decimal
         raise ValueError(f"Cannot convert partition value, value cannot have fractional digits for {primitive_type} partition")
     return int(float(value_str))
@@ -216,7 +216,7 @@ def _(primitive_type, value: Decimal) -> bytes:
     Returns:
         bytes: The byte representation of `value`
     """
-    sign, digits, exponent = value.as_tuple()
+    _, digits, exponent = value.as_tuple()
 
     if -exponent != primitive_type.scale:
         raise ValueError(f"Cannot serialize value, scale of value does not match type {primitive_type}: {-exponent}")

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -66,8 +66,8 @@ class Operation(Enum):
 
         try:
             return OPERATION_NEGATIONS[self]
-        except KeyError:
-            raise ValueError(f"No negation defined for operation {self}")
+        except KeyError as e:
+            raise ValueError(f"No negation defined for operation {self}") from e
 
 
 OPERATION_NEGATIONS = {

--- a/python/src/iceberg/expressions/literals.py
+++ b/python/src/iceberg/expressions/literals.py
@@ -18,6 +18,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=W0613
 
 import struct
 import sys
@@ -118,10 +119,8 @@ def _(value: Decimal) -> Literal[Decimal]:
     return DecimalLiteral(value)
 
 
-class AboveMax(Literal[None], Singleton):
-    def __init__(self):
-        pass
-
+class AboveMax(Singleton):
+    @property
     def value(self):
         raise ValueError("AboveMax has no value")
 
@@ -135,7 +134,7 @@ class AboveMax(Literal[None], Singleton):
         return "AboveMax"
 
 
-class BelowMin(Literal[None], Singleton):
+class BelowMin(Singleton):
     def __init__(self):
         pass
 

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -72,7 +72,7 @@ class PyArrowFile(InputFile, OutputFile):
             file_info = self._filesystem.get_file_info(self._path)
         except OSError as e:
             if e.errno == 13 or "AWS Error [code 15]" in str(e):
-                raise PermissionError(f"Cannot get file info, access denied: {self.location}")
+                raise PermissionError(f"Cannot get file info, access denied: {self.location}") from e
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
 
         if file_info.type == FileType.NotFound:
@@ -111,9 +111,9 @@ class PyArrowFile(InputFile, OutputFile):
             raise
         except OSError as e:
             if e.errno == 2 or "Path does not exist" in str(e):
-                raise FileNotFoundError(f"Cannot open file, does not exist: {self.location}")
+                raise FileNotFoundError(f"Cannot open file, does not exist: {self.location}") from e
             elif e.errno == 13 or "AWS Error [code 15]" in str(e):
-                raise PermissionError(f"Cannot open file, access denied: {self.location}")
+                raise PermissionError(f"Cannot open file, access denied: {self.location}") from e
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
         return input_file
 
@@ -144,7 +144,7 @@ class PyArrowFile(InputFile, OutputFile):
             raise
         except OSError as e:
             if e.errno == 13 or "AWS Error [code 15]" in str(e):
-                raise PermissionError(f"Cannot create file, access denied: {self.location}")
+                raise PermissionError(f"Cannot create file, access denied: {self.location}") from e
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
         return output_file
 
@@ -204,7 +204,7 @@ class PyArrowFileIO(FileIO):
             raise
         except OSError as e:
             if e.errno == 2 or "Path does not exist" in str(e):
-                raise FileNotFoundError(f"Cannot delete file, does not exist: {location}")
+                raise FileNotFoundError(f"Cannot delete file, does not exist: {location}") from e
             elif e.errno == 13 or "AWS Error [code 15]" in str(e):
-                raise PermissionError(f"Cannot delete file, access denied: {location}")
+                raise PermissionError(f"Cannot delete file, access denied: {location}") from e
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=W0511
 
 from __future__ import annotations
 
@@ -234,32 +235,26 @@ class SchemaVisitor(Generic[T], ABC):
     @abstractmethod
     def schema(self, schema: Schema, struct_result: T) -> T:
         """Visit a Schema"""
-        ...  # pragma: no cover
 
     @abstractmethod
     def struct(self, struct: StructType, field_results: List[T]) -> T:
         """Visit a StructType"""
-        ...  # pragma: no cover
 
     @abstractmethod
     def field(self, field: NestedField, field_result: T) -> T:
         """Visit a NestedField"""
-        ...  # pragma: no cover
 
     @abstractmethod
     def list(self, list_type: ListType, element_result: T) -> T:
         """Visit a ListType"""
-        ...  # pragma: no cover
 
     @abstractmethod
     def map(self, map_type: MapType, key_result: T, value_result: T) -> T:
         """Visit a MapType"""
-        ...  # pragma: no cover
 
     @abstractmethod
     def primitive(self, primitive: PrimitiveType) -> T:
         """Visit a PrimitiveType"""
-        ...  # pragma: no cover
 
 
 @dataclass(init=True, eq=True, frozen=True)
@@ -367,18 +362,18 @@ class _IndexById(SchemaVisitor[Dict[int, NestedField]]):
     def __init__(self) -> None:
         self._index: Dict[int, NestedField] = {}
 
-    def schema(self, schema: Schema, result) -> Dict[int, NestedField]:
+    def schema(self, schema: Schema, struct_result) -> Dict[int, NestedField]:
         return self._index
 
-    def struct(self, struct: StructType, result) -> Dict[int, NestedField]:
+    def struct(self, struct: StructType, field_results) -> Dict[int, NestedField]:
         return self._index
 
-    def field(self, field: NestedField, result) -> Dict[int, NestedField]:
+    def field(self, field: NestedField, field_result) -> Dict[int, NestedField]:
         """Add the field ID to the index"""
         self._index[field.field_id] = field
         return self._index
 
-    def list(self, list_type: ListType, result) -> Dict[int, NestedField]:
+    def list(self, list_type: ListType, element_result) -> Dict[int, NestedField]:
         """Add the list element ID to the index"""
         self._index[list_type.element.field_id] = list_type.element
         return self._index
@@ -439,15 +434,15 @@ class _IndexByName(SchemaVisitor[Dict[str, int]]):
     def schema(self, schema: Schema, struct_result: Dict[str, int]) -> Dict[str, int]:
         return self._index
 
-    def struct(self, struct: StructType, struct_result: List[Dict[str, int]]) -> Dict[str, int]:
+    def struct(self, struct: StructType, field_results: List[Dict[str, int]]) -> Dict[str, int]:
         return self._index
 
-    def field(self, field: NestedField, struct_result: Dict[str, int]) -> Dict[str, int]:
+    def field(self, field: NestedField, field_result: Dict[str, int]) -> Dict[str, int]:
         """Add the field name to the index"""
         self._add_field(field.name, field.field_id)
         return self._index
 
-    def list(self, list_type: ListType, struct_result: Dict[str, int]) -> Dict[str, int]:
+    def list(self, list_type: ListType, element_result: Dict[str, int]) -> Dict[str, int]:
         """Add the list element name to the index"""
         self._add_field(list_type.element.name, list_type.element.field_id)
         return self._index
@@ -566,8 +561,8 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[Position, Accessor]]):
     def _wrap_leaves(result: Dict[Position, Accessor], position: Position = 0) -> Dict[Position, Accessor]:
         return {field_id: Accessor(position, inner=inner) for field_id, inner in result.items()}
 
-    def schema(self, schema: Schema, result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
-        return result
+    def schema(self, schema: Schema, struct_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+        return struct_result
 
     def struct(self, struct: StructType, field_results: List[Dict[Position, Accessor]]) -> Dict[Position, Accessor]:
         result = {}
@@ -581,10 +576,10 @@ class _BuildPositionAccessors(SchemaVisitor[Dict[Position, Accessor]]):
 
         return result
 
-    def field(self, field: NestedField, result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
-        return result
+    def field(self, field: NestedField, field_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+        return field_result
 
-    def list(self, list_type: ListType, result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
+    def list(self, list_type: ListType, element_result: Dict[Position, Accessor]) -> Dict[Position, Accessor]:
         return {}
 
     def map(

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -256,7 +256,7 @@ class VoidTransform(Transform):
 
     _instance = None
 
-    def __new__(cls):
+    def __new__(cls):  # pylint: disable=W0221
         if cls._instance is None:
             cls._instance = super(VoidTransform, cls).__new__(cls)
         return cls._instance

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import struct
-from abc import ABC
+from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import Generic, Optional, TypeVar
 from uuid import UUID
@@ -67,12 +67,15 @@ class Transform(ABC, Generic[S, T]):
     def __call__(self, value: Optional[S]) -> Optional[T]:
         return self.apply(value)
 
+    @abstractmethod
     def apply(self, value: Optional[S]) -> Optional[T]:
         ...
 
+    @abstractmethod
     def can_transform(self, source: IcebergType) -> bool:
         return False
 
+    @abstractmethod
     def result_type(self, source: IcebergType) -> IcebergType:
         ...
 
@@ -122,6 +125,10 @@ class BaseBucketTransform(Transform[S, int]):
 
     def result_type(self, source: IcebergType) -> IcebergType:
         return IntegerType()
+
+    @abstractmethod
+    def can_transform(self, source: IcebergType) -> bool:
+        pass
 
 
 class BucketNumberTransform(BaseBucketTransform):
@@ -237,8 +244,8 @@ class UnknownTransform(Transform):
     def apply(self, value: Optional[S]):
         raise AttributeError(f"Cannot apply unsupported transform: {self}")
 
-    def can_transform(self, target: IcebergType) -> bool:
-        return self._type == target
+    def can_transform(self, source: IcebergType) -> bool:
+        return self._type == source
 
     def result_type(self, source: IcebergType) -> IcebergType:
         return StringType()
@@ -260,7 +267,7 @@ class VoidTransform(Transform):
     def apply(self, value: Optional[S]) -> None:
         return None
 
-    def can_transform(self, target: IcebergType) -> bool:
+    def can_transform(self, _: IcebergType) -> bool:
         return True
 
     def result_type(self, source: IcebergType) -> IcebergType:

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -36,7 +36,7 @@ from typing import Dict, Optional, Tuple
 class Singleton:
     _instance = None
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls):
         if not isinstance(cls._instance, cls):
             cls._instance = super(Singleton, cls).__new__(cls)
         return cls._instance

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -115,7 +115,7 @@ def test_strs(op, string):
 
 
 @pytest.mark.parametrize(
-    "input, testexpra, testexprb",
+    "exp, testexpra, testexprb",
     [
         (
             base.And(TestExpressionA(), TestExpressionB()),
@@ -132,12 +132,12 @@ def test_strs(op, string):
         (TestExpressionB(), TestExpressionB(), TestExpressionA()),
     ],
 )
-def test_eq(input, testexpra, testexprb):
-    assert input == testexpra and input != testexprb
+def test_eq(exp, testexpra, testexprb):
+    assert exp == testexpra and exp != testexprb
 
 
 @pytest.mark.parametrize(
-    "input, exp",
+    "lhs, rhs",
     [
         (
             base.And(TestExpressionA(), TestExpressionB()),
@@ -151,12 +151,12 @@ def test_eq(input, testexpra, testexprb):
         (TestExpressionA(), TestExpressionB()),
     ],
 )
-def test_negate(input, exp):
-    assert ~input == exp
+def test_negate(lhs, rhs):
+    assert ~lhs == rhs
 
 
 @pytest.mark.parametrize(
-    "input, exp",
+    "lhs, rhs",
     [
         (
             base.And(TestExpressionA(), TestExpressionB(), TestExpressionA()),
@@ -169,12 +169,12 @@ def test_negate(input, exp):
         (base.Not(base.Not(TestExpressionA())), TestExpressionA()),
     ],
 )
-def test_reduce(input, exp):
-    assert input == exp
+def test_reduce(lhs, rhs):
+    assert lhs == rhs
 
 
 @pytest.mark.parametrize(
-    "input, exp",
+    "lhs, rhs",
     [
         (base.And(base.AlwaysTrue(), TestExpressionB()), TestExpressionB()),
         (base.And(base.AlwaysFalse(), TestExpressionB()), base.AlwaysFalse()),
@@ -183,8 +183,8 @@ def test_reduce(input, exp):
         (base.Not(base.Not(TestExpressionA())), TestExpressionA()),
     ],
 )
-def test_base_AlwaysTrue_base_AlwaysFalse(input, exp):
-    assert input == exp
+def test_base_AlwaysTrue_base_AlwaysFalse(lhs, rhs):
+    assert lhs == rhs
 
 
 def test_accessor_base_class(foo_struct):

--- a/python/tests/expressions/test_literals.py
+++ b/python/tests/expressions/test_literals.py
@@ -390,28 +390,28 @@ def test_raise_on_comparison_to_none():
     fixed_lit012 = literal(bytes([0x00, 0x01, 0x02]))
 
     with pytest.raises(AttributeError):
-        bin_lit012 < None
+        _ = bin_lit012 < None
 
     with pytest.raises(AttributeError):
-        bin_lit012 <= None
+        _ = bin_lit012 <= None
 
     with pytest.raises(AttributeError):
-        bin_lit012 > None
+        _ = bin_lit012 > None
 
     with pytest.raises(AttributeError):
-        bin_lit012 >= None
+        _ = bin_lit012 >= None
 
     with pytest.raises(AttributeError):
-        fixed_lit012 < None
+        _ = fixed_lit012 < None
 
     with pytest.raises(AttributeError):
-        fixed_lit012 <= None
+        _ = fixed_lit012 <= None
 
     with pytest.raises(AttributeError):
-        fixed_lit012 > None
+        _ = fixed_lit012 > None
 
     with pytest.raises(AttributeError):
-        fixed_lit012 >= None
+        _ = fixed_lit012 >= None
 
 
 def test_binary_to_fixed():

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -456,15 +456,15 @@ def test_raise_on_unregistered_type():
 
     with pytest.raises(TypeError) as exc_info:
         conversions.partition_to_py(FooUnknownType(), "foo")
-    assert (f"Cannot convert 'foo' to unsupported type: FooUnknownType()") in str(exc_info.value)
+    assert "Cannot convert 'foo' to unsupported type: FooUnknownType()" in str(exc_info.value)
 
     with pytest.raises(TypeError) as exc_info:
         conversions.to_bytes(FooUnknownType(), "foo")
-    assert ("scale does not match FooUnknownType()") in str(exc_info.value)
+    assert "scale does not match FooUnknownType()" in str(exc_info.value)
 
     with pytest.raises(TypeError) as exc_info:
         conversions.from_bytes(FooUnknownType(), b"foo")
-    assert ("Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'") in str(exc_info.value)
+    assert "Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -49,7 +49,7 @@ def test_schema_str(table_schema_simple):
 
 
 @pytest.mark.parametrize(
-    "schema, expected_repr",
+    "schema_repr, expected_repr",
     [
         (
             schema.Schema(NestedField(1, "foo", StringType()), schema_id=1),
@@ -63,9 +63,9 @@ def test_schema_str(table_schema_simple):
         ),
     ],
 )
-def test_schema_repr(schema, expected_repr):
+def test_schema_repr(schema_repr, expected_repr):
     """Test schema representation"""
-    assert repr(schema) == expected_repr
+    assert repr(schema_repr) == expected_repr
 
 
 def test_schema_raise_on_duplicate_names():
@@ -241,7 +241,7 @@ def test_schema_find_field_by_id_raise_on_unknown_field(table_schema_simple):
     """Test raising when the field ID is not found among columns"""
     index = schema.index_by_id(table_schema_simple)
     with pytest.raises(Exception) as exc_info:
-        index[4]
+        _ = index[4]
     assert str(exc_info.value) == "4"
 
 
@@ -392,18 +392,17 @@ def test_build_position_accessors(table_schema_nested):
     }
 
 
-class TestStruct(StructProtocol):
-    def __init__(self, pos: Dict[int, Any] = None):
-        self._pos: Dict[int, Any] = pos or {}
-
-    def set(self, pos: int, value) -> None:
-        pass
-
-    def get(self, pos: int) -> Any:
-        return self._pos[pos]
-
-
 def test_build_position_accessors_with_struct(table_schema_nested):
+    class TestStruct(StructProtocol):
+        def __init__(self, pos: Dict[int, Any] = None):
+            self._pos: Dict[int, Any] = pos or {}
+
+        def set(self, pos: int, value) -> None:
+            pass
+
+        def get(self, pos: int) -> Any:
+            return self._pos[pos]
+
     accessors = build_position_accessors(table_schema_nested)
     container = TestStruct({6: TestStruct({0: "name"})})
     assert accessors.get(16).get(container) == "name"

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=W0123
 
 from decimal import Decimal
 from uuid import UUID

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint: disable=W0123,W0613
 
 import pytest
 

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -59,7 +59,7 @@ commands =
     autoflake -r --check --ignore-init-module-imports --remove-all-unused-imports src tests
     isort --profile black --check-only src tests
     black --line-length 130 --check --diff src tests
-    pylint --disable all --enable spelling --spelling-dict en_US --spelling-private-dict-file spellcheck-dictionary.txt src tests
+    pylint src tests
 
 [testenv:format]
 deps =


### PR DESCRIPTION
Couple of things and checks:

- Moved the configuration from `tox.ini` to `pylintrc`.
- Checks for Pylint warnings
- Detects unused variables, so we can spend our brain cycles on more important stuff during reviews :)
- Checks reraising of exceptions, so you can also see the underlying exception.
- If you override a function, the argument names should stay the same
- Checks on using build-in keywords (input, type, etc)