### PR TITLE
Spark: Extend CommitStateUnknown exception handling in Spark Actions

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteManifestsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteManifestsSparkAction.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.BaseRewriteManifestsActionResult;
 import org.apache.iceberg.actions.RewriteManifests;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
@@ -295,6 +296,9 @@ public class BaseRewriteManifestsSparkAction
         // delete new manifests as they were rewritten before the commit
         deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
       }
+    } catch (CommitStateUnknownException commitStateUnknownException) {
+      // don't clean up added manifest files, because they may have been successfully committed.
+      throw commitStateUnknownException;
     } catch (Exception e) {
       // delete all new manifests because the rewrite failed
       deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));


### PR DESCRIPTION
### About the Change

This is an extension of https://github.com/apache/iceberg/pull/4687

Spark actions also manipulate the table obj, apart of SparkWrite and hence, the handling of CommitStateUnknown exception when encountered, should not delete the added files.

While actions such as RewriteDatafiles have this handling :
https://github.com/apache/iceberg/blob/566b2fe3f31f4a53f5a26aca1c4239085de4a994/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java#L108-L120

found this missing in RewriteManifestSparkAction, hence added the same. 

----- 

### Testing done

Added a UT to demonstrate the E2E , without the change the UT fails with File Not found exception thus leading to table corruption 

---- 

cc @RussellSpitzer, @stevenzwu @flyrain @aokolnychyi 