### PR TITLE
Flink: Modify Table Location Strings in Tests to Fix Local Test Failures

### DIFF
--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -209,13 +209,13 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
   public void testCreateTableLocation() {
     Assume.assumeFalse("HadoopCatalog does not support creating table with location", isHadoopCatalog);
 
-    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='/tmp/location')");
+    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='file:///tmp/location')");
 
     Table table = table("tl");
     Assert.assertEquals(
         new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct(),
         table.schema().asStruct());
-    Assert.assertEquals("/tmp/location", table.location());
+    Assert.assertEquals("file:///tmp/location", table.location());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
   }
 
@@ -322,8 +322,8 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
 
     sql("CREATE TABLE tl(id BIGINT)");
-    sql("ALTER TABLE tl SET('location'='/tmp/location')");
-    Assert.assertEquals("/tmp/location", table("tl").location());
+    sql("ALTER TABLE tl SET('location'='file:///tmp/location')");
+    Assert.assertEquals("file:///tmp/location", table("tl").location());
   }
 
   @Test

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -209,13 +209,13 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
   public void testCreateTableLocation() {
     Assume.assumeFalse("HadoopCatalog does not support creating table with location", isHadoopCatalog);
 
-    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='/tmp/location')");
+    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='file:///tmp/location')");
 
     Table table = table("tl");
     Assert.assertEquals(
         new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct(),
         table.schema().asStruct());
-    Assert.assertEquals("/tmp/location", table.location());
+    Assert.assertEquals("file:///tmp/location", table.location());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
   }
 
@@ -346,8 +346,8 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
 
     sql("CREATE TABLE tl(id BIGINT)");
-    sql("ALTER TABLE tl SET('location'='/tmp/location')");
-    Assert.assertEquals("/tmp/location", table("tl").location());
+    sql("ALTER TABLE tl SET('location'='file:///tmp/location')");
+    Assert.assertEquals("file:///tmp/location", table("tl").location());
   }
 
   @Test

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -209,13 +209,13 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
   public void testCreateTableLocation() {
     Assume.assumeFalse("HadoopCatalog does not support creating table with location", isHadoopCatalog);
 
-    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='/tmp/location')");
+    sql("CREATE TABLE tl(id BIGINT) WITH ('location'='file:///tmp/location')");
 
     Table table = table("tl");
     Assert.assertEquals(
         new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct(),
         table.schema().asStruct());
-    Assert.assertEquals("/tmp/location", table.location());
+    Assert.assertEquals("file:///tmp/location", table.location());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
   }
 
@@ -346,8 +346,8 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
 
     sql("CREATE TABLE tl(id BIGINT)");
-    sql("ALTER TABLE tl SET('location'='/tmp/location')");
-    Assert.assertEquals("/tmp/location", table("tl").location());
+    sql("ALTER TABLE tl SET('location'='file:///tmp/location')");
+    Assert.assertEquals("file:///tmp/location", table("tl").location());
   }
 
   @Test


### PR DESCRIPTION
In the original code, the path is directly written `'location'='/tmp/location'` , and hdfs will access the local port 9000.
However, in general, hadoop is not installed during local testing, which causes the connection port to fail and the test case to report an error. 
So, I modified the path to store it on disk `'location'='file:///tmp/location'` , which is more convenient for local testing.