### PR TITLE
[0.13] Nessie: Fix NPE while accessing refreshed table in nessie catalog (#4509)

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -90,6 +90,7 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
         .setCurrentSchema(table.getSchemaId())
         .setDefaultSortOrder(table.getSortOrderId())
         .setDefaultPartitionSpec(table.getSpecId())
+        .withMetadataLocation(metadataLocation)
         .discardChanges()
         .build();
   }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.nessie;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
@@ -171,6 +172,32 @@ public class TestBranchVisibility extends BaseTestIceberg {
     String metadataOn2 = addRow(catalogBranch2, tableIdentifier1, "testSchemaSnapshot-in-2",
         ImmutableMap.of("id0", 43L, "id2", 666));
     Assertions.assertThat(metadataOn2).isNotEqualTo(metadataOnTest).isNotEqualTo(metadataOnTest2);
+  }
+
+  @Test
+  public void testMetadataLocation() throws Exception {
+    String branch1 = "test";
+    String branch2 = "branch-2";
+
+    // commit on tableIdentifier1 on branch1
+    NessieCatalog catalog = initCatalog(branch1);
+    String metadataLocationOfCommit1 = addRow(catalog, tableIdentifier1, "initial-data",
+        ImmutableMap.of("id0", 4L));
+
+    createBranch(branch2, catalog.currentHash(), branch1);
+    // commit on tableIdentifier1 on branch2
+    catalog = initCatalog(branch2);
+    String metadataLocationOfCommit2 = addRow(catalog, tableIdentifier1, "some-more-data",
+        ImmutableMap.of("id0", 42L));
+    Assertions.assertThat(metadataLocationOfCommit2).isNotNull().isNotEqualTo(metadataLocationOfCommit1);
+
+    catalog = initCatalog(branch1);
+    // load tableIdentifier1 on branch1
+    BaseTable table = (BaseTable) catalog.loadTable(tableIdentifier1);
+    // branch1's tableIdentifier1's metadata location
+    // should be the latest global state (aka commit2 from branch2)
+    Assertions.assertThat(table.operations().current().metadataFileLocation())
+        .isNotNull().isEqualTo(metadataLocationOfCommit2);
   }
 
   /**


### PR DESCRIPTION
This backports #4509 and the `metadataLocation` parts of #4320 to the 0.13.x branch