### PR TITLE
Minor adjustments to catalog tests for flexibility

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -279,9 +279,10 @@ public class CatalogHandlers {
   }
 
   private static TableMetadata create(TableOperations ops, TableMetadata start, UpdateTableRequest request) {
-    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
-
     // the only valid requirement is that the table will be created
+    request.requirements().forEach(requirement -> requirement.validate(ops.current()));
+
+    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
     request.updates().forEach(update -> update.applyTo(builder));
 
     // create transactions do not retry. if the table exists, retrying is not a solution


### PR DESCRIPTION
This PR makes a couple of minor changes to make the catalog tests a little bit more flexible. For example, it makes some list checks ignore element order.