### PR TITLE
Infra: add AWS CI workflow configuration

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "AWS CI"
+on:
+  push:
+    branches:
+    - 'master'
+    - '0.**'
+    tags:
+    - 'apache-iceberg-**'
+  pull_request:
+    paths:
+    - 'aws/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jvm: [8, 11]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jvm }}
+    - uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+    - name: Run AWS integration tests
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_ACCESS_KEY_ID2: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY2: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: us-east-1
+        AWS_CROSS_REGION: us-west-2
+        AWS_TEST_ACCOUNT_ID: 220427471354
+        AWS_TEST_BUCKET: iceberg-aws-ci-220427471354-us-east-1
+        AWS_TEST_CROSS_REGION_BUCKET: iceberg-aws-ci-220427471354-us-west-2
+      run: ./gradlew :iceberg-aws:integrationTest
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: test logs
+        path: |
+          **/build/testlogs

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -50,9 +50,6 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - env:
-        TEST_ENV: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      run: echo $TEST_ENV
     - name: Run AWS integration tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -50,12 +50,13 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+    - env:
+        TEST_ENV: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      run: echo $TEST_ENV
     - name: Run AWS integration tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_ACCESS_KEY_ID2: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY2: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: us-east-1
         AWS_CROSS_REGION: us-west-2
         AWS_TEST_ACCOUNT_ID: 220427471354

--- a/aws/src/integration/README.md
+++ b/aws/src/integration/README.md
@@ -1,0 +1,197 @@
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
+# AWS Integration Tests
+
+The AWS integration test suite runs tests against an AWS account to verify behaviors in a real AWS cloud environment.
+
+## Setup
+
+The test suite uses the [default AWS credential chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html) to detect the credentials used to run tests.
+For example, the AWS Tests CI workflow uses the credentials set in environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
+
+In addition, the test suite requires setting the following environment variables:
+- `AWS_REGION`: AWS region to run tests, e.g. `us-east-1`
+- `AWS_CROSS_REGION`: AWS region to run any cross-region operations, e.g. `us-west-2`
+- `AWS_TEST_ACCOUNT_ID`: AWS account ID to run tests, e.g. `123456789012`
+- `AWS_TEST_BUCKET`: S3 bucket to run tests, e.g. `my-bucket`
+- `AWS_TEST_CROSS_REGION_BUCKET`: S3 bucket to run any cross-region operations, e.g. `my-cross-region-bucket`
+
+Here is an example script to execute integration tests in terminal:
+
+```shell
+# set environment variables
+export AWS_ACCESS_KEY_ID=ABCDEFG1234567890
+export AWS_SECRET_ACCESS_KEY=qwertyuiopasdfghjklzxcvbnm
+export AWS_REGION=us-east-1
+export AWS_CROSS_REGION=us-west-2
+export AWS_TEST_ACCOUNT_ID=123456789012
+export AWS_TEST_BUCKET=my-bucket
+export AWS_TEST_CROSS_REGION_BUCKET=my-cross-region-bucket
+
+# run all tests
+./gradlew :iceberg-aws:integrationTest
+
+# run a single test suite
+./gradlew :iceberg-aws:integrationTest --tests "org.apache.iceberg.aws.s3.TestS3FileIOIntegration"
+
+# run a single test
+./gradlew :iceberg-aws:integrationTest --tests "org.apache.iceberg.aws.s3.TestS3FileIOIntegration.testServerSideKmsEncryption"
+```
+
+## Permissions
+
+The following JSON payload describes the minimum set of permissions required to execute tests.
+Developers interested in running the test suite against a personal AWS account can use this for reference.
+The AWS Tests CI workflow uses the same set of permissions.
+To add new permissions in CI, please contact [dev@iceberg.apache.org](mailto:dev@iceberg.apache.org).
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3BucketPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetAccessPoint",
+        "s3:CreateAccessPoint",
+        "s3:DeleteAccessPoint",
+        "s3:ListAccessPoints",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::iceberg-aws-ci-220427471354-us-east-1",
+        "arn:aws:s3:::iceberg-aws-ci-220427471354-us-west-2"
+      ]
+    },
+    {
+      "Sid": "S3ObjectPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObjectAcl",
+        "s3:GetObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": [
+        "arn:aws:s3:::iceberg-aws-ci-220427471354-us-east-1/*",
+        "arn:aws:s3:::iceberg-aws-ci-220427471354-us-west-2/*"
+      ]
+    },
+    {
+      "Sid": "GluePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "glue:UpdateDatabase",
+        "glue:DeleteDatabase",
+        "glue:CreateTable",
+        "glue:GetTables",
+        "glue:GetTableVersions",
+        "glue:UpdateTable",
+        "glue:DeleteTable",
+        "glue:GetDatabases",
+        "glue:GetTable",
+        "glue:GetDatabase",
+        "glue:GetTableVersion",
+        "glue:CreateDatabase"
+      ],
+      "Resource": [
+        "arn:aws:glue:us-east-1:220427471354:catalog",
+        "arn:aws:glue:us-east-1:220427471354:database/iceberg_aws_ci_*",
+        "arn:aws:glue:us-east-1:220427471354:table/iceberg_aws_ci_*/*",
+        "arn:aws:glue:us-east-1:220427471354:userDefinedFunction/iceberg_aws_ci_*/*"
+      ]
+    },
+    {
+      "Sid": "STSPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "sts:TagSession",
+        "sts:AssumeRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::220427471354:role/iceberg-aws-ci-*"
+      ]
+    },
+    {
+      "Sid": "KMSKeyCreationPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "KMSAliasPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateAlias"
+      ],
+      "Resource": [
+        "arn:aws:kms:us-east-1:220427471354:key/*",
+        "arn:aws:kms:us-east-1:220427471354:alias/iceberg-aws-ci-*"
+      ]
+    },
+    {
+      "Sid": "KMSKeyUsagePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:ScheduleKeyDeletion"
+      ],
+      "Resource": "arn:aws:kms:us-east-1:220427471354:key/*",
+      "Condition": {
+        "ForAnyValue:StringLike": {
+          "kms:ResourceAliases": "alias/iceberg-aws-ci-*"
+        }
+      }
+    },
+    {
+      "Sid": "IAMPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy"
+      ],
+      "Resource": [
+        "arn:aws:iam::220427471354:role/iceberg-aws-ci-*"
+      ]
+    },
+    {
+      "Sid": "DynamoDBPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:CreateTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:us-east-1:220427471354:table/IcebergAwsCI_*"
+      ]
+    }
+  ]
+}
+```

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -55,7 +55,7 @@ public class TestAssumeRoleAwsClientFactory {
 
   @Before
   public void before() {
-    roleName = UUID.randomUUID().toString();
+    roleName = "iceberg-aws-ci-" + UUID.randomUUID();
     iam = IamClient.builder()
         .region(Region.AWS_GLOBAL)
         .httpClientBuilder(UrlConnectionHttpClient.builder())

--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
@@ -296,6 +296,6 @@ public class TestDynamoDbCatalog {
   }
 
   private static String genRandomName() {
-    return UUID.randomUUID().toString().replace("-", "");
+    return "IcebergAwsCI_" + UUID.randomUUID().toString().replace("-", "");
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -98,7 +98,7 @@ public class GlueTestBase {
   }
 
   public static String createNamespace() {
-    String namespace = getRandomName();
+    String namespace = "iceberg_aws_ci_" + getRandomName();
     namespaces.add(namespace);
     glueCatalog.createNamespace(Namespace.of(namespace));
     return namespace;

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -56,7 +56,7 @@ public class TestLakeFormationAwsClientFactory {
 
   @Before
   public void before() {
-    roleName = UUID.randomUUID().toString();
+    roleName = "iceberg-aws-ci-" + UUID.randomUUID();
     iam = IamClient.builder()
         .region(Region.AWS_GLOBAL)
         .httpClientBuilder(UrlConnectionHttpClient.builder())

--- a/build.gradle
+++ b/build.gradle
@@ -365,9 +365,6 @@ project(':iceberg-aws') {
   task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath
-    testLogging {
-      exceptionFormat = 'full'
-    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -365,6 +365,9 @@ project(':iceberg-aws') {
   task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath
+    testLogging {
+      exceptionFormat = 'full'
+    }
   }
 }
 


### PR DESCRIPTION
@rdblue @amogh-jahagirdar @xiaoxuandev @rajarshisarkar @singhpk234 

Adding the AWS CI workflow to connect to an AWS account for running AWS module integration tests. Sorry I promised this almost a year ago and finally I am able to make it.

I did some research and there are 2 ways to do this:
1. using https://github.com/aws-actions/configure-aws-credentials action, which I have not been able to make it work yet in the GitHub OIDC mode, still trying
2. using Github secrets as stated by ASF infra page: https://infra.apache.org/github-actions-secrets.html

I will reach out to ASF infra team to see what's the best way to go with this.