### PR TITLE
Fix invalid Stream to Iterable conversion in decryption

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptionManager.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptionManager.java
@@ -20,9 +20,11 @@
 package org.apache.iceberg.encryption;
 
 import java.io.Serializable;
+import java.util.Iterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 
 /**
  * Module for encrypting and decrypting table data files.
@@ -47,9 +49,24 @@ public interface EncryptionManager extends Serializable {
    * By default this calls the single-file decryption method for each element in the iterator.
    * Implementations can override this for a variety of optimizations. For example, an
    * implementation can perform lookahead on the input iterator and fetch encryption keys in batch.
+   *
+   * @deprecated Use {@link #decrypt(Iterator)}.
    */
+  @Deprecated
   default Iterable<InputFile> decrypt(Iterable<EncryptedInputFile> encrypted) {
     return Iterables.transform(encrypted, this::decrypt);
+  }
+
+  /**
+   * Variant of {@link #decrypt(EncryptedInputFile)} that provides a sequence of files that all
+   * need to be decrypted in a single context.
+   * <p>
+   * By default this calls the single-file decryption method for each element in the iterator.
+   * Implementations can override this for a variety of optimizations. For example, an
+   * implementation can perform lookahead on the input iterator and fetch encryption keys in batch.
+   */
+  default Iterator<InputFile> decrypt(Iterator<EncryptedInputFile> encrypted) {
+    return Iterators.transform(encrypted, this::decrypt);
   }
 
   /**

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -268,10 +268,10 @@ public class ArrowReader extends CloseableGroup {
           .map(entry -> EncryptedFiles.encryptedInput(io.newInputFile(entry.getKey()), entry.getValue()));
 
       // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-      Iterable<InputFile> decryptedFiles = encryptionManager.decrypt(encrypted::iterator);
+      Iterator<InputFile> decryptedFiles = encryptionManager.decrypt(encrypted.iterator());
 
       Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(fileTasks.size());
-      decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+      decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
       this.inputFiles = ImmutableMap.copyOf(files);
       this.currentIterator = CloseableIterator.empty();
       this.expectedSchema = expectedSchema;

--- a/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.encryption;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.iceberg.CombinedScanTask;
@@ -43,10 +44,10 @@ public class InputFilesDecryptor {
         .map(entry -> EncryptedFiles.encryptedInput(io.newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-    Iterable<InputFile> decryptedFiles = encryption.decrypt(encrypted::iterator);
+    Iterator<InputFile> decryptedFiles = encryption.decrypt(encrypted.iterator());
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(keyMetadata.size());
-    decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+    decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
     this.decryptedInputFiles = Collections.unmodifiableMap(files);
   }
 

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -82,10 +82,10 @@ abstract class BaseDataReader<T> implements Closeable {
         .map(entry -> EncryptedFiles.encryptedInput(table.io().newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-    Iterable<InputFile> decryptedFiles = table.encryption().decrypt(encrypted::iterator);
+    Iterator<InputFile> decryptedFiles = table.encryption().decrypt(encrypted.iterator());
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(task.files().size());
-    decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+    decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
     this.inputFiles = ImmutableMap.copyOf(files);
 
     this.currentIterator = CloseableIterator.empty();

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -82,10 +82,10 @@ abstract class BaseDataReader<T> implements Closeable {
         .map(entry -> EncryptedFiles.encryptedInput(table.io().newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-    Iterable<InputFile> decryptedFiles = table.encryption().decrypt(encrypted::iterator);
+    Iterator<InputFile> decryptedFiles = table.encryption().decrypt(encrypted.iterator());
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(task.files().size());
-    decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+    decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
     this.inputFiles = ImmutableMap.copyOf(files);
 
     this.currentIterator = CloseableIterator.empty();

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -82,10 +82,10 @@ abstract class BaseDataReader<T> implements Closeable {
         .map(entry -> EncryptedFiles.encryptedInput(table.io().newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-    Iterable<InputFile> decryptedFiles = table.encryption().decrypt(encrypted::iterator);
+    Iterator<InputFile> decryptedFiles = table.encryption().decrypt(encrypted.iterator());
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(task.files().size());
-    decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+    decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
     this.inputFiles = ImmutableMap.copyOf(files);
 
     this.currentIterator = CloseableIterator.empty();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -82,10 +82,10 @@ abstract class BaseDataReader<T> implements Closeable {
         .map(entry -> EncryptedFiles.encryptedInput(table.io().newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
-    Iterable<InputFile> decryptedFiles = table.encryption().decrypt(encrypted::iterator);
+    Iterator<InputFile> decryptedFiles = table.encryption().decrypt(encrypted.iterator());
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(task.files().size());
-    decryptedFiles.forEach(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
+    decryptedFiles.forEachRemaining(decrypted -> files.putIfAbsent(decrypted.location(), decrypted));
     this.inputFiles = ImmutableMap.copyOf(files);
 
     this.currentIterator = CloseableIterator.empty();


### PR DESCRIPTION
`Stream.iterator` is a one-shot operation, cannot be called multiple
times, so `stream::iterator` shouldn't be used as an implementation of
`Iterable`.

While we could easily change the `InputFilesDecryptor` to implement
`Iterable` correctly, it wouldn't convey the intention that the data is
read at most once. To convey that, the encryption API is changed from
accepting `Iterable` to accepting `Iterator`.

Similar to https://github.com/apache/iceberg/pull/4863