### PR TITLE
Python - Fix tox errors for not calling super __init__ on a dataclass

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -203,7 +203,7 @@ class StructType(IcebergType):
         cls._instances[fields] = cls._instances.get(fields) or object.__new__(cls)
         return cls._instances[fields]
 
-    def __init__(self, *fields: NestedField, **kwargs):
+    def __init__(self, *fields: NestedField, **kwargs):  # pylint: disable=super-init-not-called
         if not fields and "fields" in kwargs:
             fields = kwargs["fields"]
         object.__setattr__(self, "fields", fields)


### PR DESCRIPTION
Tox tests for python 3.8 are failing, as the `StructType` is now a `dataclass`, but its parent class is not a dataclass and it has `init=False`.

To get around this, I've called `super().__init__()` in the post init method, as suggested here: https://stackoverflow.com/questions/66827839/super-classs-init-is-not-called-using-dataclass

It's also possible we want to just set an ignore on this.

cc @Fokko @samredai 