### PR TITLE
Add project method to IcebergGenerics to enable projections by Schema

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.data;
 
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
@@ -64,6 +65,11 @@ public class IcebergGenerics {
 
     public ScanBuilder select(String... selectedColumns) {
       this.tableScan = tableScan.select(ImmutableList.copyOf(selectedColumns));
+      return this;
+    }
+
+    public ScanBuilder project(Schema schema) {
+      this.tableScan = tableScan.project(schema);
       return this;
     }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -158,8 +158,12 @@ public class OrcValueReaders {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(false);
         } else {
-          this.readers[pos] = readers.get(readerIndex);
-          readerIndex++;
+          if (MetadataColumns.isMetadataColumn(field.name())) {
+            this.isConstantOrMetadataField[pos] = true;
+            this.readers[pos] = constants(null);
+          } else {
+            this.readers[pos] = readers.get(readerIndex++);
+          }
         }
       }
     }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -157,13 +157,12 @@ public class OrcValueReaders {
         } else if (field.equals(MetadataColumns.IS_DELETED)) {
           this.isConstantOrMetadataField[pos] = true;
           this.readers[pos] = constants(false);
+        } else if (MetadataColumns.isMetadataColumn(field.name())) {
+          // in case of any other metadata field, fill with nulls
+          this.isConstantOrMetadataField[pos] = true;
+          this.readers[pos] = constants(null);
         } else {
-          if (MetadataColumns.isMetadataColumn(field.name())) {
-            this.isConstantOrMetadataField[pos] = true;
-            this.readers[pos] = constants(null);
-          } else {
-            this.readers[pos] = readers.get(readerIndex++);
-          }
+          this.readers[pos] = readers.get(readerIndex++);
         }
       }
     }


### PR DESCRIPTION
This adds the project() method into IcebergGenerics so that it can forward the supplied Schema object into TableScan.
This change also fixes OrcValueReaders not being able to handle metadata columns in special cases.
cc: @pvary 