### PR TITLE
Core: Recover the schema by reading previous metadata files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -307,7 +307,10 @@ public class SnapshotUtil {
       return schema;
     }
 
-    // TODO: recover the schema by reading previous metadata files
+    snapshot = table.snapshot(snapshot.parentId());
+    if (snapshot != null) {
+      return table.schemas().get(snapshot.schemaId());
+    }
     return table.schema();
   }
 


### PR DESCRIPTION
 If snapshot was created before Iceberg added schema id to snapshot，schemaId could be null,  we could recover the schema by reading previous metadata files