### PR TITLE
OpenAPI: Have the type before type_required

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -907,17 +907,17 @@ components:
       required:
         - id
         - name
-        - required
         - type
+        - required
       properties:
         id:
           type: integer
         name:
           type: string
-        required:
-          type: boolean
         type:
           $ref: '#/components/schemas/Type'
+        required:
+          type: boolean
         doc:
           type: string
 
@@ -939,18 +939,18 @@ components:
       required:
         - type
         - element-id
-        - element-required
         - element
+        - element-required
       properties:
         type:
           type: string
           enum: ["list"]
         element-id:
           type: integer
-        element-required:
-          type: boolean
         element:
           $ref: '#/components/schemas/Type'
+        element-required:
+          type: boolean
 
     MapType:
       type: object
@@ -959,8 +959,8 @@ components:
         - key-id
         - key
         - value-id
-        - value-required
         - value
+        - value-required
       properties:
         type:
           type: string
@@ -971,10 +971,10 @@ components:
           $ref: '#/components/schemas/Type'
         value-id:
           type: integer
-        value-required:
-          type: boolean
         value:
           $ref: '#/components/schemas/Type'
+        value-required:
+          type: boolean
 
     Type:
       anyOf:


### PR DESCRIPTION
For Python, when we generate classes it is required to have the non-default variables first:

This is not allowed:
```python
class ListType(IcebergType, rest_catalog.ListType):

    def __init__(
        cls,
        element_id: int,
        element_required: bool = True,
        element: IcebergType
    ):
```
It should be:
```python
class ListType(IcebergType, rest_catalog.ListType):

    def __init__(
        cls,
        element_id: int,
        element: IcebergType,
        element_required: bool = True
    ):
```

It would be nice to have the type first (which is also more important), and then required/optional. Of course, we can just adjust this in the Python init method but would be nice to have this order the same in the open-api spec as well :)