### PR TITLE
Core: Add snapshot references metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -28,6 +28,7 @@ public enum MetadataTableType {
   HISTORY,
   METADATA_LOG_ENTRIES,
   SNAPSHOTS,
+  REFS,
   MANIFESTS,
   PARTITIONS,
   ALL_DATA_FILES,

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -62,6 +62,8 @@ public class MetadataTableUtils {
         return new SnapshotsTable(ops, baseTable, metadataTableName);
       case METADATA_LOG_ENTRIES:
         return new MetadataLogEntriesTable(ops, baseTable, metadataTableName);
+      case REFS:
+        return new RefsTable(ops, baseTable, metadataTableName);
       case MANIFESTS:
         return new ManifestsTable(ops, baseTable, metadataTableName);
       case PARTITIONS:

--- a/core/src/main/java/org/apache/iceberg/RefsTable.java
+++ b/core/src/main/java/org/apache/iceberg/RefsTable.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
+
+/** A {@link Table} implementation that exposes a table's known snapshot references as rows. */
+public class RefsTable extends BaseMetadataTable {
+  private static final Schema SNAPSHOT_REF_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "name", Types.StringType.get()),
+          Types.NestedField.required(2, "type", Types.StringType.get()),
+          Types.NestedField.required(3, "snapshot_id", Types.LongType.get()),
+          Types.NestedField.optional(4, "max_reference_age_in_ms", Types.LongType.get()),
+          Types.NestedField.optional(5, "min_snapshots_to_keep", Types.IntegerType.get()),
+          Types.NestedField.optional(6, "max_snapshot_age_in_ms", Types.LongType.get()));
+
+  RefsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".refs");
+  }
+
+  RefsTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new RefsTableScan(operations(), table());
+  }
+
+  @Override
+  public Schema schema() {
+    return SNAPSHOT_REF_SCHEMA;
+  }
+
+  private DataTask task(BaseTableScan scan) {
+    TableOperations ops = operations();
+    Collection<String> refNames = ops.current().refs().keySet();
+    return StaticDataTask.of(
+        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        schema(),
+        scan.schema(),
+        refNames,
+        referencesToRows(ops.current().refs()));
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.REFS;
+  }
+
+  private class RefsTableScan extends StaticTableScan {
+    RefsTableScan(TableOperations ops, Table table) {
+      super(ops, table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task);
+    }
+
+    RefsTableScan(TableOperations ops, Table table, TableScanContext context) {
+      super(ops, table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(
+        TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new RefsTableScan(ops, table, context);
+    }
+
+    @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      return CloseableIterable.withNoopClose(RefsTable.this.task(this));
+    }
+  }
+
+  private static Function<String, StaticDataTask.Row> referencesToRows(
+      Map<String, SnapshotRef> refs) {
+    return refName ->
+        StaticDataTask.Row.of(
+            refName,
+            refs.get(refName).type().name(),
+            refs.get(refName).snapshotId(),
+            refs.get(refName).maxRefAgeMs(),
+            refs.get(refName).minSnapshotsToKeep(),
+            refs.get(refName).maxSnapshotAgeMs());
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/RefsTable.java
+++ b/core/src/main/java/org/apache/iceberg/RefsTable.java
@@ -24,7 +24,11 @@ import java.util.function.Function;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Types;
 
-/** A {@link Table} implementation that exposes a table's known snapshot references as rows. */
+/**
+ * A {@link Table} implementation that exposes a table's known snapshot references as rows.
+ *
+ * <p>{@link SnapshotRefType} stores the valid snapshot references type.
+ */
 public class RefsTable extends BaseMetadataTable {
   private static final Schema SNAPSHOT_REF_SCHEMA =
       new Schema(

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -551,6 +551,44 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Assert.assertEquals("TAG", testTag.get(0).getAs("type"));
     Assert.assertEquals(currentSnapshotId, testTag.get(0).getAs("snapshot_id"));
     Assert.assertEquals(Long.valueOf(50), testTag.get(0).getAs("max_reference_age_in_ms"));
+
+    // Check projection in refs table
+    List<Row> testTagProjection =
+        spark
+            .sql(
+                "SELECT name,type,snapshot_id,max_reference_age_in_ms,min_snapshots_to_keep FROM "
+                    + tableName
+                    + ".refs where type='TAG'")
+            .collectAsList();
+    Assert.assertEquals("testTag", testTagProjection.get(0).getAs("name"));
+    Assert.assertEquals("TAG", testTagProjection.get(0).getAs("type"));
+    Assert.assertEquals(currentSnapshotId, testTagProjection.get(0).getAs("snapshot_id"));
+    Assert.assertEquals(
+        Long.valueOf(50), testTagProjection.get(0).getAs("max_reference_age_in_ms"));
+    Assert.assertNull(testTagProjection.get(0).getAs("min_snapshots_to_keep"));
+
+    List<Row> mainBranchProjection =
+        spark
+            .sql(
+                "SELECT name, type FROM "
+                    + tableName
+                    + ".refs WHERE name = 'main' AND type = 'BRANCH'")
+            .collectAsList();
+    Assert.assertEquals("main", mainBranchProjection.get(0).getAs("name"));
+    Assert.assertEquals("BRANCH", mainBranchProjection.get(0).getAs("type"));
+
+    List<Row> testBranchProjection =
+        spark
+            .sql(
+                "SELECT type, name, max_reference_age_in_ms, snapshot_id FROM "
+                    + tableName
+                    + ".refs WHERE name = 'testBranch' AND type = 'BRANCH'")
+            .collectAsList();
+    Assert.assertEquals("testBranch", testBranchProjection.get(0).getAs("name"));
+    Assert.assertEquals("BRANCH", testBranchProjection.get(0).getAs("type"));
+    Assert.assertEquals(currentSnapshotId, testBranchProjection.get(0).getAs("snapshot_id"));
+    Assert.assertEquals(
+        Long.valueOf(10), testBranchProjection.get(0).getAs("max_reference_age_in_ms"));
   }
 
   /**


### PR DESCRIPTION
This PR adds snapshot references metadata table to display branches and tags of a table.

```
spark-sql> DESCRIBE TABLE my_catalog.db_iceberg_poc.test_metatable.refs;
name                 	string
type                	string
snapshot_id         	bigint
max_reference_age_in_ms	bigint
min_snapshots_to_keep	int
max_snapshot_age_in_ms	bigint

scala> val df = spark.sql("SELECT * FROM my_catalog.db_iceberg_poc.test_metatable.refs");
df: org.apache.spark.sql.DataFrame = [reference: string, type: string ... 4 more fields]

scala> df.show()
+----+------+-------------------+-----------------------+---------------------+----------------------+
|name|  type|        snapshot_id|max_reference_age_in_ms|min_snapshots_to_keep|max_snapshot_age_in_ms|
+----+------+-------------------+-----------------------+---------------------+----------------------+
|main|BRANCH|4686954189838128572|                   null|                 null|                  null|
+----+------+-------------------+-----------------------+---------------------+----------------------+
```

Proposal doc: [Link](https://docs.google.com/document/d/1tbATFPrKF3vNlzkgZQdaW8CAJmbjvryfrlg6C2Ci_aA/edit#heading=h.yxi0c6l48qw0)

---

cc: @rdblue @jackye1995 @amogh-jahagirdar