### PR TITLE
Core: Remove Authorization header handling from HTTPClient

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -249,10 +249,6 @@ public class HTTPClient implements RESTClient {
     private Builder() {
     }
 
-    private static String asBearer(String token) {
-      return String.format("Bearer %s", token);
-    }
-
     public Builder uri(String baseUri) {
       Preconditions.checkNotNull(baseUri, "Invalid uri for http client: null");
       this.uri = RESTUtil.stripTrailingSlash(baseUri);
@@ -266,12 +262,6 @@ public class HTTPClient implements RESTClient {
 
     public Builder withHeaders(Map<String, String> headers) {
       baseHeaders.putAll(headers);
-      return this;
-    }
-
-    public Builder withBearerAuth(String token) {
-      Preconditions.checkNotNull(token, "Invalid auth token: null");
-      baseHeaders.put(HttpHeaders.AUTHORIZATION, asBearer(token));
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
@@ -39,15 +39,6 @@ public class HTTPClientFactory implements Function<Map<String, String>, RESTClie
 
     String baseURI = properties.get(CatalogProperties.URI).trim();
 
-    HTTPClient.Builder builder = HTTPClient.builder()
-        .uri(baseURI);
-
-    // Only apply bearer auth token if one is provided.
-    String token = properties.get(RESTCatalogProperties.AUTH_TOKEN);
-    if (token != null && !token.trim().isEmpty()) {
-      builder.withBearerAuth(token.trim());
-    }
-
-    return builder.build();
+    return HTTPClient.builder().uri(baseURI).build();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -58,11 +59,7 @@ public class TestHTTPClient {
   @BeforeClass
   public static void beforeClass() {
     mockServer = startClientAndServer(PORT);
-    restClient = HTTPClient
-        .builder()
-        .uri(URI)
-        .withBearerAuth(BEARER_AUTH_TOKEN)
-        .build();
+    restClient = HTTPClient.builder().uri(URI).build();
   }
 
   @AfterClass
@@ -197,16 +194,17 @@ public class TestHTTPClient {
   }
 
   private static Item doExecuteRequest(HttpMethod method, String path, Item body, Consumer<ErrorResponse> onError) {
+    Map<String, String> headers = ImmutableMap.of("Authorization", "Bearer " + BEARER_AUTH_TOKEN);
     switch (method) {
       case POST:
-        return restClient.post(path, body, Item.class, ImmutableMap.of(), onError);
+        return restClient.post(path, body, Item.class, headers, onError);
       case GET:
-        return restClient.get(path, Item.class, ImmutableMap.of(), onError);
+        return restClient.get(path, Item.class, headers, onError);
       case HEAD:
-        restClient.head(path, ImmutableMap.of(), onError);
+        restClient.head(path, headers, onError);
         return null;
       case DELETE:
-        return restClient.delete(path, Item.class, ImmutableMap.of(), onError);
+        return restClient.delete(path, Item.class, headers, onError);
       default:
         throw new IllegalArgumentException(String.format("Invalid method: %s", method));
     }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -115,46 +115,21 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @Test
   public void testConfigRoute() throws IOException {
-    RESTClient testClient = new RESTClient() {
+    RESTCatalogAdapter adaptor = new RESTCatalogAdapter(backendCatalog) {
       @Override
-      public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
-        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
-      }
-
-      @Override
-      public <T extends RESTResponse> T delete(String path, Class<T> responseType, Map<String, String> headers,
-                                               Consumer<ErrorResponse> errorHandler) {
-        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
-      }
-
-      @Override
-      public <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers,
-                                            Consumer<ErrorResponse> errorHandler) {
-        return (T) ConfigResponse
-            .builder()
-            .withDefaults(ImmutableMap.of(CatalogProperties.CLIENT_POOL_SIZE, "1"))
-            .withOverrides(ImmutableMap.of(CatalogProperties.CACHE_ENABLED, "false"))
-            .build();
-      }
-
-      @Override
-      public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
-                                             Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
-        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
-      }
-
-      @Override
-      public <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType,
-                                                 Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
-        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
-      }
-
-      @Override
-      public void close() {
+      public <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+        if (ResourcePaths.config().equals(path)) {
+          return castResponse(responseType, ConfigResponse
+              .builder()
+              .withDefaults(ImmutableMap.of(CatalogProperties.CLIENT_POOL_SIZE, "1"))
+              .withOverrides(ImmutableMap.of(CatalogProperties.CACHE_ENABLED, "false"))
+              .build());
+        }
+        return super.get(path, responseType, headers, errorHandler);
       }
     };
 
-    RESTCatalog restCat = new RESTCatalog((config) -> testClient);
+    RESTCatalog restCat = new RESTCatalog((config) -> adaptor);
     Map<String, String> initialConfig = ImmutableMap.of(
         CatalogProperties.URI, "http://localhost:8080",
         CatalogProperties.CACHE_ENABLED, "true");

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -117,7 +117,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   public void testConfigRoute() throws IOException {
     RESTCatalogAdapter adaptor = new RESTCatalogAdapter(backendCatalog) {
       @Override
-      public <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+      public <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers,
+                                            Consumer<ErrorResponse> errorHandler) {
         if (ResourcePaths.config().equals(path)) {
           return castResponse(responseType, ConfigResponse
               .builder()


### PR DESCRIPTION
This removes the `Authorization` header code from `HTTPClient` because the REST catalog will handle its own headers independent of the client.

This is part #4830.