### PR TITLE
Core / OpenAPI: Add RemoveSnapshotRef to MetadataUpdateParser and OpenAPI spec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -216,19 +216,19 @@ public interface MetadataUpdate extends Serializable {
   }
 
   class RemoveSnapshotRef implements MetadataUpdate {
-    private final String name;
+    private final String refName;
 
-    public RemoveSnapshotRef(String name) {
-      this.name = name;
+    public RemoveSnapshotRef(String refName) {
+      this.refName = refName;
     }
 
     public String name() {
-      return name;
+      return refName;
     }
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      metadataBuilder.removeRef(name);
+      metadataBuilder.removeRef(refName);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -51,8 +51,8 @@ public class MetadataUpdateParser {
   static final String SET_DEFAULT_SORT_ORDER = "set-default-sort-order";
   static final String ADD_SNAPSHOT = "add-snapshot";
   static final String REMOVE_SNAPSHOTS = "remove-snapshots";
-  static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
   static final String REMOVE_SNAPSHOT_REF = "remove-snapshot-ref";
+  static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
   static final String SET_PROPERTIES = "set-properties";
   static final String REMOVE_PROPERTIES = "remove-properties";
   static final String SET_LOCATION = "set-location";
@@ -89,7 +89,7 @@ public class MetadataUpdateParser {
   private static final String SNAPSHOT_IDS = "snapshot-ids";
 
   // SetSnapshotRef
-  private static final String REF_NAME = "ref-name";
+  private static final String REF_NAME = "ref-name"; // Also used in RemoveSnapshotRef
   private static final String SNAPSHOT_ID = "snapshot-id";
   private static final String TYPE = "type";
   private static final String MIN_SNAPSHOTS_TO_KEEP = "min-snapshots-to-keep";
@@ -117,8 +117,8 @@ public class MetadataUpdateParser {
       .put(MetadataUpdate.SetDefaultSortOrder.class, SET_DEFAULT_SORT_ORDER)
       .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
       .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
-      .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
       .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
+      .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
       .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
       .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)
       .put(MetadataUpdate.SetLocation.class, SET_LOCATION)
@@ -185,11 +185,11 @@ public class MetadataUpdateParser {
       case REMOVE_SNAPSHOTS:
         writeRemoveSnapshots((MetadataUpdate.RemoveSnapshot) metadataUpdate, generator);
         break;
-      case SET_SNAPSHOT_REF:
-        writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
-        break;
       case REMOVE_SNAPSHOT_REF:
         writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
+        break;
+      case SET_SNAPSHOT_REF:
+        writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
         break;
       case SET_PROPERTIES:
         writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
@@ -249,10 +249,10 @@ public class MetadataUpdateParser {
         return readAddSnapshot(jsonNode);
       case REMOVE_SNAPSHOTS:
         return readRemoveSnapshots(jsonNode);
-      case SET_SNAPSHOT_REF:
-        return readSetSnapshotRef(jsonNode);
       case REMOVE_SNAPSHOT_REF:
         return readRemoveSnapshotRef(jsonNode);
+      case SET_SNAPSHOT_REF:
+        return readSetSnapshotRef(jsonNode);
       case SET_PROPERTIES:
         return readSetProperties(jsonNode);
       case REMOVE_PROPERTIES:

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -52,6 +52,7 @@ public class MetadataUpdateParser {
   static final String ADD_SNAPSHOT = "add-snapshot";
   static final String REMOVE_SNAPSHOTS = "remove-snapshots";
   static final String SET_SNAPSHOT_REF = "set-snapshot-ref";
+  static final String REMOVE_SNAPSHOT_REF = "remove-snapshot-ref";
   static final String SET_PROPERTIES = "set-properties";
   static final String REMOVE_PROPERTIES = "remove-properties";
   static final String SET_LOCATION = "set-location";
@@ -117,6 +118,7 @@ public class MetadataUpdateParser {
       .put(MetadataUpdate.AddSnapshot.class, ADD_SNAPSHOT)
       .put(MetadataUpdate.RemoveSnapshot.class, REMOVE_SNAPSHOTS)
       .put(MetadataUpdate.SetSnapshotRef.class, SET_SNAPSHOT_REF)
+      .put(MetadataUpdate.RemoveSnapshotRef.class, REMOVE_SNAPSHOT_REF)
       .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
       .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)
       .put(MetadataUpdate.SetLocation.class, SET_LOCATION)
@@ -186,6 +188,9 @@ public class MetadataUpdateParser {
       case SET_SNAPSHOT_REF:
         writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
         break;
+      case REMOVE_SNAPSHOT_REF:
+        writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
+        break;
       case SET_PROPERTIES:
         writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
         break;
@@ -246,6 +251,8 @@ public class MetadataUpdateParser {
         return readRemoveSnapshots(jsonNode);
       case SET_SNAPSHOT_REF:
         return readSetSnapshotRef(jsonNode);
+      case REMOVE_SNAPSHOT_REF:
+        return readRemoveSnapshotRef(jsonNode);
       case SET_PROPERTIES:
         return readSetProperties(jsonNode);
       case REMOVE_PROPERTIES:
@@ -322,6 +329,12 @@ public class MetadataUpdateParser {
         update.minSnapshotsToKeep() != null, MIN_SNAPSHOTS_TO_KEEP, update.minSnapshotsToKeep(), gen);
     JsonUtil.writeLongFieldIf(update.maxSnapshotAgeMs() != null, MAX_SNAPSHOT_AGE_MS, update.maxSnapshotAgeMs(), gen);
     JsonUtil.writeLongFieldIf(update.maxRefAgeMs() != null, MAX_REF_AGE_MS, update.maxRefAgeMs(), gen);
+  }
+
+  private static void writeRemoveSnapshotRef(
+      MetadataUpdate.RemoveSnapshotRef update,
+      JsonGenerator gen) throws IOException {
+    gen.writeStringField(REF_NAME, update.name());
   }
 
   private static void writeSetProperties(MetadataUpdate.SetProperties update, JsonGenerator gen) throws IOException {
@@ -410,6 +423,11 @@ public class MetadataUpdateParser {
     Long maxRefAgeMs = JsonUtil.getLongOrNull(MAX_REF_AGE_MS, node);
     return new MetadataUpdate.SetSnapshotRef(
         refName, snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+  }
+
+  private static MetadataUpdate readRemoveSnapshotRef(JsonNode node) {
+    String refName = JsonUtil.getString(REF_NAME, node);
+    return new MetadataUpdate.RemoveSnapshotRef(refName);
   }
 
   private static MetadataUpdate readSetProperties(JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -331,9 +331,8 @@ public class MetadataUpdateParser {
     JsonUtil.writeLongFieldIf(update.maxRefAgeMs() != null, MAX_REF_AGE_MS, update.maxRefAgeMs(), gen);
   }
 
-  private static void writeRemoveSnapshotRef(
-      MetadataUpdate.RemoveSnapshotRef update,
-      JsonGenerator gen) throws IOException {
+  private static void writeRemoveSnapshotRef(MetadataUpdate.RemoveSnapshotRef update, JsonGenerator gen)
+      throws IOException {
     gen.writeStringField(REF_NAME, update.name());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -551,6 +551,26 @@ public class TestMetadataUpdateParser {
         expected, actual);
   }
 
+  /** RemoveSnapshotRef **/
+
+  @Test
+  public void testRemoveSnapshotRefFromJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOT_REF;
+    String snapshotRef = "snapshot-ref";
+    String json = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testRemoveSnapshotRefToJson() {
+    String snapshotRef = "snapshot-ref";
+    String expected = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
+    MetadataUpdate actual = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
+    Assert.assertEquals("RemoveSnapshotRef should convert to the correct JSON value",
+        expected, MetadataUpdateParser.toJson(actual));
+  }
+
   /** SetProperties */
 
   @Test
@@ -683,6 +703,10 @@ public class TestMetadataUpdateParser {
         assertEqualsSetSnapshotRef((MetadataUpdate.SetSnapshotRef) expectedUpdate,
             (MetadataUpdate.SetSnapshotRef) actualUpdate);
         break;
+      case MetadataUpdateParser.REMOVE_SNAPSHOT_REF:
+        assertEqualsRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) expectedUpdate,
+            (MetadataUpdate.RemoveSnapshotRef) actualUpdate);
+        break;
       case MetadataUpdateParser.SET_PROPERTIES:
         assertEqualsSetProperties((MetadataUpdate.SetProperties) expectedUpdate,
             (MetadataUpdate.SetProperties) actualUpdate);
@@ -807,6 +831,11 @@ public class TestMetadataUpdateParser {
         expected.maxSnapshotAgeMs(), actual.maxSnapshotAgeMs());
     Assert.assertEquals("Max ref age ms should be equal when present and null when missing or explicitly null",
         expected.maxRefAgeMs(), actual.maxRefAgeMs());
+  }
+
+  private static void assertEqualsRemoveSnapshotRef(
+      MetadataUpdate.RemoveSnapshotRef expected, MetadataUpdate.RemoveSnapshotRef actual) {
+    Assertions.assertThat(actual.name()).isEqualTo(expected.name());
   }
 
   private static void assertEqualsSetProperties(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -372,6 +372,26 @@ public class TestMetadataUpdateParser {
     Assert.assertEquals("Remove snapshots should serialize to the correct JSON value", expected, actual);
   }
 
+  /** RemoveSnapshotRef **/
+
+  @Test
+  public void testRemoveSnapshotRefFromJson() {
+    String action = MetadataUpdateParser.REMOVE_SNAPSHOT_REF;
+    String snapshotRef = "snapshot-ref";
+    String json = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
+    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
+    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
+  public void testRemoveSnapshotRefToJson() {
+    String snapshotRef = "snapshot-ref";
+    String expected = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
+    MetadataUpdate actual = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
+    Assert.assertEquals("RemoveSnapshotRef should convert to the correct JSON value",
+        expected, MetadataUpdateParser.toJson(actual));
+  }
+
   /** SetSnapshotRef **/
 
   @Test
@@ -551,26 +571,6 @@ public class TestMetadataUpdateParser {
         expected, actual);
   }
 
-  /** RemoveSnapshotRef **/
-
-  @Test
-  public void testRemoveSnapshotRefFromJson() {
-    String action = MetadataUpdateParser.REMOVE_SNAPSHOT_REF;
-    String snapshotRef = "snapshot-ref";
-    String json = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
-    MetadataUpdate expected = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
-    assertEquals(action, expected, MetadataUpdateParser.fromJson(json));
-  }
-
-  @Test
-  public void testRemoveSnapshotRefToJson() {
-    String snapshotRef = "snapshot-ref";
-    String expected = "{\"action\":\"remove-snapshot-ref\",\"ref-name\":\"snapshot-ref\"}";
-    MetadataUpdate actual = new MetadataUpdate.RemoveSnapshotRef(snapshotRef);
-    Assert.assertEquals("RemoveSnapshotRef should convert to the correct JSON value",
-        expected, MetadataUpdateParser.toJson(actual));
-  }
-
   /** SetProperties */
 
   @Test
@@ -699,13 +699,13 @@ public class TestMetadataUpdateParser {
         assertEqualsRemoveSnapshots((MetadataUpdate.RemoveSnapshot) expectedUpdate,
             (MetadataUpdate.RemoveSnapshot) actualUpdate);
         break;
-      case MetadataUpdateParser.SET_SNAPSHOT_REF:
-        assertEqualsSetSnapshotRef((MetadataUpdate.SetSnapshotRef) expectedUpdate,
-            (MetadataUpdate.SetSnapshotRef) actualUpdate);
-        break;
       case MetadataUpdateParser.REMOVE_SNAPSHOT_REF:
         assertEqualsRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) expectedUpdate,
             (MetadataUpdate.RemoveSnapshotRef) actualUpdate);
+        break;
+      case MetadataUpdateParser.SET_SNAPSHOT_REF:
+        assertEqualsSetSnapshotRef((MetadataUpdate.SetSnapshotRef) expectedUpdate,
+            (MetadataUpdate.SetSnapshotRef) actualUpdate);
         break;
       case MetadataUpdateParser.SET_PROPERTIES:
         assertEqualsSetProperties((MetadataUpdate.SetProperties) expectedUpdate,

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1351,9 +1351,8 @@ components:
           required:
             - ref-name
           properties:
-            name:
+            ref-name:
               type: string
-              description: Name of the snapshot ref to remove
 
     SetLocationUpdate:
       allOf:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1231,6 +1231,7 @@ components:
             - set-default-sort-order
             - add-snapshot
             - set-snapshot-ref
+            - remove-snapshot-ref
             - remove-snapshots
             - set-location
             - set-properties
@@ -1343,6 +1344,17 @@ components:
                 type: integer
                 format: int64
 
+    RemoveSnapshotRefUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          required:
+            - ref-name
+          properties:
+            name:
+              type: string
+              description: SnapshotRef name to remove
+
     SetLocationUpdate:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
@@ -1389,6 +1401,7 @@ components:
         - $ref: '#/components/schemas/AddSnapshotUpdate'
         - $ref: '#/components/schemas/SetSnapshotRefUpdate'
         - $ref: '#/components/schemas/RemoveSnapshotsUpdate'
+        - $ref: '#/components/schemas/RemoveSnapshotRefUpdate'
         - $ref: '#/components/schemas/SetLocationUpdate'
         - $ref: '#/components/schemas/SetPropertiesUpdate'
         - $ref: '#/components/schemas/RemovePropertiesUpdate'

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1231,8 +1231,8 @@ components:
             - set-default-sort-order
             - add-snapshot
             - set-snapshot-ref
-            - remove-snapshot-ref
             - remove-snapshots
+            - remove-snapshot-ref
             - set-location
             - set-properties
             - remove-properties
@@ -1353,7 +1353,7 @@ components:
           properties:
             name:
               type: string
-              description: SnapshotRef name to remove
+              description: Name of the snapshot ref to remove
 
     SetLocationUpdate:
       allOf:


### PR DESCRIPTION
### About the change
This PR added the `RemoveSnapshotRef` to both MetadataUpdateParser and OpenAPI spec. 

Closes https://github.com/apache/iceberg/issues/4876


P.S Thanks @kbendick for beautifully documenting the change in the above issue :) !!!

### Testing Done 
Added UT for the same.

----- 

cc @rdblue @kbendick 