### PR TITLE
Core: Refactor REST catalog to RESTSessionCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
- * Takes in the full configuration for the {@link RESTCatalog}, which should already have
+ * Takes in the full configuration for the {@link RESTSessionCatalog}, which should already have
  * called the server's initial configuration route.
  * Using the merged configuration, an instance of {@link RESTClient} is obtained that can be used with the
  * RESTCatalog.

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.rest;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 
 /**
@@ -29,16 +30,41 @@ import org.apache.iceberg.rest.responses.ErrorResponse;
  */
 public interface RESTClient extends Closeable {
 
+  default void head(String path, Supplier<Map<String, String>> headers, Consumer<ErrorResponse> errorHandler) {
+    head(path, headers.get(), errorHandler);
+  }
+
   void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler);
+
+  default <T extends RESTResponse> T delete(String path, Class<T> responseType, Supplier<Map<String, String>> headers,
+                                            Consumer<ErrorResponse> errorHandler) {
+    return delete(path, responseType, headers.get(), errorHandler);
+  }
 
   <T extends RESTResponse> T delete(String path, Class<T> responseType, Map<String, String> headers,
                                     Consumer<ErrorResponse> errorHandler);
 
+  default <T extends RESTResponse> T get(String path, Class<T> responseType, Supplier<Map<String, String>> headers,
+                                         Consumer<ErrorResponse> errorHandler) {
+    return get(path, responseType, headers.get(), errorHandler);
+  }
+
   <T extends RESTResponse> T get(String path, Class<T> responseType, Map<String, String> headers,
                                  Consumer<ErrorResponse> errorHandler);
 
+  default <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
+                                          Supplier<Map<String, String>> headers, Consumer<ErrorResponse> errorHandler) {
+    return post(path, body, responseType, headers.get(), errorHandler);
+  }
+
   <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType, Map<String, String> headers,
                                   Consumer<ErrorResponse> errorHandler);
+
+  default <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType,
+                                              Supplier<Map<String, String>> headers,
+                                              Consumer<ErrorResponse> errorHandler) {
+    return postForm(path, formData, responseType, headers.get(), errorHandler);
+  }
 
   <T extends RESTResponse> T postForm(String path, Map<String, String> formData, Class<T> responseType,
                                       Map<String, String> headers, Consumer<ErrorResponse> errorHandler);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.TableMetadata;
@@ -49,19 +50,21 @@ class RESTTableOperations implements TableOperations {
 
   private final RESTClient client;
   private final String path;
-  private final Map<String, String> headers;
+  private final Supplier<Map<String, String>> headers;
   private final FileIO io;
   private final List<MetadataUpdate> createChanges;
   private final TableMetadata replaceBase;
   private UpdateType updateType;
   private TableMetadata current;
 
-  RESTTableOperations(RESTClient client, String path, Map<String, String> headers, FileIO io, TableMetadata current) {
+  RESTTableOperations(
+      RESTClient client, String path, Supplier<Map<String, String>> headers, FileIO io, TableMetadata current) {
     this(client, path, headers, io, UpdateType.SIMPLE, Lists.newArrayList(), current);
   }
 
-  RESTTableOperations(RESTClient client, String path, Map<String, String> headers, FileIO io, UpdateType updateType,
-                      List<MetadataUpdate> createChanges, TableMetadata current) {
+  RESTTableOperations(
+      RESTClient client, String path, Supplier<Map<String, String>> headers, FileIO io, UpdateType updateType,
+      List<MetadataUpdate> createChanges, TableMetadata current) {
     this.client = client;
     this.path = path;
     this.headers = headers;


### PR DESCRIPTION
This is a minimal set of changes to refactor the `RESTCatalog` to a `RESTSessionCatalog`. The current `RESTCatalog` is removed to show changes between the session version and the original catalog implementation. A wrapper will be added in a follow-up commit.