### PR TITLE
Catalog: Use ImmutableMap for catalog properties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.aws.glue;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,7 +92,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
   private FileIO fileIO;
   private LockManager lockManager;
   private CloseableGroup closeableGroup;
-  private Map<String, String> catalogProperties = Collections.emptyMap();
+  private Map<String, String> catalogProperties;
 
   // Attempt to set versionId if available on the path
   private static final DynMethods.UnboundMethod SET_VERSION_ID = DynMethods.builder("versionId")
@@ -111,7 +110,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
-    this.catalogProperties = properties;
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     AwsClientFactory awsClientFactory;
     FileIO catalogFileIO;
     if (PropertyUtil.propertyAsBoolean(
@@ -165,8 +164,14 @@ public class GlueCatalog extends BaseMetastoreCatalog
   }
 
   @VisibleForTesting
-  void initialize(String name, String path, AwsProperties properties, GlueClient client,
-      LockManager lock, FileIO io, Map<String, String> catalogProps) {
+  void initialize(
+      String name,
+      String path,
+      AwsProperties properties,
+      GlueClient client,
+      LockManager lock,
+      FileIO io,
+      Map<String, String> catalogProps) {
     this.catalogProperties = catalogProps;
     initialize(name, path, properties, client, lock, io);
   }
@@ -507,6 +512,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   protected Map<String, String> properties() {
-    return catalogProperties;
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -229,7 +229,10 @@ public abstract class BaseMetastoreCatalog implements Catalog {
      * @return default table properties specified in catalog properties
      */
     private Map<String, String> tableDefaultProperties() {
-      return PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
+      Map<String, String> tableDefaultProperties =
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_DEFAULT_PREFIX);
+      LOG.info("Table properties set at catalog level through catalog properties: {}", tableDefaultProperties);
+      return tableDefaultProperties;
     }
 
     /**
@@ -238,7 +241,10 @@ public abstract class BaseMetastoreCatalog implements Catalog {
      * @return default table properties enforced through catalog properties
      */
     private Map<String, String> tableOverrideProperties() {
-      return PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
+      Map<String, String> tableOverrideProperties =
+          PropertyUtil.propertiesWithPrefix(properties(), CatalogProperties.TABLE_OVERRIDE_PREFIX);
+      LOG.info("Table properties enforced at catalog level through catalog properties: {}", tableOverrideProperties);
+      return tableOverrideProperties;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import java.util.Collections;
 import java.util.Map;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -28,6 +27,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
@@ -97,7 +97,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
   }
 
   protected Map<String, String> properties() {
-    return Collections.emptyMap();
+    return ImmutableMap.of();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AccessDeniedException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,14 +93,14 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   private FileIO fileIO;
   private LockManager lockManager;
   private boolean suppressPermissionError = false;
-  private Map<String, String> catalogProperties = Collections.emptyMap();
+  private Map<String, String> catalogProperties;
 
   public HadoopCatalog() {
   }
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
-    this.catalogProperties = properties;
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
     Preconditions.checkArgument(inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
         "Cannot initialize HadoopCatalog because warehousePath must not be null or empty");
@@ -398,7 +397,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   @Override
   protected Map<String, String> properties() {
-    return catalogProperties;
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 
   private class HadoopCatalogTableBuilder extends BaseMetastoreCatalogTableBuilder {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hive;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
 import org.apache.thrift.TException;
@@ -74,14 +74,14 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   private FileIO fileIO;
   private ClientPool<IMetaStoreClient, TException> clients;
   private boolean listAllTables = false;
-  private Map<String, String> catalogProperties = Collections.emptyMap();
+  private Map<String, String> catalogProperties;
 
   public HiveCatalog() {
   }
 
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
-    this.catalogProperties = properties;
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     this.name = inputName;
     if (conf == null) {
       LOG.warn("No Hadoop Configuration was set, using the default environment Configuration");
@@ -544,7 +544,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
   @Override
   protected Map<String, String> properties() {
-    return catalogProperties;
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
This PR addresses the nits of https://github.com/apache/iceberg/pull/4011:
- Use ImmutableMap for catalog properties.
- Correct indentation.
- Add loggers for table default and table override catalog properties.

---

cc: @rdblue @kbendick @SinghAsDev 