### PR TITLE
remove operations from base expressions; add in expression

### DIFF
--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -83,17 +83,17 @@ class BooleanExpression(ABC):
 
 
 class BoundPredicate(ABC):
-    def __init__(self, left, right):
-        """A concrete predicate must have a `left` and `right`"""
-        self._left = left
-        self._right = right
+    def __init__(self, term, literal):
+        """A concrete predicate must have a `term` and `literal`"""
+        self._term = term
+        self._literal = literal
 
 
 class UnboundPredicate:
-    def __init__(self, left, right):
-        """A concrete predicate must have a `left` and `right`"""
-        self._left = left
-        self._right = right
+    def __init__(self, term, literal):
+        """A concrete predicate must have a `term` and `literal`"""
+        self._term = term
+        self._literal = literal
 
     @abstractmethod
     def bind(self, schema: Schema, case_sensitive: bool) -> BoundPredicate:

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -292,7 +292,7 @@ class In(BooleanExpression, BoundPredicate):
         return f"({self.left} in {self.right})"
 
     def eval(self, struct: StructProtocol):
-        return self.ref.eval(struct)
+        return self.left.eval(struct)
 
 
 class BoundReference:
@@ -312,6 +312,9 @@ class BoundReference:
 
     def __repr__(self):
         return f"BoundReference(field={repr(self.field)}, accessor={repr(self._accessor)})"
+
+    def __eq__(self, other) -> bool:
+        return id(self) == id(other) or (self.field == other.field and self.accessor == other.accessor)
 
     @property
     def field(self) -> NestedField:
@@ -350,6 +353,9 @@ class UnboundReference:
 
     def __repr__(self) -> str:
         return f"UnboundReference(name={repr(self.name)})"
+
+    def __eq__(self, other) -> bool:
+        return id(self) == id(other) or self.name == other.name
 
     @property
     def name(self) -> str:

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -249,19 +249,19 @@ class UnboundIn(BooleanExpression, UnboundPredicate):
         return self._right
 
     def __eq__(self, other) -> bool:
-        return id(self) == id(other) or (isinstance(other, UnboundIn) and self.ref == other.ref and self.list == other.list)
+        return id(self) == id(other) or (isinstance(other, UnboundIn) and self.left == other.left and self.right == other.right)
 
     def __invert__(self) -> Not:
         return Not(self)
 
     def __repr__(self) -> str:
-        return f"UnboundIn({repr(self.ref)}, {repr(self.list)})"
+        return f"UnboundIn({repr(self.left)}, {repr(self.right)})"
 
     def __str__(self) -> str:
-        return f"({self.ref} in {self.list})"
+        return f"({self.left} in {self.right})"
 
     def bind(self, schema: Schema, case_sensitive: bool) -> "In":
-        return In(self.ref.bind(schema, case_sensitive), self.list)
+        return In(self.left.bind(schema, case_sensitive), self.right)
 
 
 class In(BooleanExpression, BoundPredicate):
@@ -280,16 +280,16 @@ class In(BooleanExpression, BoundPredicate):
         return self._right
 
     def __eq__(self, other) -> bool:
-        return id(self) == id(other) or (isinstance(other, UnboundIn) and self.ref == other.ref and self.list == other.list)
+        return id(self) == id(other) or (isinstance(other, UnboundIn) and self.left == other.left and self.right == other.right)
 
     def __invert__(self) -> Not:
         return Not(self)
 
     def __repr__(self) -> str:
-        return f"In({repr(self.ref)}, {repr(self.list)})"
+        return f"In({repr(self.left)}, {repr(self.right)})"
 
     def __str__(self) -> str:
-        return f"({self.ref} in {self.list})"
+        return f"({self.left} in {self.right})"
 
     def eval(self, struct: StructProtocol):
         return self.ref.eval(struct)

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -17,7 +17,12 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import reduce, singledispatch
-from typing import Generic, Tuple, TypeVar
+from typing import (
+    Any,
+    Generic,
+    Tuple,
+    TypeVar,
+)
 
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.types import NestedField
@@ -118,6 +123,15 @@ class BoundReference(BoundTerm[T], Reference[T]):
 
     field: NestedField
     accessor: Accessor
+
+    def eval(self, schema: Schema) -> Any:
+        """Returns the value at the referenced field's position in an object that abides by the StructProtocol
+        Args:
+            struct (StructProtocol): A row object that abides by the StructProtocol and returns values given a position
+        Returns:
+            Any: The value at the referenced field's position in `struct`
+        """
+        return self.accessor.get(schema)
 
 
 @dataclass(frozen=True)

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -88,10 +88,6 @@ class BoundPredicate(ABC):
         self._left = left
         self._right = right
 
-    @abstractmethod
-    def eval(self, struct: StructProtocol) -> bool:
-        """Evaluate the bound predicate"""
-
 
 class UnboundPredicate:
     def __init__(self, left, right):
@@ -235,7 +231,7 @@ class AlwaysFalse(BooleanExpression, ABC, Singleton):
 
 
 @dataclass
-class UnboundIn(BooleanExpression, UnboundPredicate):
+class In(BooleanExpression, UnboundPredicate):
     term: "UnboundReference"
     literal: List[Literal]
 
@@ -254,9 +250,6 @@ class BoundIn(BooleanExpression, BoundPredicate):
 
     def __invert__(self):
         raise TypeError("In expressions do not support negation.")
-
-    def eval(self, struct: StructProtocol):
-        return self.term.eval(struct)
 
 
 @dataclass

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -236,7 +236,7 @@ class AlwaysFalse(BooleanExpression, ABC, Singleton):
 class UnboundIn(BooleanExpression, UnboundPredicate):
     """IN operation expression"""
 
-    def __init__(self, left: "UnboundReference", right: List[Literal]):
+    def __init__(self, left: "UnboundReference", right: List[Literal]):  # pylint: disable=super-init-not-called
         self._left = left
         self._right = right
 

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -46,7 +46,7 @@ class Literal(Generic[T], ABC):
         return self._value  # type: ignore
 
     @abstractmethod
-    def to(self, type_var):
+    def to(self, type_var) -> "Literal":
         ...  # pragma: no cover
 
     def __repr__(self):
@@ -243,12 +243,12 @@ class UnboundIn(BooleanExpression, UnboundPredicate):
         raise TypeError("In expressions do not support negation.")
 
     def bind(self, schema: Schema, case_sensitive: bool) -> "In":
-        return In(self.term.bind(schema, case_sensitive), self.literal)
+        bound_ref = self.term.bind(schema, case_sensitive)
+        return In(bound_ref, [lit.to(bound_ref.field.field_type) for lit in self.literal])
 
 
+@dataclass
 class In(BooleanExpression, BoundPredicate):
-    """IN operation expression"""
-
     term: "BoundReference"
     literal: List[Literal]
 

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -241,11 +241,11 @@ class UnboundIn(BooleanExpression, UnboundPredicate):
         self._right = right
 
     @property
-    def ref(self) -> "UnboundReference":
+    def left(self) -> "UnboundReference":
         return self._left
 
     @property
-    def list(self) -> List[Literal]:
+    def right(self) -> List[Literal]:
         return self._right
 
     def __eq__(self, other) -> bool:
@@ -272,11 +272,11 @@ class In(BooleanExpression, BoundPredicate):
         self._right = right
 
     @property
-    def ref(self) -> "BoundReference":
+    def left(self) -> "BoundReference":
         return self._left
 
     @property
-    def list(self) -> List[Literal]:
+    def right(self) -> List[Literal]:
         return self._right
 
     def __eq__(self, other) -> bool:

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -24,6 +24,7 @@ from typing import (
     TypeVar,
 )
 
+from pyiceberg.files import StructProtocol
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.types import NestedField
 from pyiceberg.utils.singleton import Singleton
@@ -84,7 +85,7 @@ class BooleanExpression(ABC):
 class Bound(Generic[T], ABC):
     """Represents a bound value expression."""
 
-    def eval(self, schema: Schema):  # pylint: disable=W0613
+    def eval(self, struct: StructProtocol):  # pylint: disable=W0613
         ...  # pragma: no cover
 
 
@@ -124,14 +125,14 @@ class BoundReference(BoundTerm[T], Reference[T]):
     field: NestedField
     accessor: Accessor
 
-    def eval(self, schema: Schema) -> Any:
+    def eval(self, struct: StructProtocol) -> Any:
         """Returns the value at the referenced field's position in an object that abides by the StructProtocol
         Args:
             struct (StructProtocol): A row object that abides by the StructProtocol and returns values given a position
         Returns:
             Any: The value at the referenced field's position in `struct`
         """
-        return self.accessor.get(schema)
+        return self.accessor.get(struct)
 
 
 @dataclass(frozen=True)

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -267,7 +267,7 @@ class UnboundIn(BooleanExpression, UnboundPredicate):
 class In(BooleanExpression, BoundPredicate):
     """IN operation expression"""
 
-    def __init__(self, left: "BoundReference", right: List[Literal]):
+    def __init__(self, left: "BoundReference", right: List[Literal]):  # pylint: disable=super-init-not-called
         self._left = left
         self._right = right
 

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -26,44 +26,6 @@ from pyiceberg.types import NestedField, StringType
 from pyiceberg.utils.singleton import Singleton
 
 
-@pytest.mark.parametrize(
-    "operation,opposite_operation",
-    [
-        (base.Operation.TRUE, base.Operation.FALSE),
-        (base.Operation.FALSE, base.Operation.TRUE),
-        (base.Operation.IS_NULL, base.Operation.NOT_NULL),
-        (base.Operation.NOT_NULL, base.Operation.IS_NULL),
-        (base.Operation.IS_NAN, base.Operation.NOT_NAN),
-        (base.Operation.NOT_NAN, base.Operation.IS_NAN),
-        (base.Operation.LT, base.Operation.GT_EQ),
-        (base.Operation.LT_EQ, base.Operation.GT),
-        (base.Operation.GT, base.Operation.LT_EQ),
-        (base.Operation.GT_EQ, base.Operation.LT),
-        (base.Operation.EQ, base.Operation.NOT_EQ),
-        (base.Operation.NOT_EQ, base.Operation.EQ),
-        (base.Operation.IN, base.Operation.NOT_IN),
-        (base.Operation.NOT_IN, base.Operation.IN),
-    ],
-)
-def test_negation_of_operations(operation, opposite_operation):
-    assert operation.negate() == opposite_operation
-
-
-@pytest.mark.parametrize(
-    "operation",
-    [
-        base.Operation.NOT,
-        base.Operation.AND,
-        base.Operation.OR,
-    ],
-)
-def test_raise_on_no_negation_for_operation(operation):
-    with pytest.raises(ValueError) as exc_info:
-        operation.negate()
-
-    assert str(exc_info.value) == f"No negation defined for operation {operation}"
-
-
 class TestExpressionA(base.BooleanExpression, Singleton):
     def __invert__(self):
         return TestExpressionB()

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -142,25 +142,25 @@ def test_strs(op, string):
     "a,  schema, case_sensitive, success",
     [
         (
-            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             True,
             True,
         ),
         (
-            base.In(base.UnboundReference("not_foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("not_foo"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             False,
             False,
         ),
         (
-            base.In(base.UnboundReference("Bar"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("Bar"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             False,
             True,
         ),
         (
-            base.In(base.UnboundReference("Bar"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("Bar"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             True,
             False,
@@ -193,14 +193,14 @@ def test_bind(a, schema, case_sensitive, success, request):
         (ExpressionA(), ExpressionA(), ExpressionB()),
         (ExpressionB(), ExpressionB(), ExpressionA()),
         (
-            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
-            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
-            base.In(base.UnboundReference("not_foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("not_foo"), (literal("hello"), literal("world"))),
         ),
         (
-            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
-            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
-            base.In(base.UnboundReference("foo"), (literal("goodbye"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.Reference("foo"), (literal("goodbye"), literal("world"))),
         ),
     ],
 )
@@ -214,7 +214,7 @@ def test_eq(exp, testexpra, testexprb):
         (base.And(ExpressionA(), ExpressionB()), base.Or(ExpressionB(), ExpressionA()), False),
         (base.Or(ExpressionA(), ExpressionB()), base.And(ExpressionB(), ExpressionA()), False),
         (base.Not(ExpressionA()), ExpressionA(), False),
-        (base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))), None, True),
+        (base.In(base.Reference("foo"), (literal("hello"), literal("world"))), None, True),
         (ExpressionA(), ExpressionB(), False),
     ],
 )

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -19,7 +19,6 @@ import uuid
 from decimal import Decimal
 from typing import List
 
-import iceberg.expressions.literals as literals
 import pytest
 
 from pyiceberg.expressions import base
@@ -167,7 +166,7 @@ def test_strs(op, string):
             False,
         ),
         (
-            base.UnboundIn(base.UnboundReference("location.latitude"), [literals.DecimalLiteral(Decimal('3'))]),
+            base.UnboundIn(base.UnboundReference("location.latitude"), [literals.DecimalLiteral(Decimal("3"))]),
             "table_schema_nested",
             True,
             True,
@@ -177,7 +176,7 @@ def test_strs(op, string):
 def test_bind(a, schema, case_sensitive, success, request):
     schema = request.getfixturevalue(schema)
     if success:
-        assert a.bind(schema, case_sensitive).term == schema.find_field(a.term.name)
+        assert a.bind(schema, case_sensitive).term.field == schema.find_field(a.term.name, case_sensitive)
     else:
         with pytest.raises(ValueError):
             a.bind(schema, case_sensitive)

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -27,29 +27,29 @@ from pyiceberg.types import NestedField, StringType
 from pyiceberg.utils.singleton import Singleton
 
 
-class TestExpressionA(base.BooleanExpression, Singleton):
+class ExpressionA(base.BooleanExpression, Singleton):
     def __invert__(self):
-        return TestExpressionB()
+        return ExpressionB()
 
     def __repr__(self):
-        return "TestExpressionA()"
+        return "ExpressionA()"
 
     def __str__(self):
         return "testexpra"
 
 
-class TestExpressionB(base.BooleanExpression, Singleton):
+class ExpressionB(base.BooleanExpression, Singleton):
     def __invert__(self):
-        return TestExpressionA()
+        return ExpressionA()
 
     def __repr__(self):
-        return "TestExpressionB()"
+        return "ExpressionB()"
 
     def __str__(self):
         return "testexprb"
 
 
-class TestBooleanExpressionVisitor(base.BooleanExpressionVisitor[List]):
+class BooleanExpressionVisitor(base.BooleanExpressionVisitor[List]):
     """A test implementation of a BooleanExpressionVisit
 
     As this visitor visits each node, it appends an element to a `visit_histor` list. This enables testing that a given expression is
@@ -88,23 +88,23 @@ class TestBooleanExpressionVisitor(base.BooleanExpressionVisitor[List]):
         return self.visit_history
 
     def visit_test_expression_a(self) -> List:
-        self.visit_history.append("TestExpressionA")
+        self.visit_history.append("ExpressionA")
         return self.visit_history
 
     def visit_test_expression_b(self) -> List:
-        self.visit_history.append("TestExpressionB")
+        self.visit_history.append("ExpressionB")
         return self.visit_history
 
 
-@base.visit.register(TestExpressionA)
-def _(obj: TestExpressionA, visitor: TestBooleanExpressionVisitor) -> List:
-    """Visit a TestExpressionA with a TestBooleanExpressionVisitor"""
+@base.visit.register(ExpressionA)
+def _(obj: ExpressionA, visitor: BooleanExpressionVisitor) -> List:
+    """Visit a ExpressionA with a BooleanExpressionVisitor"""
     return visitor.visit_test_expression_a()
 
 
-@base.visit.register(TestExpressionB)
-def _(obj: TestExpressionB, visitor: TestBooleanExpressionVisitor) -> List:
-    """Visit a TestExpressionB with a TestBooleanExpressionVisitor"""
+@base.visit.register(ExpressionB)
+def _(obj: ExpressionB, visitor: BooleanExpressionVisitor) -> List:
+    """Visit a ExpressionB with a BooleanExpressionVisitor"""
     return visitor.visit_test_expression_b()
 
 
@@ -112,14 +112,14 @@ def _(obj: TestExpressionB, visitor: TestBooleanExpressionVisitor) -> List:
     "op, rep",
     [
         (
-            base.And(TestExpressionA(), TestExpressionB()),
-            "And(TestExpressionA(), TestExpressionB())",
+            base.And(ExpressionA(), ExpressionB()),
+            "And(ExpressionA(), ExpressionB())",
         ),
         (
-            base.Or(TestExpressionA(), TestExpressionB()),
-            "Or(TestExpressionA(), TestExpressionB())",
+            base.Or(ExpressionA(), ExpressionB()),
+            "Or(ExpressionA(), ExpressionB())",
         ),
-        (base.Not(TestExpressionA()), "Not(TestExpressionA())"),
+        (base.Not(ExpressionA()), "Not(ExpressionA())"),
     ],
 )
 def test_reprs(op, rep):
@@ -129,84 +129,79 @@ def test_reprs(op, rep):
 @pytest.mark.parametrize(
     "op, string",
     [
-        (base.And(TestExpressionA(), TestExpressionB()), "(testexpra and testexprb)"),
-        (base.Or(TestExpressionA(), TestExpressionB()), "(testexpra or testexprb)"),
-        (base.Not(TestExpressionA()), "(not testexpra)"),
+        (base.And(ExpressionA(), ExpressionB()), "(testexpra and testexprb)"),
+        (base.Or(ExpressionA(), ExpressionB()), "(testexpra or testexprb)"),
+        (base.Not(ExpressionA()), "(not testexpra)"),
     ],
 )
 def test_strs(op, string):
     assert str(op) == string
 
 
-@pytest.mark.parametrize(
-    "a,  schema, case_sensitive, success",
-    [
-        (
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            "table_schema_simple",
-            True,
-            True,
-        ),
-        (
-            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
-            "table_schema_simple",
-            False,
-            False,
-        ),
-        (
-            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
-            "table_schema_simple",
-            False,
-            True,
-        ),
-        (
-            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
-            "table_schema_simple",
-            True,
-            False,
-        ),
-        (
-            base.In(base.UnboundReference("location.latitude"), [literals.DecimalLiteral(Decimal("3"))]),
-            "table_schema_nested",
-            True,
-            True,
-        ),
-    ],
-)
-def test_bind(a, schema, case_sensitive, success, request):
-    schema = request.getfixturevalue(schema)
-    if success:
-        assert a.bind(schema, case_sensitive).term.field == schema.find_field(a.term.name, case_sensitive)
-    else:
-        with pytest.raises(ValueError):
-            a.bind(schema, case_sensitive)
+# @pytest.mark.parametrize(
+#     "a,  schema, case_sensitive, success",
+#     [
+#         (
+#             base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+#             "table_schema_simple",
+#             True,
+#             True,
+#         ),
+#         (
+#             base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+#             "table_schema_simple",
+#             False,
+#             False,
+#         ),
+#         (
+#             base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+#             "table_schema_simple",
+#             False,
+#             True,
+#         ),
+#         (
+#             base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+#             "table_schema_simple",
+#             True,
+#             False,
+#         ),
+
+#     ],
+# )
+# def test_bind(a, schema, case_sensitive, success, request):
+#     schema = request.getfixturevalue(schema)
+#     if success:
+#         assert a.bind(schema, case_sensitive).term.field == schema.find_field(a.term.name, case_sensitive)
+#     else:
+#         with pytest.raises(ValueError):
+#             a.bind(schema, case_sensitive)
 
 
 @pytest.mark.parametrize(
     "exp, testexpra, testexprb",
     [
         (
-            base.And(TestExpressionA(), TestExpressionB()),
-            base.And(TestExpressionA(), TestExpressionB()),
-            base.Or(TestExpressionA(), TestExpressionB()),
+            base.And(ExpressionA(), ExpressionB()),
+            base.And(ExpressionA(), ExpressionB()),
+            base.Or(ExpressionA(), ExpressionB()),
         ),
         (
-            base.Or(TestExpressionA(), TestExpressionB()),
-            base.Or(TestExpressionA(), TestExpressionB()),
-            base.And(TestExpressionA(), TestExpressionB()),
+            base.Or(ExpressionA(), ExpressionB()),
+            base.Or(ExpressionA(), ExpressionB()),
+            base.And(ExpressionA(), ExpressionB()),
         ),
-        (base.Not(TestExpressionA()), base.Not(TestExpressionA()), TestExpressionB()),
-        (TestExpressionA(), TestExpressionA(), TestExpressionB()),
-        (TestExpressionB(), TestExpressionB(), TestExpressionA()),
+        (base.Not(ExpressionA()), base.Not(ExpressionA()), ExpressionB()),
+        (ExpressionA(), ExpressionA(), ExpressionB()),
+        (ExpressionB(), ExpressionB(), ExpressionA()),
         (
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.UnboundReference("not_foo"), (literal("hello"), literal("world"))),
         ),
         (
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.In(base.UnboundReference("foo"), [literal("goodbye"), literal("world")]),
+            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
+            base.In(base.UnboundReference("foo"), (literal("goodbye"), literal("world"))),
         ),
     ],
 )
@@ -217,11 +212,11 @@ def test_eq(exp, testexpra, testexprb):
 @pytest.mark.parametrize(
     "lhs, rhs, raises",
     [
-        (base.And(TestExpressionA(), TestExpressionB()), base.Or(TestExpressionB(), TestExpressionA()), False),
-        (base.Or(TestExpressionA(), TestExpressionB()), base.And(TestExpressionB(), TestExpressionA()), False),
-        (base.Not(TestExpressionA()), TestExpressionA(), False),
-        (base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]), None, True),
-        (TestExpressionA(), TestExpressionB(), False),
+        (base.And(ExpressionA(), ExpressionB()), base.Or(ExpressionB(), ExpressionA()), False),
+        (base.Or(ExpressionA(), ExpressionB()), base.And(ExpressionB(), ExpressionA()), False),
+        (base.Not(ExpressionA()), ExpressionA(), False),
+        (base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))), None, True),
+        (ExpressionA(), ExpressionB(), False),
     ],
 )
 def test_negate(lhs, rhs, raises):
@@ -229,21 +224,21 @@ def test_negate(lhs, rhs, raises):
         assert ~lhs == rhs
     else:
         with pytest.raises(TypeError):
-            ~lhs
+            ~lhs  # pylint: disable=W0104
 
 
 @pytest.mark.parametrize(
     "lhs, rhs",
     [
         (
-            base.And(TestExpressionA(), TestExpressionB(), TestExpressionA()),
-            base.And(base.And(TestExpressionA(), TestExpressionB()), TestExpressionA()),
+            base.And(ExpressionA(), ExpressionB(), ExpressionA()),
+            base.And(base.And(ExpressionA(), ExpressionB()), ExpressionA()),
         ),
         (
-            base.Or(TestExpressionA(), TestExpressionB(), TestExpressionA()),
-            base.Or(base.Or(TestExpressionA(), TestExpressionB()), TestExpressionA()),
+            base.Or(ExpressionA(), ExpressionB(), ExpressionA()),
+            base.Or(base.Or(ExpressionA(), ExpressionB()), ExpressionA()),
         ),
-        (base.Not(base.Not(TestExpressionA())), TestExpressionA()),
+        (base.Not(base.Not(ExpressionA())), ExpressionA()),
     ],
 )
 def test_reduce(lhs, rhs):
@@ -253,11 +248,11 @@ def test_reduce(lhs, rhs):
 @pytest.mark.parametrize(
     "lhs, rhs",
     [
-        (base.And(base.AlwaysTrue(), TestExpressionB()), TestExpressionB()),
-        (base.And(base.AlwaysFalse(), TestExpressionB()), base.AlwaysFalse()),
-        (base.Or(base.AlwaysTrue(), TestExpressionB()), base.AlwaysTrue()),
-        (base.Or(base.AlwaysFalse(), TestExpressionB()), TestExpressionB()),
-        (base.Not(base.Not(TestExpressionA())), TestExpressionA()),
+        (base.And(base.AlwaysTrue(), ExpressionB()), ExpressionB()),
+        (base.And(base.AlwaysFalse(), ExpressionB()), base.AlwaysFalse()),
+        (base.Or(base.AlwaysTrue(), ExpressionB()), base.AlwaysTrue()),
+        (base.Or(base.AlwaysFalse(), ExpressionB()), ExpressionB()),
+        (base.Not(base.Not(ExpressionA())), ExpressionA()),
     ],
 )
 def test_base_AlwaysTrue_base_AlwaysFalse(lhs, rhs):
@@ -313,59 +308,59 @@ def test_bound_reference_field_property():
     assert bound_ref.field == NestedField(field_id=1, name="foo", field_type=StringType(), required=False)
 
 
-def test_bound_reference(table_schema_simple, foo_struct):
-    """Test creating a BoundReference and evaluating it on a StructProtocol"""
-    foo_struct.set(pos=1, value="foovalue")
-    foo_struct.set(pos=2, value=123)
-    foo_struct.set(pos=3, value=True)
+# def test_bound_reference(table_schema_simple, foo_struct):
+#     """Test creating a BoundReference and evaluating it on a StructProtocol"""
+#     foo_struct.set(pos=1, value="foovalue")
+#     foo_struct.set(pos=2, value=123)
+#     foo_struct.set(pos=3, value=True)
 
-    position1_accessor = base.Accessor(position=1)
-    position2_accessor = base.Accessor(position=2)
-    position3_accessor = base.Accessor(position=3)
+#     position1_accessor = base.Accessor(position=1)
+#     position2_accessor = base.Accessor(position=2)
+#     position3_accessor = base.Accessor(position=3)
 
-    field1 = table_schema_simple.find_field(1)
-    field2 = table_schema_simple.find_field(2)
-    field3 = table_schema_simple.find_field(3)
+#     field1 = table_schema_simple.find_field(1)
+#     field2 = table_schema_simple.find_field(2)
+#     field3 = table_schema_simple.find_field(3)
 
-    bound_ref1 = base.BoundReference(field=field1, accessor=position1_accessor)
-    bound_ref2 = base.BoundReference(field=field2, accessor=position2_accessor)
-    bound_ref3 = base.BoundReference(field=field3, accessor=position3_accessor)
+#     bound_ref1 = base.BoundReference(field=field1, accessor=position1_accessor)
+#     bound_ref2 = base.BoundReference(field=field2, accessor=position2_accessor)
+#     bound_ref3 = base.BoundReference(field=field3, accessor=position3_accessor)
 
-    assert bound_ref1.eval(foo_struct) == "foovalue"
-    assert bound_ref2.eval(foo_struct) == 123
-    assert bound_ref3.eval(foo_struct) is True
+#     assert bound_ref1.eval(foo_struct) == "foovalue"
+#     assert bound_ref2.eval(foo_struct) == 123
+#     assert bound_ref3.eval(foo_struct) is True
 
 
 def test_boolean_expression_visitor():
     """Test post-order traversal of boolean expression visit method"""
     expr = base.And(
-        base.Or(base.Not(TestExpressionA()), base.Not(TestExpressionB()), TestExpressionA(), TestExpressionB()),
-        base.Not(TestExpressionA()),
-        TestExpressionB(),
+        base.Or(base.Not(ExpressionA()), base.Not(ExpressionB()), ExpressionA(), ExpressionB()),
+        base.Not(ExpressionA()),
+        ExpressionB(),
     )
-    visitor = TestBooleanExpressionVisitor()
+    visitor = BooleanExpressionVisitor()
     result = base.visit(expr, visitor=visitor)
     assert result == [
-        "TestExpressionA",
+        "ExpressionA",
         "NOT",
-        "TestExpressionB",
+        "ExpressionB",
         "NOT",
         "OR",
-        "TestExpressionA",
+        "ExpressionA",
         "OR",
-        "TestExpressionB",
+        "ExpressionB",
         "OR",
-        "TestExpressionA",
+        "ExpressionA",
         "NOT",
         "AND",
-        "TestExpressionB",
+        "ExpressionB",
         "AND",
     ]
 
 
 def test_boolean_expression_visit_raise_not_implemented_error():
     """Test raise NotImplementedError when visiting an unsupported object type"""
-    visitor = TestBooleanExpressionVisitor()
+    visitor = BooleanExpressionVisitor()
     with pytest.raises(NotImplementedError) as exc_info:
         base.visit("foo", visitor=visitor)
 

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -138,43 +138,43 @@ def test_strs(op, string):
     assert str(op) == string
 
 
-# @pytest.mark.parametrize(
-#     "a,  schema, case_sensitive, success",
-#     [
-#         (
-#             base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-#             "table_schema_simple",
-#             True,
-#             True,
-#         ),
-#         (
-#             base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
-#             "table_schema_simple",
-#             False,
-#             False,
-#         ),
-#         (
-#             base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
-#             "table_schema_simple",
-#             False,
-#             True,
-#         ),
-#         (
-#             base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
-#             "table_schema_simple",
-#             True,
-#             False,
-#         ),
+@pytest.mark.parametrize(
+    "a,  schema, case_sensitive, success",
+    [
+        (
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            "table_schema_simple",
+            True,
+            True,
+        ),
+        (
+            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+            "table_schema_simple",
+            False,
+            False,
+        ),
+        (
+            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            "table_schema_simple",
+            False,
+            True,
+        ),
+        (
+            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            "table_schema_simple",
+            True,
+            False,
+        ),
 
-#     ],
-# )
-# def test_bind(a, schema, case_sensitive, success, request):
-#     schema = request.getfixturevalue(schema)
-#     if success:
-#         assert a.bind(schema, case_sensitive).term.field == schema.find_field(a.term.name, case_sensitive)
-#     else:
-#         with pytest.raises(ValueError):
-#             a.bind(schema, case_sensitive)
+    ],
+)
+def test_bind(a, schema, case_sensitive, success, request):
+    schema = request.getfixturevalue(schema)
+    if success:
+        assert a.bind(schema, case_sensitive).term.field == schema.find_field(a.term.name, case_sensitive)
+    else:
+        with pytest.raises(ValueError):
+            a.bind(schema, case_sensitive)
 
 
 @pytest.mark.parametrize(
@@ -308,27 +308,27 @@ def test_bound_reference_field_property():
     assert bound_ref.field == NestedField(field_id=1, name="foo", field_type=StringType(), required=False)
 
 
-# def test_bound_reference(table_schema_simple, foo_struct):
-#     """Test creating a BoundReference and evaluating it on a StructProtocol"""
-#     foo_struct.set(pos=1, value="foovalue")
-#     foo_struct.set(pos=2, value=123)
-#     foo_struct.set(pos=3, value=True)
+def test_bound_reference(table_schema_simple, foo_struct):
+    """Test creating a BoundReference and evaluating it on a StructProtocol"""
+    foo_struct.set(pos=1, value="foovalue")
+    foo_struct.set(pos=2, value=123)
+    foo_struct.set(pos=3, value=True)
 
-#     position1_accessor = base.Accessor(position=1)
-#     position2_accessor = base.Accessor(position=2)
-#     position3_accessor = base.Accessor(position=3)
+    position1_accessor = base.Accessor(position=1)
+    position2_accessor = base.Accessor(position=2)
+    position3_accessor = base.Accessor(position=3)
 
-#     field1 = table_schema_simple.find_field(1)
-#     field2 = table_schema_simple.find_field(2)
-#     field3 = table_schema_simple.find_field(3)
+    field1 = table_schema_simple.find_field(1)
+    field2 = table_schema_simple.find_field(2)
+    field3 = table_schema_simple.find_field(3)
 
-#     bound_ref1 = base.BoundReference(field=field1, accessor=position1_accessor)
-#     bound_ref2 = base.BoundReference(field=field2, accessor=position2_accessor)
-#     bound_ref3 = base.BoundReference(field=field3, accessor=position3_accessor)
+    bound_ref1 = base.BoundReference(field=field1, accessor=position1_accessor)
+    bound_ref2 = base.BoundReference(field=field2, accessor=position2_accessor)
+    bound_ref3 = base.BoundReference(field=field3, accessor=position3_accessor)
 
-#     assert bound_ref1.eval(foo_struct) == "foovalue"
-#     assert bound_ref2.eval(foo_struct) == 123
-#     assert bound_ref3.eval(foo_struct) is True
+    assert bound_ref1.eval(foo_struct) == "foovalue"
+    assert bound_ref2.eval(foo_struct) == 123
+    assert bound_ref3.eval(foo_struct) is True
 
 
 def test_boolean_expression_visitor():

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -142,30 +142,29 @@ def test_strs(op, string):
     "a,  schema, case_sensitive, success",
     [
         (
-            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             True,
             True,
         ),
         (
-            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("not_foo"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             False,
             False,
         ),
         (
-            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("Bar"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             False,
             True,
         ),
         (
-            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("Bar"), (literal("hello"), literal("world"))),
             "table_schema_simple",
             True,
             False,
         ),
-
     ],
 )
 def test_bind(a, schema, case_sensitive, success, request):

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -142,31 +142,31 @@ def test_strs(op, string):
     "a,  schema, case_sensitive, success",
     [
         (
-            base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
             "table_schema_simple",
             True,
             True,
         ),
         (
-            base.UnboundIn(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
             "table_schema_simple",
             False,
             False,
         ),
         (
-            base.UnboundIn(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
             "table_schema_simple",
             False,
             True,
         ),
         (
-            base.UnboundIn(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("Bar"), [literal("hello"), literal("world")]),
             "table_schema_simple",
             True,
             False,
         ),
         (
-            base.UnboundIn(base.UnboundReference("location.latitude"), [literals.DecimalLiteral(Decimal("3"))]),
+            base.In(base.UnboundReference("location.latitude"), [literals.DecimalLiteral(Decimal("3"))]),
             "table_schema_nested",
             True,
             True,
@@ -199,14 +199,14 @@ def test_bind(a, schema, case_sensitive, success, request):
         (TestExpressionA(), TestExpressionA(), TestExpressionB()),
         (TestExpressionB(), TestExpressionB(), TestExpressionA()),
         (
-            base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.UnboundIn(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("not_foo"), [literal("hello"), literal("world")]),
         ),
         (
-            base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
-            base.UnboundIn(base.UnboundReference("foo"), [literal("goodbye"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]),
+            base.In(base.UnboundReference("foo"), [literal("goodbye"), literal("world")]),
         ),
     ],
 )
@@ -220,7 +220,7 @@ def test_eq(exp, testexpra, testexprb):
         (base.And(TestExpressionA(), TestExpressionB()), base.Or(TestExpressionB(), TestExpressionA()), False),
         (base.Or(TestExpressionA(), TestExpressionB()), base.And(TestExpressionB(), TestExpressionA()), False),
         (base.Not(TestExpressionA()), TestExpressionA(), False),
-        (base.UnboundIn(base.UnboundReference("foo"), [literal("hello"), literal("world")]), None, True),
+        (base.In(base.UnboundReference("foo"), [literal("hello"), literal("world")]), None, True),
         (TestExpressionA(), TestExpressionB(), False),
     ],
 )


### PR DESCRIPTION
@samredai @rdblue 
Opening a draft PR introducing the `In` expression to get confirmation of the api. 

Is `def __init__(self, ref: 'UnboundReference', list: List[Literal]):` the correct signature?

I'll add the tests next and if this PR succeeds I will add the remaining boolean expressions