### PR TITLE
[Core][Spark] Improve DeleteOrphanFiles action to return additional details of deleted orphan files

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -30,7 +30,9 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method java.lang.Iterable<org.apache.iceberg.actions.DeleteOrphanFiles.OrphanFileStatus>\
         \ org.apache.iceberg.actions.DeleteOrphanFiles.Result::orphanFiles()"
-      justification: "Accept all changes prior to introducing API compatibility checks"
+      justification: "Introduced improved API to represent results of DeleteOrphanFiles\
+        \ action. The new API will allow users to gracefully deal with failure encountered\
+        \ during file deletion"
     - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedEqualityDeleteFilesCount()"
       justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -28,6 +28,10 @@ acceptedBreaks:
       new: "method ThisT org.apache.iceberg.SnapshotUpdate<ThisT>::scanManifestsWith(java.util.concurrent.ExecutorService)"
       justification: "Accept all changes prior to introducing API compatibility checks"
     - code: "java.method.addedToInterface"
+      new: "method java.lang.Iterable<org.apache.iceberg.actions.DeleteOrphanFiles.OrphanFileStatus>\
+        \ org.apache.iceberg.actions.DeleteOrphanFiles.Result::orphanFiles()"
+      justification: "Accept all changes prior to introducing API compatibility checks"
+    - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedEqualityDeleteFilesCount()"
       justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"
     - code: "java.method.addedToInterface"

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -85,8 +85,26 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
    */
   interface Result {
     /**
-     * Returns locations of orphan files.
+     * Returns orphan files.
      */
-    Iterable<String> orphanFileLocations();
+    Iterable<OrphanFileStatus> orphanFiles();
+  }
+
+  interface OrphanFileStatus {
+
+    /**
+     * Returns the location of the orphan file.
+     */
+    String location();
+
+    /**
+     * Returns whether the orphan file was successfully deleted or not.
+     */
+    boolean deleted();
+
+    /**
+     * Returns the exception that occurred while deleting the file, else returns null.
+     */
+    Exception failureCause();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -85,6 +85,13 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
    */
   interface Result {
     /**
+     * @deprecated since 0.14.0, will be removed in 0.15.0; use {@link #orphanFiles()} instead.
+     * Returns locations of orphan files.
+     */
+    @Deprecated
+    Iterable<String> orphanFileLocations();
+
+    /**
      * Returns orphan files.
      */
     Iterable<OrphanFileStatus> orphanFiles();

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
@@ -21,14 +21,14 @@ package org.apache.iceberg.actions;
 
 public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
 
-  private final Iterable<String> orphanFileLocations;
+  private final Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileLocations;
 
-  public BaseDeleteOrphanFilesActionResult(Iterable<String> orphanFileLocations) {
+  public BaseDeleteOrphanFilesActionResult(Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileLocations) {
     this.orphanFileLocations = orphanFileLocations;
   }
 
   @Override
-  public Iterable<String> orphanFileLocations() {
+  public Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFiles() {
     return orphanFileLocations;
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -222,14 +222,22 @@ public class BaseDeleteOrphanFilesSparkAction
         .as(Encoders.STRING())
         .collectAsList();
 
+    List<DeleteOrphanFiles.OrphanFileStatus> orphanFileStatuses = Lists.newArrayListWithCapacity(orphanFiles.size());
+
     Tasks.foreach(orphanFiles)
         .noRetry()
         .executeWith(deleteExecutorService)
         .suppressFailureWhenFinished()
-        .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
-        .run(deleteFunc::accept);
+        .onFailure((file, exc) -> {
+          LOG.warn("Failed to delete file: {}", file, exc);
+          orphanFileStatuses.add(new BaseOrphanFileStatus(file, /* deleted = */ false, exc));
+        })
+        .run((file) -> {
+          deleteFunc.accept(file);
+          orphanFileStatuses.add(new BaseOrphanFileStatus(file));
+        });
 
-    return new BaseDeleteOrphanFilesActionResult(orphanFiles);
+    return new BaseDeleteOrphanFilesActionResult(orphanFileStatuses);
   }
 
   private Dataset<Row> buildActualFileDF() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -230,7 +230,7 @@ public class BaseDeleteOrphanFilesSparkAction
         .suppressFailureWhenFinished()
         .onFailure((file, exc) -> {
           LOG.warn("Failed to delete file: {}", file, exc);
-          orphanFileStatuses.add(new BaseOrphanFileStatus(file, /* deleted = */ false, exc));
+          orphanFileStatuses.add(new BaseOrphanFileStatus(file, /* deleted */ false, exc));
         })
         .run((file) -> {
           deleteFunc.accept(file);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
@@ -17,28 +17,38 @@
  * under the License.
  */
 
-package org.apache.iceberg.actions;
+package org.apache.iceberg.spark.actions;
 
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
 
-public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
+public class BaseOrphanFileStatus implements DeleteOrphanFiles.OrphanFileStatus {
 
-  private final Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileLocations;
+  private final String location;
+  private final boolean deleted;
+  private final Exception failureCause;
 
-  public BaseDeleteOrphanFilesActionResult(Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileLocations) {
-    this.orphanFileLocations = orphanFileLocations;
+  public BaseOrphanFileStatus(String location) {
+    this(location, true, null);
+  }
+
+  public BaseOrphanFileStatus(String location, boolean deleted, Exception failureCause) {
+    this.location = location;
+    this.deleted = deleted;
+    this.failureCause = failureCause;
   }
 
   @Override
-  public Iterable<String> orphanFileLocations() {
-    return StreamSupport.stream(this.orphanFileLocations.spliterator(), false)
-        .map(DeleteOrphanFiles.OrphanFileStatus::location)
-        .collect(Collectors.toList());
+  public String location() {
+    return location;
   }
 
   @Override
-  public Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFiles() {
-    return orphanFileLocations;
+  public boolean deleted() {
+    return deleted;
+  }
+
+  @Override
+  public Exception failureCause() {
+    return failureCause;
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -54,8 +54,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       ProcedureParameter.optional("file_list_view", DataTypes.StringType)
   };
 
-  private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
-      new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty())
+  private static final StructType OUTPUT_TYPE = new StructType(new StructField[] {
+      new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty()),
+      new StructField("deleted", DataTypes.BooleanType, false, Metadata.empty()),
+      new StructField("error_message", DataTypes.StringType, true, Metadata.empty())
   });
 
   public static ProcedureBuilder builder() {
@@ -123,19 +125,23 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
       DeleteOrphanFiles.Result result = action.execute();
 
-      return toOutputRows(result);
+      return toOutputRows(dryRun, result);
     });
   }
 
-  private InternalRow[] toOutputRows(DeleteOrphanFiles.Result result) {
-    Iterable<String> orphanFileLocations = result.orphanFileLocations();
+  private InternalRow[] toOutputRows(boolean dryRun, DeleteOrphanFiles.Result result) {
+    Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileStatuses = result.orphanFiles();
 
-    int orphanFileLocationsCount = Iterables.size(orphanFileLocations);
+    int orphanFileLocationsCount = Iterables.size(orphanFileStatuses);
     InternalRow[] rows = new InternalRow[orphanFileLocationsCount];
 
     int index = 0;
-    for (String fileLocation : orphanFileLocations) {
-      rows[index] = newInternalRow(UTF8String.fromString(fileLocation));
+    for (DeleteOrphanFiles.OrphanFileStatus fileStatus : orphanFileStatuses) {
+      String errorMessage = fileStatus.failureCause() != null ? fileStatus.failureCause().getMessage() : null;
+      // During dry run DeleteOrphanFiles.OrphanFileStatus#deleted() will be ignored and deleted will always be false.
+      // For an actual run, deleted will use the value of DeleteOrphanFiles.OrphanFileStatus#deleted().
+      boolean deleted = !dryRun && fileStatus.deleted();
+      rows[index] = newInternalRow(UTF8String.fromString(fileStatus.location()), deleted, errorMessage);
       index++;
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -141,7 +141,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       // During dry run DeleteOrphanFiles.OrphanFileStatus#deleted() will be ignored and deleted will always be false.
       // For an actual run, deleted will use the value of DeleteOrphanFiles.OrphanFileStatus#deleted().
       boolean deleted = dryRun ? false : fileStatus.deleted();
-      rows[index] = newInternalRow(UTF8String.fromString(fileStatus.location()), deleted, errorMessage);
+      rows[index] = newInternalRow(UTF8String.fromString(fileStatus.location()), deleted,
+          UTF8String.fromString(errorMessage));
       index++;
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -55,9 +55,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[] {
-      new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty()),
-      new StructField("deleted", DataTypes.BooleanType, false, Metadata.empty()),
-      new StructField("error_message", DataTypes.StringType, true, Metadata.empty())
+      new StructField("orphan_file_location", DataTypes.StringType, /* nullable */ false, Metadata.empty()),
+      new StructField("deleted", DataTypes.BooleanType, /* nullable */ false, Metadata.empty()),
+      new StructField("error_message", DataTypes.StringType, /* nullable */ true, Metadata.empty())
   });
 
   public static ProcedureBuilder builder() {
@@ -140,7 +140,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       String errorMessage = fileStatus.failureCause() != null ? fileStatus.failureCause().getMessage() : null;
       // During dry run DeleteOrphanFiles.OrphanFileStatus#deleted() will be ignored and deleted will always be false.
       // For an actual run, deleted will use the value of DeleteOrphanFiles.OrphanFileStatus#deleted().
-      boolean deleted = !dryRun && fileStatus.deleted();
+      boolean deleted = dryRun ? false : fileStatus.deleted();
       rows[index] = newInternalRow(UTF8String.fromString(fileStatus.location()), deleted, errorMessage);
       index++;
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -309,10 +309,10 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFiles()));
     Assert.assertTrue("Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
 
     DeleteReachableFiles baseRemoveFilesSparkAction = sparkActions()
         .deleteReachableFiles(metadataLocation(table))

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -59,9 +59,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     Assert.assertTrue("trash file should be removed",
         StreamSupport.stream(results.orphanFiles().spliterator(), false)
             .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
-    Assert.assertTrue("orphan file deleted status should be true",
-        StreamSupport.stream(results.orphanFiles().spliterator(), false)
-            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    assertDeletedStatusAndFailureCause(results.orphanFiles());
   }
 
   @Test
@@ -88,9 +86,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     Assert.assertTrue("trash file should be removed",
         StreamSupport.stream(results.orphanFiles().spliterator(), false)
             .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
-    Assert.assertTrue("orphan file deleted status should be true",
-        StreamSupport.stream(results.orphanFiles().spliterator(), false)
-            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    assertDeletedStatusAndFailureCause(results.orphanFiles());
   }
 
   @Test
@@ -117,9 +113,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     Assert.assertTrue("trash file should be removed",
         StreamSupport.stream(results.orphanFiles().spliterator(), false)
             .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
-    Assert.assertTrue("orphan file deleted status should be true",
-        StreamSupport.stream(results.orphanFiles().spliterator(), false)
-            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    assertDeletedStatusAndFailureCause(results.orphanFiles());
   }
 
   @Test
@@ -146,9 +140,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     Assert.assertTrue("trash file should be removed",
         StreamSupport.stream(results.orphanFiles().spliterator(), false)
             .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
-    Assert.assertTrue("orphan file deleted status should be true",
-        StreamSupport.stream(results.orphanFiles().spliterator(), false)
-            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    assertDeletedStatusAndFailureCause(results.orphanFiles());
   }
 
   @Test
@@ -175,9 +167,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     Assert.assertTrue("trash file should be removed",
         StreamSupport.stream(results.orphanFiles().spliterator(), false)
             .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
-    Assert.assertTrue("orphan file deleted status should be true",
-        StreamSupport.stream(results.orphanFiles().spliterator(), false)
-            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    assertDeletedStatusAndFailureCause(results.orphanFiles());
   }
 
   @After

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -57,8 +57,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     DeleteOrphanFiles.Result results = SparkActions.get().deleteOrphanFiles(table.table())
         .olderThan(System.currentTimeMillis() + 1000).execute();
     Assert.assertTrue("trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    Assert.assertTrue("orphan file deleted status should be true",
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
   }
 
   @Test
@@ -83,8 +86,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     DeleteOrphanFiles.Result results = SparkActions.get().deleteOrphanFiles(table.table())
         .olderThan(System.currentTimeMillis() + 1000).execute();
     Assert.assertTrue("trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    Assert.assertTrue("orphan file deleted status should be true",
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
   }
 
   @Test
@@ -109,8 +115,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     DeleteOrphanFiles.Result results = SparkActions.get().deleteOrphanFiles(table.table())
         .olderThan(System.currentTimeMillis() + 1000).execute();
     Assert.assertTrue("trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    Assert.assertTrue("orphan file deleted status should be true",
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
   }
 
   @Test
@@ -135,8 +144,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     DeleteOrphanFiles.Result results = SparkActions.get().deleteOrphanFiles(table.table())
         .olderThan(System.currentTimeMillis() + 1000).execute();
     Assert.assertTrue("trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    Assert.assertTrue("orphan file deleted status should be true",
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
   }
 
   @Test
@@ -161,8 +173,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     DeleteOrphanFiles.Result results = SparkActions.get().deleteOrphanFiles(table.table())
         .olderThan(System.currentTimeMillis() + 1000).execute();
     Assert.assertTrue("trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    Assert.assertTrue("orphan file deleted status should be true",
+        StreamSupport.stream(results.orphanFiles().spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
   }
 
   @After

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1302,7 +1302,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         actions().deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis())
             .execute()
-            .orphanFileLocations());
+            .orphanFiles());
   }
 
   protected void shouldHaveACleanCache(Table table) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1459,12 +1459,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .location(table.location() + "/metadata")
         .olderThan(System.currentTimeMillis())
         .execute();
-    Assert.assertTrue("Should not delete any metadata files", Iterables.isEmpty(result1.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any metadata files", Iterables.isEmpty(result1.orphanFiles()));
 
     DeleteOrphanFiles.Result result2 = actions.deleteOrphanFiles(table)
         .olderThan(System.currentTimeMillis())
         .execute();
-    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.orphanFiles()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords = resultDF


### PR DESCRIPTION
## What changes are proposed in this PR?

This PR adds a new Interface `OrphanFileStatus` that indicates if an orphan file was deleted or not. In cases of failure during file deletion, It provides a reference to the encountered exception.

With this additional information, a user can choose to record this failure and retry the deletion process in a controlled fashion in the future.

## Why are the changes are needed?

During the execution of the DeleteOrphanFiles spark action or remove_orphan_files SQL procedure, a failure encountered during deletion of the orphan file is not bubbled up to the user nor is there any indication of the failure in the returned result.

The return value of the Spark action is Iterable<String> and the SQL procedure simply displays a list of orphan files in a table. With this limited information, the only way for the user to know if the orphan file was deleted or not is to
- grep the logs for the warning
- for each of the locations returned in the iterable, query the cloud storage for its existence

https://github.com/apache/iceberg/blob/71282b8ca7d0c703e4fd4ad460821eaec52124ce/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java#L225-L230

https://github.com/apache/iceberg/blob/71282b8ca7d0c703e4fd4ad460821eaec52124ce/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java#L31

https://github.com/apache/iceberg/blob/71282b8ca7d0c703e4fd4ad460821eaec52124ce/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java#L57-L59

One can re-run the expensive delete action to delete the files that failed during the previous delete action run, however, that is not very desirable since re-listing the dir contents to identify the orphan files would result in duplicate work plus wastage of precious API calls. One of the common causes of delete failure in the public cloud is hitting the API quotas and unnecessary re-runs of the delete action can lead to a temporary denial of access to other workloads accessing the same storage resource.

## Output

### Before this change

#### DryRun => true/false
```bash
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => true)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+
|orphan_file_location                                                                                                      |
+--------------------------------------------------------------------------------------------------------------------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|
+--------------------------------------------------------------------------------------------------------------------------+
```

### After this change

#### DryRun => true
```bash
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => true)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|orphan_file_location                                                                                                      |deleted|error_message|
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|false   |null         |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|false   |null         |
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
```

#### DryRun => false
```bash
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => false)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|orphan_file_location                                                                                                      |deleted|error_message|
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|true   |null         |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|true   |null         |
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
```

#### DryRun => false, simulating failure during delete
```bash
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
|orphan_file_location                                                                                                      |deleted|error_message                          |
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-615125af-bfbb-4279-b22b-559dee4f0b13-c000.snappy.parquet|true   |null                                   |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|false  |simulating failure during file deletion|
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
```