### PR TITLE
API：Set index to return value

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/IndexById.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexById.java
@@ -42,7 +42,7 @@ class IndexById extends TypeUtil.SchemaVisitor<Map<Integer, Types.NestedField>> 
   public Map<Integer, Types.NestedField> field(
       Types.NestedField field, Map<Integer, Types.NestedField> fieldResult) {
     index.put(field.fieldId(), field);
-    return null;
+    return index;
   }
 
   @Override
@@ -50,7 +50,7 @@ class IndexById extends TypeUtil.SchemaVisitor<Map<Integer, Types.NestedField>> 
     for (Types.NestedField field : list.fields()) {
       index.put(field.fieldId(), field);
     }
-    return null;
+    return index;
   }
 
   @Override
@@ -59,6 +59,6 @@ class IndexById extends TypeUtil.SchemaVisitor<Map<Integer, Types.NestedField>> 
     for (Types.NestedField field : map.fields()) {
       index.put(field.fieldId(), field);
     }
-    return null;
+    return index;
   }
 }


### PR DESCRIPTION
Closed #4762 
The override method in IndexByName or IndexParents all return the corresponding variables, but IndexById is not, I think it should also needs to return the corresponding variable