### PR TITLE
Core: Add OAuth2 helpers for REST catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -42,10 +42,13 @@ import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.rest.auth.OAuth2Properties;
+import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.requests.UpdateRequirementParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.JsonUtil;
 
 public class RESTSerializers {
@@ -73,7 +76,9 @@ public class RESTSerializers {
         .addSerializer(TableMetadata.class, new TableMetadataSerializer())
         .addDeserializer(TableMetadata.class, new TableMetadataDeserializer())
         .addSerializer(UpdateRequirement.class, new UpdateRequirementSerializer())
-        .addDeserializer(UpdateRequirement.class, new UpdateRequirementDeserializer());
+        .addDeserializer(UpdateRequirement.class, new UpdateRequirementDeserializer())
+        .addSerializer(OAuthTokenResponse.class, new OAuthTokenResponseSerializer())
+        .addDeserializer(OAuthTokenResponse.class, new OAuthTokenResponseDeserializer());
     mapper.registerModule(module);
   }
 
@@ -224,6 +229,22 @@ public class RESTSerializers {
     public UnboundSortOrder deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return SortOrderParser.fromJson(jsonNode);
+    }
+  }
+
+  public static class OAuthTokenResponseSerializer extends JsonSerializer<OAuthTokenResponse> {
+    @Override
+    public void serialize(OAuthTokenResponse tokenResponse, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      OAuth2Util.tokenResponseToJson(tokenResponse, gen);
+    }
+  }
+
+  public static class OAuthTokenResponseDeserializer extends JsonDeserializer<OAuthTokenResponse> {
+    @Override
+    public OAuthTokenResponse deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return OAuth2Util.tokenResponseFromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -42,7 +42,6 @@ import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
-import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.requests.UpdateRequirementParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -36,6 +36,10 @@ public class ResourcePaths {
     return "v1/config";
   }
 
+  public static String tokens() {
+    return "v1/oauth/tokens";
+  }
+
   private final String prefix;
 
   public ResourcePaths(String prefix) {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.auth;
+
+public class OAuth2Properties {
+  private OAuth2Properties() {
+  }
+
+  /**
+   * A Bearer token which will be used for interaction with the server.
+   */
+  public static final String TOKEN = "token";
+
+  /**
+   * A credential to exchange for a token in the OAuth2 client credentials flow.
+   */
+  public static final String CREDENTIAL = "credential";
+
+  /**
+   * Scope for OAuth2 flows.
+   */
+  public static final String CATALOG_SCOPE = "catalog";
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -169,7 +169,6 @@ public class OAuth2Util {
       tokenResponseToJson(response, generator);
       generator.flush();
       return writer.toString();
-
     } catch (IOException e) {
       throw new RuntimeIOException(e);
     }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.rest.auth;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.StringWriter;

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -136,7 +136,7 @@ public class OAuth2Util {
         // client ID and client secret
         return Pair.of(parts.get(0), parts.get(1));
       case 1:
-        // client ID
+        // client secret
         return Pair.of(null, parts.get(0));
       default:
         // this should never happen because the credential splitter is limited to 2

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.auth;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.Pair;
+
+public class OAuth2Util {
+  private OAuth2Util() {
+  }
+
+  // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
+  private static final Pattern VALID_SCOPE_TOKEN = Pattern.compile("^[!-~&&[^\"\\\\]]+$");
+  private static final Splitter SCOPE_DELIMITER = Splitter.on(" ");
+  private static final Joiner SCOPE_JOINER = Joiner.on(" ");
+
+  private static final String AUTHORIZATION_HEADER = "Authorization";
+  private static final String BEARER_PREFIX = "Bearer ";
+
+  private static final Splitter CREDENTIAL_SPLITTER = Splitter.on(":").limit(2).trimResults();
+  private static final String GRANT_TYPE = "grant_type";
+  private static final String CLIENT_CREDENTIALS = "client_credentials";
+  private static final String TOKEN_EXCHANGE = "urn:ietf:params:oauth:grant-type:token-exchange";
+  private static final String SCOPE = "scope";
+  private static final String CATALOG = "catalog";
+
+  // Client credentials flow
+  private static final String CLIENT_ID = "client_id";
+  private static final String CLIENT_SECRET = "client_secret";
+
+  // Token exchange flow
+  private static final String SUBJECT_TOKEN = "subject_token";
+  private static final String SUBJECT_TOKEN_TYPE = "subject_token_type";
+  private static final String ACTOR_TOKEN = "actor_token";
+  private static final String ACTOR_TOKEN_TYPE = "actor_token_type";
+  private static final Set<String> VALID_TOKEN_TYPES = Sets.newHashSet(
+      "urn:ietf:params:oauth:token-type:access_token",
+      "urn:ietf:params:oauth:token-type:refresh_token",
+      "urn:ietf:params:oauth:token-type:id_token",
+      "urn:ietf:params:oauth:token-type:saml1",
+      "urn:ietf:params:oauth:token-type:saml2",
+      "urn:ietf:params:oauth:token-type:jwt");
+
+  // response serialization
+  private static final String ACCESS_TOKEN = "access_token";
+  private static final String TOKEN_TYPE = "token_type";
+  private static final String EXPIRES_IN = "expires_in";
+  private static final String ISSUED_TOKEN_TYPE = "issued_token_type";
+  private static final String REFRESH_TOKEN = "refresh_token";
+
+  public static Map<String, String> authHeaders(String token) {
+    if (token != null) {
+      return ImmutableMap.of(AUTHORIZATION_HEADER, BEARER_PREFIX + token);
+    } else {
+      return ImmutableMap.of();
+    }
+  }
+
+  public static boolean isValidScopeToken(String scopeToken) {
+    return VALID_SCOPE_TOKEN.matcher(scopeToken).matches();
+  }
+
+  public static List<String> parseScope(String scope) {
+    return SCOPE_DELIMITER.splitToList(scope);
+  }
+
+  public static String toScope(Iterable<String> scopes) {
+    return SCOPE_JOINER.join(scopes);
+  }
+
+  public static Map<String, String> tokenExchangeRequest(String subjectToken, String subjectTokenType,
+                                                         List<String> scopes) {
+    return tokenExchangeRequest(subjectToken, subjectTokenType, null, null, scopes);
+  }
+
+  public static Map<String, String> tokenExchangeRequest(String subjectToken, String subjectTokenType,
+                                                         String actorToken, String actorTokenType,
+                                                         List<String> scopes) {
+    Preconditions.checkArgument(VALID_TOKEN_TYPES.contains(subjectTokenType),
+        "Invalid token type: %s", subjectTokenType);
+    Preconditions.checkArgument(actorToken == null || VALID_TOKEN_TYPES.contains(actorTokenType),
+        "Invalid token type: %s", actorTokenType);
+
+    ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
+    formData.put(GRANT_TYPE, TOKEN_EXCHANGE);
+    formData.put(SCOPE, toScope(scopes));
+    formData.put(SUBJECT_TOKEN, subjectToken);
+    formData.put(SUBJECT_TOKEN_TYPE, subjectTokenType);
+    if (actorToken != null) {
+      formData.put(ACTOR_TOKEN, actorToken);
+      formData.put(ACTOR_TOKEN_TYPE, actorTokenType);
+    }
+
+    return formData.build();
+  }
+
+  private static Pair<String, String> parseCredential(String credential) {
+    Preconditions.checkNotNull(credential, "Invalid credential: null");
+    List<String> parts = CREDENTIAL_SPLITTER.splitToList(credential);
+    switch (parts.size()) {
+      case 2:
+        // client ID and client secret
+        return Pair.of(parts.get(0), parts.get(1));
+      case 1:
+        // client ID
+        return Pair.of(null, parts.get(0));
+      default:
+        // this should never happen because the credential splitter is limited to 2
+        throw new IllegalArgumentException("Invalid credential: " + credential);
+    }
+  }
+
+  public static Map<String, String> clientCredentialsRequest(String credential, List<String> scopes) {
+    Pair<String, String> credentialPair = parseCredential(credential);
+    return clientCredentialsRequest(credentialPair.first(), credentialPair.second(), scopes);
+  }
+
+  public static Map<String, String> clientCredentialsRequest(String clientId, String clientSecret,
+                                                             List<String> scopes) {
+    ImmutableMap.Builder<String, String> formData = ImmutableMap.builder();
+    formData.put(GRANT_TYPE, CLIENT_CREDENTIALS);
+    if (clientId != null) {
+      formData.put(CLIENT_ID, clientId);
+    }
+    formData.put(CLIENT_SECRET, clientSecret);
+    formData.put(SCOPE, toScope(Iterables.concat(scopes, ImmutableList.of(CATALOG))));
+
+    return formData.build();
+  }
+
+  public static String tokenResponseToJson(OAuthTokenResponse response) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      tokenResponseToJson(response, generator);
+      generator.flush();
+      return writer.toString();
+
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
+  }
+
+  public static void tokenResponseToJson(OAuthTokenResponse response, JsonGenerator gen) throws IOException {
+    response.validate();
+
+    gen.writeStartObject();
+
+    gen.writeStringField(ACCESS_TOKEN, response.token());
+    gen.writeStringField(TOKEN_TYPE, response.tokenType());
+
+    if (response.issuedTokenType() != null) {
+      gen.writeStringField(ISSUED_TOKEN_TYPE, response.issuedTokenType());
+    }
+
+    if (response.expiresInSeconds() != null) {
+      gen.writeNumberField(EXPIRES_IN, response.expiresInSeconds());
+    }
+
+    if (response.scopes() != null && !response.scopes().isEmpty()) {
+      gen.writeStringField(SCOPE, toScope(response.scopes()));
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static OAuthTokenResponse tokenResponseFromJson(String json) {
+    try {
+      return tokenResponseFromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new RuntimeIOException(e);
+    }
+  }
+
+  public static OAuthTokenResponse tokenResponseFromJson(JsonNode json) {
+    Preconditions.checkArgument(json.isObject(), "Cannot parse token response from non-object: %s", json);
+
+    OAuthTokenResponse.Builder builder = OAuthTokenResponse.builder()
+        .withToken(JsonUtil.getString(ACCESS_TOKEN, json))
+        .withTokenType(JsonUtil.getString(TOKEN_TYPE, json))
+        .withIssuedTokenType(JsonUtil.getStringOrNull(ISSUED_TOKEN_TYPE, json));
+
+    if (json.has(EXPIRES_IN)) {
+      builder.setExpirationInSeconds(JsonUtil.getInt(EXPIRES_IN, json));
+    }
+
+    if (json.has(SCOPE)) {
+      builder.addScopes(parseScope(JsonUtil.getString(SCOPE, json)));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -23,8 +23,8 @@ import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.RESTResponse;
+import org.apache.iceberg.rest.auth.OAuth2Util;
 
 public class OAuthTokenResponse implements RESTResponse {
   private final String accessToken;

--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.RESTResponse;
+
+public class OAuthTokenResponse implements RESTResponse {
+  private final String accessToken;
+  private final String issuedTokenType;
+  private final String tokenType;
+  private final Integer expiresIn;
+  private final String scope;
+
+  private OAuthTokenResponse(String accessToken, String issuedTokenType, String tokenType, Integer expiresIn,
+                            String scope) {
+    this.accessToken = accessToken;
+    this.issuedTokenType = issuedTokenType;
+    this.tokenType = tokenType;
+    this.expiresIn = expiresIn;
+    this.scope = scope;
+  }
+
+  @Override
+  public void validate() {
+    Preconditions.checkNotNull(accessToken, "Invalid access token: null");
+    Preconditions.checkArgument("bearer".equalsIgnoreCase(tokenType) || "N_A".equalsIgnoreCase(tokenType),
+        "Unsupported token type: %s (must be \"bearer\" or \"N_A\")", tokenType);
+  }
+
+  public String token() {
+    return accessToken;
+  }
+
+  public String issuedTokenType() {
+    return issuedTokenType;
+  }
+
+  public String tokenType() {
+    return tokenType;
+  }
+
+  public Integer expiresInSeconds() {
+    return expiresIn;
+  }
+
+  public List<String> scopes() {
+    return scope != null ? OAuth2Util.parseScope(scope) : ImmutableList.of();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String accessToken;
+    private String issuedTokenType;
+    private String tokenType;
+    private Integer expiresInSeconds;
+    private final List<String> scopes = Lists.newArrayList();
+
+    public Builder withToken(String token) {
+      this.accessToken = token;
+      return this;
+    }
+
+    public Builder withIssuedTokenType(String issuedType) {
+      this.issuedTokenType = issuedType;
+      return this;
+    }
+
+    public Builder withTokenType(String type) {
+      this.tokenType = type;
+      return this;
+    }
+
+    public Builder setExpirationInSeconds(int durationInSeconds) {
+      this.expiresInSeconds = durationInSeconds;
+      return this;
+    }
+
+    public Builder addScope(String scope) {
+      Preconditions.checkArgument(OAuth2Util.isValidScopeToken(scope), "Invalid scope: %s");
+      this.scopes.add(scope);
+      return this;
+    }
+
+    public Builder addScopes(List<String> scope) {
+      scope.forEach(this::addScope);
+      return this;
+    }
+
+    public OAuthTokenResponse build() {
+      String scope = scopes.isEmpty() ? null : OAuth2Util.toScope(scopes);
+      return new OAuthTokenResponse(accessToken, issuedTokenType, tokenType, expiresInSeconds, scope);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
@@ -48,6 +49,7 @@ import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.Pair;
 
 /**
@@ -89,6 +91,7 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   private enum Route {
+    TOKENS(HTTPMethod.POST, "v1/oauth/tokens"),
     CONFIG(HTTPMethod.GET, "v1/config"),
     LIST_NAMESPACES(HTTPMethod.GET, "v1/namespaces"),
     CREATE_NAMESPACE(HTTPMethod.POST, "v1/namespaces"),
@@ -155,6 +158,30 @@ public class RESTCatalogAdapter implements RESTClient {
   public <T extends RESTResponse> T handleRequest(Route route, Map<String, String> vars,
                                                   Object body, Class<T> responseType) {
     switch (route) {
+      case TOKENS: {
+        @SuppressWarnings("unchecked")
+        Map<String, String> request = (Map<String, String>) castRequest(Map.class, body);
+        String grantType = request.get("grant_type");
+        switch (grantType) {
+          case "client_credentials":
+            return castResponse(responseType, OAuthTokenResponse.builder()
+                .withToken("client-credentials-token:sub=" + request.get("client_id"))
+                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+                .withTokenType("Bearer")
+                .build());
+
+          case "urn:ietf:params:oauth:grant-type:token-exchange":
+            return castResponse(responseType, OAuthTokenResponse.builder()
+                .withToken("token-exchange-token:sub=" + request.get("subject_token"))
+                .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+                .withTokenType("Bearer")
+                .build());
+
+          default:
+            throw new UnsupportedOperationException("Unsupported grant_type: " + grantType);
+        }
+      }
+
       case CONFIG:
         return castResponse(responseType, ConfigResponse.builder().build());
 

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;

--- a/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
@@ -59,6 +59,13 @@ public abstract class RequestResponseTestBase<T extends RESTMessage> {
   public abstract T deserialize(String json) throws JsonProcessingException;
 
   /**
+   * Serialize T to a String.
+   */
+  public String serialize(T object) throws JsonProcessingException {
+    return MAPPER.writeValueAsString(object);
+  }
+
+  /**
    * This test ensures that only the fields that are expected, e.g. from the spec, are found on the class.
    * If new fields are added to the spec, they should be added to the function
    * {@link RequestResponseTestBase#allFieldsFromSpec()}
@@ -67,8 +74,7 @@ public abstract class RequestResponseTestBase<T extends RESTMessage> {
   public void testHasOnlyKnownFields() {
     T value = createExampleInstance();
 
-    Assertions.assertThat(value)
-        .hasOnlyFields(allFieldsFromSpec());
+    Assertions.assertThat(value).hasOnlyFields(allFieldsFromSpec());
   }
 
   /**
@@ -81,7 +87,6 @@ public abstract class RequestResponseTestBase<T extends RESTMessage> {
     assertEquals(actual, expected);
 
     // Check that the deserialized value serializes back into the original JSON
-    Assertions.assertThat(MAPPER.writeValueAsString(actual))
-        .isEqualTo(json);
+    Assertions.assertThat(serialize(expected)).isEqualTo(json);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.auth;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOAuth2Util {
+  @Test
+  public void testOAuthScopeTokenValidation() {
+    // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
+    // test characters that are outside of the ! to ~ range and the excluded characters, " and \
+    Assert.assertFalse("Should reject scope token with \\", OAuth2Util.isValidScopeToken("a\\b"));
+    Assert.assertFalse("Should reject scope token with space", OAuth2Util.isValidScopeToken("a b"));
+    Assert.assertFalse("Should reject scope token with \"", OAuth2Util.isValidScopeToken("a\"b"));
+    Assert.assertFalse("Should reject scope token with DEL", OAuth2Util.isValidScopeToken("\u007F"));
+    // test all characters that are inside of the ! to ~ range and are not excluded
+    Assert.assertTrue("Should accept scope token with !-/", OAuth2Util.isValidScopeToken("!#$%&'()*+,-./"));
+    Assert.assertTrue("Should accept scope token with 0-9", OAuth2Util.isValidScopeToken("0123456789"));
+    Assert.assertTrue("Should accept scope token with :-@", OAuth2Util.isValidScopeToken(":;<=>?@"));
+    Assert.assertTrue("Should accept scope token with A-M", OAuth2Util.isValidScopeToken("ABCDEFGHIJKLM"));
+    Assert.assertTrue("Should accept scope token with N-Z", OAuth2Util.isValidScopeToken("NOPQRSTUVWXYZ"));
+    Assert.assertTrue("Should accept scope token with [-`, not \\", OAuth2Util.isValidScopeToken("[]^_`"));
+    Assert.assertTrue("Should accept scope token with a-m", OAuth2Util.isValidScopeToken("abcdefghijklm"));
+    Assert.assertTrue("Should accept scope token with n-z", OAuth2Util.isValidScopeToken("nopqrstuvwxyz"));
+    Assert.assertTrue("Should accept scope token with {-~", OAuth2Util.isValidScopeToken("{|}~"));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.util.JsonUtil;
+import org.assertj.core.util.Sets;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOAuthTokenResponse extends RequestResponseTestBase<OAuthTokenResponse> {
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "access_token", "token_type", "issued_token_type", "expires_in", "scope" };
+  }
+
+  @Override
+  public OAuthTokenResponse createExampleInstance() {
+    return OAuthTokenResponse.builder()
+        .setExpirationInSeconds(600)
+        .withToken("test-token")
+        .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+        .withTokenType("Bearer")
+        .addScope("catalog")
+        .build();
+  }
+
+  @Override
+  public void assertEquals(OAuthTokenResponse actual, OAuthTokenResponse expected) {
+    Assert.assertEquals("Token should match", expected.token(), actual.token());
+    Assert.assertEquals("Token type should match", expected.tokenType(), actual.tokenType());
+    Assert.assertEquals("Issued token type should match", expected.issuedTokenType(), actual.issuedTokenType());
+    Assert.assertEquals("Expiration should match", expected.expiresInSeconds(), actual.expiresInSeconds());
+    Assert.assertEquals("Scope should match", expected.scopes(), actual.scopes());
+  }
+
+  @Override
+  public OAuthTokenResponse deserialize(String json) throws JsonProcessingException {
+    return OAuth2Util.tokenResponseFromJson(json);
+  }
+
+  @Override
+  public String serialize(OAuthTokenResponse response) throws JsonProcessingException {
+    return OAuth2Util.tokenResponseToJson(response);
+  }
+
+  @Override
+  public void testHasOnlyKnownFields() {
+    Set<String> fieldsFromSpec = Sets.newHashSet();
+    Collections.addAll(fieldsFromSpec, allFieldsFromSpec());
+    try {
+      JsonNode node = JsonUtil.mapper().readValue(serialize(createExampleInstance()), JsonNode.class);
+      for (String field : fieldsFromSpec) {
+        Assert.assertTrue("Should have field: " + field, node.has(field));
+      }
+
+      for (String field : ((Iterable<? extends String>) node::fieldNames)) {
+        Assert.assertTrue("Should not have field: " + field, fieldsFromSpec.contains(field));
+      }
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testRoundTrip() throws Exception {
+    assertRoundTripSerializesEquallyFrom(
+        "{\"access_token\":\"bearer-token\",\"token_type\":\"bearer\"}",
+        OAuthTokenResponse.builder().withToken("bearer-token").withTokenType("bearer").build());
+
+    assertRoundTripSerializesEquallyFrom(
+        "{\"access_token\":\"bearer-token\",\"token_type\":\"bearer\"," +
+            "\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"}",
+        OAuthTokenResponse.builder()
+            .withToken("bearer-token")
+            .withTokenType("bearer")
+            .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+            .build());
+
+    assertRoundTripSerializesEquallyFrom(
+        "{\"access_token\":\"bearer-token\",\"token_type\":\"bearer\",\"expires_in\":600}",
+        OAuthTokenResponse.builder()
+            .withToken("bearer-token")
+            .withTokenType("bearer")
+            .setExpirationInSeconds(600)
+            .build());
+
+    assertRoundTripSerializesEquallyFrom(
+        "{\"access_token\":\"bearer-token\",\"token_type\":\"bearer\",\"scope\":\"a b\"}",
+        OAuthTokenResponse.builder()
+            .withToken("bearer-token")
+            .withTokenType("bearer")
+            .addScope("a")
+            .addScope("b")
+            .build());
+
+    assertRoundTripSerializesEquallyFrom(
+        "{\"access_token\":\"bearer-token\",\"token_type\":\"bearer\"," +
+            "\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"," +
+            "\"expires_in\":600,\"scope\":\"a b\"}",
+        OAuthTokenResponse.builder()
+            .withToken("bearer-token")
+            .withTokenType("bearer")
+            .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
+            .setExpirationInSeconds(600)
+            .addScope("a")
+            .addScope("b")
+            .build());
+  }
+
+  @Test
+  public void testFailures() {
+    AssertHelpers.assertThrows(
+        "Token should be required",
+        IllegalArgumentException.class,
+        "missing string access_token",
+        () -> deserialize("{\"token_type\":\"bearer\"}"));
+
+    AssertHelpers.assertThrows(
+        "Token should be string",
+        IllegalArgumentException.class,
+        "Cannot parse access_token to a string value: 34",
+        () -> deserialize("{\"access_token\":34,\"token_type\":\"bearer\"}"));
+
+    AssertHelpers.assertThrows(
+        "Token type should be required",
+        IllegalArgumentException.class,
+        "missing string token_type",
+        () -> deserialize("{\"access_token\":\"bearer-token\"}"));
+
+    AssertHelpers.assertThrows(
+        "Token type should be string",
+        IllegalArgumentException.class,
+        "Cannot parse token_type to a string value: 34",
+        () -> deserialize("{\"access_token\":\"bearer-token\",\"token_type\":34}"));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RequestResponseTestBase;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.util.JsonUtil;
-import org.assertj.core.util.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
This adds the OAuth2 classes needed by the REST catalog, from #4830.

This also fixes review feedback from that PR: add serialization tests, refactor into `rest.auth` module.