### PR TITLE
Core: Add REST catalog session timeout

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -83,6 +83,9 @@ public class CatalogProperties {
   public static final String APP_ID = "app-id";
   public static final String USER = "user";
 
+  public static final String AUTH_DEFAULT_REFRESH_ENABLED = "auth.default-refresh-enabled";
+  public static final boolean AUTH_DEFAULT_REFRESH_ENABLED_DEFAULT = false;
+
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -83,4 +83,6 @@ public class CatalogProperties {
   public static final String APP_ID = "app-id";
   public static final String USER = "user";
 
+  public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
+  public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -611,7 +611,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
 
   private long expiresInMs(Map<String, String> properties) {
     return PropertyUtil.propertyAsLong(
-        properties, OAuth2Properties.EXCHANGE_TOKEN_MS, OAuth2Properties.EXCHANGE_TOKEN_MS_DEFAULT);
+        properties, OAuth2Properties.TOKEN_EXPIRES_IN_MS, OAuth2Properties.TOKEN_EXPIRES_IN_MS_DEFAULT);
   }
 
   private static Map<String, String> configHeaders(Map<String, String> properties) {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
@@ -37,8 +37,8 @@ public class OAuth2Properties {
    * Interval in milliseconds to wait before attempting to exchange the configured catalog Bearer token.
    * By default, token exchange will be attempted after 1 hour.
    */
-  public static final String EXCHANGE_TOKEN_MS = "exchange-token-in-ms";
-  public static final long EXCHANGE_TOKEN_MS_DEFAULT = 3_600_000; // 1 hour
+  public static final String TOKEN_EXPIRES_IN_MS = "token-expires-in-ms";
+  public static final long TOKEN_EXPIRES_IN_MS_DEFAULT = 3_600_000; // 1 hour
 
   /**
    * Additional scope for OAuth2.

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -280,6 +280,7 @@ public class OAuth2Util {
     private Map<String, String> headers;
     private String token;
     private String tokenType;
+    private volatile boolean keepRefreshed = true;
 
     public AuthSession(Map<String, String> baseHeaders, String token, String tokenType) {
       this.headers = RESTUtil.merge(baseHeaders, authHeaders(token));
@@ -299,6 +300,10 @@ public class OAuth2Util {
       return tokenType;
     }
 
+    public void stopRefreshing() {
+      this.keepRefreshed = false;
+    }
+
     /**
      * Attempt to refresh the session token using the token exchange flow.
      *
@@ -306,7 +311,7 @@ public class OAuth2Util {
      * @return interval to wait before calling refresh again, or null if no refresh is needed
      */
     public Pair<Integer, TimeUnit> refresh(RESTClient client) {
-      if (token != null) {
+      if (token != null && keepRefreshed) {
         AtomicReference<OAuthTokenResponse> ref = new AtomicReference<>(null);
         boolean isSuccessful = Tasks.foreach(ref)
             .suppressFailureWhenFinished()


### PR DESCRIPTION
This adds a timeout for REST catalog sessions. After the timeout is reached after a session is used, it will be removed and its token will no longer be refreshed using token exchange.

This also cleans up catalog options for token refresh:
* Renamed token expiration property to `token-expires-in-ms`
* `auth.default-refresh-enabled` should be set to enable token refresh when `token-expires-in-ms` is not present

The default refresh option is needed for long-running environments that need to refresh tokens because references are kept for a long time, like Flink jobs. The default is to not refresh for environments like Trino that should not continuously refresh tokens that are no longer referenced and used.