### PR TITLE
[CORE] Support file filtering based on schema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -35,6 +35,11 @@ public interface ContentFile<F> {
   Long pos();
 
   /**
+   * Return id of the schema when write this file.
+   */
+  int schemaId();
+
+  /**
    * Returns id of the partition spec used for partition metadata.
    */
   int specId();

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -63,11 +63,12 @@ public interface DataFile extends ContentFile<DataFile> {
       "Equality comparison field IDs");
   Types.NestedField SORT_ORDER_ID = optional(140, "sort_order_id", IntegerType.get(), "Sort order ID");
   Types.NestedField SPEC_ID = optional(141, "spec_id", IntegerType.get(), "Partition spec ID");
+  Types.NestedField SCHEMA_ID = optional(142, "schema_id", IntegerType.get(), "Schema ID");
 
   int PARTITION_ID = 102;
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
-  // NEXT ID TO ASSIGN: 142
+  // NEXT ID TO ASSIGN: 143
 
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
@@ -88,7 +89,8 @@ public interface DataFile extends ContentFile<DataFile> {
         KEY_METADATA,
         SPLIT_OFFSETS,
         EQUALITY_IDS,
-        SORT_ORDER_ID
+        SORT_ORDER_ID,
+        SCHEMA_ID
     );
   }
 

--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -64,14 +64,15 @@ public interface ManifestFile {
       "Summary for each partition");
   Types.NestedField KEY_METADATA = optional(519, "key_metadata", Types.BinaryType.get(),
       "Encryption key metadata blob");
-  // next ID to assign: 520
+  Types.NestedField SCHEMA_ID = optional(520, "schema_id", Types.IntegerType.get(), "");
+  // next ID to assign: 521
 
   Schema SCHEMA = new Schema(
       PATH, LENGTH, SPEC_ID, MANIFEST_CONTENT,
       SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER, SNAPSHOT_ID,
       ADDED_FILES_COUNT, EXISTING_FILES_COUNT, DELETED_FILES_COUNT,
       ADDED_ROWS_COUNT, EXISTING_ROWS_COUNT, DELETED_ROWS_COUNT,
-      PARTITION_SUMMARIES, KEY_METADATA);
+      PARTITION_SUMMARIES, KEY_METADATA, SCHEMA_ID);
 
   static Schema schema() {
     return SCHEMA;
@@ -187,6 +188,12 @@ public interface ManifestFile {
   default ByteBuffer keyMetadata() {
     return null;
   }
+
+  /**
+   * Returns ID of the {@link Schema} used to write the manifest file. This could be -1 when not all the
+   * entries have the same schema ID.
+   */
+  int schemaId();
 
   /**
    * Copies this {@link ManifestFile manifest file}. Readers can reuse manifest file instances; use

--- a/api/src/main/java/org/apache/iceberg/expressions/SchemaEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/SchemaEvaluator.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.expressions;
+
+import java.io.Serializable;
+import java.util.Set;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+
+import static org.apache.iceberg.expressions.Expressions.rewriteNot;
+
+/**
+ * Evaluates an {@link Expression} on a {@link Schema} to test whether the file with the schema may match.
+ */
+public class SchemaEvaluator implements Serializable {
+  private final Expression expr;
+
+  public SchemaEvaluator(Types.StructType struct, Expression unbound) {
+    this(struct, unbound, true);
+  }
+
+  public SchemaEvaluator(Types.StructType struct, Expression unbound, boolean caseSensitive) {
+    this.expr = Binder.bind(struct, rewriteNot(unbound), caseSensitive);
+  }
+
+  public boolean eval(Schema schema) {
+    return new EvalVisitor().eval(schema);
+  }
+
+  private class EvalVisitor extends ExpressionVisitors.BoundVisitor<Boolean> {
+    private Schema schema;
+
+    private boolean eval(Schema evalSchema) {
+      this.schema = evalSchema;
+      return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public Boolean alwaysTrue() {
+      return true;
+    }
+
+    @Override
+    public Boolean alwaysFalse() {
+      return false;
+    }
+
+    @Override
+    public Boolean not(Boolean result) {
+      return !result;
+    }
+
+    @Override
+    public Boolean and(Boolean leftResult, Boolean rightResult) {
+      return leftResult && rightResult;
+    }
+
+    @Override
+    public Boolean or(Boolean leftResult, Boolean rightResult) {
+      return leftResult || rightResult;
+    }
+
+    @Override
+    public <T> Boolean isNull(Bound<T> valueExpr) {
+      // column exists, it could be null
+      // column does not exist, it is null
+      return true;
+    }
+
+    @Override
+    public <T> Boolean notNull(Bound<T> valueExpr) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean isNaN(Bound<T> valueExpr) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean notNaN(Bound<T> valueExpr) {
+      // column exists, it could be NaN
+      // column does not exist, column value is null. Null could not be NaN.
+      return true;
+    }
+
+    @Override
+    public <T> Boolean lt(Bound<T> valueExpr, Literal<T> lit) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean ltEq(Bound<T> valueExpr, Literal<T> lit) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean gt(Bound<T> valueExpr, Literal<T> lit) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean gtEq(Bound<T> valueExpr, Literal<T> lit) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean eq(Bound<T> valueExpr, Literal<T> lit) {
+      // lit could not be null, so it should be return true when column exists
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean notEq(Bound<T> valueExpr, Literal<T> lit) {
+      // column exists, it could be not equal to lit
+      // column does not exist, column value is null. Null not equal to lit because lit could not be null
+      return true;
+    }
+
+    @Override
+    public <T> Boolean in(Bound<T> valueExpr, Set<T> literalSet) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean notIn(Bound<T> valueExpr, Set<T> literalSet) {
+      // column exists, it could be not in literalSet
+      // column does not exist, column values it null. Null could not be in literalSet
+      return true;
+    }
+
+    @Override
+    public <T> Boolean startsWith(Bound<T> valueExpr, Literal<T> lit) {
+      return columnExists(valueExpr);
+    }
+
+    @Override
+    public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
+      // column exists, it could be not start with lit.
+      // column does not exist, it is not start with lit.
+      return true;
+    }
+
+    private <T> boolean columnExists(Bound<T> valueExpr) {
+      return schema.findField(valueExpr.ref().fieldId()) != null;
+    }
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -371,6 +371,11 @@ public class TestHelpers {
     }
 
     @Override
+    public int schemaId() {
+      return -1;
+    }
+
+    @Override
     public ManifestFile copy() {
       return this;
     }
@@ -474,6 +479,11 @@ public class TestHelpers {
     @Override
     public ByteBuffer keyMetadata() {
       return null;
+    }
+
+    @Override
+    public int schemaId() {
+      return -1;
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestSchemaEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestSchemaEvaluator.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
+import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.in;
+import static org.apache.iceberg.expressions.Expressions.isNaN;
+import static org.apache.iceberg.expressions.Expressions.isNull;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.not;
+import static org.apache.iceberg.expressions.Expressions.notEqual;
+import static org.apache.iceberg.expressions.Expressions.notIn;
+import static org.apache.iceberg.expressions.Expressions.notNaN;
+import static org.apache.iceberg.expressions.Expressions.notNull;
+import static org.apache.iceberg.expressions.Expressions.notStartsWith;
+import static org.apache.iceberg.expressions.Expressions.or;
+import static org.apache.iceberg.expressions.Expressions.startsWith;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestSchemaEvaluator {
+  private static final Schema OLD_SCHEMA = new Schema(
+      required(1, "int_col", Types.IntegerType.get()),
+      optional(2, "double_col", Types.DoubleType.get()),
+      optional(3, "str_col", Types.StringType.get())
+  );
+
+  private static final Schema NEW_SCHEMA = new Schema(
+      required(1, "int_col", Types.IntegerType.get()),
+      optional(2, "double_col", Types.DoubleType.get()),
+      optional(3, "str_col", Types.StringType.get()),
+      optional(4, "new_int_col", Types.IntegerType.get()),
+      optional(5, "new_double_col", Types.DoubleType.get()),
+      optional(6, "new_str_col", Types.StringType.get()),
+      optional(7, "struct_col", Types.StructType.of(
+          Types.NestedField.optional(8, "nest_col1", Types.StructType.of(
+              Types.NestedField.optional(9, "nest_col2", Types.FloatType.get())))))
+  );
+
+  @Test
+  public void testLessThan() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThan("int_col", 7));
+    Assert.assertTrue("existed int_col could be less than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThan("double_col", 7));
+    Assert.assertTrue("existed double_col could be less than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThan("new_int_col", 7));
+    Assert.assertFalse("not existed new_int_col could not be less than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThan("new_double_col", 7));
+    Assert.assertFalse("not existed new_double_col could not be less than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThan("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be less than 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testLessThanOrEqual() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThanOrEqual("int_col", 7));
+    Assert.assertTrue("existed int_col could be less than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThanOrEqual("double_col", 7));
+    Assert.assertTrue("existed double_col could be less than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThanOrEqual("new_int_col", 7));
+    Assert.assertFalse("not existed new_int_col could not be less than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThanOrEqual("new_double_col", 7));
+    Assert.assertFalse("not existed new_double_col could not be less than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), lessThanOrEqual("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be less than or equal 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testGreaterThan() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThan("int_col", 7));
+    Assert.assertTrue("existed int_col could be greater than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThan("double_col", 7));
+    Assert.assertTrue("existed double_col could be greater than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThan("new_int_col", 7));
+    Assert.assertFalse("not existed new_int_col could not be greater than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThan("new_double_col", 7));
+    Assert.assertFalse("not existed new_double_col could not be greater than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThan("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be greater than 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testGreaterThanOrEqual() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThanOrEqual("int_col", 7));
+    Assert.assertTrue("existed int_col could be greater than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThanOrEqual("double_col", 7));
+    Assert.assertTrue("existed double_col could be greater than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThanOrEqual("new_int_col", 7));
+    Assert.assertFalse("not existed new_int_col could not be greater than or equal 7t", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThanOrEqual("new_double_col", 7));
+    Assert.assertFalse("not existed new_double_col could not be greater than or equal 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), greaterThanOrEqual("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be greater than or equal 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testEqual() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("int_col", 7));
+    Assert.assertTrue("existed int_col could be equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("double_col", 7));
+    Assert.assertTrue("existed double_col could be equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("str_col", "abc"));
+    Assert.assertTrue("existed str_col could be equal to abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("new_int_col", 7));
+    Assert.assertFalse("not existed new_int_col could not be equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("new_double_col", 7));
+    Assert.assertFalse("not existed new_double_col could not be equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("new_str_col", "abc"));
+    Assert.assertFalse("not existed new_str_col could not be equal to abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), equal("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be equal to 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNotEqual() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("int_col", 7));
+    Assert.assertTrue("existed int_col could be not equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("double_col", 7));
+    Assert.assertTrue("existed double_col could be not equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("str_col", "abc"));
+    Assert.assertTrue("existed str_col could be not equal to abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("new_int_col", 7));
+    Assert.assertTrue("not existed new_int_col should be not equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("new_double_col", 7));
+    Assert.assertTrue("not existed new_double_col should be not equal to 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("new_str_col", "abc"));
+    Assert.assertTrue("not existed new_str_col should be not equal to abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notEqual("struct_col.nest_col1.nest_col2", 7));
+    Assert.assertTrue(
+        "not existed struct_col.nest_col1.nest_col2 should be not equal to 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testStartWith() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), startsWith("str_col", "abc"));
+    Assert.assertTrue("existed str_col could be start with abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), startsWith("new_str_col", "abc"));
+    Assert.assertFalse("not existed new_str_col could not be start with abc", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNotStartWith() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notStartsWith("str_col", "abc"));
+    Assert.assertTrue("existed str_col could be not start with abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notStartsWith("new_str_col", "abc"));
+    Assert.assertTrue("not existed new_str_col should not start with exists", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testAlwaysTrue() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), alwaysTrue());
+    Assert.assertTrue("always true", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testAlwaysFalse() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), alwaysFalse());
+    Assert.assertFalse("always false", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testIsNull() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNull("double_col"));
+    Assert.assertTrue("existed double_col could be null ", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNull("str_col"));
+    Assert.assertTrue("existed str_col could be null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNull("new_double_col"));
+    Assert.assertTrue("not existed new_double_col col is null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNull("new_str_col"));
+    Assert.assertTrue("not existed new_str_col col is null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNull("struct_col.nest_col1.nest_col2"));
+    Assert.assertTrue("not existed struct_col.nest_col1.nest_col2 col is null", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNotNull() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNull("double_col"));
+    Assert.assertTrue("existed double_col could be not null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNull("str_col"));
+    Assert.assertTrue("existed str_col could be not null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNull("new_double_col"));
+    Assert.assertFalse("not existed new_double_col could not be not null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNull("new_str_col"));
+    Assert.assertFalse("not existed new_str_col could not be not null", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNull("struct_col.nest_col1.nest_col2"));
+    Assert.assertFalse("not existed struct_col.nest_col1.nest_col2 could not be not null", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testIsNaN() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNaN("double_col"));
+    Assert.assertTrue("existed double_col could be NaN ", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), isNaN("new_double_col"));
+    Assert.assertFalse("not existed new_double_col could not be NaN ", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNotNaN() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNaN("double_col"));
+    Assert.assertTrue("existed double_col could be not NaN ", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notNaN("new_double_col"));
+    Assert.assertTrue("not existed new_double_col should not be NaN ", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testIn() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), in("int_col", 5, 6, 7));
+    Assert.assertTrue("existed int_col could be in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), in("double_col", 5, 6, 7));
+    Assert.assertTrue("existed double_col could be in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), in("new_int_col", 5, 6, 7));
+    Assert.assertFalse("not existed new_int_col could not be in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), in("new_double_col", 5, 6, 7));
+    Assert.assertFalse("not existed new_double_col could not be in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), in("struct_col.nest_col1.nest_col2", 5, 6, 7));
+    Assert.assertFalse(
+        "not existed struct_col.nest_col1.nest_col2 could not be in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNotIn() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notIn("int_col", 5, 6, 7));
+    Assert.assertTrue("existed int_col could be not in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notIn("double_col", 5, 6, 7));
+    Assert.assertTrue("existed double_col could be not in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notIn("new_int_col", 5, 6, 7));
+    Assert.assertTrue("not existed new_int_col could be not in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notIn("new_double_col", 5, 6, 7));
+    Assert.assertTrue("not existed new_double_col could be not in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), notIn("struct_col.nest_col1.nest_col2", 5, 6, 7));
+    Assert.assertTrue(
+        "not existed struct_col.nest_col1.nest_col2 could be not in 5, 6, 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+
+  @Test
+  public void testAnd() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(
+        NEW_SCHEMA.asStruct(), and(isNull("double_col"), startsWith("str_col", "abc")));
+    Assert.assertTrue(
+        "existed double_col could be null and existed str_col could be start with abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(
+        NEW_SCHEMA.asStruct(), and(isNull("new_double_col"), startsWith("new_str_col", "abc")));
+    Assert.assertFalse(
+        "not existed double_col is null and not existed str_col should not be start with abc",
+        evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testOr() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(
+        NEW_SCHEMA.asStruct(), or(isNull("double_col"), startsWith("str_col", "abc")));
+    Assert.assertTrue(
+        "existed double_col could be null or existed str_col could be start with abc", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(
+        NEW_SCHEMA.asStruct(), or(isNull("new_double_col"), startsWith("new_str_col", "abc")));
+    Assert.assertTrue(
+        "not existed double_col is null or not existed str_col should not be start with abc",
+        evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testNot() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), not(lessThan("int_col", 7)));
+    Assert.assertTrue("existed int_col could be not less than 7", evaluator.eval(OLD_SCHEMA));
+
+    evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), not(lessThan("new_int_col", 7)));
+    Assert.assertFalse("not existed new_int_col could not be not less than 7", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testCaseInsensitive() {
+    SchemaEvaluator evaluator = new SchemaEvaluator(NEW_SCHEMA.asStruct(), startsWith("STR_COL", "abc"), false);
+    Assert.assertTrue("existed str_col could be start with abc", evaluator.eval(OLD_SCHEMA));
+  }
+
+  @Test
+  public void testCaseSensitive() {
+    AssertHelpers.assertThrows(
+        "INT_COL != int_col when case sensitivity is on",
+        ValidationException.class,
+        "Cannot find field 'INT_COL' in struct",
+        () -> new SchemaEvaluator(NEW_SCHEMA.asStruct(), not(lessThan("INT_COL", 7)), true)
+    );
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -54,6 +54,7 @@ abstract class BaseFile<F>
   private Types.StructType partitionType;
 
   private Long fileOrdinal = null;
+  private int schemaId = -1;
   private int partitionSpecId = -1;
   private FileContent content = FileContent.DATA;
   private String filePath = null;
@@ -116,12 +117,13 @@ abstract class BaseFile<F>
     this.partitionData = new PartitionData(partitionType);
   }
 
-  BaseFile(int specId, FileContent content, String filePath, FileFormat format,
+  BaseFile(int schemaId, int specId, FileContent content, String filePath, FileFormat format,
            PartitionData partition, long fileSizeInBytes, long recordCount,
            Map<Integer, Long> columnSizes, Map<Integer, Long> valueCounts,
            Map<Integer, Long> nullValueCounts, Map<Integer, Long> nanValueCounts,
            Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds, List<Long> splitOffsets,
            int[] equalityFieldIds, Integer sortOrderId, ByteBuffer keyMetadata) {
+    this.schemaId = schemaId;
     this.partitionSpecId = specId;
     this.content = content;
     this.filePath = filePath;
@@ -159,6 +161,7 @@ abstract class BaseFile<F>
    */
   BaseFile(BaseFile<F> toCopy, boolean fullCopy) {
     this.fileOrdinal = toCopy.fileOrdinal;
+    this.schemaId = toCopy.schemaId;
     this.partitionSpecId = toCopy.partitionSpecId;
     this.content = toCopy.content;
     this.filePath = toCopy.filePath;
@@ -277,6 +280,9 @@ abstract class BaseFile<F>
         this.sortOrderId = (Integer) value;
         return;
       case 17:
+        this.schemaId = (int) value;
+        return;
+      case 18:
         this.fileOrdinal = (long) value;
         return;
       default:
@@ -332,6 +338,8 @@ abstract class BaseFile<F>
       case 16:
         return sortOrderId;
       case 17:
+        return schemaId;
+      case 18:
         return fileOrdinal;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
@@ -351,6 +359,11 @@ abstract class BaseFile<F>
   @Override
   public Long pos() {
     return fileOrdinal;
+  }
+
+  @Override
+  public int schemaId() {
+    return schemaId;
   }
 
   @Override
@@ -461,6 +474,7 @@ abstract class BaseFile<F>
         .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
         .add("equality_ids", equalityIds == null ? "null" : equalityFieldIds())
         .add("sort_order_id", sortOrderId)
+        .add("schema_id", schemaId)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -122,6 +122,7 @@ public class DataFiles {
     private long recordCount = -1L;
     private long fileSizeInBytes = -1L;
     private Integer sortOrderId = SortOrder.unsorted().orderId();
+    private int schemaId = -1;
 
     // optional fields
     private Map<Integer, Long> columnSizes = null;
@@ -156,6 +157,7 @@ public class DataFiles {
       this.upperBounds = null;
       this.splitOffsets = null;
       this.sortOrderId = SortOrder.unsorted().orderId();
+      this.schemaId = -1;
     }
 
     public Builder copy(DataFile toCopy) {
@@ -177,6 +179,7 @@ public class DataFiles {
           : ByteBuffers.copy(toCopy.keyMetadata());
       this.splitOffsets = toCopy.splitOffsets() == null ? null : copyList(toCopy.splitOffsets());
       this.sortOrderId = toCopy.sortOrderId();
+      this.schemaId = toCopy.schemaId();
       return this;
     }
 
@@ -278,6 +281,11 @@ public class DataFiles {
       return this;
     }
 
+    public Builder withSchemaId(int newSchemaId) {
+      this.schemaId = newSchemaId;
+      return this;
+    }
+
     public DataFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -288,7 +296,7 @@ public class DataFiles {
       Preconditions.checkArgument(recordCount >= 0, "Record count is required");
 
       return new GenericDataFile(
-          specId, filePath, format, isPartitioned ? partitionData.copy() : null,
+          schemaId, specId, filePath, format, isPartitioned ? partitionData.copy() : null,
           fileSizeInBytes, new Metrics(
               recordCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds),
           keyMetadata, splitOffsets, sortOrderId);

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.util.SnapshotUtil;
 public class DataTableScan extends BaseTableScan {
   static final ImmutableList<String> SCAN_COLUMNS = ImmutableList.of(
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
-      "file_size_in_bytes", "record_count", "partition", "key_metadata", "split_offsets"
+      "file_size_in_bytes", "record_count", "partition", "key_metadata", "split_offsets", "schema_id"
   );
   static final ImmutableList<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
       .addAll(SCAN_COLUMNS)
@@ -83,6 +83,7 @@ public class DataTableScan extends BaseTableScan {
         .caseSensitive(isCaseSensitive())
         .select(colStats() ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
         .filterData(filter())
+        .schemasById(table().schema(), table().schemas())
         .specsById(table().specs())
         .ignoreDeleted();
 

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -49,6 +49,7 @@ public class FileMetadata {
     private FileFormat format = null;
     private long recordCount = -1L;
     private long fileSizeInBytes = -1L;
+    private int schemaId = -1;
 
     // optional fields
     private Map<Integer, Long> columnSizes = null;
@@ -65,6 +66,7 @@ public class FileMetadata {
       this.specId = spec.specId();
       this.isPartitioned = spec.fields().size() > 0;
       this.partitionData = isPartitioned ? DataFiles.newPartitionData(spec) : null;
+      this.schemaId = spec.schema().schemaId();
     }
 
     public void clear() {
@@ -82,6 +84,7 @@ public class FileMetadata {
       this.lowerBounds = null;
       this.upperBounds = null;
       this.sortOrderId = null;
+      this.schemaId = -1;
     }
 
     public Builder copy(DeleteFile toCopy) {
@@ -103,6 +106,7 @@ public class FileMetadata {
       this.keyMetadata = toCopy.keyMetadata() == null ? null
           : ByteBuffers.copy(toCopy.keyMetadata());
       this.sortOrderId = toCopy.sortOrderId();
+      this.schemaId = toCopy.schemaId();
       return this;
     }
 
@@ -207,6 +211,11 @@ public class FileMetadata {
       return this;
     }
 
+    public Builder withSchemaId(int newSchemaId) {
+      this.schemaId = newSchemaId;
+      return this;
+    }
+
     public DeleteFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -232,7 +241,7 @@ public class FileMetadata {
       }
 
       return new GenericDeleteFile(
-          specId, content, filePath, format, isPartitioned ? DataFiles.copy(spec, partitionData) : null,
+          schemaId, specId, content, filePath, format, isPartitioned ? DataFiles.copy(spec, partitionData) : null,
           fileSizeInBytes, new Metrics(
           recordCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds),
           equalityFieldIds, sortOrderId, keyMetadata);

--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -204,6 +204,7 @@ public class FindFiles {
 
       // when snapshot is not null
       CloseableIterable<ManifestEntry<DataFile>> entries = new ManifestGroup(ops.io(), snapshot.dataManifests())
+          .schemasById(ops.current().schema(), ops.current().schemasById())
           .specsById(ops.current().specsById())
           .filterData(rowFilter)
           .filterFiles(fileFilter)

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -34,10 +34,10 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
     super(avroSchema);
   }
 
-  GenericDataFile(int specId, String filePath, FileFormat format, PartitionData partition,
+  GenericDataFile(int schemaId, int specId, String filePath, FileFormat format, PartitionData partition,
                   long fileSizeInBytes, Metrics metrics,
                   ByteBuffer keyMetadata, List<Long> splitOffsets, Integer sortOrderId) {
-    super(specId, FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+    super(schemaId, specId, FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(), metrics.nanValueCounts(),
         metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, null, sortOrderId, keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -34,10 +34,10 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
     super(avroSchema);
   }
 
-  GenericDeleteFile(int specId, FileContent content, String filePath, FileFormat format, PartitionData partition,
-                    long fileSizeInBytes, Metrics metrics, int[] equalityFieldIds,
+  GenericDeleteFile(int schemaId, int specId, FileContent content, String filePath, FileFormat format,
+                    PartitionData partition, long fileSizeInBytes, Metrics metrics, int[] equalityFieldIds,
                     Integer sortOrderId, ByteBuffer keyMetadata) {
-    super(specId, content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+    super(schemaId, specId, content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(), metrics.nanValueCounts(),
         metrics.lowerBounds(), metrics.upperBounds(), null, equalityFieldIds, sortOrderId, keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -88,6 +88,7 @@ class IncrementalDataTableScan extends DataTableScan {
             manifestEntry ->
                 snapshotIds.contains(manifestEntry.snapshotId()) &&
                 manifestEntry.status() == ManifestEntry.Status.ADDED)
+        .schemasById(table().schema(), table().schemas())
         .specsById(table().specs())
         .ignoreDeleted();
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -343,7 +343,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         .ignoreExisting();
 
     if (dataFilter != null) {
-      manifestGroup = manifestGroup.filterData(dataFilter);
+      manifestGroup = manifestGroup.filterData(dataFilter).schemasById(base.schema(), base.schemasById());
     }
 
     if (partitionSet != null) {
@@ -556,7 +556,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         .ignoreExisting();
 
     if (dataFilter != null) {
-      manifestGroup = manifestGroup.filterData(dataFilter);
+      manifestGroup = manifestGroup.filterData(dataFilter).schemasById(base.schema(), base.schemasById());
     }
 
     if (partitionSet != null) {
@@ -870,7 +870,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   private class DataFileFilterManager extends ManifestFilterManager<DataFile> {
     private DataFileFilterManager() {
-      super(ops.current().specsById(), MergingSnapshotProducer.this::workerPool);
+      super(ops.current().schema(), ops.current().schemasById(), ops.current().specsById(),
+          MergingSnapshotProducer.this::workerPool);
     }
 
     @Override
@@ -922,7 +923,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   private class DeleteFileFilterManager extends ManifestFilterManager<DeleteFile> {
     private DeleteFileFilterManager() {
-      super(ops.current().specsById(), MergingSnapshotProducer.this::workerPool);
+      super(ops.current().schema(), ops.current().schemasById(), ops.current().specsById(),
+          MergingSnapshotProducer.this::workerPool);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -220,6 +220,7 @@ public class ScanSummary {
           limit, throwIfLimited, Comparators.charSequences());
 
       try (CloseableIterable<ManifestEntry<DataFile>> entries = new ManifestGroup(ops.io(), manifests)
+          .schemasById(ops.current().schema(), ops.current().schemasById())
           .specsById(ops.current().specsById())
           .filterData(rowFilter)
           .ignoreDeleted()

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -462,7 +462,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       return new GenericManifestFile(manifest.path(), manifest.length(), manifest.partitionSpecId(),
           ManifestContent.DATA, manifest.sequenceNumber(), manifest.minSequenceNumber(), snapshotId,
-          addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries(), null);
+          addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries(),
+          null, manifest.schemaId());
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read manifest: %s", manifest.path());

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -181,6 +181,11 @@ class V1Metadata {
     }
 
     @Override
+    public int schemaId() {
+      return wrapped.schemaId();
+    }
+
+    @Override
     public ManifestFile copy() {
       return wrapped.copy();
     }
@@ -215,7 +220,8 @@ class V1Metadata {
         DataFile.UPPER_BOUNDS,
         DataFile.KEY_METADATA,
         DataFile.SPLIT_OFFSETS,
-        DataFile.SORT_ORDER_ID
+        DataFile.SORT_ORDER_ID,
+        DataFile.SCHEMA_ID
     );
   }
 
@@ -356,6 +362,8 @@ class V1Metadata {
           return wrapped.splitOffsets();
         case 14:
           return wrapped.sortOrderId();
+        case 15:
+          return wrapped.schemaId();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -453,6 +461,11 @@ class V1Metadata {
     @Override
     public Integer sortOrderId() {
       return wrapped.sortOrderId();
+    }
+
+    @Override
+    public int schemaId() {
+      return wrapped.schemaId();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -47,7 +47,9 @@ class V2Metadata {
       ManifestFile.ADDED_ROWS_COUNT.asRequired(),
       ManifestFile.EXISTING_ROWS_COUNT.asRequired(),
       ManifestFile.DELETED_ROWS_COUNT.asRequired(),
-      ManifestFile.PARTITION_SUMMARIES
+      ManifestFile.PARTITION_SUMMARIES,
+      ManifestFile.KEY_METADATA,
+      ManifestFile.SCHEMA_ID
   );
 
   /**
@@ -134,6 +136,8 @@ class V2Metadata {
           return wrapped.partitions();
         case 14:
           return wrapped.keyMetadata();
+        case 15:
+          return wrapped.schemaId();
         default:
           throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
@@ -230,6 +234,11 @@ class V2Metadata {
     }
 
     @Override
+    public int schemaId() {
+      return wrapped.schemaId();
+    }
+
+    @Override
     public ManifestFile copy() {
       return wrapped.copy();
     }
@@ -263,7 +272,8 @@ class V2Metadata {
         DataFile.KEY_METADATA,
         DataFile.SPLIT_OFFSETS,
         DataFile.EQUALITY_IDS,
-        DataFile.SORT_ORDER_ID
+        DataFile.SORT_ORDER_ID,
+        DataFile.SCHEMA_ID
     );
   }
 
@@ -419,6 +429,8 @@ class V2Metadata {
           return wrapped.equalityFieldIds();
         case 15:
           return wrapped.sortOrderId();
+        case 16:
+          return wrapped.schemaId();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -516,6 +528,11 @@ class V2Metadata {
     @Override
     public Integer sortOrderId() {
       return wrapped.sortOrderId();
+    }
+
+    @Override
+    public int schemaId() {
+      return wrapped.schemaId();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -42,11 +42,18 @@ public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult>
   private final ByteBuffer keyMetadata;
   private final int[] equalityFieldIds;
   private final SortOrder sortOrder;
+  private final int schemaId;
   private DeleteFile deleteFile = null;
 
   public EqualityDeleteWriter(FileAppender<T> appender, FileFormat format, String location,
                               PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata,
                               SortOrder sortOrder, int... equalityFieldIds) {
+    this(appender, format, location, spec, partition, keyMetadata, sortOrder, -1, equalityFieldIds);
+  }
+
+  public EqualityDeleteWriter(FileAppender<T> appender, FileFormat format, String location,
+                              PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata,
+                              SortOrder sortOrder, int schemaId, int... equalityFieldIds) {
     this.appender = appender;
     this.format = format;
     this.location = location;
@@ -54,6 +61,7 @@ public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult>
     this.partition = partition;
     this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
     this.sortOrder = sortOrder;
+    this.schemaId = schemaId;
     this.equalityFieldIds = equalityFieldIds;
   }
 
@@ -100,6 +108,7 @@ public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult>
           .withFileSizeInBytes(appender.length())
           .withMetrics(appender.metrics())
           .withSortOrder(sortOrder)
+          .withSchemaId(schemaId)
           .build();
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -42,10 +42,17 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
   private final ByteBuffer keyMetadata;
   private final PositionDelete<T> delete;
   private final CharSequenceSet referencedDataFiles;
+  private final int schemaId;
   private DeleteFile deleteFile = null;
 
   public PositionDeleteWriter(FileAppender<StructLike> appender, FileFormat format, String location,
                               PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata) {
+    this(appender, format, location, spec, partition, keyMetadata, -1);
+  }
+
+  public PositionDeleteWriter(FileAppender<StructLike> appender, FileFormat format, String location,
+                              PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata,
+                              int schemaId) {
     this.appender = appender;
     this.format = format;
     this.location = location;
@@ -54,6 +61,7 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
     this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
     this.delete = PositionDelete.create();
     this.referencedDataFiles = CharSequenceSet.empty();
+    this.schemaId = schemaId;
   }
 
   @Override
@@ -100,6 +108,7 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
           .withEncryptionKeyMetadata(keyMetadata)
           .withFileSizeInBytes(appender.length())
           .withMetrics(appender.metrics())
+          .withSchemaId(schemaId)
           .build();
     }
   }

--- a/core/src/main/java/org/apache/iceberg/io/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/DataWriter.java
@@ -38,6 +38,7 @@ public class DataWriter<T> implements FileWriter<T, DataWriteResult> {
   private final StructLike partition;
   private final ByteBuffer keyMetadata;
   private final SortOrder sortOrder;
+  private final int schemaId;
   private DataFile dataFile = null;
 
   public DataWriter(FileAppender<T> appender, FileFormat format, String location,
@@ -47,6 +48,11 @@ public class DataWriter<T> implements FileWriter<T, DataWriteResult> {
 
   public DataWriter(FileAppender<T> appender, FileFormat format, String location,
                     PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata, SortOrder sortOrder) {
+    this(appender, format, location, spec, partition, keyMetadata, sortOrder, -1);
+  }
+
+  public DataWriter(FileAppender<T> appender, FileFormat format, String location, PartitionSpec spec,
+                    StructLike partition, EncryptionKeyMetadata keyMetadata, SortOrder sortOrder, int schemaId) {
     this.appender = appender;
     this.format = format;
     this.location = location;
@@ -54,6 +60,7 @@ public class DataWriter<T> implements FileWriter<T, DataWriteResult> {
     this.partition = partition;
     this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
     this.sortOrder = sortOrder;
+    this.schemaId = schemaId;
   }
 
   @Override
@@ -89,6 +96,7 @@ public class DataWriter<T> implements FileWriter<T, DataWriteResult> {
           .withMetrics(appender.metrics())
           .withSplitOffsets(appender.splitOffsets())
           .withSortOrder(sortOrder)
+          .withSchemaId(schemaId)
           .build();
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -452,6 +452,7 @@ public class TableTestBase {
         .withFileSizeInBytes(10)
         .withPartitionPath(partitionPath)
         .withRecordCount(1)
+        .withSchemaId(table.schema().schemaId())
         .build();
   }
 
@@ -463,6 +464,7 @@ public class TableTestBase {
         .withFileSizeInBytes(10)
         .withPartitionPath(partitionPath)
         .withRecordCount(1)
+        .withSchemaId(table.schema().schemaId())
         .build();
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
@@ -56,18 +56,19 @@ public class TestManifestListVersions {
   private static final long EXISTING_ROWS = 857273L;
   private static final int DELETED_FILES = 1;
   private static final long DELETED_ROWS = 22910L;
+  private static final int SCHEMA_ID = 1;
   private static final List<ManifestFile.PartitionFieldSummary> PARTITION_SUMMARIES = ImmutableList.of();
   private static final ByteBuffer KEY_METADATA = null;
 
   private static final ManifestFile TEST_MANIFEST = new GenericManifestFile(
       PATH, LENGTH, SPEC_ID, ManifestContent.DATA, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
       ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-      PARTITION_SUMMARIES, KEY_METADATA);
+      PARTITION_SUMMARIES, KEY_METADATA, SCHEMA_ID);
 
   private static final ManifestFile TEST_DELETE_MANIFEST = new GenericManifestFile(
       PATH, LENGTH, SPEC_ID, ManifestContent.DELETES, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
       ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-      PARTITION_SUMMARIES, KEY_METADATA);
+      PARTITION_SUMMARIES, KEY_METADATA, SCHEMA_ID);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -99,6 +100,7 @@ public class TestManifestListVersions {
     Assert.assertEquals("Added rows count", ADDED_ROWS, (long) manifest.addedRowsCount());
     Assert.assertEquals("Existing rows count", EXISTING_ROWS, (long) manifest.existingRowsCount());
     Assert.assertEquals("Deleted rows count", DELETED_ROWS, (long) manifest.deletedRowsCount());
+    Assert.assertEquals("Schema id", -1, manifest.schemaId());
   }
 
   @Test
@@ -119,6 +121,7 @@ public class TestManifestListVersions {
     Assert.assertEquals("Existing rows count", EXISTING_ROWS, (long) manifest.existingRowsCount());
     Assert.assertEquals("Deleted files count", DELETED_FILES, (int) manifest.deletedFilesCount());
     Assert.assertEquals("Deleted rows count", DELETED_ROWS, (long) manifest.deletedRowsCount());
+    Assert.assertEquals("Schema id", SCHEMA_ID, manifest.schemaId());
   }
 
   @Test
@@ -225,7 +228,7 @@ public class TestManifestListVersions {
     ManifestFile manifest = new GenericManifestFile(
         PATH, LENGTH, SPEC_ID, ManifestContent.DATA, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
         ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-        partitionFieldSummaries, KEY_METADATA);
+        partitionFieldSummaries, KEY_METADATA, -1);
 
     InputFile manifestList = writeManifestList(manifest, 2);
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -72,13 +72,13 @@ public class TestManifestWriterVersions {
   private static final Integer SORT_ORDER_ID = 2;
 
   private static final DataFile DATA_FILE = new GenericDataFile(
-      0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS, SORT_ORDER_ID);
+      -1, 0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS, SORT_ORDER_ID);
 
   private static final List<Integer> EQUALITY_IDS = ImmutableList.of(1);
   private static final int[] EQUALITY_ID_ARR = new int[] { 1 };
 
-  private static final DeleteFile DELETE_FILE = new GenericDeleteFile(
-      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, EQUALITY_ID_ARR, SORT_ORDER_ID, null);
+  private static final DeleteFile DELETE_FILE = new GenericDeleteFile(-1, 0, FileContent.EQUALITY_DELETES,
+      PATH, FORMAT, PARTITION, 22905L, METRICS, EQUALITY_ID_ARR, SORT_ORDER_ID, null);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
@@ -53,6 +53,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
   private final Schema equalityDeleteRowSchema;
   private final SortOrder equalityDeleteSortOrder;
   private final Schema positionDeleteRowSchema;
+  private final int schemaId;
 
   protected BaseFileWriterFactory(Table table, FileFormat dataFileFormat, Schema dataSchema,
                                   SortOrder dataSortOrder, FileFormat deleteFileFormat,
@@ -67,6 +68,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
     this.equalityDeleteRowSchema = equalityDeleteRowSchema;
     this.equalityDeleteSortOrder = equalityDeleteSortOrder;
     this.positionDeleteRowSchema = positionDeleteRowSchema;
+    this.schemaId = table.schema().schemaId();
   }
 
   protected abstract void configureDataWrite(Avro.DataWriteBuilder builder);
@@ -99,6 +101,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(dataSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureDataWrite(avroBuilder);
@@ -114,6 +117,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(dataSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureDataWrite(parquetBuilder);
@@ -129,6 +133,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(dataSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureDataWrite(orcBuilder);
@@ -163,6 +168,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(equalityDeleteSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureEqualityDelete(avroBuilder);
@@ -179,6 +185,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(equalityDeleteSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureEqualityDelete(parquetBuilder);
@@ -195,6 +202,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
               .withSortOrder(equalityDeleteSortOrder)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configureEqualityDelete(orcBuilder);
@@ -227,6 +235,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withSpec(spec)
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configurePositionDelete(avroBuilder);
@@ -241,6 +250,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withSpec(spec)
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configurePositionDelete(parquetBuilder);
@@ -255,6 +265,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
               .withSpec(spec)
               .withPartition(partition)
               .withKeyMetadata(keyMetadata)
+              .withSchemaId(schemaId)
               .overwrite();
 
           configurePositionDelete(orcBuilder);

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -755,7 +755,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private ManifestFile createTestingManifestFile(Path manifestPath) {
     return new GenericManifestFile(manifestPath.toAbsolutePath().toString(), manifestPath.toFile().length(), 0,
-        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null);
+        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null, -1);
   }
 
   private List<Path> assertFlinkManifests(int expectedCount) throws IOException {

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -765,7 +765,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private ManifestFile createTestingManifestFile(Path manifestPath) {
     return new GenericManifestFile(manifestPath.toAbsolutePath().toString(), manifestPath.toFile().length(), 0,
-        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null);
+        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null, -1);
   }
 
   private List<Path> assertFlinkManifests(int expectedCount) throws IOException {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -761,7 +761,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private ManifestFile createTestingManifestFile(Path manifestPath) {
     return new GenericManifestFile(manifestPath.toAbsolutePath().toString(), manifestPath.toFile().length(), 0,
-        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null);
+        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null, -1);
   }
 
   private List<Path> assertFlinkManifests(int expectedCount) throws IOException {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -48,6 +48,7 @@ public class SparkDataFile implements DataFile {
   private final int keyMetadataPosition;
   private final int splitOffsetsPosition;
   private final int sortOrderIdPosition;
+  private final int schemaIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -81,6 +82,7 @@ public class SparkDataFile implements DataFile {
     keyMetadataPosition = positions.get("key_metadata");
     splitOffsetsPosition = positions.get("split_offsets");
     sortOrderIdPosition = positions.get("sort_order_id");
+    schemaIdPosition = positions.get("schema_id");
   }
 
   public SparkDataFile wrap(Row row) {
@@ -182,6 +184,11 @@ public class SparkDataFile implements DataFile {
   @Override
   public Integer sortOrderId() {
     return wrapped.getAs(sortOrderIdPosition);
+  }
+
+  @Override
+  public int schemaId() {
+    return wrapped.getAs(schemaIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -138,6 +138,11 @@ public class ManifestFileBean implements ManifestFile {
   }
 
   @Override
+  public int schemaId() {
+    return -1;
+  }
+
+  @Override
   public ManifestFile copy() {
     throw new UnsupportedOperationException("Cannot copy");
   }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -48,6 +48,7 @@ public class SparkDataFile implements DataFile {
   private final int keyMetadataPosition;
   private final int splitOffsetsPosition;
   private final int sortOrderIdPosition;
+  private final int schemaIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -81,6 +82,7 @@ public class SparkDataFile implements DataFile {
     keyMetadataPosition = positions.get("key_metadata");
     splitOffsetsPosition = positions.get("split_offsets");
     sortOrderIdPosition = positions.get("sort_order_id");
+    schemaIdPosition = positions.get("schema_id");
   }
 
   public SparkDataFile wrap(Row row) {
@@ -182,6 +184,11 @@ public class SparkDataFile implements DataFile {
   @Override
   public Integer sortOrderId() {
     return wrapped.getAs(sortOrderIdPosition);
+  }
+
+  @Override
+  public int schemaId() {
+    return wrapped.getAs(schemaIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -138,6 +138,11 @@ public class ManifestFileBean implements ManifestFile {
   }
 
   @Override
+  public int schemaId() {
+    return -1;
+  }
+
+  @Override
   public ManifestFile copy() {
     throw new UnsupportedOperationException("Cannot copy");
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -48,6 +48,7 @@ public class SparkDataFile implements DataFile {
   private final int keyMetadataPosition;
   private final int splitOffsetsPosition;
   private final int sortOrderIdPosition;
+  private final int schemaIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -81,6 +82,7 @@ public class SparkDataFile implements DataFile {
     keyMetadataPosition = positions.get("key_metadata");
     splitOffsetsPosition = positions.get("split_offsets");
     sortOrderIdPosition = positions.get("sort_order_id");
+    schemaIdPosition = positions.get("schema_id");
   }
 
   public SparkDataFile wrap(Row row) {
@@ -182,6 +184,11 @@ public class SparkDataFile implements DataFile {
   @Override
   public Integer sortOrderId() {
     return wrapped.getAs(sortOrderIdPosition);
+  }
+
+  @Override
+  public int schemaId() {
+    return wrapped.getAs(schemaIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -138,6 +138,11 @@ public class ManifestFileBean implements ManifestFile {
   }
 
   @Override
+  public int schemaId() {
+    return -1;
+  }
+
+  @Override
   public ManifestFile copy() {
     throw new UnsupportedOperationException("Cannot copy");
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -48,6 +48,7 @@ public class SparkDataFile implements DataFile {
   private final int keyMetadataPosition;
   private final int splitOffsetsPosition;
   private final int sortOrderIdPosition;
+  private final int schemaIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -81,6 +82,7 @@ public class SparkDataFile implements DataFile {
     keyMetadataPosition = positions.get("key_metadata");
     splitOffsetsPosition = positions.get("split_offsets");
     sortOrderIdPosition = positions.get("sort_order_id");
+    schemaIdPosition = positions.get("schema_id");
   }
 
   public SparkDataFile wrap(Row row) {
@@ -182,6 +184,11 @@ public class SparkDataFile implements DataFile {
   @Override
   public Integer sortOrderId() {
     return wrapped.getAs(sortOrderIdPosition);
+  }
+
+  @Override
+  public int schemaId() {
+    return wrapped.getAs(schemaIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -147,6 +147,11 @@ public class ManifestFileBean implements ManifestFile {
   }
 
   @Override
+  public int schemaId() {
+    return -1;
+  }
+
+  @Override
   public ManifestFile copy() {
     throw new UnsupportedOperationException("Cannot copy");
   }


### PR DESCRIPTION
This patch adds the support of file filtering based on the schema. This aims to reduce the file scan time when we have done a schema evaluation. For the following example:
```
1. create a table with schema <id: long, name: string> and partition on id
2. add new files
3. update the schema and add a new column: address. Now the schema is <id: long, name: string, address: string>
4. add new files
// Before this patch, we have to read those files added at 2 and do the filter after reading those files.
6. scan with filter start_with('address', 'some_value') and id > 10;
```
This adds the `SchemaId` to both `DataFile` and `ManifestFile`, we will filter the `ManifestFile` first and then on `DataFile` when needed.