### PR TITLE
Uniform partition field names generation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.PartitionNameGenerator;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.transforms.UnknownTransform;
@@ -413,7 +414,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder identity(String sourceName) {
-      return identity(sourceName, sourceName);
+      String targetName = PartitionNameGenerator.getInstance().identity(sourceName, -1);
+      return identity(sourceName, targetName);
     }
 
     public Builder year(String sourceName, String targetName) {
@@ -427,7 +429,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder year(String sourceName) {
-      return year(sourceName, sourceName + "_year");
+      String targetName = PartitionNameGenerator.getInstance().year(sourceName, -1);
+      return year(sourceName, targetName);
     }
 
     public Builder month(String sourceName, String targetName) {
@@ -441,7 +444,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder month(String sourceName) {
-      return month(sourceName, sourceName + "_month");
+      String targetName = PartitionNameGenerator.getInstance().month(sourceName, -1);
+      return month(sourceName, targetName);
     }
 
     public Builder day(String sourceName, String targetName) {
@@ -455,7 +459,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder day(String sourceName) {
-      return day(sourceName, sourceName + "_day");
+      String targetName = PartitionNameGenerator.getInstance().day(sourceName, -1);
+      return day(sourceName, targetName);
     }
 
     public Builder hour(String sourceName, String targetName) {
@@ -469,7 +474,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder hour(String sourceName) {
-      return hour(sourceName, sourceName + "_hour");
+      String targetName = PartitionNameGenerator.getInstance().hour(sourceName, -1);
+      return hour(sourceName, targetName);
     }
 
     public Builder bucket(String sourceName, int numBuckets, String targetName) {
@@ -481,7 +487,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder bucket(String sourceName, int numBuckets) {
-      return bucket(sourceName, numBuckets, sourceName + "_bucket");
+      String targetName = PartitionNameGenerator.getInstance().bucket(sourceName, -1, numBuckets);
+      return bucket(sourceName, numBuckets, targetName);
     }
 
     public Builder truncate(String sourceName, int width, String targetName) {
@@ -493,7 +500,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder truncate(String sourceName, int width) {
-      return truncate(sourceName, width, sourceName + "_trunc");
+      String targetName = PartitionNameGenerator.getInstance().truncate(sourceName, -1, width);
+      return truncate(sourceName, width, targetName);
     }
 
     public Builder alwaysNull(String sourceName, String targetName) {
@@ -504,7 +512,8 @@ public class PartitionSpec implements Serializable {
     }
 
     public Builder alwaysNull(String sourceName) {
-      return alwaysNull(sourceName, sourceName + "_null");
+      String targetName = PartitionNameGenerator.getInstance().alwaysNull(sourceName, -1);
+      return alwaysNull(sourceName, targetName);
     }
 
     // add a partition field with an auto-increment partition field id starting from PARTITION_DATA_ID_START

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionNameGenerator.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionNameGenerator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.transforms;
+
+public class PartitionNameGenerator implements PartitionSpecVisitor<String> {
+  private static final PartitionNameGenerator INSTANCE = new PartitionNameGenerator();
+
+  private PartitionNameGenerator() {
+  }
+
+  public static PartitionNameGenerator getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String identity(int fieldId, String sourceName, int sourceId) {
+    return sourceName;
+  }
+
+  @Override
+  public String identity(String sourceName, int sourceId) {
+    return identity(-1, sourceName, sourceId);
+  }
+
+  @Override
+  public String bucket(int fieldId, String sourceName, int sourceId, int numBuckets) {
+    return sourceName + "_bucket_" + numBuckets;
+  }
+
+  @Override
+  public String bucket(String sourceName, int sourceId, int numBuckets) {
+    return bucket(-1, sourceName, sourceId, numBuckets);
+  }
+
+  @Override
+  public String truncate(int fieldId, String sourceName, int sourceId, int width) {
+    return sourceName + "_trunc_" + width;
+  }
+
+  @Override
+  public String truncate(String sourceName, int sourceId, int width) {
+    return truncate(-1, sourceName, sourceId, width);
+  }
+
+  @Override
+  public String year(int fieldId, String sourceName, int sourceId) {
+    return sourceName + "_year";
+  }
+
+  @Override
+  public String year(String sourceName, int sourceId) {
+    return year(-1, sourceName, sourceId);
+  }
+
+  @Override
+  public String month(int fieldId, String sourceName, int sourceId) {
+    return sourceName + "_month";
+  }
+
+  @Override
+  public String month(String sourceName, int sourceId) {
+    return month(-1, sourceName, sourceId);
+  }
+
+  @Override
+  public String day(int fieldId, String sourceName, int sourceId) {
+    return sourceName + "_day";
+  }
+
+  @Override
+  public String day(String sourceName, int sourceId) {
+    return day(-1, sourceName, sourceId);
+  }
+
+  @Override
+  public String hour(int fieldId, String sourceName, int sourceId) {
+    return sourceName + "_hour";
+  }
+
+  @Override
+  public String hour(String sourceName, int sourceId) {
+    return hour(-1, sourceName, sourceId);
+  }
+
+  @Override
+  public String alwaysNull(int fieldId, String sourceName, int sourceId) {
+    return sourceName + "_null";
+  }
+
+  @Override
+  public String alwaysNull(String sourceName, int sourceId) {
+    return alwaysNull(-1, sourceName, sourceId);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -86,6 +86,10 @@ public interface PartitionSpecVisitor<T> {
     throw new UnsupportedOperationException("Void transform is not supported");
   }
 
+  default T alwaysNull(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Void transform is not supported");
+  }
+
   default T unknown(int fieldId, String sourceName, int sourceId, String transform) {
     throw new UnsupportedOperationException(String.format("Unknown transform %s is not supported", transform));
   }

--- a/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
@@ -51,7 +51,7 @@ public class TestPartitionPaths {
     Row partition = Row.of(tsHour, idBucket);
 
     Assert.assertEquals("Should produce expected partition key",
-        "ts_hour=2017-12-01-10/id_bucket=" + idBucket, spec.partitionToPath(partition));
+        "ts_hour=2017-12-01-10/id_bucket_10=" + idBucket, spec.partitionToPath(partition));
   }
 
   @Test
@@ -62,7 +62,7 @@ public class TestPartitionPaths {
         .build();
 
     Assert.assertEquals("Should escape / as %2F",
-        "data=a%2Fb%2Fc%2Fd/data_trunc=a%2Fb%2Fc%2Fd",
+        "data=a%2Fb%2Fc%2Fd/data_trunc_10=a%2Fb%2Fc%2Fd",
         spec.partitionToPath(Row.of("a/b/c/d", "a/b/c/d")));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -354,17 +354,17 @@ public class TestProjection {
 
     predicate = (UnboundPredicate<Integer>) Projections
         .strict(partitionSpec).project(equal(bucket("long", 10), 20));
-    Assert.assertEquals("should expected long_bucket", "long_bucket", predicate.ref().name());
+    Assert.assertEquals("should expected long_bucket", "long_bucket_10", predicate.ref().name());
     predicate = (UnboundPredicate<Integer>) Projections
         .inclusive(partitionSpec).project(equal(bucket("long", 10), 20));
-    Assert.assertEquals("should expected long_bucket", "long_bucket", predicate.ref().name());
+    Assert.assertEquals("should expected long_bucket", "long_bucket_10", predicate.ref().name());
 
     predicate = (UnboundPredicate<Integer>) Projections
         .strict(partitionSpec).project(equal(truncate("string", 10), "abc"));
-    Assert.assertEquals("should expected string_trunc", "string_trunc", predicate.ref().name());
+    Assert.assertEquals("should expected string_trunc", "string_trunc_10", predicate.ref().name());
     predicate = (UnboundPredicate<Integer>) Projections
         .inclusive(partitionSpec).project(equal(truncate("string", 10), "abc"));
-    Assert.assertEquals("should expected string_trunc", "string_trunc", predicate.ref().name());
+    Assert.assertEquals("should expected string_trunc", "string_trunc_10", predicate.ref().name());
   }
 
 }

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.PartitionNameGenerator;
 import org.apache.iceberg.transforms.PartitionSpecVisitor;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
@@ -160,7 +161,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     PartitionField newField = new PartitionField(
         sourceTransform.first(), assignFieldId(), name, sourceTransform.second());
     if (newField.name() == null) {
-      String partitionName = PartitionSpecVisitor.visit(schema, newField, PartitionNameGenerator.INSTANCE);
+      String partitionName = PartitionSpecVisitor.visit(schema, newField, PartitionNameGenerator.getInstance());
       newField = new PartitionField(newField.sourceId(), newField.fieldId(), partitionName, newField.transform());
     }
 
@@ -441,53 +442,6 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     @Override
     public Boolean unknown(int fieldId, String sourceName, int sourceId, String transform) {
       return false;
-    }
-  }
-
-  private static class PartitionNameGenerator implements PartitionSpecVisitor<String> {
-    private static final PartitionNameGenerator INSTANCE = new PartitionNameGenerator();
-
-    private PartitionNameGenerator() {
-    }
-
-    @Override
-    public String identity(int fieldId, String sourceName, int sourceId) {
-      return sourceName;
-    }
-
-    @Override
-    public String bucket(int fieldId, String sourceName, int sourceId, int numBuckets) {
-      return sourceName + "_bucket_" + numBuckets;
-    }
-
-    @Override
-    public String truncate(int fieldId, String sourceName, int sourceId, int width) {
-      return sourceName + "_trunc_" + width;
-    }
-
-    @Override
-    public String year(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_year";
-    }
-
-    @Override
-    public String month(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_month";
-    }
-
-    @Override
-    public String day(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_day";
-    }
-
-    @Override
-    public String hour(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_hour";
-    }
-
-    @Override
-    public String alwaysNull(int fieldId, String sourceName, int sourceId) {
-      return sourceName + "_null";
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -64,20 +64,20 @@ public class TableTestBase {
   static final DataFile FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_A2 = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a-2.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DeleteFile FILE_A_DELETES = FileMetadata.deleteFileBuilder(SPEC)
       .ofPositionDeletes()
       .withPath("/path/to/data-a-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   // Equality delete files.
@@ -85,46 +85,46 @@ public class TableTestBase {
       .ofEqualityDeletes(1)
       .withPath("/path/to/data-a2-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0")
+      .withPartitionPath("data_bucket_16=0")
       .withRecordCount(1)
       .build();
   static final DataFile FILE_B = DataFiles.builder(SPEC)
       .withPath("/path/to/data-b.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=1") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DeleteFile FILE_B_DELETES = FileMetadata.deleteFileBuilder(SPEC)
       .ofPositionDeletes()
       .withPath("/path/to/data-b-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=1") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_C = DataFiles.builder(SPEC)
       .withPath("/path/to/data-c.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=2") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DeleteFile FILE_C2_DELETES = FileMetadata.deleteFileBuilder(SPEC)
       .ofEqualityDeletes(1)
       .withPath("/path/to/data-c-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=2") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_D = DataFiles.builder(SPEC)
       .withPath("/path/to/data-d.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=3") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DeleteFile FILE_D2_DELETES = FileMetadata.deleteFileBuilder(SPEC)
       .ofEqualityDeletes(1)
       .withPath("/path/to/data-d-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=3") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_WITH_STATS = DataFiles.builder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -38,7 +38,7 @@ public class TestDeleteFiles extends TableTestBase {
   private static final DataFile DATA_FILE_BUCKET_0_IDS_0_2 = DataFiles.builder(SPEC)
       .withPath("/path/to/data-1.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0")
+        .withPartitionPath("data_bucket_16=0")
         .withMetrics(new Metrics(5L,
             null, // no column sizes
       ImmutableMap.of(1, 5L, 2, 5L), // value count
@@ -52,7 +52,7 @@ public class TestDeleteFiles extends TableTestBase {
   private static final DataFile DATA_FILE_BUCKET_0_IDS_8_10 = DataFiles.builder(SPEC)
       .withPath("/path/to/data-2.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0")
+      .withPartitionPath("data_bucket_16=0")
       .withMetrics(new Metrics(5L,
           null, // no column sizes
           ImmutableMap.of(1, 5L, 2, 5L), // value count
@@ -116,7 +116,7 @@ public class TestDeleteFiles extends TableTestBase {
     DataFile firstDataFile = DataFiles.builder(spec)
         .withPath("/path/to/data-2.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0")
+        .withPartitionPath("data_bucket_16=0")
         .withMetrics(new Metrics(5L,
             null, // no column sizes
             ImmutableMap.of(1, 5L, 2, 5L), // value count
@@ -130,7 +130,7 @@ public class TestDeleteFiles extends TableTestBase {
     DataFile secondDataFile = DataFiles.builder(spec)
         .withPath("/path/to/data-1.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0")
+        .withPartitionPath("data_bucket_16=0")
         .withMetrics(new Metrics(5L,
             null, // no column sizes
             ImmutableMap.of(1, 5L, 2, 5L), // value count

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -450,7 +450,7 @@ public class TestFastAppend extends TableTestBase {
     Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
 
     String partitionSummary = table.currentSnapshot().summary()
-        .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
+        .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket_16=0");
     Assert.assertEquals("Summary should include 1 file with 1 record that is 10 bytes",
         "added-data-files=1,added-records=1,added-files-size=10", partitionSummary);
   }

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -76,7 +76,7 @@ public class TestFindFiles extends TableTestBase {
     table.newAppend()
         .appendFile(DataFiles.builder(SPEC)
             .withInputFile(Files.localInput("/path/to/data-e.parquet"))
-            .withPartitionPath("data_bucket=4")
+            .withPartitionPath("data_bucket_16=4")
             .withMetrics(new Metrics(3L,
                 null, // no column sizes
                 ImmutableMap.of(1, 3L), // value count

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -260,7 +260,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     return DataFiles.builder(SPEC)
             .withPath(name + ".parquet")
             .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+            .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
             .withRecordCount(1)
             .build();
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -91,7 +91,7 @@ public class TestManifestReader extends TableTestBase {
       List<Types.NestedField> fields = ((PartitionData) entry.file().partition()).getPartitionType().fields();
       Assert.assertEquals(1, fields.size());
       Assert.assertEquals(1000, fields.get(0).fieldId());
-      Assert.assertEquals("data_bucket", fields.get(0).name());
+      Assert.assertEquals("data_bucket_16", fields.get(0).name());
       Assert.assertEquals(Types.IntegerType.get(), fields.get(0).type());
     }
   }
@@ -112,11 +112,11 @@ public class TestManifestReader extends TableTestBase {
       List<Types.NestedField> fields = ((PartitionData) entry.file().partition()).getPartitionType().fields();
       Assert.assertEquals(2, fields.size());
       Assert.assertEquals(1000, fields.get(0).fieldId());
-      Assert.assertEquals("id_bucket", fields.get(0).name());
+      Assert.assertEquals("id_bucket_8", fields.get(0).name());
       Assert.assertEquals(Types.IntegerType.get(), fields.get(0).type());
 
       Assert.assertEquals(1001, fields.get(1).fieldId());
-      Assert.assertEquals("data_bucket", fields.get(1).name());
+      Assert.assertEquals("data_bucket_16", fields.get(1).name());
       Assert.assertEquals(Types.IntegerType.get(), fields.get(1).type());
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -58,7 +58,7 @@ public class TestManifestReaderStats extends TableTestBase {
   private static final DataFile FILE = DataFiles.builder(SPEC)
       .withPath(FILE_PATH)
       .withFileSizeInBytes(10)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(3)
       .withMetrics(METRICS)
       .build();

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -57,9 +57,10 @@ public class TestManifestWriterVersions {
 
   private static final long SEQUENCE_NUMBER = 34L;
   private static final long SNAPSHOT_ID = 987134631982734L;
-  private static final String PATH = "s3://bucket/table/category=cheesy/timestamp_hour=10/id_bucket=3/file.avro";
+  private static final String PATH = "s3://bucket/table/category=cheesy/timestamp_hour=10/id_bucket_16=3/file.avro";
   private static final FileFormat FORMAT = FileFormat.AVRO;
-  private static final PartitionData PARTITION = DataFiles.data(SPEC, "category=cheesy/timestamp_hour=10/id_bucket=3");
+  private static final PartitionData PARTITION = DataFiles.data(SPEC, "category=cheesy/timestamp_hour=10/id_bucket_16" +
+      "=3");
   private static final Metrics METRICS = new Metrics(
       1587L,
       ImmutableMap.of(1, 15L, 2, 122L, 3, 4021L, 4, 9411L, 5, 15L), // sizes

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -708,7 +708,7 @@ public class TestMergeAppend extends TableTestBase {
     DataFile newFileY = DataFiles.builder(newSpec)
         .withPath("/path/to/data-y.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=3")
         .withRecordCount(1)
         .build();
 
@@ -776,7 +776,7 @@ public class TestMergeAppend extends TableTestBase {
     DataFile newFileY = DataFiles.builder(table.spec())
         .withPath("/path/to/data-y.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=3")
         .withRecordCount(1)
         .build();
 
@@ -1111,7 +1111,7 @@ public class TestMergeAppend extends TableTestBase {
     Types.StructType structType = partitionSpec.partitionType();
     List<Types.NestedField> fields = structType.fields();
     Assert.assertEquals(1, fields.size());
-    Assert.assertEquals("data_bucket", fields.get(0).name());
+    Assert.assertEquals("data_bucket_16", fields.get(0).name());
     Assert.assertEquals(1000, fields.get(0).fieldId());
 
     partitionSpec = partitionSpecs.get(1);
@@ -1120,11 +1120,11 @@ public class TestMergeAppend extends TableTestBase {
     structType = partitionSpec.partitionType();
     fields = structType.fields();
     Assert.assertEquals(4, fields.size());
-    Assert.assertEquals("id_bucket", fields.get(0).name());
+    Assert.assertEquals("id_bucket_16", fields.get(0).name());
     Assert.assertEquals(1000, fields.get(0).fieldId());
     Assert.assertEquals("data", fields.get(1).name());
     Assert.assertEquals(1001, fields.get(1).fieldId());
-    Assert.assertEquals("data_bucket", fields.get(2).name());
+    Assert.assertEquals("data_bucket_4", fields.get(2).name());
     Assert.assertEquals(1002, fields.get(2).fieldId());
     Assert.assertEquals("data_partition", fields.get(3).name());
     Assert.assertEquals(1003, fields.get(3).fieldId());
@@ -1161,7 +1161,7 @@ public class TestMergeAppend extends TableTestBase {
     DataFile newFile = DataFiles.builder(table.spec())
         .withPath("/path/to/data-x.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("id_bucket=1/data_bucket=1")
+        .withPartitionPath("id_bucket_8=1/data_bucket_8=1")
         .withRecordCount(1)
         .build();
 
@@ -1192,15 +1192,15 @@ public class TestMergeAppend extends TableTestBase {
         .entries().iterator().next();
     Types.NestedField field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
     Assert.assertEquals(1000, field.fieldId());
-    Assert.assertEquals("id_bucket", field.name());
+    Assert.assertEquals("id_bucket_8", field.name());
     field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(1);
     Assert.assertEquals(1001, field.fieldId());
-    Assert.assertEquals("data_bucket", field.name());
+    Assert.assertEquals("data_bucket_8", field.name());
 
     entry = ManifestFiles.read(committedSnapshot.allManifests().get(1), FILE_IO).entries().iterator().next();
     field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
     Assert.assertEquals(1000, field.fieldId());
-    Assert.assertEquals("data_bucket", field.name());
+    Assert.assertEquals("data_bucket_16", field.name());
   }
 
   @Test
@@ -1245,7 +1245,7 @@ public class TestMergeAppend extends TableTestBase {
     Assert.assertEquals("Should set changed partition count", "1", changedPartitions);
 
     String partitionSummary = table.currentSnapshot().summary()
-        .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket=0");
+        .get(SnapshotSummary.CHANGED_PARTITION_PREFIX + "data_bucket_16=0");
     Assert.assertEquals("Summary should include 1 file with 1 record that is 10 bytes",
         "added-data-files=1,added-records=1,added-files-size=10", partitionSummary);
   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -166,10 +166,10 @@ public class TestMetadataTableFilters extends TableTestBase {
     Table metadataTable = createMetadataTable();
     Types.StructType expected = new Schema(
         required(102, "partition", Types.StructType.of(
-            optional(1000, "data_bucket", Types.IntegerType.get())),
+            optional(1000, "data_bucket_16", Types.IntegerType.get())),
             "Partition data tuple, schema based on the partition spec")).asStruct();
 
-    TableScan scan = metadataTable.newScan().select("partition.data_bucket");
+    TableScan scan = metadataTable.newScan().select("partition.data_bucket_16");
     Assert.assertEquals(expected, scan.schema().asStruct());
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
 
@@ -185,7 +185,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Table metadataTable = createMetadataTable();
 
     Expression and = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(and);
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
@@ -198,7 +198,7 @@ public class TestMetadataTableFilters extends TableTestBase {
   public void testLt() {
     Table metadataTable = createMetadataTable();
 
-    Expression lt = Expressions.lessThan("partition.data_bucket", 2);
+    Expression lt = Expressions.lessThan("partition.data_bucket_16", 2);
     TableScan scan = metadataTable.newScan().filter(lt);
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
     Assert.assertEquals(expectedScanTaskCount(2), Iterables.size(tasks));
@@ -211,7 +211,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Table metadataTable = createMetadataTable();
 
     Expression or = Expressions.or(
-        Expressions.equal("partition.data_bucket", 2),
+        Expressions.equal("partition.data_bucket_16", 2),
         Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(or);
 
@@ -228,7 +228,7 @@ public class TestMetadataTableFilters extends TableTestBase {
   public void testNot() {
     Table metadataTable = createMetadataTable();
 
-    Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
+    Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket_16", 2));
     TableScan scan = metadataTable.newScan().filter(not);
 
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
@@ -241,7 +241,7 @@ public class TestMetadataTableFilters extends TableTestBase {
   public void testIn() {
     Table metadataTable = createMetadataTable();
 
-    Expression set = Expressions.in("partition.data_bucket", 2, 3);
+    Expression set = Expressions.in("partition.data_bucket_16", 2, 3);
     TableScan scan = metadataTable.newScan().filter(set);
 
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
@@ -254,7 +254,7 @@ public class TestMetadataTableFilters extends TableTestBase {
   @Test
   public void testNotNull() {
     Table metadataTable = createMetadataTable();
-    Expression unary = Expressions.notNull("partition.data_bucket");
+    Expression unary = Expressions.notNull("partition.data_bucket_16");
     TableScan scan = metadataTable.newScan().filter(unary);
 
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
@@ -271,7 +271,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Table metadataTable = createMetadataTable();
 
     Expression and = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
 
     TableScan scan = metadataTable.newScan().filter(and);
@@ -331,7 +331,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
 
     filter = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = scan.planFiles();
@@ -406,7 +406,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
 
     filter = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = scan.planFiles();
@@ -467,7 +467,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
 
     filter = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = scan.planFiles();
@@ -491,27 +491,27 @@ public class TestMetadataTableFilters extends TableTestBase {
         .withPath("/path/to/data-10.parquet")
         .withRecordCount(10)
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0/id=10")
+        .withPartitionPath("data_bucket_16=0/id=10")
         .build();
     DataFile data11 = DataFiles.builder(newSpec)
         .withPath("/path/to/data-11.parquet")
         .withRecordCount(10)
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=1/id=11")
+        .withPartitionPath("data_bucket_16=1/id=11")
         .build();
 
     DeleteFile delete10 = FileMetadata.deleteFileBuilder(newSpec)
         .ofPositionDeletes()
         .withPath("/path/to/data-10-deletes.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0/id=10")
+        .withPartitionPath("data_bucket_16=0/id=10")
         .withRecordCount(1)
         .build();
     DeleteFile delete11 = FileMetadata.deleteFileBuilder(newSpec)
         .ofPositionDeletes()
         .withPath("/path/to/data-11-deletes.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=1/id=11")
+        .withPartitionPath("data_bucket_16=1/id=11")
         .withRecordCount(1)
         .build();
 
@@ -542,7 +542,7 @@ public class TestMetadataTableFilters extends TableTestBase {
     Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
 
     filter = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
+        Expressions.equal("partition.data_bucket_16", 0),
         Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
     tasks = scan.planFiles();

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -150,12 +150,12 @@ public class TestMetadataUpdateParser {
     String specString = "{" +
         "\"spec-id\":1," +
         "\"fields\":[{" +
-        "\"name\":\"id_bucket\"," +
+        "\"name\":\"id_bucket_8\"," +
         "\"transform\":\"bucket[8]\"," +
         "\"source-id\":1," +
         "\"field-id\":1000" +
         "},{" +
-        "\"name\":\"data_bucket\"," +
+        "\"name\":\"data_bucket_16\"," +
         "\"transform\":\"bucket[16]\"," +
         "\"source-id\":2," +
         "\"field-id\":1001" +
@@ -182,11 +182,11 @@ public class TestMetadataUpdateParser {
     String specString = "{" +
         "\"spec-id\":1," +
         "\"fields\":[{" +
-        "\"name\":\"id_bucket\"," +
+        "\"name\":\"id_bucket_8\"," +
         "\"transform\":\"bucket[8]\"," +
         "\"source-id\":1" +
         "},{" +
-        "\"name\": \"data_bucket\"," +
+        "\"name\": \"data_bucket_16\"," +
         "\"transform\":\"bucket[16]\"," +
         "\"source-id\":2" +
         "}]" +
@@ -210,12 +210,12 @@ public class TestMetadataUpdateParser {
     String specString = "{" +
         "\"spec-id\":1," +
         "\"fields\":[{" +
-        "\"name\":\"id_bucket\"," +
+        "\"name\":\"id_bucket_8\"," +
         "\"transform\":\"bucket[8]\"," +
         "\"source-id\":1," +
         "\"field-id\":1000" +
         "},{" +
-        "\"name\":\"data_bucket\"," +
+        "\"name\":\"data_bucket_16\"," +
         "\"transform\":\"bucket[16]\"," +
         "\"source-id\":2," +
         "\"field-id\":1001" +

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -144,7 +144,7 @@ public class TestMicroBatchBuilder extends TableTestBase {
     return DataFiles.builder(SPEC)
         .withPath(name + ".parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
         .withRecordCount(1)
         .build();
   }

--- a/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionSpecParser.java
@@ -32,7 +32,7 @@ public class TestPartitionSpecParser extends TableTestBase {
     String expected = "{\n" +
         "  \"spec-id\" : 0,\n" +
         "  \"fields\" : [ {\n" +
-        "    \"name\" : \"data_bucket\",\n" +
+        "    \"name\" : \"data_bucket_16\",\n" +
         "    \"transform\" : \"bucket[16]\",\n" +
         "    \"source-id\" : 2,\n" +
         "    \"field-id\" : 1000\n" +
@@ -50,12 +50,12 @@ public class TestPartitionSpecParser extends TableTestBase {
     expected = "{\n" +
         "  \"spec-id\" : 1,\n" +
         "  \"fields\" : [ {\n" +
-        "    \"name\" : \"id_bucket\",\n" +
+        "    \"name\" : \"id_bucket_8\",\n" +
         "    \"transform\" : \"bucket[8]\",\n" +
         "    \"source-id\" : 1,\n" +
         "    \"field-id\" : 1000\n" +
         "  }, {\n" +
-        "    \"name\" : \"data_bucket\",\n" +
+        "    \"name\" : \"data_bucket_16\",\n" +
         "    \"transform\" : \"bucket[16]\",\n" +
         "    \"source-id\" : 2,\n" +
         "    \"field-id\" : 1001\n" +
@@ -69,12 +69,12 @@ public class TestPartitionSpecParser extends TableTestBase {
     String specString = "{\n" +
         "  \"spec-id\" : 1,\n" +
         "  \"fields\" : [ {\n" +
-        "    \"name\" : \"id_bucket\",\n" +
+        "    \"name\" : \"id_bucket_8\",\n" +
         "    \"transform\" : \"bucket[8]\",\n" +
         "    \"source-id\" : 1,\n" +
         "    \"field-id\" : 1001\n" +
         "  }, {\n" +
-        "    \"name\" : \"data_bucket\",\n" +
+        "    \"name\" : \"data_bucket_16\",\n" +
         "    \"transform\" : \"bucket[16]\",\n" +
         "    \"source-id\" : 2,\n" +
         "    \"field-id\" : 1000\n" +
@@ -94,11 +94,11 @@ public class TestPartitionSpecParser extends TableTestBase {
     String specString = "{\n" +
         "  \"spec-id\" : 1,\n" +
         "  \"fields\" : [ {\n" +
-        "    \"name\" : \"id_bucket\",\n" +
+        "    \"name\" : \"id_bucket_8\",\n" +
         "    \"transform\" : \"bucket[8]\",\n" +
         "    \"source-id\" : 1\n" +
         "  }, {\n" +
-        "    \"name\" : \"data_bucket\",\n" +
+        "    \"name\" : \"data_bucket_16\",\n" +
         "    \"transform\" : \"bucket[16]\",\n" +
         "    \"source-id\" : 2\n" +
         "  } ]\n" +

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -35,21 +35,21 @@ public class TestReplacePartitions extends TableTestBase {
   static final DataFile FILE_E = DataFiles.builder(SPEC)
       .withPath("/path/to/data-e.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=0") // same partition as FILE_A
+      .withPartitionPath("data_bucket_16=0") // same partition as FILE_A
       .withRecordCount(0)
       .build();
 
   static final DataFile FILE_F = DataFiles.builder(SPEC)
       .withPath("/path/to/data-f.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=1") // same partition as FILE_B
+      .withPartitionPath("data_bucket_16=1") // same partition as FILE_B
       .withRecordCount(0)
       .build();
 
   static final DataFile FILE_G = DataFiles.builder(SPEC)
       .withPath("/path/to/data-g.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=10") // no other partition
+      .withPartitionPath("data_bucket_16=10") // no other partition
       .withRecordCount(0)
       .build();
 
@@ -310,7 +310,7 @@ public class TestReplacePartitions extends TableTestBase {
     AssertHelpers.assertThrows("Should reject commit with file matching partitions replaced",
         ValidationException.class,
         "Found conflicting files that can contain records matching partitions " +
-            "[data_bucket=0, data_bucket=1]: [/path/to/data-a.parquet]",
+            "[data_bucket_16=0, data_bucket_16=1]: [/path/to/data-a.parquet]",
         () ->
             replace
                 .addFile(FILE_A)
@@ -338,7 +338,7 @@ public class TestReplacePartitions extends TableTestBase {
     AssertHelpers.assertThrows("Should reject commit with file matching partitions replaced",
         ValidationException.class,
         "Found conflicting files that can contain records matching partitions " +
-            "[data_bucket=0, data_bucket=1]: [/path/to/data-a.parquet]",
+            "[data_bucket_16=0, data_bucket_16=1]: [/path/to/data-a.parquet]",
         () ->
             table.newReplacePartitions()
                 .validateFromSnapshot(baseId)
@@ -430,7 +430,7 @@ public class TestReplacePartitions extends TableTestBase {
     AssertHelpers.assertThrows("Should reject commit with file matching partitions replaced",
         ValidationException.class,
         "Found conflicting files that can contain records matching partitions " +
-            "[data_bucket=0, data_bucket=1]: [/path/to/data-b.parquet]",
+            "[data_bucket_16=0, data_bucket_16=1]: [/path/to/data-b.parquet]",
         () ->
             table.newReplacePartitions()
                 .validateFromSnapshot(baseId)
@@ -529,7 +529,7 @@ public class TestReplacePartitions extends TableTestBase {
     AssertHelpers.assertThrows("Should reject commit with file matching partitions replaced",
         ValidationException.class,
         "Found new conflicting delete files that can apply to records matching " +
-            "[data_bucket=0]: [/path/to/data-a-deletes.parquet]",
+            "[data_bucket_16=0]: [/path/to/data-a-deletes.parquet]",
         () ->
             table.newReplacePartitions()
                 .validateFromSnapshot(baseId)
@@ -631,7 +631,7 @@ public class TestReplacePartitions extends TableTestBase {
     AssertHelpers.assertThrows("Should reject commit with file matching partitions replaced",
         ValidationException.class,
         "Found conflicting deleted files that can apply to records matching " +
-            "[data_bucket=0]: [/path/to/data-a.parquet]",
+            "[data_bucket_16=0]: [/path/to/data-a.parquet]",
         () ->
             table.newReplacePartitions()
                 .validateFromSnapshot(baseId)

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -88,7 +88,7 @@ public class TestReplaceTransaction extends TableTestBase {
         v2Expected, table.spec());
 
     PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .withSpecId(1)
         .build();
     V1Assert.assertEquals("Table should have a spec with one void field",
@@ -136,7 +136,7 @@ public class TestReplaceTransaction extends TableTestBase {
         v2Expected, table.spec());
 
     PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .withSpecId(1)
         .build();
     V1Assert.assertEquals("Table should have a spec with one void field",
@@ -206,7 +206,7 @@ public class TestReplaceTransaction extends TableTestBase {
         v2Expected, table.spec());
 
     PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .withSpecId(1)
         .build();
     V1Assert.assertEquals("Table should have a spec with one void field",

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -612,7 +612,7 @@ public class TestRewriteManifests extends TableTestBase {
     DataFile newFileY = DataFiles.builder(table.spec())
         .withPath("/path/to/data-y.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=3")
         .withRecordCount(1)
         .build();
 
@@ -623,7 +623,7 @@ public class TestRewriteManifests extends TableTestBase {
     DataFile newFileZ = DataFiles.builder(table.spec())
         .withPath("/path/to/data-z.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=4")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=4")
         .withRecordCount(1)
         .build();
 
@@ -685,7 +685,7 @@ public class TestRewriteManifests extends TableTestBase {
     DataFile newFileY = DataFiles.builder(table.spec())
         .withPath("/path/to/data-y.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=3")
         .withRecordCount(1)
         .build();
 
@@ -696,7 +696,7 @@ public class TestRewriteManifests extends TableTestBase {
     DataFile newFileZ = DataFiles.builder(table.spec())
         .withPath("/path/to/data-z.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=2/id_bucket=4")
+        .withPartitionPath("data_bucket_16=2/id_bucket_4=4")
         .withRecordCount(1)
         .build();
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -772,7 +772,7 @@ public class TestRowDelta extends V2TableTestBase {
         .commit();
 
     // append a partitioned data file
-    DataFile firstSnapshotDataFile = newDataFile("data_bucket=0");
+    DataFile firstSnapshotDataFile = newDataFile("data_bucket_16=0");
     table.newAppend()
         .appendFile(firstSnapshotDataFile)
         .commit();
@@ -805,7 +805,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     // commit a row delta with 1 data file and 3 delete files where delete files have different specs
     DataFile dataFile = newDataFile("data=xyz");
-    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket=0");
+    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket_16=0");
     DeleteFile secondDeleteFile = newDeleteFile(secondSnapshotDataFile.specId(), "");
     DeleteFile thirdDeleteFile = newDeleteFile(thirdSnapshotDataFile.specId(), "data=abc");
 
@@ -834,7 +834,7 @@ public class TestRowDelta extends V2TableTestBase {
     Assert.assertTrue("Partition metrics must be correct",
         summary.get(CHANGED_PARTITION_PREFIX).contains(ADDED_DELETE_FILES_PROP + "=1"));
     Assert.assertTrue("Partition metrics must be correct",
-        summary.get(CHANGED_PARTITION_PREFIX + "data_bucket=0").contains(ADDED_DELETE_FILES_PROP + "=1"));
+        summary.get(CHANGED_PARTITION_PREFIX + "data_bucket_16=0").contains(ADDED_DELETE_FILES_PROP + "=1"));
     Assert.assertTrue("Partition metrics must be correct",
         summary.get(CHANGED_PARTITION_PREFIX + "data=abc").contains(ADDED_DELETE_FILES_PROP + "=1"));
     Assert.assertTrue("Partition metrics must be correct",
@@ -889,7 +889,7 @@ public class TestRowDelta extends V2TableTestBase {
         .commit();
 
     // append a partitioned data file
-    DataFile firstSnapshotDataFile = newDataFile("data_bucket=0");
+    DataFile firstSnapshotDataFile = newDataFile("data_bucket_16=0");
     table.newAppend()
         .appendFile(firstSnapshotDataFile)
         .commit();
@@ -908,7 +908,7 @@ public class TestRowDelta extends V2TableTestBase {
         .commit();
 
     // commit two delete files to two specs in a single operation
-    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket=0");
+    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket_16=0");
     DeleteFile secondDeleteFile = newDeleteFile(secondSnapshotDataFile.specId(), "");
 
     table.newRowDelta()
@@ -923,7 +923,7 @@ public class TestRowDelta extends V2TableTestBase {
     Assert.assertEquals("Should have 2 delete manifest", 2, thirdSnapshot.deleteManifests().size());
 
     // commit two more delete files to the same specs to trigger merging
-    DeleteFile thirdDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket=0");
+    DeleteFile thirdDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket_16=0");
     DeleteFile fourthDeleteFile = newDeleteFile(secondSnapshotDataFile.specId(), "");
 
     table.newRowDelta()
@@ -959,7 +959,7 @@ public class TestRowDelta extends V2TableTestBase {
   @Test
   public void testAbortMultipleSpecs() {
     // append a partitioned data file
-    DataFile firstSnapshotDataFile = newDataFile("data_bucket=0");
+    DataFile firstSnapshotDataFile = newDataFile("data_bucket_16=0");
     table.newAppend()
         .appendFile(firstSnapshotDataFile)
         .commit();
@@ -978,7 +978,7 @@ public class TestRowDelta extends V2TableTestBase {
         .commit();
 
     // prepare two delete files that belong to different specs
-    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket=0");
+    DeleteFile firstDeleteFile = newDeleteFile(firstSnapshotDataFile.specId(), "data_bucket_16=0");
     DeleteFile secondDeleteFile = newDeleteFile(secondSnapshotDataFile.specId(), "");
 
     // capture all deletes

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -33,7 +33,7 @@ public class TestSnapshotManager extends TableTestBase {
   static final DataFile REPLACEMENT_FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a-replacement.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
 
@@ -41,7 +41,7 @@ public class TestSnapshotManager extends TableTestBase {
   static final DataFile CONFLICT_FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a-conflict.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
@@ -63,7 +63,7 @@ public class TestSnapshotSelection extends TableTestBase {
     DataFile fileWithStats = DataFiles.builder(SPEC)
         .withPath("/path/to/data-with-stats.parquet")
         .withFileSizeInBytes(10)
-        .withPartitionPath("data_bucket=0")
+        .withPartitionPath("data_bucket_16=0")
         .withRecordCount(10)
         .withMetrics(new Metrics(3L,
             null, // no column sizes

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -715,7 +715,7 @@ public class TestTableMetadata {
     PartitionSpec expected = PartitionSpec.builderFor(updated.schema()).withSpecId(1)
         .add(1, 1000, "x", "identity")
         .add(2, 1001, "y", "void")
-        .add(3, 1002, "z_bucket", "bucket[8]")
+        .add(3, 1002, "z_bucket_8", "bucket[8]")
         .build();
     Assert.assertEquals(
         "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields",
@@ -748,7 +748,7 @@ public class TestTableMetadata {
     TableMetadata updated = metadata.buildReplacement(
         updatedSchema, updatedSpec, SortOrder.unsorted(), location, ImmutableMap.of());
     PartitionSpec expected = PartitionSpec.builderFor(updated.schema()).withSpecId(1)
-        .add(3, 1002, "z_bucket", "bucket[8]")
+        .add(3, 1002, "z_bucket_8", "bucket[8]")
         .add(1, 1000, "x", "identity")
         .build();
     Assert.assertEquals(

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -67,13 +67,13 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
 
     table.updateSpec()
         .removeField("id_bucket_8")
-        .removeField("data_bucket")
+        .removeField("data_bucket_16")
         .addField(truncate("data", 8))
         .commit();
 
     V1Assert.assertEquals("Should soft delete id and data buckets", PartitionSpec.builderFor(table.schema())
         .withSpecId(2)
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .alwaysNull("id", "id_bucket_8")
         .truncate("data", 8, "data_trunc_8")
         .build(), table.spec());
@@ -101,7 +101,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
 
     // no-op commit due to no-op rename
     table.updateSpec()
-        .renameField("data_bucket", "data_bucket")
+        .renameField("data_bucket_16", "data_bucket_16")
         .commit();
     updated = table.ops().current();
     updatedVersion = TestTables.metadataVersion("test");
@@ -113,7 +113,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRenameField() {
     table.updateSpec()
-        .renameField("data_bucket", "data_partition")
+        .renameField("data_bucket_16", "data_partition")
         .addField(bucket("id", 8))
         .commit();
 
@@ -145,7 +145,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRenameOnlyEvolution() {
     table.updateSpec()
-        .renameField("data_bucket", "data_partition")
+        .renameField("data_bucket_16", "data_partition")
         .commit();
 
     PartitionSpec evolvedSpec = PartitionSpec.builderFor(table.schema())
@@ -160,13 +160,13 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRemoveAndAddField() {
     table.updateSpec()
-        .removeField("data_bucket")
+        .removeField("data_bucket_16")
         .addField(bucket("id", 8))
         .commit();
 
     V1Assert.assertEquals("Should soft delete data bucket", PartitionSpec.builderFor(table.schema())
         .withSpecId(1)
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .bucket("id", 8, "id_bucket_8")
         .build(), table.spec());
 
@@ -182,12 +182,12 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
   public void testAddAndRemoveField() {
     table.updateSpec()
         .addField(bucket("data", 6))
-        .removeField("data_bucket")
+        .removeField("data_bucket_16")
         .commit();
 
     V1Assert.assertEquals("Should remove and then add a bucket field", PartitionSpec.builderFor(table.schema())
         .withSpecId(1)
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .bucket("data", 6, "data_bucket_6")
         .build(), table.spec());
     V2Assert.assertEquals("Should remove and then add a bucket field", PartitionSpec.builderFor(table.schema())
@@ -200,12 +200,12 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testAddAfterLastFieldRemoved() {
     table.updateSpec()
-        .removeField("data_bucket")
+        .removeField("data_bucket_16")
         .commit();
 
     V1Assert.assertEquals("Should add a new id bucket", PartitionSpec.builderFor(table.schema())
         .withSpecId(1)
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .build(), table.spec());
     V1Assert.assertEquals("Should match the last assigned field id",
         1000, table.spec().lastAssignedFieldId());
@@ -222,7 +222,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
 
     V1Assert.assertEquals("Should add a new id bucket", PartitionSpec.builderFor(table.schema())
         .withSpecId(2)
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .bucket("id", 8, "id_bucket_8")
         .build(), table.spec());
     V2Assert.assertEquals("Should add a new id bucket", PartitionSpec.builderFor(table.schema())

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -364,7 +364,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRename() {
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
-        .renameField("shard", "id_bucket") // rename back to default
+        .renameField("shard", "id_bucket_16") // rename back to default
         .apply();
 
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
@@ -387,7 +387,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     PartitionSpec v1Expected = PartitionSpec.builderFor(SCHEMA)
         .identity("category")
         .alwaysNull("ts", "ts_day")
-        .bucket("id", 16)
+        .bucket("id", 16, "id_bucket")
         .truncate("data", 4, "prefix")
         .build();
 

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -124,21 +124,21 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   static final DataFile FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("id_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("id_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
 
   static final DataFile FILE_B = DataFiles.builder(SPEC)
       .withPath("/path/to/data-b.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("id_bucket=1") // easy way to set partition data for now
+      .withPartitionPath("id_bucket_16=1") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
 
   static final DataFile FILE_C = DataFiles.builder(SPEC)
       .withPath("/path/to/data-c.parquet")
       .withFileSizeInBytes(10)
-      .withPartitionPath("id_bucket=2") // easy way to set partition data for now
+      .withPartitionPath("id_bucket_16=2") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -82,32 +82,32 @@ public class HadoopTableTestBase {
   static final DataFile FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
   static final DataFile FILE_B = DataFiles.builder(SPEC)
       .withPath("/path/to/data-b.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=1") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
   static final DeleteFile FILE_B_DELETES = FileMetadata.deleteFileBuilder(SPEC)
       .ofPositionDeletes()
       .withPath("/path/to/data-b-deletes.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=1")
+      .withPartitionPath("data_bucket_16=1")
       .withRecordCount(1)
       .build();
   static final DataFile FILE_C = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=2") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
   static final DataFile FILE_D = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+      .withPartitionPath("data_bucket_16=3") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
       .build();
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -113,7 +113,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     table = catalog.loadTable(tableIdent);
     Assert.assertNull(table.currentSnapshot());
     PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .withSpecId(1)
         .build();
     Assert.assertEquals("Table should have a spec with one void field",

--- a/core/src/test/java/org/apache/iceberg/io/TestOutputFileFactory.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestOutputFileFactory.java
@@ -76,6 +76,6 @@ public class TestOutputFileFactory extends TableTestBase {
     partitionKey.partition(record);
     EncryptedOutputFile partitionedFile = fileFactory.newOutputFile(table.spec(), partitionKey);
     String partitionedFileLocation = partitionedFile.encryptingOutputFile().location();
-    Assert.assertTrue(partitionedFileLocation.endsWith("data_bucket=7/00001-100-append-00002.parquet"));
+    Assert.assertTrue(partitionedFileLocation.endsWith("data_bucket_16=7/00001-100-append-00002.parquet"));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -178,7 +178,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     final DataFile fileA = DataFiles.builder(PARTITION_SPEC)
         .withPath("/path/to/data-a.parquet")
         .withFileSizeInBytes(0)
-        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withPartitionPath("data_bucket_16=0") // easy way to set partition data for now
         .withRecordCount(2) // needs at least one record or else metrics will filter it out
         .build();
 
@@ -204,7 +204,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     table = catalog.loadTable(tableIdent);
     Assert.assertNull(table.currentSnapshot());
     PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-        .alwaysNull("data", "data_bucket")
+        .alwaysNull("data", "data_bucket_16")
         .withSpecId(1)
         .build();
     Assert.assertEquals("Table should have a spec with one void field",

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -230,7 +230,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
       Assert.assertEquals(newLocation, table.location());
       Assert.assertNull(table.currentSnapshot());
       PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
-          .alwaysNull("data", "data_bucket")
+          .alwaysNull("data", "data_bucket_16")
           .withSpecId(1)
           .build();
       Assert.assertEquals("Table should have a spec with one void field",

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -417,7 +417,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteErrorsOut() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -446,7 +446,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipDeleteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -470,7 +470,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipOverwriteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -417,7 +417,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteErrorsOut() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -446,7 +446,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipDeleteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -470,7 +470,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipOverwriteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -576,8 +576,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .mode("append")
         .save(tableLocation);
 
-    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc=AA/c3=AAAA");
-    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc=AA/c3=AAAA");
+    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc_2=AA/c3=AAAA");
+    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc_2=AA/c3=AAAA");
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -617,13 +617,13 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .mode("append")
         .save(tableLocation);
 
-    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc=AA");
+    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc_2=AA");
 
     table.updateSpec()
         .addField("_c1")
         .commit();
 
-    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc=AA/_c1=1");
+    df.write().mode("append").parquet(tableLocation + "/data/_c2_trunc_2=AA/_c1=1");
 
     waitUntilAfter(System.currentTimeMillis());
 
@@ -666,7 +666,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     Path dataPath = new Path(tableLocation + "/data");
     FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
-    Path pathToFileInHiddenFolder = new Path(dataPath, "_c2_trunc/file.txt");
+    Path pathToFileInHiddenFolder = new Path(dataPath, "_c2_trunc_2/file.txt");
     fs.createNewFile(pathToFileInHiddenFolder);
 
     waitUntilAfter(System.currentTimeMillis());

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -417,7 +417,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteErrorsOut() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -446,7 +446,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipDeleteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 
@@ -470,7 +470,7 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
   @Test
   public void testReadStreamWithSnapshotTypeDeleteAndSkipOverwriteOption() throws Exception {
     table.updateSpec()
-        .removeField("id_bucket")
+        .removeField("id_bucket_3")
         .addField(ref("id"))
         .commit();
 


### PR DESCRIPTION
We have two different ways of generating the partition field column name:
https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java#L460 generates data_bucket_16, while
https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/PartitionSpec.java#L484 generates data_bucket.

This PR tries to unify this, so that the former method would be applicable everywhere.
Related PR: [4662](https://github.com/apache/iceberg/pull/4662)