### PR TITLE
OpenAPI: Make the type of the StructType required

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -924,6 +924,7 @@ components:
     StructType:
       type: object
       required:
+        - type
         - fields
       properties:
         type:


### PR DESCRIPTION
This is the case for the MapType and ListType, and makes sense for the StructType as well:

https://github.com/apache/iceberg/blob/29f294610a012a60f3c3452a2608e386df54e48b/open-api/rest-catalog-open-api.yaml#L937-L943

https://github.com/apache/iceberg/blob/29f294610a012a60f3c3452a2608e386df54e48b/open-api/rest-catalog-open-api.yaml#L955-L963