### PR TITLE
AWS: handle certain glue exceptions as iceberg errors

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -30,12 +30,17 @@ import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.ValidationException;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -242,6 +247,75 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
       table.updateSchema().addColumn("newCol", Types.IntegerType.get()).commit();
       throw new RuntimeException("Datacenter on fire");
     }).when(spyOperations).persistGlueTable(Matchers.any(), Matchers.anyMap(), Matchers.any());
+  }
+
+  @Test
+  public void testCreateTableWithInvalidDB() {
+    Table table = setupTable();
+    GlueTableOperations ops = (GlueTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+    TableMetadata metadataV2 = updateTable(table, ops);
+
+    GlueTableOperations spyOps = Mockito.spy(ops);
+    failCommitAndThrowException(spyOps, EntityNotFoundException.builder().build());
+
+    AssertHelpers.assertThrows(
+            "Should throw not found exception",
+            NotFoundException.class,
+            "Cannot commit because Glue cannot find the requested entity",
+            () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
+    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+  }
+
+  @Test
+  public void testGlueAccessDeniedException() {
+    Table table = setupTable();
+    GlueTableOperations ops = (GlueTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+    TableMetadata metadataV2 = updateTable(table, ops);
+
+    GlueTableOperations spyOps = Mockito.spy(ops);
+    failCommitAndThrowException(spyOps, AccessDeniedException.builder().build());
+
+    AssertHelpers.assertThrows(
+            "Should throw forbidden exception",
+            ForbiddenException.class,
+            "Cannot commit because Glue cannot access the requested resources",
+            () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
+    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
+  }
+
+  @Test
+  public void testGlueValidationException() {
+    Table table = setupTable();
+    GlueTableOperations ops = (GlueTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+    TableMetadata metadataV2 = updateTable(table, ops);
+
+    GlueTableOperations spyOps = Mockito.spy(ops);
+    failCommitAndThrowException(spyOps, ValidationException.builder().build());
+
+    AssertHelpers.assertThrows(
+            "Should throw validation exception",
+            org.apache.iceberg.exceptions.ValidationException.class,
+            "Cannot commit because Glue encountered a validation exception while accessing requested resources",
+            () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
+    Assert.assertEquals("No new metadata files should exist", 2, metadataFileCount(ops.current()));
   }
 
   private Table setupTable() {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -133,14 +133,14 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
           "Cannot commit %s because its Glue table already exists when trying to create one", tableName());
     } catch (software.amazon.awssdk.services.glue.model.EntityNotFoundException e) {
       throw new NotFoundException(e,
-              "Cannot commit %s because Glue cannot find the requested entity", tableName());
+          "Cannot commit %s because Glue cannot find the requested entity", tableName());
     } catch (software.amazon.awssdk.services.glue.model.AccessDeniedException e) {
       throw new ForbiddenException(e,
-              "Cannot commit %s because Glue cannot access the requested resources", tableName());
+          "Cannot commit %s because Glue cannot access the requested resources", tableName());
     } catch (software.amazon.awssdk.services.glue.model.ValidationException e) {
       throw new ValidationException(e,
-              "Cannot commit %s because Glue encountered a validation exception " +
-                  "while accessing requested resources",
+          "Cannot commit %s because Glue encountered a validation exception " +
+              "while accessing requested resources",
           tableName());
     } catch (RuntimeException persistFailure) {
       LOG.error("Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -31,7 +31,10 @@ import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -128,6 +131,16 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
       throw new AlreadyExistsException(e,
           "Cannot commit %s because its Glue table already exists when trying to create one", tableName());
+    } catch (software.amazon.awssdk.services.glue.model.EntityNotFoundException e) {
+      throw new NotFoundException(e,
+              "Cannot commit %s because Glue cannot find the requested entity", tableName());
+    } catch (software.amazon.awssdk.services.glue.model.AccessDeniedException e) {
+      throw new ForbiddenException(e,
+              "Cannot commit %s because Glue cannot access the requested resources", tableName());
+    } catch (software.amazon.awssdk.services.glue.model.ValidationException e) {
+      throw new ValidationException(e,
+              "Cannot commit %s because Glue encountered a validation exception " +
+                      "while accessing requested resources", tableName());
     } catch (RuntimeException persistFailure) {
       LOG.error("Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
           fullTableName, persistFailure);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -140,7 +140,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     } catch (software.amazon.awssdk.services.glue.model.ValidationException e) {
       throw new ValidationException(e,
               "Cannot commit %s because Glue encountered a validation exception " +
-                      "while accessing requested resources", tableName());
+                  "while accessing requested resources",
+          tableName());
     } catch (RuntimeException persistFailure) {
       LOG.error("Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
           fullTableName, persistFailure);


### PR DESCRIPTION
Handle certain glue exceptions as iceberg errors to be further processed as user errors instead of server internal errors