### PR TITLE
OpenAPI: Move to oneOf for the types

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -978,7 +978,7 @@ components:
           type: boolean
 
     Type:
-      anyOf:
+      oneOf:
         - $ref: '#/components/schemas/PrimitiveType'
         - $ref: '#/components/schemas/StructType'
         - $ref: '#/components/schemas/ListType'


### PR DESCRIPTION
All the types match exactly one of the schemas:

```json
# PrimitiveType
"string"

# StructType
{"type": "struct", ...}

# ListType
{"type": "list", ...}

# MapType
{"type": "map", ...}
```

For more information:
https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/

The types are mutually exclusive (in the schema, technically an int can also be promoted to a long). The aforementioned types should map to exactly one type.

We could also add a discriminator if we bump the primitive type to an object as well. My suggestion would be to break down:

```json
"fixed[22]"

# and

"string"
```

into

```json
{"type": "fixed", "size": 22}

# and

{"type": "string"}
```

This would allow us to set:

```yaml
    Type:
      oneOf:
        - $ref: '#/components/schemas/PrimitiveType'
        - $ref: '#/components/schemas/StructType'
        - $ref: '#/components/schemas/ListType'
        - $ref: '#/components/schemas/MapType'
      discriminator:
        propertyName: type
```

This way the OpenAPI spec also defines how to distinguish the different types.