### PR TITLE
Parquet: Fix Iceberg's parquet reader returning binary data instead of string data

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -291,7 +291,11 @@ public abstract class BaseParquetReaders<T> {
         case FIXED_LEN_BYTE_ARRAY:
           return new FixedReader(desc);
         case BINARY:
-          return new ParquetValueReaders.BytesReader(desc);
+          if (expected != null && expected.typeId() == org.apache.iceberg.types.Type.TypeID.STRING) {
+            return new ParquetValueReaders.StringReader(desc);
+          } else {
+            return new ParquetValueReaders.BytesReader(desc);
+          }
         case INT32:
           if (expected != null && expected.typeId() == org.apache.iceberg.types.Type.TypeID.LONG) {
             return new ParquetValueReaders.IntAsLongReader(desc);


### PR DESCRIPTION
String columns from Parquet files written by writers that don't use logical type annotations are converted into binary data. This can be reproduced with older versions of Hive or Impala. 