### PR TITLE
Python: Fix issue related to Pyenchant with executing linters on Apple Silicons

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -64,7 +64,7 @@ brew install enchant
 ```
 Set environment variable `PYENCHANT_LIBRARY_PATH` to point to the installed enchant library before running `tox`.
 ```shell
-export PYENCHANT_LIBRARY_PATH = /opt/homebrew/lib/libenchant-2.dylib
+export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
 ```
 You can set this environment variable in your `~/.zshrc` or in your IDE to avoid doing it everytime.
 

--- a/python/README.md
+++ b/python/README.md
@@ -52,5 +52,21 @@ Once all three versions are installed, you can set an application-specific pyenv
 pyenv local 3.7.12 3.8.12 3.9.10
 ```
 
+## Pyenchant linter errors on Apple Silicons
+
+If you are using an M1 Mac to run tox, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that you would run into while running `linters`. 
+This happens because python distributions installed by `pyenv` are in the default M1 architecture (aarch64), and can't find a compatible enchant library.  
+As a workaround, you can follow the below steps. 
+
+Install enchant with Homebrew 
+```shell
+brew install enchant
+```
+Set environment variable `PYENCHANT_LIBRARY_PATH` to point to the installed enchant library before running `tox`.
+```shell
+export PYENCHANT_LIBRARY_PATH = /opt/homebrew/lib/libenchant-2.dylib
+```
+You can set this environment variable in your `~/.zshrc` or in your IDE to avoid doing it everytime.
+
 ## Get in Touch
 - [Iceberg community](https://iceberg.apache.org/community/)

--- a/python/README.md
+++ b/python/README.md
@@ -67,6 +67,9 @@ Set environment variable `PYENCHANT_LIBRARY_PATH` to point to the installed ench
 export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib
 ```
 You can set this environment variable in your `~/.zshrc` or in your IDE to avoid doing it everytime.
+```shell
+echo 'export PYENCHANT_LIBRARY_PATH="/opt/homebrew/lib/libenchant-2.dylib"' >> ~/.zshrc
+```
 
 ## Get in Touch
 - [Iceberg community](https://iceberg.apache.org/community/)

--- a/python/README.md
+++ b/python/README.md
@@ -56,7 +56,7 @@ pyenv local 3.7.12 3.8.12 3.9.10
 
 If you are using an M1 Mac to run tox, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that you would run into while running `linters`. 
 This happens because python distributions installed by `pyenv` are in the default M1 architecture (aarch64), and can't find a compatible enchant library.  
-As a workaround, you can follow the below steps. 
+As a workaround, you can follow the steps below:
 
 Install enchant with Homebrew 
 ```shell

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -32,6 +32,10 @@ deps =
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv
+passenv =
+    # Workaround for pyenchant on Apple Silicons
+    # Ref: https://github.com/pyenchant/pyenchant/issues/265
+    PYENCHANT_LIBRARY_PATH
 commands =
     coverage run --source src --parallel-mode -m pytest {posargs}
     coverage combine


### PR DESCRIPTION
If you are using an M1 Mac to run tox, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that you would run into while running `linters`. This happens because python distributions installed by `pyenv` are in the default M1 architecture (aarch64), and can't find a compatible enchant library. As a workaround, you can follow the below steps. 

Install enchant with Homebrew 
```shell
brew install enchant
```
Set environment variable `PYENCHANT_LIBRARY_PATH` to point to the installed enchant library before running `tox`.
```shell
export PYENCHANT_LIBRARY_PATH = /opt/homebrew/lib/libenchant-2.dylib
```
You can set this environment variable in your `~/.zshrc` or in your IDE to avoid doing it everytime.