### PR TITLE
API: Add CredentialSupplier to get credentials from FileIO

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
+++ b/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+/**
+ * Interface used to expose credentials held by a FileIO instance.
+ * <p>
+ * Tables supply a FileIO instance to use for file access that is configured with the credentials needed to access the
+ * table's files. Systems that do not use FileIO can use this interface to get the configured credential as a string,
+ * and use the credential for file access via other IO libraries.
+ */
+public interface CredentialSupplier {
+  /**
+   * @return the credential string
+   */
+  String getCredential();
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -27,9 +27,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CredentialSupplier;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -65,11 +67,12 @@ import software.amazon.awssdk.services.s3.model.Tagging;
  * URIs with schemes s3a, s3n, https are also treated as s3 file paths.
  * Using this FileIO with other schemes will result in {@link org.apache.iceberg.exceptions.ValidationException}.
  */
-public class S3FileIO implements FileIO, SupportsBulkOperations {
+public class S3FileIO implements FileIO, SupportsBulkOperations, CredentialSupplier {
   private static final Logger LOG = LoggerFactory.getLogger(S3FileIO.class);
   private static final String DEFAULT_METRICS_IMPL = "org.apache.iceberg.hadoop.HadoopMetricsContext";
   private static volatile ExecutorService executorService;
 
+  private String credential = null;
   private SerializableSupplier<S3Client> s3;
   private AwsProperties awsProperties;
   private transient volatile S3Client client;
@@ -263,12 +266,21 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
   }
 
   @Override
+  public String getCredential() {
+    return credential;
+  }
+
+  @Override
   public void initialize(Map<String, String> properties) {
     this.awsProperties = new AwsProperties(properties);
 
     // Do not override s3 client if it was provided
     if (s3 == null) {
-      this.s3 = AwsClientFactories.from(properties)::s3;
+      AwsClientFactory clientFactory = AwsClientFactories.from(properties);
+      if (clientFactory instanceof CredentialSupplier) {
+        this.credential = ((CredentialSupplier) clientFactory).getCredential();
+      }
+      this.s3 = clientFactory::s3;
     }
 
     // Report Hadoop metrics if Hadoop is available


### PR DESCRIPTION
This adds an interface, `CredentialSupplier`, for engines that don't use `FileIO` and need to get some credential from a table's `FileIO` to access files through some other object store library.