### PR TITLE
Python: Fix the type_string of the NestedField

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -140,6 +140,14 @@ class NestedField(IcebergType):
         ...     is_optional=False,
         ... ))
         '1: foo: required fixed[22]'
+        >>> str(NestedField(
+        ...     field_id=2,
+        ...     name='bar',
+        ...     field_type=LongType(),
+        ...     is_optional=False,
+        ...     doc="Just a long"
+        ... ))
+        '2: bar: required long (Just a long)'
     """
 
     field_id: int = field()
@@ -168,11 +176,9 @@ class NestedField(IcebergType):
 
     @property
     def string_type(self) -> str:
-        return (
-            f"{self.field_id}: {self.name}: {'optional' if self.is_optional else 'required'} {self.field_type}"
-            if self.doc is None
-            else f" ({self.doc})"
-        )
+        doc = "" if not self.doc else f" ({self.doc})"
+        req = "optional" if self.is_optional else "required"
+        return f"{self.field_id}: {self.name}: {req} {self.field_type}{doc}"
 
 
 @dataclass(frozen=True, init=False)


### PR DESCRIPTION
If there is a doc, the rest gets ignored, which is kind of awkward.

Before:
```python
➜  python git:(master) ✗ python3
Python 3.9.12 (main, Mar 26 2022, 15:44:31)
[Clang 13.1.6 (clang-1316.0.21.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from iceberg.types import NestedField, LongType
>>> str(NestedField(
...     field_id=2,
...     name='bar',
...     field_type=LongType(),
...     is_optional=False
... ))
'2: bar: required long'
>>> str(NestedField(
...     field_id=2,
...     name='bar',
...     field_type=LongType(),
...     is_optional=False,
...     doc="Just a long"
... ))
' (Just a long)'
```

Now:
```python
➜  python git:(master) ✗ python3
Python 3.9.12 (main, Mar 26 2022, 15:44:31)
[Clang 13.1.6 (clang-1316.0.21.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> str(NestedField(
...     field_id=2,
...     name='bar',
...     field_type=LongType(),
...     is_optional=False,
...     doc="Just a long"
... ))
'2: bar: required long (Just a long)'
```