### PR TITLE
Spark: Use options as a CaseSensitiveMap

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -118,8 +118,7 @@ public class SparkCatalog extends BaseCatalog {
    */
   protected Catalog buildIcebergCatalog(String name, CaseInsensitiveStringMap options) {
     Configuration conf = SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name);
-    Map<String, String> optionsMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    optionsMap.putAll(options);
+    Map<String, String> optionsMap = new TreeMap<>(options.asCaseSensitiveMap());
     optionsMap.put(CatalogProperties.APP_ID, SparkSession.active().sparkContext().applicationId());
     optionsMap.put(CatalogProperties.USER, SparkSession.active().sparkContext().sparkUser());
     return CatalogUtil.buildIcebergCatalog(name, optionsMap, conf);


### PR DESCRIPTION
Recently, it was reported in Slack general channel that [AWS S3 tagging](https://github.com/apache/iceberg/blob/master/docs/integrations/aws.md#s3-tags) present in master branch is not working for keys with upper case.

Reference: https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1653879105452189

This is because we use `CaseInsensitiveStringMap` for options in `SparkCatalog`. This PR uses options as a `CaseSensitiveMap`.

With this change, the following Spark configurations:
```
sh spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://iceberg-dev/warehouse.case-sensitive \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.MY_key2=my_val2
```
now saves the S3 tags as:

```
my_key = my_val
MY_key2 = my_val2
```


---

cc: @RussellSpitzer @jackye1995 