### PR TITLE
[Python] Define a TableBuilder API to create a Table, without Transaction API (#4827)

### DIFF
--- a/python/src/iceberg/table/base.py
+++ b/python/src/iceberg/table/base.py
@@ -1,0 +1,86 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+from __future__ import annotations
+
+from abc import ABC
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from iceberg.schema import Schema
+from iceberg.table.order import SortOrder
+
+Identifier = Tuple[str, ...]
+Properties = Dict[str, str]
+
+
+class Table(ABC):
+    """Placeholder for Table managed by the Catalog that points to the current Table Metadata.
+
+    To be implemented by https://github.com/apache/iceberg/issues/3227
+    """
+
+
+class PartitionSpec:
+    """Placeholder for Partition Specification
+
+    To be implemented by https://github.com/apache/iceberg/issues/4631
+    """
+
+
+@dataclass(frozen=True)
+class TableBuilder:
+    """A builder used to create valid tables or start create/replace transactions.
+
+    Usage:
+        table = TableBuilder(
+            identifier = ('com','organization','department','my_table'),
+            schema = Schema(schema_id=1),
+            location = "protocol://some/location",  // Optional
+            partition_spec = PartitionSpec(),       // Optional
+            sort_order = SortOrder(),               // Optional
+            properties = [                          // Optional
+                "key1": "value1",
+                "key2": "value2",
+            ]
+        )
+        .create()
+    """
+
+    identifier: Identifier
+    schema: Schema
+    location: Optional[str] = field(default=None)
+    partition_spec: Optional[PartitionSpec] = field(default=None)
+    sort_order: Optional[SortOrder] = field(default=None)
+    properties: Properties = field(default_factory=dict)
+
+    def __post_init__(self):
+        """Validates the table builder.
+
+        Raises:
+            ValueError: If the instance is in an invalid state
+        """
+
+    def create(self) -> Table:
+        """Creates the table.
+
+        Returns:
+            Table: the created table
+
+        Raises:
+            AlreadyExistsError: If a table with the given identifier already exists
+        """

--- a/python/src/iceberg/table/order.py
+++ b/python/src/iceberg/table/order.py
@@ -1,0 +1,24 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+
+class SortOrder:
+    """Placeholder for Table Sort Order.
+
+    A sort order that defines how data and delete files should be ordered in a table.
+    To be implemented by https://github.com/apache/iceberg/issues/3227
+    """

--- a/python/tests/table/test_base.py
+++ b/python/tests/table/test_base.py
@@ -1,0 +1,41 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from dataclasses import FrozenInstanceError
+from unittest.mock import patch
+
+import pytest
+
+from iceberg.schema import Schema
+from iceberg.table.base import TableBuilder
+
+VALUE_ERROR_IDENTIFIER_NONE = "Table identifier has invalid value: None"
+TEST_TABLE_IDENTIFIER = ("com", "org", "dept", "table")
+
+
+def test_table_builder_raises_value_error_at_instantiation():
+    with patch("iceberg.table.base.TableBuilder.__post_init__", side_effect=ValueError(VALUE_ERROR_IDENTIFIER_NONE)):
+        with pytest.raises(ValueError, match=VALUE_ERROR_IDENTIFIER_NONE):
+            TableBuilder(None, Schema(schema_id=1))
+
+
+def test_table_builder_is_immutable():
+    # Given
+    table_builder = TableBuilder(TEST_TABLE_IDENTIFIER, Schema(schema_id=1))
+    # Then
+    with pytest.raises(FrozenInstanceError):
+        # When
+        table_builder.schema = Schema(schema_id=2)


### PR DESCRIPTION
**WORK IN PROGRESS** This is a draft pull request, and is NOT yet ready for review.

The purpose of this PR is to define a TableBuilder API to create a Table, without Transaction API to begin with. This adresses #4827 which is a child issue for the larger epic #3227 