### PR TITLE
[REST Catalog Spec] Add MetadataUpdate.AssignUUID to the OpenAPI Specification

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1222,6 +1222,7 @@ components:
         action:
           type: string
           enum:
+            - assign-uuid
             - upgrade-format-version
             - add-schema
             - set-current-schema
@@ -1235,6 +1236,17 @@ components:
             - set-location
             - set-properties
             - remove-properties
+
+    AssignUUIDUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          required:
+            - uuid
+          properties:
+            uuid:
+              type: string
+              description: Table UUID to set as current
 
     UpgradeFormatVersionUpdate:
       allOf:
@@ -1379,6 +1391,7 @@ components:
 
     TableUpdate:
       anyOf:
+        - $ref: '#/components/schemas/AssignUUIDUpdate'
         - $ref: '#/components/schemas/UpgradeFormatVersionUpdate'
         - $ref: '#/components/schemas/AddSchemaUpdate'
         - $ref: '#/components/schemas/SetCurrentSchemaUpdate'


### PR DESCRIPTION
This closes issue https://github.com/apache/iceberg/issues/4828

For some very old tables (e.g. from the 0.9.x-era or incubating era), the table does not have UUID in it.

This class allows server side implementors to add a UUID to those tables (in case they havent been touched in a very long time).

This is a _very_ rare use case, so we've encoded it in the `MetadataUpdate` if people need it, but it's a very rare corner case.

This is encoded in the class MetadataUpdate.AssignUUID, but it's not present in the REST Catalog's spec.
https://github.com/apache/iceberg/blob/b8626eecc139f638b162f06a5f8f3c8bb210346a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java#L34-L49

Normally, a table's UUID will be udated as part of the normal update table / create table workload.