### PR TITLE
Core - Use unbound variants of SortOrder / PartitionSpec for REST Catalog's CreateTableRequest

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -135,7 +135,7 @@ public class SortOrder implements Serializable {
     return fieldList;
   }
 
-  UnboundSortOrder toUnbound() {
+  public UnboundSortOrder toUnbound() {
     UnboundSortOrder.Builder builder = UnboundSortOrder.builder().withOrderId(orderId);
 
     for (SortField field : fields) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.UnboundPartitionSpec;
+import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -38,8 +40,8 @@ public class CreateTableRequest implements RESTRequest {
   private String name;
   private String location;
   private Schema schema;
-  private PartitionSpec spec;
-  private SortOrder order;
+  private UnboundPartitionSpec spec;
+  private UnboundSortOrder order;
   private Map<String, String> properties;
   private Boolean stageCreate;
 
@@ -52,8 +54,8 @@ public class CreateTableRequest implements RESTRequest {
     this.name = name;
     this.location = location;
     this.schema = schema;
-    this.spec = spec;
-    this.order = order;
+    this.spec = spec != null ? spec.toUnbound() : null;
+    this.order = order != null ? order.toUnbound() : null;
     this.properties = properties;
     this.stageCreate = stageCreate;
     validate();
@@ -79,11 +81,11 @@ public class CreateTableRequest implements RESTRequest {
   }
 
   public PartitionSpec spec() {
-    return spec;
+    return spec != null ? spec.bind(schema) : null;
   }
 
   public SortOrder writeOrder() {
-    return order;
+    return order != null ? order.bind(schema) : null;
   }
 
   public Map<String, String> properties() {


### PR DESCRIPTION
As I've been working on some serialization related tests for the REST catalog, it came to my attention that we should be storing the create table requests sort order and partition spec as `UnboundSortOrder` and `UnboundPartitionSpec`, respectively.

Generally speaking, we are moving towards using `Unbound` variants of all things whenever possible, and letting the binding to actual fields take place later in the process.

I am working on some PRs that add additional serialization tests in, but I wanted to get these changes in sooner so that anybody who might be implementing or testing agains the RESTCatalog would have these changes available to them.