### PR TITLE
Test: Make Flink unit tests run properly on Windows

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.Files;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.TestPathUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -191,8 +192,12 @@ public class HadoopTableTestBase {
         "hadoop",
         ImmutableMap.<String, String>builder()
             .putAll(catalogProperties)
-            .put(CatalogProperties.WAREHOUSE_LOCATION, temp.newFolder().getAbsolutePath())
+            .put(CatalogProperties.WAREHOUSE_LOCATION, getCrossOSPath(temp.newFolder()))
             .build());
     return hadoopCatalog;
+  }
+
+  protected static String getCrossOSPath(File file) {
+    return TestPathUtil.getCrossOSPath(file);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestPathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPathUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.File;
+import org.apache.commons.lang3.StringUtils;
+
+public class TestPathUtil {
+
+  private TestPathUtil() {
+  }
+
+  public static String getCrossOSPath(File file) {
+    String absolutePath = file.getAbsolutePath();
+    // Handle windows
+    if (absolutePath.contains(":\\")) {
+      absolutePath = "/" + absolutePath;
+    }
+    return StringUtils.replace(absolutePath, "\\", "/");
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -93,7 +93,7 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     this.baseNamespace = baseNamespace;
     this.isHadoopCatalog = catalogName.startsWith("testhadoop");
     this.validationCatalog = isHadoopCatalog ?
-        new HadoopCatalog(hiveConf, "file:" + hadoopWarehouse.getRoot()) :
+        new HadoopCatalog(hiveConf, "file:" + getCrossOSPath(hadoopWarehouse.getRoot())) :
         catalog;
     this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
 
@@ -115,9 +115,9 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
 
   protected String warehouseRoot() {
     if (isHadoopCatalog) {
-      return hadoopWarehouse.getRoot().getAbsolutePath();
+      return getCrossOSPath(hadoopWarehouse.getRoot());
     } else {
-      return hiveWarehouse.getRoot().getAbsolutePath();
+      return getCrossOSPath(hiveWarehouse.getRoot());
     }
   }
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.flink;
 
+import java.io.File;
 import java.util.List;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -33,6 +34,7 @@ import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.TestPathUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -115,5 +117,9 @@ public abstract class FlinkTestBase extends TestBaseUtils {
         .isNotNull()
         .as(message)
         .containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  protected static String getCrossOSPath(File file) {
+    return TestPathUtil.getCrossOSPath(file);
   }
 }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -71,7 +71,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
   @Test
   public void testHadoopCatalogLoader() throws IOException, ClassNotFoundException {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(CatalogProperties.WAREHOUSE_LOCATION, "file:" + warehouse);
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, "file:" + getCrossOSPath(warehouse));
     CatalogLoader loader = CatalogLoader.hadoop("my_catalog", hiveConf, properties);
     validateCatalogLoader(loader);
   }
@@ -84,7 +84,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @Test
   public void testHadoopTableLoader() throws IOException, ClassNotFoundException {
-    String location = "file:" + warehouse + "/my_table";
+    String location = "file:" + getCrossOSPath(warehouse) + "/my_table";
     new HadoopTables(hiveConf).create(SCHEMA, location);
     validateTableLoader(TableLoader.fromHadoopTable(location, hiveConf));
   }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -80,7 +80,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public static void createWarehouse() throws IOException {
     File warehouseFile = TEMPORARY_FOLDER.newFolder();
     Assert.assertTrue("The warehouse should be deleted", warehouseFile.delete());
-    warehouse = String.format("file:%s", warehouseFile);
+    warehouse = String.format("file:%s", getCrossOSPath(warehouseFile));
   }
 
   @Before

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -227,14 +227,14 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
     File location = TEMPORARY_FOLDER.newFile();
     Assert.assertTrue(location.delete());
 
-    sql("CREATE DATABASE %s WITH ('location'='%s')", flinkDatabase, location);
+    sql("CREATE DATABASE %s WITH ('location'='%s')", flinkDatabase, getCrossOSPath(location));
 
     Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(icebergNamespace));
 
     Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(icebergNamespace);
 
     Assert.assertEquals("Namespace should have expected location",
-        "file:" + location.getPath(), nsMetadata.get("location"));
+        "file:" + getCrossOSPath(location), nsMetadata.get("location"));
   }
 
   @Test

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
@@ -47,7 +47,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     props.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
 
     File warehouseDir = tempFolder.newFolder();
-    props.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + warehouseDir.getAbsolutePath());
+    props.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + getCrossOSPath(warehouseDir));
 
     checkSQLQuery(props, warehouseDir);
   }
@@ -61,7 +61,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     try (FileOutputStream fos = new FileOutputStream(hiveSiteXML)) {
       Configuration newConf = new Configuration(hiveConf);
       // Set another new directory which is different with the hive metastore's warehouse path.
-      newConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file://" + warehouseDir.getAbsolutePath());
+      newConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file://" + getCrossOSPath(warehouseDir));
       newConf.writeXml(fos);
     }
     Assert.assertTrue("hive-site.xml should be created now.", Files.exists(hiveSiteXML.toPath()));

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -72,7 +72,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     File warehouseFile = TEMPORARY_FOLDER.newFolder();
     Assert.assertTrue("The warehouse should be deleted", warehouseFile.delete());
     // before variables
-    warehouse = "file:" + warehouseFile;
+    warehouse = "file:" + getCrossOSPath(warehouseFile);
   }
 
   @Before

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUpsert.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -109,13 +108,6 @@ public class TestFlinkUpsert extends FlinkCatalogTestBase {
     sql("CREATE DATABASE IF NOT EXISTS %s", flinkDatabase);
     sql("USE CATALOG %s", catalogName);
     sql("USE %s", DATABASE);
-  }
-
-  @Override
-  @After
-  public void clean() {
-    sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
-    super.clean();
   }
 
   @Test

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -348,7 +348,7 @@ public class TestIcebergConnector extends FlinkTestBase {
 
   private static String createWarehouse() {
     try {
-      return String.format("file://%s", WAREHOUSE.newFolder().getAbsolutePath());
+      return String.format("file://%s", getCrossOSPath(WAREHOUSE.newFolder()));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.FileFormat;
@@ -60,7 +61,7 @@ public class SplitHelpers {
       TemporaryFolder temporaryFolder, int fileCount, int filesPerSplit) throws Exception {
     final File warehouseFile = temporaryFolder.newFolder();
     Assert.assertTrue(warehouseFile.delete());
-    final String warehouse = "file:" + warehouseFile;
+    final String warehouse = "file:" + getCrossOSPath(warehouseFile);
     Configuration hadoopConf = new Configuration();
     final HadoopCatalog catalog = new HadoopCatalog(hadoopConf, warehouse);
     try {
@@ -88,5 +89,14 @@ public class SplitHelpers {
       catalog.dropTable(TestFixtures.TABLE_IDENTIFIER);
       catalog.close();
     }
+  }
+
+  private static String getCrossOSPath(File file) {
+    String absolutePath = file.getAbsolutePath();
+    // Handle windows
+    if (absolutePath.contains(":\\")) {
+      absolutePath = "/" + absolutePath;
+    }
+    return StringUtils.replace(absolutePath, "\\", "/");
   }
 }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.TestPathUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -93,7 +94,7 @@ public abstract class TestFlinkScan {
     File warehouseFile = TEMPORARY_FOLDER.newFolder();
     Assert.assertTrue(warehouseFile.delete());
     // before variables
-    warehouse = "file:" + warehouseFile;
+    warehouse = "file:" + getCrossOSPath(warehouseFile);
     Configuration conf = new Configuration();
     catalog = new HadoopCatalog(conf, warehouse);
     location = String.format("%s/%s/%s", warehouse, TestFixtures.DATABASE, TestFixtures.TABLE);
@@ -329,5 +330,9 @@ public abstract class TestFlinkScan {
     while (current <= timestampMillis) {
       current = System.currentTimeMillis();
     }
+  }
+
+  protected static String getCrossOSPath(File file) {
+    return TestPathUtil.getCrossOSPath(file);
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -29,6 +29,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -52,8 +53,6 @@ import org.apache.thrift.transport.TTransportFactory;
 import org.junit.Assert;
 
 import static java.nio.file.Files.createTempDirectory;
-import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
-import static java.nio.file.attribute.PosixFilePermissions.fromString;
 
 public class TestHiveMetastore {
 
@@ -90,10 +89,10 @@ public class TestHiveMetastore {
 
   static {
     try {
-      HIVE_LOCAL_DIR = createTempDirectory("hive", asFileAttribute(fromString("rwxrwxrwx"))).toFile();
+      HIVE_LOCAL_DIR = createTempDirectory("hive").toFile();
       DERBY_PATH = new File(HIVE_LOCAL_DIR, "metastore_db").getPath();
       File derbyLogFile = new File(HIVE_LOCAL_DIR, "derby.log");
-      System.setProperty("derby.stream.error.file", derbyLogFile.getAbsolutePath());
+      System.setProperty("derby.stream.error.file", getCrossOSPath(derbyLogFile));
       setupMetastoreDB("jdbc:derby:" + DERBY_PATH + ";create=true");
       Runtime.getRuntime().addShutdownHook(new Thread(() -> {
         Path localDirPath = new Path(HIVE_LOCAL_DIR.getAbsolutePath());
@@ -179,7 +178,8 @@ public class TestHiveMetastore {
 
   public String getDatabasePath(String dbName) {
     File dbDir = new File(HIVE_LOCAL_DIR, dbName + ".db");
-    return dbDir.getPath();
+
+    return getCrossOSPath(dbDir);
   }
 
   public void reset() throws Exception {
@@ -238,7 +238,7 @@ public class TestHiveMetastore {
 
   private void initConf(HiveConf conf, int port) {
     conf.set(HiveConf.ConfVars.METASTOREURIS.varname, "thrift://localhost:" + port);
-    conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + HIVE_LOCAL_DIR.getAbsolutePath());
+    conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + getCrossOSPath(HIVE_LOCAL_DIR));
     conf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
     conf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     conf.set("iceberg.hive.client-pool-size", "2");
@@ -253,5 +253,14 @@ public class TestHiveMetastore {
     try (Reader reader = new InputStreamReader(inputStream)) {
       scriptRunner.runScript(reader);
     }
+  }
+
+  private static String getCrossOSPath(File file) {
+    String absolutePath = file.getAbsolutePath();
+    // Handle windows
+    if (absolutePath.contains(":\\")) {
+      absolutePath = "/" + absolutePath;
+    }
+    return StringUtils.replace(absolutePath, "\\", "/");
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, iceberg flink unit tests cannot be started on Windows OS, this makes it very inconvenient for developers who use Windows as their workhorse (like me, huh). This PR aims to make unit tests compatible with Windows and Linux at the same time.


## Brief change log

The main reason for incompatibility with Windows is the error related to the file path, specifically due to: "URISyntaxException: Relative Path in Absolute URI". For example, `file:C:\\Users` should be changed to `file:/C:/Users`.

I've added a method to handle windows path.

## Verifying this change

On my own Windows PC, verifying this change with the following command:
```
./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=1.15 :iceberg-flink:iceberg-flink-1.15:check :iceberg-flink:iceberg-flink-runtime-1.15:check -Pquick=true -x javadoc
```