### PR TITLE
API: Cleanup SnapshotRef to avoid unnecessary boxing in equality check by comparing snapshotID via ==

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -86,7 +86,7 @@ public class SnapshotRef implements Serializable {
     }
 
     SnapshotRef ref = (SnapshotRef) other;
-    return Objects.equals(ref.snapshotId(), snapshotId) &&
+    return ref.snapshotId == snapshotId &&
         Objects.equals(ref.type(), type) &&
         Objects.equals(ref.maxRefAgeMs(), maxRefAgeMs) &&
         Objects.equals(ref.minSnapshotsToKeep(), minSnapshotsToKeep) &&


### PR DESCRIPTION
Cleanup SnapshotRef to avoid unnecessary boxing in equality check by comparing snapshotID via ==