### PR TITLE
Docs: Fix a typo. Add using for writeTo when creating a table.

### DIFF
--- a/docs/spark/spark-ddl.md
+++ b/docs/spark/spark-ddl.md
@@ -46,7 +46,7 @@ Iceberg will convert the column type in Spark to corresponding Iceberg type. Ple
 
 Table create commands, including CTAS and RTAS, support the full range of Spark create clauses, including:
 
-* `PARTITION BY (partition-expressions)` to configure partitioning
+* `PARTITIONED BY (partition-expressions)` to configure partitioning
 * `LOCATION '(fully-qualified-uri)'` to set the table location
 * `COMMENT 'table documentation'` to set a table description
 * `TBLPROPERTIES ('key'='value', ...)` to set [table configuration](../configuration)

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -287,14 +287,20 @@ To run a CTAS or RTAS, use `create`, `replace`, or `createOrReplace` operations:
 
 ```scala
 val data: DataFrame = ...
-data.writeTo("prod.db.table").using("iceberg").create()
+data.writeTo("prod.db.table").create()
+```
+
+If you have replaced the default Spark catalog (`spark_catalog`) with Iceberg's `SparkSessionCatalog`, do:
+
+```scala
+val data: DataFrame = ...
+data.writeTo("db.table").using("iceberg").create()
 ```
 
 Create and replace operations support table configuration methods, like `partitionedBy` and `tableProperty`:
 
 ```scala
 data.writeTo("prod.db.table")
-    .using("iceberg")
     .tableProperty("write.format.default", "orc")
     .partitionedBy($"level", days($"ts"))
     .createOrReplace()

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -287,13 +287,14 @@ To run a CTAS or RTAS, use `create`, `replace`, or `createOrReplace` operations:
 
 ```scala
 val data: DataFrame = ...
-data.writeTo("prod.db.table").create()
+data.writeTo("prod.db.table").using("iceberg").create()
 ```
 
 Create and replace operations support table configuration methods, like `partitionedBy` and `tableProperty`:
 
 ```scala
 data.writeTo("prod.db.table")
+    .using("iceberg")
     .tableProperty("write.format.default", "orc")
     .partitionedBy($"level", days($"ts"))
     .createOrReplace()


### PR DESCRIPTION
Fix two issues in Spark documentation.
1. Typo in Spark DDL doc.
2. Examples for creating/replacing a table using `writeTo` need `using("iceberg")`.