### PR TITLE
Flink: new sink base on the unified sink API

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -91,6 +91,12 @@ public class FlinkConfigOptions {
           .defaultValue(false)
           .withDescription("Use the FLIP-27 based Iceberg source implementation.");
 
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_USE_FLIP143_SINK =
+      ConfigOptions.key("table.exec.iceberg.use-flip143-sink")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Use the FLIP-143 based Iceberg sink implementation.");
+
   public static final ConfigOption<SplitAssignerType> TABLE_EXEC_SPLIT_ASSIGNER_TYPE =
       ConfigOptions.key("table.exec.iceberg.split-assigner-type")
           .enumType(SplitAssignerType.class)

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifests.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
-class DeltaManifests {
+public class DeltaManifests {
 
   private static final CharSequence[] EMPTY_REF_DATA_FILES = new CharSequence[0];
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/DeltaManifestsSerializer.java
@@ -28,12 +28,12 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-class DeltaManifestsSerializer implements SimpleVersionedSerializer<DeltaManifests> {
+public class DeltaManifestsSerializer implements SimpleVersionedSerializer<DeltaManifests> {
   private static final int VERSION_1 = 1;
   private static final int VERSION_2 = 2;
   private static final byte[] EMPTY_BINARY = new byte[0];
 
-  static final DeltaManifestsSerializer INSTANCE = new DeltaManifestsSerializer();
+  public static final DeltaManifestsSerializer INSTANCE = new DeltaManifestsSerializer();
 
   @Override
   public int getVersion() {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
-class FlinkManifestUtil {
+public class FlinkManifestUtil {
   private static final int FORMAT_V2 = 2;
   private static final Long DUMMY_SNAPSHOT_ID = 0L;
 
@@ -60,7 +60,20 @@ class FlinkManifestUtil {
     }
   }
 
-  static ManifestOutputFileFactory createOutputFileFactory(
+  public static ManifestOutputFileFactory createOutputFileFactory(
+      Table table, int subTaskId, long attemptNumber) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+    return new ManifestOutputFileFactory(
+        ops,
+        table.io(),
+        table.properties(),
+        "flinkJobId",
+        "operatorUniqueId",
+        subTaskId,
+        attemptNumber);
+  }
+
+  public static ManifestOutputFileFactory createOutputFileFactory(
       Table table, String flinkJobId, String operatorUniqueId, int subTaskId, long attemptNumber) {
     TableOperations ops = ((HasTableOperations) table).operations();
     return new ManifestOutputFileFactory(
@@ -73,7 +86,7 @@ class FlinkManifestUtil {
         attemptNumber);
   }
 
-  static DeltaManifests writeCompletedFiles(
+  public static DeltaManifests writeCompletedFiles(
       WriteResult result, Supplier<OutputFile> outputFileSupplier, PartitionSpec spec)
       throws IOException {
 
@@ -104,7 +117,7 @@ class FlinkManifestUtil {
     return new DeltaManifests(dataManifest, deleteManifest, result.referencedDataFiles());
   }
 
-  static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io)
+  public static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io)
       throws IOException {
     WriteResult.Builder builder = WriteResult.builder();
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -1,0 +1,694 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.committer.FilesCommittable;
+import org.apache.iceberg.flink.sink.committer.FilesCommittableSerializer;
+import org.apache.iceberg.flink.sink.committer.FilesCommitter;
+import org.apache.iceberg.flink.sink.writer.StreamWriter;
+import org.apache.iceberg.flink.sink.writer.StreamWriterState;
+import org.apache.iceberg.flink.sink.writer.StreamWriterStateSerializer;
+import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Flink v2 sink offer different hooks to insert custom topologies into the sink. It includes
+ * writers that can write data to files in parallel and route commit info globally to one Committer.
+ * Post commit topology will take of compacting the already written files and updating the file log
+ * after the compaction.
+ *
+ * <pre>{@code
+ *                            Flink sink
+ *               +------------------------------------------------------------------+
+ *               |                                                                  |
+ * +-------+     | +-------------+       +---------------+                          |
+ * | Map 1 | ==> | | writer 1 | =|       | committer 1   |                          |
+ * +-------+     | +-------------+       +---------------+                          |
+ *               |                 \                                                |
+ *               |                  \                                               |
+ *               |                   \                                              |
+ * +-------+     | +-------------+    \  +---------------+        +---------------+ |
+ * | Map 2 | ==> | | writer 2 | =| ---  >| committer 2   |  --->  | post commit   | |
+ * +-------+     | +-------------+       +---------------+        +---------------+ |
+ *               |                                                                  |
+ *               +------------------------------------------------------------------+
+ * }</pre>
+ */
+public class IcebergSink
+    implements StatefulSink<RowData, StreamWriterState>,
+        WithPreWriteTopology<RowData>,
+        WithPreCommitTopology<RowData, FilesCommittable>,
+        WithPostCommitTopology<RowData, FilesCommittable> {
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergSink.class);
+
+  private final TableLoader tableLoader;
+  private final Table table;
+  private final boolean overwrite;
+  private final boolean upsertMode;
+  private final DistributionMode distributionMode;
+  private final List<String> equalityFieldColumns;
+  private final List<Integer> equalityFieldIds;
+  private final FileFormat dataFileFormat;
+  private final int workerPoolSize;
+  private final long targetDataFileSize;
+  private final String uidPrefix;
+  private final Map<String, String> snapshotProperties;
+  private final RowType flinkRowType;
+  private Committer<FilesCommittable> committer;
+
+  private IcebergSink(
+      TableLoader tableLoader,
+      @Nullable Table table,
+      List<Integer> equalityFieldIds,
+      List<String> equalityFieldColumns,
+      @Nullable String uidPrefix,
+      Map<String, String> snapshotProperties,
+      boolean upsertMode,
+      boolean overwrite,
+      TableSchema tableSchema,
+      DistributionMode distributionMode,
+      int workerPoolSize,
+      long targetDataFileSize,
+      FileFormat dataFileFormat) {
+    Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
+    Preconditions.checkNotNull(table, "Table shouldn't be null");
+
+    this.tableLoader = tableLoader;
+    this.table = table;
+    this.equalityFieldIds = equalityFieldIds;
+    this.equalityFieldColumns = equalityFieldColumns;
+    this.uidPrefix = uidPrefix == null ? "" : uidPrefix;
+    this.snapshotProperties = snapshotProperties;
+    this.flinkRowType = toFlinkRowType(table.schema(), tableSchema);
+    this.upsertMode = upsertMode;
+    this.overwrite = overwrite;
+    this.distributionMode = distributionMode;
+    this.workerPoolSize = workerPoolSize;
+    this.targetDataFileSize = targetDataFileSize;
+    this.dataFileFormat = dataFileFormat;
+  }
+
+  @Override
+  public DataStream<RowData> addPreWriteTopology(DataStream<RowData> inputDataStream) {
+    return distributeDataStream(
+        inputDataStream,
+        equalityFieldIds,
+        table.spec(),
+        table.schema(),
+        flinkRowType,
+        distributionMode,
+        equalityFieldColumns);
+  }
+
+  @Override
+  public StreamWriter createWriter(InitContext context) {
+    return restoreWriter(context, Lists.newArrayList());
+  }
+
+  @Override
+  public StreamWriter restoreWriter(
+      InitContext context, Collection<StreamWriterState> recoveredState) {
+    RowDataTaskWriterFactory taskWriterFactory =
+        new RowDataTaskWriterFactory(
+            SerializableTable.copyOf(table),
+            flinkRowType,
+            targetDataFileSize,
+            dataFileFormat,
+            equalityFieldIds,
+            upsertMode);
+    StreamWriter streamWriter =
+        new StreamWriter(
+            table.name(),
+            taskWriterFactory,
+            context.getSubtaskId(),
+            context.getNumberOfParallelSubtasks());
+
+    return streamWriter.initializeState(recoveredState);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<StreamWriterState> getWriterStateSerializer() {
+    return new StreamWriterStateSerializer();
+  }
+
+  @Override
+  public DataStream<CommittableMessage<FilesCommittable>> addPreCommitTopology(
+      DataStream<CommittableMessage<FilesCommittable>> writeResults) {
+    return writeResults
+        .map(
+            new RichMapFunction<
+                CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>() {
+              @Override
+              public CommittableMessage<FilesCommittable> map(
+                  CommittableMessage<FilesCommittable> message) {
+                if (message instanceof CommittableWithLineage) {
+                  CommittableWithLineage<FilesCommittable> committableWithLineage =
+                      (CommittableWithLineage<FilesCommittable>) message;
+                  FilesCommittable committable = committableWithLineage.getCommittable();
+                  committable.checkpointId(committableWithLineage.getCheckpointId().orElse(-1));
+                  committable.subtaskId(committableWithLineage.getSubtaskId());
+                  committable.jobID(getRuntimeContext().getJobId().toString());
+                }
+                return message;
+              }
+            })
+        .uid(uidPrefix + "-pre-commit-topology")
+        .global();
+  }
+
+  @Override
+  public Committer<FilesCommittable> createCommitter() {
+    return committer != null
+        ? committer
+        : new FilesCommitter(tableLoader, overwrite, snapshotProperties, workerPoolSize);
+  }
+
+  @VisibleForTesting
+  void setCommitter(Committer<FilesCommittable> committer) {
+    this.committer = committer;
+  }
+
+  @Override
+  public SimpleVersionedSerializer<FilesCommittable> getCommittableSerializer() {
+    return new FilesCommittableSerializer();
+  }
+
+  @Override
+  public void addPostCommitTopology(DataStream<CommittableMessage<FilesCommittable>> committables) {
+    // TODO Support small file compaction
+  }
+
+  /**
+   * Initialize a {@link Builder} to export the data from generic input data stream into iceberg
+   * table. We use {@link RowData} inside the sink connector, so users need to provide a mapper
+   * function and a {@link TypeInformation} to convert those generic records to a RowData
+   * DataStream.
+   *
+   * @param input the generic source input data stream.
+   * @param mapper function to convert the generic data to {@link RowData}
+   * @param outputType to define the {@link TypeInformation} for the input data.
+   * @param <T> the data type of records.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  public static <T> Builder builderFor(
+      DataStream<T> input, MapFunction<T, RowData> mapper, TypeInformation<RowData> outputType) {
+    return new Builder().forMapperOutputType(input, mapper, outputType);
+  }
+
+  /**
+   * Initialize a {@link Builder} to export the data from input data stream with {@link Row}s into
+   * iceberg table. We use {@link RowData} inside the sink connector, so users need to provide a
+   * {@link TableSchema} for builder to convert those {@link Row}s to a {@link RowData} DataStream.
+   *
+   * @param input the source input data stream with {@link Row}s.
+   * @param tableSchema defines the {@link TypeInformation} for input data.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  public static Builder forRow(DataStream<Row> input, TableSchema tableSchema) {
+    RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
+    DataType[] fieldDataTypes = tableSchema.getFieldDataTypes();
+
+    DataFormatConverters.RowConverter rowConverter =
+        new DataFormatConverters.RowConverter(fieldDataTypes);
+    return builderFor(input, rowConverter::toInternal, FlinkCompatibilityUtil.toTypeInfo(rowType))
+        .tableSchema(tableSchema);
+  }
+
+  /**
+   * Initialize a {@link Builder} to export the data from input data stream with {@link RowData}s
+   * into iceberg table.
+   *
+   * @param input the source input data stream with {@link RowData}s.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  public static Builder forRowData(DataStream<RowData> input) {
+    return new Builder().forRowData(input);
+  }
+
+  /**
+   * Initialize a {@link Builder} to export the data from input data stream with {@link RowData}s
+   * into iceberg table.
+   *
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Function<String, DataStream<RowData>> inputCreator = null;
+    private TableLoader tableLoader;
+    private Table table;
+    private FlinkWriteConf flinkWriteConf;
+    private TableSchema tableSchema;
+    private Integer writeParallelism = null;
+    private List<String> equalityFieldColumns = null;
+    private String uidPrefix = "iceberg-flink-job";
+    private final Map<String, String> snapshotProperties = Maps.newHashMap();
+    private ReadableConfig readableConfig = new Configuration();
+    private final Map<String, String> writeOptions = Maps.newHashMap();
+
+    private Builder() {}
+
+    private Builder forRowData(DataStream<RowData> newRowDataInput) {
+      this.inputCreator = ignored -> newRowDataInput;
+      return this;
+    }
+
+    private <T> Builder forMapperOutputType(
+        DataStream<T> input, MapFunction<T, RowData> mapper, TypeInformation<RowData> outputType) {
+      this.inputCreator =
+          newUidPrefix -> {
+            // Input stream order is crucial for some situation (e.g. in cdc case).
+            // Therefore, we need to set the parallelismof map operator same as its input to keep
+            // map operator chaining its input, and avoid rebalanced by default.
+            SingleOutputStreamOperator<RowData> inputStream =
+                input.map(mapper, outputType).setParallelism(input.getParallelism());
+            if (newUidPrefix != null) {
+              inputStream
+                  .name(Builder.this.operatorName(newUidPrefix))
+                  .uid(newUidPrefix + "-mapper");
+            }
+            return inputStream;
+          };
+      return this;
+    }
+
+    /**
+     * This iceberg {@link Table} instance is used for initializing {@link StreamWriter} which will
+     * write all the records into {@link DataFile}s and emit them to downstream operator. Providing
+     * a table would avoid so many table loading from each separate task.
+     *
+     * @param newTable the loaded iceberg table instance.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder table(Table newTable) {
+      this.table = newTable;
+      return this;
+    }
+
+    /**
+     * The table loader is used for loading tables in {@link FilesCommitter} lazily, we need this
+     * loader because {@link Table} is not serializable and could not just use the loaded table from
+     * Builder#table in the remote task manager.
+     *
+     * @param newTableLoader to load iceberg table inside tasks.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder tableLoader(TableLoader newTableLoader) {
+      this.tableLoader = newTableLoader;
+      return this;
+    }
+
+    /**
+     * Set the write properties for Flink sink. View the supported properties in {@link
+     * FlinkWriteOptions}
+     */
+    public Builder set(String property, String value) {
+      writeOptions.put(property, value);
+      return this;
+    }
+
+    /**
+     * Set the write properties for Flink sink. View the supported properties in {@link
+     * FlinkWriteOptions}
+     */
+    public Builder setAll(Map<String, String> properties) {
+      writeOptions.putAll(properties);
+      return this;
+    }
+
+    public Builder tableSchema(TableSchema newTableSchema) {
+      this.tableSchema = newTableSchema;
+      return this;
+    }
+
+    public Builder overwrite(boolean newOverwrite) {
+      writeOptions.put(FlinkWriteOptions.OVERWRITE_MODE.key(), Boolean.toString(newOverwrite));
+      return this;
+    }
+
+    public Builder flinkConf(ReadableConfig config) {
+      this.readableConfig = config;
+      return this;
+    }
+
+    /**
+     * Configure the write {@link DistributionMode} that the flink sink will use. Currently, flink
+     * support {@link DistributionMode#NONE} and {@link DistributionMode#HASH}.
+     *
+     * @param mode to specify the write distribution mode.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder distributionMode(DistributionMode mode) {
+      Preconditions.checkArgument(
+          !DistributionMode.RANGE.equals(mode),
+          "Flink does not support 'range' write distribution mode now.");
+      if (mode != null) {
+        writeOptions.put(FlinkWriteOptions.DISTRIBUTION_MODE.key(), mode.modeName());
+      }
+      return this;
+    }
+
+    /**
+     * Configuring the write parallel number for iceberg stream writer.
+     *
+     * @param newWriteParallelism the number of parallel iceberg stream writer.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder writeParallelism(int newWriteParallelism) {
+      this.writeParallelism = newWriteParallelism;
+      return this;
+    }
+
+    /**
+     * All INSERT/UPDATE_AFTER events from input stream will be transformed to UPSERT events, which
+     * means it will DELETE the old records and then INSERT the new records. In partitioned table,
+     * the partition fields should be a subset of equality fields, otherwise the old row that
+     * located in partition-A could not be deleted by the new row that located in partition-B.
+     *
+     * @param enabled indicate whether it should transform all INSERT/UPDATE_AFTER events to UPSERT.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder upsert(boolean enabled) {
+      writeOptions.put(FlinkWriteOptions.WRITE_UPSERT_ENABLED.key(), Boolean.toString(enabled));
+      return this;
+    }
+
+    /**
+     * Configuring the equality field columns for iceberg table that accept CDC or UPSERT events.
+     *
+     * @param columns defines the iceberg table's key.
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder equalityFieldColumns(List<String> columns) {
+      this.equalityFieldColumns = columns;
+      return this;
+    }
+
+    /**
+     * Set the uid prefix for FlinkSink. Actually operator uid will be appended with a suffix like
+     * "uidPrefix-sink". <br>
+     * <br>
+     * If provided, this prefix is also applied to operator names. <br>
+     * <br>
+     * Flink auto generates operator uid if not set explicitly. It is a recommended <a
+     * href="https://ci.apache.org/projects/flink/flink-docs-master/docs/ops/production_ready/">
+     * best-practice to set uid for all operators</a> before deploying to production. Flink has an
+     * option to {@code pipeline.auto-generate-uid=false} to disable auto-generation and force
+     * explicit setting of all operator uid. <br>
+     * <br>
+     * Be careful with setting this for an existing job, because now we are changing the operator
+     * uid from an auto-generated one to this new value. When deploying the change with a
+     * checkpoint, Flink won't be able to restore the previous Flink sink state. You need to use
+     * {@code --allowNonRestoredState} to ignore the previous sink state. During restore Flink sink
+     * state is used to check if last commit was actually successful or not. {@code
+     * --allowNonRestoredState} can lead to data loss if the Iceberg commit failed in the last
+     * completed checkpoint.
+     *
+     * @param newPrefix prefix for Flink sink operator uid and name
+     * @return {@link Builder} to connect the iceberg table.
+     */
+    public Builder uidPrefix(String newPrefix) {
+      this.uidPrefix = newPrefix == null ? "" : newPrefix;
+      return this;
+    }
+
+    public Builder setSnapshotProperties(Map<String, String> properties) {
+      snapshotProperties.putAll(properties);
+      return this;
+    }
+
+    public Builder setSnapshotProperty(String property, String value) {
+      snapshotProperties.put(property, value);
+      return this;
+    }
+
+    /** Append the iceberg sink operators to write records to iceberg table. */
+    @SuppressWarnings("unchecked")
+    public DataStreamSink<Void> append() {
+      Preconditions.checkArgument(
+          inputCreator != null,
+          "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
+      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
+
+      DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
+      DataStreamSink rowDataDataStreamSink = rowDataInput.sinkTo(build()).uid(uidPrefix + "-sink");
+      if (writeParallelism != null) {
+        rowDataDataStreamSink.setParallelism(writeParallelism);
+      }
+      return rowDataDataStreamSink;
+    }
+
+    public IcebergSink build() {
+      this.table = checkAndGetTable(tableLoader, table);
+      List<Integer> equalityFieldIds = checkAndGetEqualityFieldIds(table, equalityFieldColumns);
+      this.flinkWriteConf = new FlinkWriteConf(table, writeOptions, readableConfig);
+      validateUpsertMode(
+          table,
+          equalityFieldIds,
+          equalityFieldColumns,
+          flinkWriteConf.upsertMode(),
+          flinkWriteConf.overwriteMode());
+
+      return new IcebergSink(
+          tableLoader,
+          table,
+          equalityFieldIds,
+          equalityFieldColumns,
+          uidPrefix,
+          snapshotProperties,
+          flinkWriteConf.upsertMode(),
+          flinkWriteConf.overwriteMode(),
+          tableSchema,
+          flinkWriteConf.distributionMode(),
+          flinkWriteConf.workerPoolSize(),
+          flinkWriteConf.targetDataFileSize(),
+          flinkWriteConf.dataFileFormat());
+    }
+
+    private String operatorName(String suffix) {
+      return uidPrefix != null ? uidPrefix + "-" + suffix : suffix;
+    }
+  }
+
+  static RowType toFlinkRowType(Schema schema, TableSchema requestedSchema) {
+    if (requestedSchema != null) {
+      // Convert the flink schema to iceberg schema firstly, then reassign ids to match the existing
+      // iceberg schema.
+      Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(requestedSchema), schema);
+      TypeUtil.validateWriteSchema(schema, writeSchema, true, true);
+
+      // We use this flink schema to read values from RowData. The flink's TINYINT and SMALLINT will
+      // be promoted to iceberg INTEGER, that means if we use iceberg's table schema to read TINYINT
+      // (backend by 1 'byte'), we will read 4 bytes rather than 1 byte, it will mess up the byte
+      // array in
+      // BinaryRowData. So here we must use flink schema.
+      return (RowType) requestedSchema.toRowDataType().getLogicalType();
+    } else {
+      return FlinkSchemaUtil.convert(schema);
+    }
+  }
+
+  static DataStream<RowData> distributeDataStream(
+      DataStream<RowData> input,
+      List<Integer> equalityFieldIds,
+      PartitionSpec partitionSpec,
+      Schema iSchema,
+      RowType flinkRowType,
+      DistributionMode distributionMode,
+      List<String> equalityFieldColumns) {
+    LOG.info("Write distribution mode is '{}'", distributionMode.modeName());
+    switch (distributionMode) {
+      case NONE:
+        if (equalityFieldIds.isEmpty()) {
+          return input;
+        } else {
+          LOG.info("Distribute rows by equality fields, because there are equality fields set");
+          return input.keyBy(new EqualityFieldKeySelector(iSchema, flinkRowType, equalityFieldIds));
+        }
+
+      case HASH:
+        if (equalityFieldIds.isEmpty()) {
+          if (partitionSpec.isUnpartitioned()) {
+            LOG.warn(
+                "Fallback to use 'none' distribution mode, because there are no equality fields set "
+                    + "and table is unpartitioned");
+            return input;
+          } else {
+            return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
+          }
+        } else {
+          if (partitionSpec.isUnpartitioned()) {
+            LOG.info(
+                "Distribute rows by equality fields, because there are equality fields set "
+                    + "and table is unpartitioned");
+            return input.keyBy(
+                new EqualityFieldKeySelector(iSchema, flinkRowType, equalityFieldIds));
+          } else {
+            for (PartitionField partitionField : partitionSpec.fields()) {
+              Preconditions.checkState(
+                  equalityFieldIds.contains(partitionField.sourceId()),
+                  "In 'hash' distribution mode with equality fields set, partition field '%s' "
+                      + "should be included in equality fields: '%s'",
+                  partitionField,
+                  equalityFieldColumns);
+            }
+            return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
+          }
+        }
+
+      case RANGE:
+        if (equalityFieldIds.isEmpty()) {
+          LOG.warn(
+              "Fallback to use 'none' distribution mode, because there are no equality fields set "
+                  + "and {}=range is not supported yet in flink",
+              WRITE_DISTRIBUTION_MODE);
+          return input;
+        } else {
+          LOG.info(
+              "Distribute rows by equality fields, because there are equality fields set "
+                  + "and {}=range is not supported yet in flink",
+              WRITE_DISTRIBUTION_MODE);
+          return input.keyBy(new EqualityFieldKeySelector(iSchema, flinkRowType, equalityFieldIds));
+        }
+
+      default:
+        throw new RuntimeException(
+            "Unrecognized " + WRITE_DISTRIBUTION_MODE + ": " + distributionMode);
+    }
+  }
+
+  static List<Integer> checkAndGetEqualityFieldIds(Table table, List<String> equalityFieldColumns) {
+    List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().identifierFieldIds());
+    if (equalityFieldColumns != null && equalityFieldColumns.size() > 0) {
+      Set<Integer> equalityFieldSet = Sets.newHashSetWithExpectedSize(equalityFieldColumns.size());
+      for (String column : equalityFieldColumns) {
+        org.apache.iceberg.types.Types.NestedField field = table.schema().findField(column);
+        Preconditions.checkNotNull(
+            field,
+            "Missing required equality field column '%s' in table schema %s",
+            column,
+            table.schema());
+        equalityFieldSet.add(field.fieldId());
+      }
+
+      if (!equalityFieldSet.equals(table.schema().identifierFieldIds())) {
+        LOG.warn(
+            "The configured equality field column IDs {} are not matched with the schema identifier field IDs"
+                + " {}, use job specified equality field columns as the equality fields by default.",
+            equalityFieldSet,
+            table.schema().identifierFieldIds());
+      }
+
+      equalityFieldIds = Lists.newArrayList(equalityFieldSet);
+    }
+    return equalityFieldIds;
+  }
+
+  static Table checkAndGetTable(TableLoader tableLoader, Table table) {
+    if (table == null) {
+      tableLoader.open();
+      try (TableLoader loader = tableLoader) {
+        return SerializableTable.copyOf(loader.loadTable());
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Failed to load iceberg table from table loader: " + tableLoader, e);
+      }
+    }
+    return SerializableTable.copyOf(table);
+  }
+
+  static void validateUpsertMode(
+      Table table,
+      List<Integer> equalityFieldIds,
+      List<String> equalityFieldColumns,
+      boolean upsertMode,
+      boolean overwriteMode) {
+    // Validate the equality fields and partition fields if we enable the upsert mode.
+    if (upsertMode) {
+      Preconditions.checkState(
+          !overwriteMode,
+          "OVERWRITE mode shouldn't be enable when configuring to use UPSERT data stream.");
+      Preconditions.checkState(
+          !equalityFieldIds.isEmpty(),
+          "Equality field columns shouldn't be empty when configuring to use UPSERT data stream.");
+      if (!table.spec().isUnpartitioned()) {
+        for (PartitionField partitionField : table.spec().fields()) {
+          Preconditions.checkState(
+              equalityFieldIds.contains(partitionField.sourceId()),
+              "In UPSERT mode, partition field '%s' should be included in equality fields: '%s'",
+              partitionField,
+              equalityFieldColumns);
+        }
+      }
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
-class ManifestOutputFileFactory {
+public class ManifestOutputFileFactory {
   // Users could define their own flink manifests directory by setting this value in table
   // properties.
   static final String FLINK_MANIFEST_LOCATION = "flink.manifests.location";
@@ -69,7 +69,11 @@ class ManifestOutputFileFactory {
             fileCount.incrementAndGet()));
   }
 
-  OutputFile create(long checkpointId) {
+  public OutputFile create() {
+    return create(0);
+  }
+
+  public OutputFile create(long checkpointId) {
     String flinkManifestDir = props.get(FLINK_MANIFEST_LOCATION);
 
     String newManifestFullPath;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommittable.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommittable.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.committer;
+
+import java.io.Serializable;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+public class FilesCommittable implements Serializable {
+  private final WriteResult committable;
+  private String jobId = "";
+  private long checkpointId;
+  private int subtaskId;
+
+  public FilesCommittable(WriteResult committable) {
+    this.committable = committable;
+  }
+
+  public FilesCommittable(WriteResult committable, String jobId, long checkpointId, int subtaskId) {
+    this.committable = committable;
+    this.jobId = jobId;
+    this.checkpointId = checkpointId;
+    this.subtaskId = subtaskId;
+  }
+
+  public WriteResult committable() {
+    return committable;
+  }
+
+  public Long checkpointId() {
+    return checkpointId;
+  }
+
+  public String jobID() {
+    return jobId;
+  }
+
+  public void jobID(String newJobId) {
+    this.jobId = newJobId;
+  }
+
+  public void checkpointId(long newCheckpointId) {
+    this.checkpointId = newCheckpointId;
+  }
+
+  public void subtaskId(int newSubtaskId) {
+    this.subtaskId = newSubtaskId;
+  }
+
+  public int subtaskId() {
+    return subtaskId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("committable", committable)
+        .add("jobID", jobId)
+        .add("checkpointId", checkpointId)
+        .add("subtaskId", subtaskId)
+        .toString();
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommittableSerializer.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommittableSerializer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.committer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.iceberg.io.WriteResult;
+
+public class FilesCommittableSerializer implements SimpleVersionedSerializer<FilesCommittable> {
+  private static final int VERSION_1 = 1;
+
+  @Override
+  public int getVersion() {
+    return VERSION_1;
+  }
+
+  @Override
+  public byte[] serialize(FilesCommittable committable) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    byte[] serialize = writeResultSerializer.serialize(committable.committable());
+    view.writeUTF(committable.jobID());
+    view.writeLong(committable.checkpointId());
+    view.writeInt(committable.subtaskId());
+    view.writeInt(serialize.length);
+    view.write(serialize);
+    return out.toByteArray();
+  }
+
+  @Override
+  public FilesCommittable deserialize(int version, byte[] serialized) throws IOException {
+    switch (version) {
+      case VERSION_1:
+        DataInputDeserializer view = new DataInputDeserializer(serialized);
+        String jobID = view.readUTF();
+        long checkpointId = view.readLong();
+        int subtaskId = view.readInt();
+        int len = view.readInt();
+        byte[] buf = new byte[len];
+        view.read(buf);
+        WriteResult writeResult =
+            writeResultSerializer.deserialize(writeResultSerializer.getVersion(), buf);
+        return new FilesCommittable(writeResult, jobID, checkpointId, subtaskId);
+      default:
+        throw new IOException("Unrecognized version or corrupt state: " + version);
+    }
+  }
+
+  private final SimpleVersionedSerializer<WriteResult> writeResultSerializer =
+      new SimpleVersionedSerializer<WriteResult>() {
+        @Override
+        public int getVersion() {
+          return VERSION_1;
+        }
+
+        @Override
+        public byte[] serialize(WriteResult writeResult) throws IOException {
+          return InstantiationUtil.serializeObject(writeResult);
+        }
+
+        @Override
+        public WriteResult deserialize(int version, byte[] serialized) throws IOException {
+          try {
+            return InstantiationUtil.deserializeObject(
+                serialized, WriteResult.class.getClassLoader());
+          } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to deserialize the WriteResult.", e);
+          }
+        }
+      };
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/committer/FilesCommitter.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.committer;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.SnapshotUpdate;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FilesCommitter implements Committer<FilesCommittable>, Serializable {
+  private static final long serialVersionUID = 1L;
+  private static final long INITIAL_CHECKPOINT_ID = -1L;
+  private static final Logger LOG = LoggerFactory.getLogger(FilesCommitter.class);
+  private static final String FLINK_JOB_ID = "flink.job-id";
+
+  private static final String MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
+
+  // TableLoader to load iceberg table lazily.
+  private final TableLoader tableLoader;
+  private final boolean replacePartitions;
+  private final Map<String, String> snapshotProperties;
+
+  // It will have an unique identifier for one job.
+  private final Table table;
+  private transient Map<String, Long> maxCommittedCheckpointIdForJob = Maps.newHashMap();
+
+  private transient ExecutorService workerPool;
+
+  public FilesCommitter(
+      TableLoader tableLoader,
+      boolean replacePartitions,
+      Map<String, String> snapshotProperties,
+      int workerPoolSize) {
+    this.tableLoader = tableLoader;
+    this.replacePartitions = replacePartitions;
+    this.snapshotProperties = snapshotProperties;
+
+    this.workerPool =
+        ThreadPools.newWorkerPool(
+            "iceberg-worker-pool-" + Thread.currentThread().getName(), workerPoolSize);
+
+    // Open the table loader and load the table.
+    this.tableLoader.open();
+    this.table = tableLoader.loadTable();
+  }
+
+  @Override
+  public void commit(Collection<CommitRequest<FilesCommittable>> commitRequests)
+      throws IOException, InterruptedException {
+    int dataFilesNum = 0;
+    int deleteFilesNum = 0;
+
+    List<CommitRequest<FilesCommittable>> store = Lists.newArrayList();
+    String jobId = null;
+    long maxCommittableCheckpointId = INITIAL_CHECKPOINT_ID;
+
+    for (CommitRequest<FilesCommittable> commitRequest : commitRequests) {
+      WriteResult committable = commitRequest.getCommittable().committable();
+      Long committableCheckpointId = commitRequest.getCommittable().checkpointId();
+      jobId = commitRequest.getCommittable().jobID();
+      if (committableCheckpointId
+              > maxCommittedCheckpointIdForJob.getOrDefault(jobId, Long.MAX_VALUE)
+          || getMaxCommittedCheckpointId(table, jobId) == -1) {
+        // committableCheckpointId > maxCommittableCheckpointId or the job id has never written data
+        // to the table.
+        store.add(commitRequest);
+        dataFilesNum = dataFilesNum + committable.dataFiles().length;
+        deleteFilesNum = deleteFilesNum + committable.deleteFiles().length;
+        maxCommittableCheckpointId = committableCheckpointId;
+      } else if (committableCheckpointId > getMaxCommittedCheckpointId(table, jobId)) {
+        // committable is restored from the previous job that committed data to the table.
+        commitResult(
+            committable.dataFiles().length,
+            committable.deleteFiles().length,
+            Lists.newArrayList(commitRequest));
+        maxCommittedCheckpointIdForJob.put(jobId, committableCheckpointId);
+      } else {
+        commitRequest.signalFailedWithKnownReason(
+            new CommitFailedException(
+                "The data could not be committed, perhaps because the data was committed."));
+      }
+    }
+
+    commitResult(dataFilesNum, deleteFilesNum, store);
+    // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new
+    // flink job even if it's restored from a snapshot created by another different flink job, so
+    // it's safe to assign the max committed checkpoint id from restored flink job to the current
+    // flink job.
+    maxCommittedCheckpointIdForJob.put(jobId, maxCommittableCheckpointId);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
+  }
+
+  private void commitResult(
+      int dataFilesNum, int deleteFilesNum, List<CommitRequest<FilesCommittable>> commitRequests) {
+    int totalFiles = dataFilesNum + deleteFilesNum;
+
+    if (totalFiles != 0) {
+      if (replacePartitions) {
+        replacePartitions(commitRequests, dataFilesNum, deleteFilesNum);
+      } else {
+        commitDeltaTxn(commitRequests, dataFilesNum, deleteFilesNum);
+      }
+    }
+  }
+
+  private void replacePartitions(
+      List<CommitRequest<FilesCommittable>> writeResults, int dataFilesNum, int deleteFilesNum) {
+    // Partition overwrite does not support delete files.
+    Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
+
+    // Commit the overwrite transaction.
+    ReplacePartitions dynamicOverwrite = table.newReplacePartitions().scanManifestsWith(workerPool);
+
+    String flinkJobId = null;
+    long checkpointId = -1;
+    for (CommitRequest<FilesCommittable> commitRequest : writeResults) {
+      WriteResult result = commitRequest.getCommittable().committable();
+      Preconditions.checkState(
+          result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+      flinkJobId = commitRequest.getCommittable().jobID();
+      checkpointId = commitRequest.getCommittable().checkpointId();
+      Arrays.stream(result.dataFiles()).forEach(dynamicOverwrite::addFile);
+    }
+
+    commitOperation(
+        writeResults,
+        dynamicOverwrite,
+        dataFilesNum,
+        0,
+        "dynamic partition overwrite",
+        flinkJobId,
+        checkpointId);
+  }
+
+  private void commitDeltaTxn(
+      List<CommitRequest<FilesCommittable>> commitRequests, int dataFilesNum, int deleteFilesNum) {
+    if (deleteFilesNum == 0) {
+      // To be compatible with iceberg format V1.
+      AppendFiles appendFiles = table.newAppend().scanManifestsWith(workerPool);
+      String flinkJobId = null;
+      long checkpointId = -1;
+      for (CommitRequest<FilesCommittable> commitRequest : commitRequests) {
+        WriteResult result = commitRequest.getCommittable().committable();
+        Preconditions.checkState(
+            result.referencedDataFiles().length == 0, "Should have no referenced data files.");
+        Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+        flinkJobId = commitRequest.getCommittable().jobID();
+        checkpointId = commitRequest.getCommittable().checkpointId();
+      }
+
+      commitOperation(
+          commitRequests, appendFiles, dataFilesNum, 0, "append", flinkJobId, checkpointId);
+    } else {
+      // To be compatible with iceberg format V2.
+      for (CommitRequest<FilesCommittable> commitRequest : commitRequests) {
+        // We don't commit the merged result into a single transaction because for the sequential
+        // transaction txn1 and txn2, the equality-delete files of txn2 are required to be applied
+        // to data files from txn1. Committing the merged one will lead to the incorrect delete
+        // semantic.
+        WriteResult result = commitRequest.getCommittable().committable();
+
+        // Row delta validations are not needed for streaming changes that write equality deletes.
+        // Equality deletes are applied to data in all previous sequence numbers, so retries may
+        // push deletes further in the future, but do not affect correctness. Position deletes
+        // committed to the table in this path are used only to delete rows from data files that are
+        // being added in this commit. There is no way for data files added along with the delete
+        // files to be concurrently removed, so there is no need to validate the files referenced by
+        // the position delete files that are being committed.
+        RowDelta rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
+        Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+        Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+
+        String flinkJobId = commitRequest.getCommittable().jobID();
+        long checkpointId = commitRequest.getCommittable().checkpointId();
+        commitOperation(
+            Lists.newArrayList(commitRequest),
+            rowDelta,
+            dataFilesNum,
+            deleteFilesNum,
+            "rowDelta",
+            flinkJobId,
+            checkpointId);
+      }
+    }
+  }
+
+  private void commitOperation(
+      List<CommitRequest<FilesCommittable>> commitRequests,
+      SnapshotUpdate<?> operation,
+      int numDataFiles,
+      int numDeleteFiles,
+      String description,
+      String newFlinkJobId,
+      long checkpointId) {
+    try {
+      LOG.info(
+          "Committing {} with {} data files and {} delete files to table {}",
+          description,
+          numDataFiles,
+          numDeleteFiles,
+          table);
+      // custom snapshot metadata properties will be overridden if they conflict with internal ones
+      // used by the sink.
+      snapshotProperties.forEach(operation::set);
+      operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
+      operation.set(FLINK_JOB_ID, newFlinkJobId);
+
+      long start = System.currentTimeMillis();
+      operation.commit(); // abort is automatically called if this fails.
+      long duration = System.currentTimeMillis() - start;
+      LOG.info("Committed in {} ms", duration);
+    } catch (AlreadyExistsException | UnsupportedOperationException e) {
+      commitRequests.forEach(request -> request.signalFailedWithKnownReason(e));
+    } catch (Exception e) {
+      commitRequests.forEach(request -> request.signalFailedWithUnknownReason(e));
+    }
+  }
+
+  static long getMaxCommittedCheckpointId(Table table, String flinkJobId) {
+    return table.history().stream()
+        .map(history -> table.snapshot(history.snapshotId()).summary())
+        .filter(summary -> StringUtils.equals(summary.get(FLINK_JOB_ID), flinkJobId))
+        .findFirst()
+        .map(summary -> Long.parseLong(summary.get(MAX_COMMITTED_CHECKPOINT_ID)))
+        .orElse(INITIAL_CHECKPOINT_ID);
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.writer;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.flink.sink.TaskWriterFactory;
+import org.apache.iceberg.flink.sink.committer.FilesCommittable;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class StreamWriter
+    implements StatefulSinkWriter<RowData, StreamWriterState>,
+        TwoPhaseCommittingSink.PrecommittingSinkWriter<RowData, FilesCommittable> {
+  private static final long serialVersionUID = 1L;
+
+  private final String fullTableName;
+  private final TaskWriterFactory<RowData> taskWriterFactory;
+  private transient TaskWriter<RowData> writer;
+  private transient int subTaskId;
+  private final List<FilesCommittable> writeResultsState = Lists.newArrayList();
+
+  public StreamWriter(
+      String fullTableName,
+      TaskWriterFactory<RowData> taskWriterFactory,
+      int subTaskId,
+      int numberOfParallelSubtasks) {
+    this.fullTableName = fullTableName;
+    this.subTaskId = subTaskId;
+
+    this.taskWriterFactory = taskWriterFactory;
+    // Initialize the task writer factory.
+    taskWriterFactory.initialize(numberOfParallelSubtasks, subTaskId);
+    // Initialize the task writer.
+    this.writer = taskWriterFactory.create();
+  }
+
+  @Override
+  public void write(RowData element, Context context) throws IOException, InterruptedException {
+    writer.write(element);
+  }
+
+  @Override
+  public void flush(boolean endOfInput) throws IOException {}
+
+  @Override
+  public void close() throws Exception {
+    if (writer != null) {
+      writer.close();
+      writer = null;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("table_name", fullTableName)
+        .add("subtask_id", subTaskId)
+        .toString();
+  }
+
+  @Override
+  public Collection<FilesCommittable> prepareCommit() throws IOException {
+    writeResultsState.add(new FilesCommittable(writer.complete()));
+    this.writer = taskWriterFactory.create();
+    return writeResultsState;
+  }
+
+  @Override
+  public List<StreamWriterState> snapshotState(long checkpointId) {
+    List<StreamWriterState> state = Lists.newArrayList();
+    state.add(new StreamWriterState(Lists.newArrayList(writeResultsState)));
+    writeResultsState.clear();
+    return state;
+  }
+
+  public StreamWriter initializeState(Collection<StreamWriterState> recoveredState) {
+    for (StreamWriterState streamWriterState : recoveredState) {
+      this.writeResultsState.addAll(streamWriterState.writeResults());
+    }
+
+    return this;
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriterState.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriterState.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.writer;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.iceberg.flink.sink.committer.FilesCommittable;
+
+public class StreamWriterState implements Serializable {
+
+  private List<FilesCommittable> writeResults;
+
+  public StreamWriterState(List<FilesCommittable> writeResults) {
+    this.writeResults = writeResults;
+  }
+
+  public List<FilesCommittable> writeResults() {
+    return writeResults;
+  }
+
+  public void writeResults(List<FilesCommittable> newWriteResults) {
+    this.writeResults = newWriteResults;
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriterStateSerializer.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/writer/StreamWriterStateSerializer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.writer;
+
+import java.io.IOException;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.InstantiationUtil;
+
+public class StreamWriterStateSerializer implements SimpleVersionedSerializer<StreamWriterState> {
+  private static final int VERSION_1 = 1;
+
+  @Override
+  public int getVersion() {
+    return VERSION_1;
+  }
+
+  @Override
+  public byte[] serialize(StreamWriterState streamWriterState) throws IOException {
+    return InstantiationUtil.serializeObject(streamWriterState);
+  }
+
+  @Override
+  public StreamWriterState deserialize(int version, byte[] serialized) throws IOException {
+    switch (version) {
+      case VERSION_1:
+        try {
+          return InstantiationUtil.deserializeObject(
+              serialized, StreamWriterState.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+          throw new RuntimeException("Failed to deserialize the IcebergStreamWriterState.", e);
+        }
+      default:
+        throw new IOException("Unrecognized version or corrupt state: " + version);
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -67,9 +67,10 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
 
   private final FileFormat format;
   private final boolean isStreamingJob;
+  private final boolean useNewSink;
 
   @Parameterized.Parameters(
-      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}")
+      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}, useNewSink={4}")
   public static Iterable<Object[]> parameters() {
     List<Object[]> parameters = Lists.newArrayList();
     for (FileFormat format :
@@ -78,7 +79,8 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
         for (Object[] catalogParams : FlinkCatalogTestBase.parameters()) {
           String catalogName = (String) catalogParams[0];
           Namespace baseNamespace = (Namespace) catalogParams[1];
-          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming});
+          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, true});
+          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming, false});
         }
       }
     }
@@ -86,10 +88,15 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
   }
 
   public TestFlinkTableSink(
-      String catalogName, Namespace baseNamespace, FileFormat format, Boolean isStreamingJob) {
+      String catalogName,
+      Namespace baseNamespace,
+      FileFormat format,
+      Boolean isStreamingJob,
+      Boolean useNewSink) {
     super(catalogName, baseNamespace);
     this.format = format;
     this.isStreamingJob = isStreamingJob;
+    this.useNewSink = useNewSink;
   }
 
   @Override
@@ -110,6 +117,10 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
           settingsBuilder.inBatchMode();
           tEnv = TableEnvironment.create(settingsBuilder.build());
         }
+
+        tEnv.getConfig()
+            .getConfiguration()
+            .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP143_SINK, useNewSink);
       }
     }
     return tEnv;

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/SinkTestUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/SinkTestUtil.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+class SinkTestUtil {
+
+  private SinkTestUtil() {}
+
+  static StreamRecord<byte[]> committableRecord(String element) {
+    return new StreamRecord<>(toBytes(element));
+  }
+
+  static List<StreamRecord<byte[]>> committableRecords(Collection<String> elements) {
+    return elements.stream().map(SinkTestUtil::committableRecord).collect(Collectors.toList());
+  }
+
+  static List<byte[]> toBytes(String... elements) {
+    return Arrays.stream(elements).map(SinkTestUtil::toBytes).collect(Collectors.toList());
+  }
+
+  static List<byte[]> toBytes(Collection<String> elements) {
+    return elements.stream().map(SinkTestUtil::toBytes).collect(Collectors.toList());
+  }
+
+  static byte[] toBytes(String obj) {
+    try {
+      return SimpleVersionedSerialization.writeVersionAndSerialize(
+          TestSink.StringCommittableSerializer.INSTANCE, obj);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  static List<String> fromRecords(Collection<StreamRecord<byte[]>> elements) {
+    return elements.stream().map(SinkTestUtil::fromRecord).collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("unchecked")
+  static List<StreamElement> fromOutput(Collection<Object> elements) {
+    return elements.stream()
+        .map(
+            element -> {
+              if (element instanceof StreamRecord) {
+                return new StreamRecord<>(
+                    ((StreamRecord<CommittableMessage<?>>) element).getValue());
+              }
+              return (StreamElement) element;
+            })
+        .collect(Collectors.toList());
+  }
+
+  static String fromRecord(StreamRecord<byte[]> obj) {
+    return fromBytes(obj.getValue());
+  }
+
+  static String fromBytes(byte[] obj) {
+    try {
+      return SimpleVersionedSerialization.readVersionAndDeSerialize(
+          TestSink.StringCommittableSerializer.INSTANCE, obj);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public static CommittableSummary<?> toCommittableSummary(StreamElement element) {
+    final Object value = element.asRecord().getValue();
+    assertThat(value).isInstanceOf(CommittableSummary.class);
+    return (CommittableSummary<?>) value;
+  }
+
+  public static CommittableWithLineage<?> toCommittableWithLinage(StreamElement element) {
+    final Object value = element.asRecord().getValue();
+    assertThat(value).isInstanceOf(CommittableWithLineage.class);
+    return (CommittableWithLineage<?>) value;
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFilesCommitterOperator.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFilesCommitterOperator.java
@@ -1,0 +1,785 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.apache.iceberg.flink.sink.SinkTestUtil.fromOutput;
+import static org.apache.iceberg.flink.sink.SinkTestUtil.toCommittableSummary;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessageSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
+import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.RowData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.committer.FilesCommittable;
+import org.apache.iceberg.flink.sink.committer.FilesCommittableSerializer;
+import org.apache.iceberg.flink.sink.committer.FilesCommitter;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestFilesCommitterOperator extends TableTestBase {
+  private static final Configuration CONF = new Configuration();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private Table table;
+  private TableLoader tableLoader;
+  private final FileFormat format;
+  private final Boolean isBatchMode;
+  private final Boolean isCheckpointingEnabled;
+
+  private final long dataFIleRowCount = 5L;
+
+  private final DataFile dataFileTest1 =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-1.parquet")
+          .withFileSizeInBytes(0)
+          .withMetrics(
+              new Metrics(
+                  dataFIleRowCount,
+                  null, // no column sizes
+                  ImmutableMap.of(1, 5L), // value count
+                  ImmutableMap.of(1, 0L), // null count
+                  null,
+                  ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
+                  ImmutableMap.of(1, longToBuffer(4L)) // upper bounds
+                  ))
+          .build();
+
+  private final DataFile dataFileTest2 =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-2.parquet")
+          .withFileSizeInBytes(0)
+          .withMetrics(
+              new Metrics(
+                  dataFIleRowCount,
+                  null, // no column sizes
+                  ImmutableMap.of(1, 5L), // value count
+                  ImmutableMap.of(1, 0L), // null count
+                  null,
+                  ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
+                  ImmutableMap.of(1, longToBuffer(4L)) // upper bounds
+                  ))
+          .build();
+
+  @Parameterized.Parameters(name = "format={0}, isStreaming={1}, isCheckpointingEnabled={2}")
+  public static Iterable<Object[]> parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (FileFormat format :
+        new FileFormat[] {FileFormat.PARQUET, FileFormat.AVRO, FileFormat.ORC}) {
+      for (Boolean isBatchMode : new Boolean[] {true, false}) {
+        for (Boolean isCheckpointingEnabled : new Boolean[] {true, false}) {
+          parameters.add(new Object[] {2, format, isBatchMode, isCheckpointingEnabled});
+        }
+      }
+    }
+    return parameters;
+  }
+
+  @Before
+  public void before() throws IOException {
+    File folder = TEMPORARY_FOLDER.newFolder();
+    String warehouse = folder.getAbsolutePath();
+
+    String tablePath = warehouse.concat("/test");
+    Assert.assertTrue("Should create the table path correctly.", new File(tablePath).mkdir());
+
+    Map<String, String> props =
+        ImmutableMap.of(
+            TableProperties.DEFAULT_FILE_FORMAT, format.name(),
+            TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    table = SimpleDataUtil.createTable(tablePath, props, false);
+    tableLoader = TableLoader.fromHadoopTable(tablePath);
+  }
+
+  public TestFilesCommitterOperator(
+      int formatVersion, FileFormat format, Boolean isBatchMode, Boolean isCheckpointingEnabled) {
+    super(formatVersion);
+    this.format = format;
+    this.isBatchMode = isBatchMode;
+    this.isCheckpointingEnabled = isCheckpointingEnabled;
+  }
+
+  @Test
+  public void testEmitCommittablesMock() throws Exception {
+    final ForwardingCommitter committer = new ForwardingCommitter(tableLoader);
+    IcebergSink sink = IcebergSink.builder().table(table).tableLoader(tableLoader).build();
+    sink.setCommitter(committer);
+
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness =
+            new OneInputStreamOperatorTestHarness<>(
+                new CommitterOperatorFactory<>(
+                    (TwoPhaseCommittingSink<RowData, FilesCommittable>) sink, false, true));
+    testHarness.open();
+
+    FilesCommittable commit = new FilesCommittable(WriteResult.builder().build());
+    final CommittableSummary<FilesCommittable> committableSummary =
+        new CommittableSummary<>(1, 1, 1L, 1, 1, 0);
+    testHarness.processElement(new StreamRecord<>(committableSummary));
+    final CommittableWithLineage<FilesCommittable> committableWithLineage =
+        new CommittableWithLineage<>(commit, 1L, 1);
+    testHarness.processElement(new StreamRecord<>(committableWithLineage));
+
+    // Trigger commit
+    testHarness.notifyOfCompletedCheckpoint(1);
+
+    assertThat(committer.getSuccessfulCommits()).isEqualTo(1);
+    final List<StreamElement> output = fromOutput(testHarness.getOutput());
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+    testHarness.close();
+  }
+
+  @Test
+  public void testEmitCommittables() throws Exception {
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness = getTestHarness();
+    testHarness.open();
+
+    String jobId1 = "jobId1";
+    long checkpointId = 0;
+    CommittableSummary<FilesCommittable> committableSummary =
+        processElement(dataFileTest1, jobId1, checkpointId, testHarness, 1);
+
+    // Trigger commit
+    testHarness.notifyOfCompletedCheckpoint(1);
+
+    assertSnapshotSize(1);
+    assertMaxCommittedCheckpointId(jobId1, 0L);
+
+    final List<StreamElement> output = fromOutput(testHarness.getOutput());
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+    testHarness.close();
+
+    table.refresh();
+    Snapshot currentSnapshot = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount,
+        Long.parseLong(currentSnapshot.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("1", currentSnapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+  }
+
+  /** The data was not committed in the previous job. */
+  @Test
+  public void testStateRestoreFromPreJob() throws Exception {
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        preJobTestHarness = getTestHarness();
+    preJobTestHarness.open();
+
+    String jobId1 = "jobId1";
+    long checkpointId = 0;
+    CommittableSummary<FilesCommittable> committableSummary =
+        processElement(dataFileTest1, jobId1, checkpointId, preJobTestHarness, 1);
+
+    final OperatorSubtaskState snapshot = preJobTestHarness.snapshot(checkpointId, 2L);
+
+    assertThat(preJobTestHarness.getOutput()).isEmpty();
+    preJobTestHarness.close();
+
+    assertSnapshotSize(0);
+    assertMaxCommittedCheckpointId(jobId1, -1L);
+
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        restored = getTestHarness();
+    restored.setup(committableMessageTypeSerializer);
+    restored.initializeState(snapshot);
+    restored.open();
+
+    // Previous committables are immediately committed if possible
+    final List<StreamElement> output = fromOutput(restored.getOutput());
+    assertThat(output).hasSize(2);
+
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+
+    table.refresh();
+    Snapshot currentSnapshot = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount,
+        Long.parseLong(currentSnapshot.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("1", currentSnapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId1, currentSnapshot.summary().get("flink.job-id"));
+
+    String jobId2 = "jobId2";
+    CommittableSummary<FilesCommittable> committableSummary2 =
+        processElement(dataFileTest2, jobId2, checkpointId, restored, 1);
+
+    // Trigger commit
+    restored.notifyOfCompletedCheckpoint(0);
+
+    final List<StreamElement> output2 = fromOutput(restored.getOutput());
+    SinkV2Assertions.assertThat(toCommittableSummary(output2.get(0)))
+        .hasFailedCommittables(committableSummary2.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary2.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+    restored.close();
+
+    assertSnapshotSize(2);
+    assertMaxCommittedCheckpointId(jobId2, 0);
+
+    table.refresh();
+    Snapshot currentSnapshot2 = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount * 2,
+        Long.parseLong(currentSnapshot2.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("2", currentSnapshot2.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId2, currentSnapshot2.summary().get("flink.job-id"));
+  }
+
+  /** The data was committed in the previous job. */
+  @Test
+  public void testStateRestoreFromPreJob2() throws Exception {
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        preJobTestHarness = getTestHarness();
+
+    preJobTestHarness.open();
+
+    String jobId1 = "jobId1";
+    long checkpointId = 0;
+    CommittableSummary<FilesCommittable> committableSummary =
+        processElement(dataFileTest1, jobId1, checkpointId, preJobTestHarness, 1);
+
+    final OperatorSubtaskState snapshot = preJobTestHarness.snapshot(checkpointId, 2L);
+    // commit snapshot
+    preJobTestHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+    final List<StreamElement> output = fromOutput(preJobTestHarness.getOutput());
+    assertThat(output).hasSize(2);
+
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+
+    preJobTestHarness.close();
+
+    assertSnapshotSize(1);
+    assertMaxCommittedCheckpointId(jobId1, 0L);
+    table.refresh();
+    long proJobSnapshotId = table.currentSnapshot().snapshotId();
+
+    String jobId2 = "jobId2";
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        restored = getTestHarness();
+
+    restored.initializeState(snapshot);
+    restored.open();
+
+    // The committed data will not be recommitted
+    final List<StreamElement> output2 = fromOutput(restored.getOutput());
+    assertThat(output2).hasSize(0);
+
+    table.refresh();
+    long restoredSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals(
+        "The table does not generate a new snapshot without data being committed.",
+        proJobSnapshotId,
+        restoredSnapshotId);
+    Assert.assertEquals(
+        dataFIleRowCount,
+        Long.parseLong(table.currentSnapshot().summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals(
+        "1", table.currentSnapshot().summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId1, table.currentSnapshot().summary().get("flink.job-id"));
+
+    // Commit new data file
+    checkpointId = 1;
+    CommittableSummary<FilesCommittable> committableSummary2 =
+        processElement(dataFileTest2, jobId2, checkpointId, restored, 1);
+
+    // Trigger commit
+    restored.notifyOfCompletedCheckpoint(checkpointId);
+
+    final List<StreamElement> output3 = fromOutput(restored.getOutput());
+    assertThat(output3).hasSize(2);
+    SinkV2Assertions.assertThat(toCommittableSummary(output3.get(0)))
+        .hasFailedCommittables(committableSummary2.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary2.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+    restored.close();
+
+    assertSnapshotSize(2);
+    assertMaxCommittedCheckpointId(jobId2, 1L);
+
+    table.refresh();
+    Snapshot currentSnapshot2 = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount * 2,
+        Long.parseLong(currentSnapshot2.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("2", currentSnapshot2.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId2, currentSnapshot2.summary().get("flink.job-id"));
+  }
+
+  @Test
+  public void testStateRestoreFromCurrJob() throws Exception {
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness = getTestHarness();
+
+    testHarness.open();
+
+    String jobId1 = "jobId1";
+    long checkpointId = 0;
+    CommittableSummary<FilesCommittable> committableSummary =
+        processElement(dataFileTest1, jobId1, checkpointId, testHarness, 1);
+
+    final OperatorSubtaskState snapshot = testHarness.snapshot(checkpointId, 2L);
+
+    assertThat(testHarness.getOutput()).isEmpty();
+    testHarness.close();
+
+    assertSnapshotSize(0);
+    assertMaxCommittedCheckpointId(jobId1, -1L);
+
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        restored = getTestHarness();
+
+    restored.setup(committableMessageTypeSerializer);
+
+    restored.initializeState(snapshot);
+    restored.open();
+
+    // Previous committables are immediately committed if possible
+    final List<StreamElement> output = fromOutput(restored.getOutput());
+    assertThat(output).hasSize(2);
+
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+
+    table.refresh();
+    Snapshot currentSnapshot = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount,
+        Long.parseLong(currentSnapshot.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("1", currentSnapshot.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId1, currentSnapshot.summary().get("flink.job-id"));
+
+    String jobId2 = "jobId2";
+    checkpointId = 1;
+    CommittableSummary<FilesCommittable> committableSummary2 =
+        processElement(dataFileTest2, jobId2, checkpointId, restored, 1);
+
+    // Trigger commit
+    restored.notifyOfCompletedCheckpoint(checkpointId);
+
+    final List<StreamElement> output2 = fromOutput(restored.getOutput());
+    SinkV2Assertions.assertThat(toCommittableSummary(output2.get(0)))
+        .hasFailedCommittables(committableSummary2.getNumberOfFailedCommittables())
+        .hasOverallCommittables(committableSummary2.getNumberOfCommittables())
+        .hasPendingCommittables(0);
+    restored.close();
+
+    assertSnapshotSize(2);
+    assertMaxCommittedCheckpointId(jobId2, 1L);
+
+    table.refresh();
+    Snapshot currentSnapshot2 = table.currentSnapshot();
+    Assert.assertEquals(
+        dataFIleRowCount * 2,
+        Long.parseLong(currentSnapshot2.summary().get(SnapshotSummary.TOTAL_RECORDS_PROP)));
+    Assert.assertEquals("2", currentSnapshot2.summary().get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    Assert.assertEquals(jobId2, currentSnapshot2.summary().get("flink.job-id"));
+  }
+
+  @Test
+  public void testHandleEndInput() throws Exception {
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness = getTestHarness();
+
+    testHarness.open();
+
+    String jobId1 = "jobId1";
+    long checkpointId = 0;
+    processElement(dataFileTest1, jobId1, checkpointId, testHarness, 1);
+
+    testHarness.endInput();
+
+    // If checkpointing enabled endInput does not emit anything because a final checkpoint follows
+    if (isCheckpointingEnabled) {
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
+    }
+
+    final List<StreamElement> output = fromOutput(testHarness.getOutput());
+    assertThat(output).hasSize(2);
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasCheckpointId(checkpointId)
+        .hasPendingCommittables(0)
+        .hasOverallCommittables(1)
+        .hasFailedCommittables(0);
+
+    // Future emission calls should change the output
+    testHarness.notifyOfCompletedCheckpoint(2);
+    testHarness.endInput();
+
+    assertThat(testHarness.getOutput()).hasSize(2);
+  }
+
+  @Test
+  public void testDeleteFiles() throws Exception {
+    Assume.assumeFalse("Only support delete in format v2.", formatVersion < 2);
+    FileAppenderFactory<RowData> appenderFactory = createDeletableAppenderFactory();
+
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness = getTestHarness();
+
+    testHarness.open();
+    String jobId = "jobId1";
+    long checkpointId = 0;
+    RowData row1 = SimpleDataUtil.createInsert(1, "aaa");
+    DataFile dataFile1 = writeDataFile("data-file-1", ImmutableList.of(row1));
+    processElement(dataFile1, jobId, checkpointId, testHarness, 1);
+
+    testHarness.snapshot(checkpointId, 0);
+    testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+    assertSnapshotSize(1);
+    assertMaxCommittedCheckpointId(jobId, checkpointId);
+
+    final List<StreamElement> output = fromOutput(testHarness.getOutput());
+    assertThat(output).hasSize(2);
+    SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
+        .hasCheckpointId(checkpointId)
+        .hasPendingCommittables(0)
+        .hasOverallCommittables(1)
+        .hasFailedCommittables(0);
+    SimpleDataUtil.assertTableRows(table, ImmutableList.of(row1));
+
+    // The 2. commit
+    checkpointId = 1;
+    RowData row2 = SimpleDataUtil.createInsert(2, "bbb");
+    DataFile dataFile2 = writeDataFile("data-file-2", ImmutableList.of(row2));
+    processElement(dataFile2, jobId, checkpointId, testHarness, 1);
+
+    RowData row3 = SimpleDataUtil.createInsert(3, "ccc");
+    DataFile dataFile3 = writeDataFile("data-file-3", ImmutableList.of(row3));
+    processElement(dataFile3, jobId, checkpointId, testHarness, 2);
+
+    testHarness.snapshot(checkpointId, 1);
+    testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+    assertSnapshotSize(2);
+    assertMaxCommittedCheckpointId(jobId, checkpointId);
+
+    final List<StreamElement> output2 = fromOutput(testHarness.getOutput());
+    assertThat(output2).hasSize(2 + 3);
+    SinkV2Assertions.assertThat(toCommittableSummary(output2.get(2)))
+        .hasCheckpointId(checkpointId)
+        .hasPendingCommittables(0)
+        .hasOverallCommittables(2)
+        .hasFailedCommittables(0);
+
+    // The 3. commit
+    checkpointId = 2;
+    RowData delete1 = SimpleDataUtil.createDelete(1, "aaa");
+    DeleteFile deleteFile1 =
+        writeEqDeleteFile(appenderFactory, "delete-file-1", ImmutableList.of(delete1));
+    RowData row4 = SimpleDataUtil.createInsert(4, "ddd");
+    DataFile dataFile4 = writeDataFile("data-file-4", ImmutableList.of(row4));
+    WriteResult withRecord4 =
+        WriteResult.builder().addDataFiles(dataFile4).addDeleteFiles(deleteFile1).build();
+    processElement(withRecord4, jobId, checkpointId, testHarness, 1);
+
+    RowData row5 = SimpleDataUtil.createInsert(5, "eee");
+    DataFile dataFile5 = writeDataFile("data-file-5", ImmutableList.of(row5));
+    WriteResult withRecord5 = WriteResult.builder().addDataFiles(dataFile5).build();
+    processElement(withRecord5, jobId, checkpointId, testHarness, 2);
+
+    testHarness.snapshot(checkpointId, 3);
+    testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+    assertSnapshotSize(4);
+    assertMaxCommittedCheckpointId(jobId, checkpointId);
+
+    final List<StreamElement> output3 = fromOutput(testHarness.getOutput());
+    assertThat(output3).hasSize(2 + 3 + 3);
+    SinkV2Assertions.assertThat(toCommittableSummary(output3.get(5)))
+        .hasCheckpointId(checkpointId)
+        .hasPendingCommittables(0)
+        .hasOverallCommittables(2)
+        .hasFailedCommittables(0);
+
+    SimpleDataUtil.assertTableRows(table, ImmutableList.of(row2, row3, row4, row5));
+  }
+
+  private CommittableSummary<FilesCommittable> processElement(
+      WriteResult withRecord,
+      String jobId,
+      long checkpointId,
+      OneInputStreamOperatorTestHarness testHarness,
+      int subTaskId)
+      throws Exception {
+    FilesCommittable commit = new FilesCommittable(withRecord, jobId, checkpointId, subTaskId);
+    final CommittableSummary<FilesCommittable> committableSummary =
+        new CommittableSummary<>(subTaskId, 1, checkpointId, 1, 1, 0);
+    testHarness.processElement(new StreamRecord<>(committableSummary));
+    final CommittableWithLineage<FilesCommittable> committable =
+        new CommittableWithLineage<>(commit, checkpointId, subTaskId);
+    testHarness.processElement(new StreamRecord<>(committable));
+    return committableSummary;
+  }
+
+  private CommittableSummary<FilesCommittable> processElement(
+      DataFile dataFile,
+      String jobId,
+      long checkpointId,
+      OneInputStreamOperatorTestHarness testHarness,
+      int subTaskId)
+      throws Exception {
+    WriteResult withRecord = WriteResult.builder().addDataFiles(dataFile).build();
+    return processElement(withRecord, jobId, checkpointId, testHarness, subTaskId);
+  }
+
+  private FileAppenderFactory<RowData> createDeletableAppenderFactory() {
+    int[] equalityFieldIds =
+        new int[] {
+          table.schema().findField("id").fieldId(), table.schema().findField("data").fieldId()
+        };
+    return new FlinkAppenderFactory(
+        table.schema(),
+        FlinkSchemaUtil.convert(table.schema()),
+        table.properties(),
+        table.spec(),
+        equalityFieldIds,
+        table.schema(),
+        null);
+  }
+
+  private DataFile writeDataFile(String filename, List<RowData> rows) throws IOException {
+    return SimpleDataUtil.writeFile(
+        table.schema(), table.spec(), CONF, table.location(), format.addExtension(filename), rows);
+  }
+
+  private DeleteFile writeEqDeleteFile(
+      FileAppenderFactory<RowData> appenderFactory, String filename, List<RowData> deletes)
+      throws IOException {
+    return SimpleDataUtil.writeEqDeleteFile(table, format, filename, appenderFactory, deletes);
+  }
+
+  private OneInputStreamOperatorTestHarness<
+          CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+      getTestHarness() throws Exception {
+    IcebergSink sink = IcebergSink.builder().table(table).tableLoader(tableLoader).build();
+
+    final OneInputStreamOperatorTestHarness<
+            CommittableMessage<FilesCommittable>, CommittableMessage<FilesCommittable>>
+        testHarness =
+            new OneInputStreamOperatorTestHarness<>(
+                new CommitterOperatorFactory<>(
+                    (TwoPhaseCommittingSink<RowData, FilesCommittable>) sink,
+                    isBatchMode,
+                    isCheckpointingEnabled));
+    testHarness.setup(committableMessageTypeSerializer);
+
+    return testHarness;
+  }
+
+  // ------------------------------- Mock Classes --------------------------------
+
+  private static class ForwardingCommitter extends FilesCommitter {
+    private int successfulCommits = 0;
+
+    ForwardingCommitter(TableLoader tableLoader) {
+      super(tableLoader, false, Maps.newHashMap(), 2);
+    }
+
+    @Override
+    public void commit(Collection<CommitRequest<FilesCommittable>> commitRequests)
+        throws IOException, InterruptedException {
+      // super.commit(requests);
+      commitRequests.forEach(
+          one -> {
+            System.out.println(one.getNumberOfRetries());
+          });
+      successfulCommits += commitRequests.size();
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    public int getSuccessfulCommits() {
+      return successfulCommits;
+    }
+  }
+
+  // ------------------------------- Utility Methods --------------------------------
+
+  private void assertMaxCommittedCheckpointId(String jobID, long expectedId) {
+    table.refresh();
+    long actualId = IcebergFilesCommitter.getMaxCommittedCheckpointId(table, jobID);
+    Assert.assertEquals(expectedId, actualId);
+  }
+
+  private void assertSnapshotSize(int expectedSnapshotSize) {
+    table.refresh();
+    Assert.assertEquals(expectedSnapshotSize, Lists.newArrayList(table.snapshots()).size());
+  }
+
+  private static ByteBuffer longToBuffer(long value) {
+    return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+  }
+
+  final TypeSerializer<CommittableMessage<FilesCommittable>> committableMessageTypeSerializer =
+      new TypeSerializer<CommittableMessage<FilesCommittable>>() {
+
+        final CommittableMessageSerializer<FilesCommittable> serializer =
+            new CommittableMessageSerializer<>(new FilesCommittableSerializer());
+
+        @Override
+        public boolean isImmutableType() {
+          return false;
+        }
+
+        @Override
+        public TypeSerializer<CommittableMessage<FilesCommittable>> duplicate() {
+          return null;
+        }
+
+        @Override
+        public CommittableMessage<FilesCommittable> createInstance() {
+          return null;
+        }
+
+        @Override
+        public CommittableMessage<FilesCommittable> copy(
+            CommittableMessage<FilesCommittable> from) {
+          return from;
+        }
+
+        @Override
+        public CommittableMessage<FilesCommittable> copy(
+            CommittableMessage<FilesCommittable> from, CommittableMessage<FilesCommittable> reuse) {
+          return from;
+        }
+
+        @Override
+        public int getLength() {
+          return 0;
+        }
+
+        @Override
+        public void serialize(CommittableMessage<FilesCommittable> record, DataOutputView target)
+            throws IOException {
+          byte[] serialize = serializer.serialize(record);
+          target.writeInt(serialize.length);
+          target.write(serialize);
+        }
+
+        @Override
+        public CommittableMessage<FilesCommittable> deserialize(DataInputView source)
+            throws IOException {
+          int length = source.readInt();
+          byte[] bytes = new byte[length];
+          source.read(bytes);
+          return serializer.deserialize(1, bytes);
+        }
+
+        @Override
+        public CommittableMessage<FilesCommittable> deserialize(
+            CommittableMessage<FilesCommittable> reuse, DataInputView source) throws IOException {
+          return deserialize(source);
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) throws IOException {
+          CommittableMessage<FilesCommittable> deserialize = deserialize(source);
+          serialize(deserialize, target);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+          return false;
+        }
+
+        @Override
+        public int hashCode() {
+          return 0;
+        }
+
+        @Override
+        public TypeSerializerSnapshot<CommittableMessage<FilesCommittable>>
+            snapshotConfiguration() {
+          return null;
+        }
+      };
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestStreamWriter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestStreamWriter.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.sink.committer.FilesCommittable;
+import org.apache.iceberg.flink.sink.writer.StreamWriter;
+import org.apache.iceberg.flink.sink.writer.StreamWriterState;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestStreamWriter {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+  private MetricListener metricListener;
+  private Table table;
+
+  private final FileFormat format;
+  private final boolean partitioned;
+
+  @Parameterized.Parameters(name = "format = {0}, partitioned = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"avro", true},
+      {"avro", false},
+      {"orc", true},
+      {"orc", false},
+      {"parquet", true},
+      {"parquet", false}
+    };
+  }
+
+  public TestStreamWriter(String format, boolean partitioned) {
+    this.format = FileFormat.valueOf(format.toUpperCase(Locale.ENGLISH));
+    this.partitioned = partitioned;
+  }
+
+  @Before
+  public void before() throws IOException {
+    metricListener = new MetricListener();
+    File folder = tempFolder.newFolder();
+    // Construct the iceberg table.
+    Map<String, String> props = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name());
+    table = SimpleDataUtil.createTable(folder.getAbsolutePath(), props, partitioned);
+  }
+
+  @Test
+  public void testPreCommit() throws Exception {
+    StreamWriter streamWriter = createIcebergStreamWriter();
+    streamWriter.write(SimpleDataUtil.createRowData(1, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(2, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(3, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(4, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(5, "hello"), new ContextImpl());
+
+    Collection<FilesCommittable> filesCommittables = streamWriter.prepareCommit();
+    Assert.assertEquals(filesCommittables.size(), 1);
+  }
+
+  @Test
+  public void testWritingTable() throws Exception {
+    StreamWriter streamWriter = createIcebergStreamWriter();
+    // The first checkpoint
+    streamWriter.write(SimpleDataUtil.createRowData(1, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(2, "world"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(3, "hello"), new ContextImpl());
+
+    Collection<FilesCommittable> filesCommittables = streamWriter.prepareCommit();
+    Assert.assertEquals(filesCommittables.size(), 1);
+
+    AppendFiles appendFiles = table.newAppend();
+
+    WriteResult result = null;
+    for (FilesCommittable filesCommittable : filesCommittables) {
+      result = filesCommittable.committable();
+    }
+
+    long expectedDataFiles = partitioned ? 2 : 1;
+    Assert.assertEquals(0, result.deleteFiles().length);
+    Assert.assertEquals(expectedDataFiles, result.dataFiles().length);
+
+    Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+
+    // The second checkpoint
+    streamWriter.write(SimpleDataUtil.createRowData(4, "foo"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(5, "bar"), new ContextImpl());
+
+    filesCommittables = streamWriter.prepareCommit();
+    for (FilesCommittable filesCommittable : filesCommittables) {
+      result = filesCommittable.committable();
+    }
+
+    expectedDataFiles = partitioned ? 2 : 1;
+
+    Assert.assertEquals(0, result.deleteFiles().length);
+    Assert.assertEquals(expectedDataFiles, result.dataFiles().length);
+
+    // Commit the iceberg transaction.
+    Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+    appendFiles.commit();
+
+    // Assert the table records.
+    SimpleDataUtil.assertTableRecords(
+        table,
+        Lists.newArrayList(
+            SimpleDataUtil.createRecord(1, "hello"),
+            SimpleDataUtil.createRecord(2, "world"),
+            SimpleDataUtil.createRecord(3, "hello"),
+            SimpleDataUtil.createRecord(4, "foo"),
+            SimpleDataUtil.createRecord(5, "bar")));
+  }
+
+  @Test
+  public void testSnapshotAndRestore() throws Exception {
+    StreamWriter streamWriter = createIcebergStreamWriter();
+    streamWriter.write(SimpleDataUtil.createRowData(1, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(2, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(3, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(4, "hello"), new ContextImpl());
+    streamWriter.write(SimpleDataUtil.createRowData(5, "hello"), new ContextImpl());
+
+    Collection<StreamWriterState> streamWriterStates = streamWriter.snapshotState(1L);
+    streamWriter.prepareCommit();
+    Assert.assertEquals(streamWriterStates.size(), 1);
+
+    StreamWriter streamWriterRestore =
+        createIcebergStreamWriter().initializeState(streamWriterStates);
+
+    List<StreamWriterState> streamWriterStatesRestore = streamWriterRestore.snapshotState(2L);
+    Assert.assertEquals(streamWriterStates.size(), streamWriterStatesRestore.size());
+  }
+
+  @Test
+  public void testTableWithTargetFileSize() throws Exception {
+    // Adjust the target-file-size in table properties.
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "4") // ~4 bytes; low enough to trigger
+        .commit();
+
+    List<RowData> rows = Lists.newArrayListWithCapacity(8000);
+    List<Record> records = Lists.newArrayListWithCapacity(8000);
+    for (int i = 0; i < 2000; i++) {
+      for (String data : new String[] {"a", "b", "c", "d"}) {
+        rows.add(SimpleDataUtil.createRowData(i, data));
+        records.add(SimpleDataUtil.createRecord(i, data));
+      }
+    }
+
+    try (StreamWriter streamWriter = createIcebergStreamWriter()) {
+      for (RowData row : rows) {
+        streamWriter.write(row, new ContextImpl());
+      }
+      Collection<FilesCommittable> filesCommittables = streamWriter.prepareCommit();
+      WriteResult result = filesCommittables.stream().findFirst().get().committable();
+      Assert.assertEquals(0, result.deleteFiles().length);
+      Assert.assertEquals(8, result.dataFiles().length);
+
+      // Assert that the data file have the expected records.
+      for (DataFile dataFile : result.dataFiles()) {
+        Assert.assertEquals(1000, dataFile.recordCount());
+      }
+
+      // Commit the iceberg transaction.
+      AppendFiles appendFiles = table.newAppend();
+      Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+      appendFiles.commit();
+    }
+    // Assert the table records.
+    SimpleDataUtil.assertTableRecords(table, records);
+  }
+
+  @Test
+  public void testPromotedFlinkDataType() throws Exception {
+    Schema iSchema =
+        new Schema(
+            Types.NestedField.required(1, "tinyint", Types.IntegerType.get()),
+            Types.NestedField.required(2, "smallint", Types.IntegerType.get()),
+            Types.NestedField.optional(3, "int", Types.IntegerType.get()));
+    TableSchema flinkSchema =
+        TableSchema.builder()
+            .field("tinyint", DataTypes.TINYINT().notNull())
+            .field("smallint", DataTypes.SMALLINT().notNull())
+            .field("int", DataTypes.INT().nullable())
+            .build();
+
+    PartitionSpec spec;
+    if (partitioned) {
+      spec =
+          PartitionSpec.builderFor(iSchema)
+              .identity("smallint")
+              .identity("tinyint")
+              .identity("int")
+              .build();
+    } else {
+      spec = PartitionSpec.unpartitioned();
+    }
+
+    String location = tempFolder.newFolder().getAbsolutePath();
+    Map<String, String> props = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name());
+    Table icebergTable = new HadoopTables().create(iSchema, spec, props, location);
+
+    List<RowData> rows =
+        Lists.newArrayList(
+            GenericRowData.of((byte) 0x01, (short) -32768, 101),
+            GenericRowData.of((byte) 0x02, (short) 0, 102),
+            GenericRowData.of((byte) 0x03, (short) 32767, 103));
+
+    Record record = GenericRecord.create(iSchema);
+    List<Record> expected =
+        Lists.newArrayList(
+            record.copy(ImmutableMap.of("tinyint", 1, "smallint", -32768, "int", 101)),
+            record.copy(ImmutableMap.of("tinyint", 2, "smallint", 0, "int", 102)),
+            record.copy(ImmutableMap.of("tinyint", 3, "smallint", 32767, "int", 103)));
+
+    StreamWriter streamWriter = createIcebergStreamWriter(icebergTable, flinkSchema);
+    for (RowData row : rows) {
+      streamWriter.write(row, new ContextImpl());
+    }
+
+    Collection<FilesCommittable> filesCommittables = streamWriter.prepareCommit();
+
+    WriteResult result = null;
+    for (FilesCommittable filesCommittable : filesCommittables) {
+      result = filesCommittable.committable();
+    }
+
+    Assert.assertEquals(0, result.deleteFiles().length);
+    Assert.assertEquals(partitioned ? 3 : 1, result.dataFiles().length);
+
+    // Commit the iceberg transaction.
+    AppendFiles appendFiles = icebergTable.newAppend();
+    Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+    appendFiles.commit();
+
+    SimpleDataUtil.assertTableRecords(location, expected);
+  }
+
+  // ------------------------------- Utility Methods --------------------------------
+
+  private static class ContextImpl implements SinkWriter.Context {
+    private final long watermark;
+    private final Long timestamp;
+
+    ContextImpl() {
+      this(0, 0L);
+    }
+
+    private ContextImpl(long watermark, Long timestamp) {
+      this.watermark = watermark;
+      this.timestamp = timestamp;
+    }
+
+    @Override
+    public long currentWatermark() {
+      return watermark;
+    }
+
+    @Override
+    public Long timestamp() {
+      return timestamp;
+    }
+  }
+
+  StreamWriter createIcebergStreamWriter() {
+    return createIcebergStreamWriter(table, SimpleDataUtil.FLINK_SCHEMA);
+  }
+
+  StreamWriter createIcebergStreamWriter(Table icebergTable, TableSchema flinkSchema) {
+    RowType flinkRowType = IcebergSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
+
+    return createStreamWriter(icebergTable, flinkRowType, null, false);
+  }
+
+  StreamWriter createStreamWriter(
+      Table newTable,
+      RowType newFlinkRowType,
+      List<Integer> newEqualityFieldIds,
+      boolean newUpsert) {
+    Map<String, String> writeOptions = Maps.newHashMap();
+    writeOptions.put(FlinkWriteOptions.WRITE_UPSERT_ENABLED.key(), Boolean.toString(newUpsert));
+    FlinkWriteConf flinkWriteConf = new FlinkWriteConf(newTable, writeOptions, new Configuration());
+
+    RowDataTaskWriterFactory taskWriterFactory =
+        new RowDataTaskWriterFactory(
+            SerializableTable.copyOf(newTable),
+            newFlinkRowType,
+            flinkWriteConf.targetDataFileSize(),
+            flinkWriteConf.dataFileFormat(),
+            newEqualityFieldIds,
+            flinkWriteConf.upsertMode());
+
+    return new StreamWriter(newTable.name(), taskWriterFactory, 1, 1);
+  }
+}


### PR DESCRIPTION
Co-authored-by: Kyle Bendickson kjbendickson@gmail.com

## What is the purpose of the change
There is a preliminary proposal:
https://docs.google.com/document/d/1G4O6JidAoKgbIdy8Ts73OfG_KBEMpsW-LkXIb89I5k8/edit?usp=sharing

## Motivation & Structure

In Flink 1.12 the community focused on implementing a unified Data Sink API ([FLIP-143](https://cwiki.apache.org/confluence/display/FLINK/FLIP-143%3A+Unified+Sink+API)). The new abstraction introduces a write/commit protocol and a more modular interface where the individual components are transparently exposed to the framework.
A Sink implementor will have to provide the what and how: a [SinkWriter](https://nightlies.apache.org/flink/flink-docs-release-1.12/api/java/org/apache/flink/api/connector/sink/SinkWriter.html) that writes data and outputs what needs to be committed (i.e. committables); and a [Committer](https://nightlies.apache.org/flink/flink-docs-release-1.12/api/java/org/apache/flink/api/connector/sink/Committer.html) and [GlobalCommitter](https://nightlies.apache.org/flink/flink-docs-release-1.12/api/java/org/apache/flink/api/connector/sink/GlobalCommitter.html) that encapsulate how to handle the committables. The framework is responsible for the when and where: at what time and on which machine or process to commit.

![image](https://user-images.githubusercontent.com/59213263/178431505-e7191685-2a14-45d3-8800-ce5dfcad09f8.png)


[GlobalCommitter](https://nightlies.apache.org/flink/flink-docs-release-1.12/api/java/org/apache/flink/api/connector/sink/GlobalCommitter.html) can complete the action of submitting snapshots in Iceberg.
There is a QA related to Iceberg in its design documentation.

> Is the sink an operator or a topology?
> From the discussion in the long run we should give the sink developer the ability of building “arbitrary” topologies. But for Flink-1.12 we should be more focused on only satisfying the S3/HDFS/Iceberg sink.

The current Writing process of Iceberg Flink Sink is as follows:

![image](https://user-images.githubusercontent.com/59213263/178431650-05723ed7-e33a-42c7-8344-19cd7626168a.png)


In the figure above, data is written by multiple write operators, and then snapshot is submitted by an operator with 1 parallelism. Finally, an empty Sink node is added to end the whole process.
Based on the FLIP 143, the above flow can be modified to:
![image](https://user-images.githubusercontent.com/59213263/178431686-7f92420d-2338-469f-a7a3-de40820df1af.png)

The Sink node writes data, and the GlobalCommiter operator commits the snapshot.

There is an unsolved problem in the above structure. When streaming data is written, Sink will generate a large number of small files, which accumulate over a long period of time and eventually lead to problems such as excessive system pressure and decreased reading performance. This problem not only exists in Iceberg, but also in file storage.

Flink tried to solve this problem with [FLIP-191](https://cwiki.apache.org/confluence/display/FLINK/FLIP-191%3A+Extend+unified+Sink+interface+to+support+small+file+compaction?src=contextnavpagetreemode).

> Motivation
> With FLIP-143 we introduced the unified Sink API to make it easier for connector developers to support batch and streaming scenarios. While developing the unified Sink API it was already noted that the unified Sink API might not be flexible enough to support all scenarios from the beginning.
> With this document, we mainly focus on the small-file-compaction problem which is one of the not yet covered scenarios. The problem manifests when using the FileSink  and you want to guarantee a certain file size and not end up with a lot of small files (i.e. one file per parallel subtask). It becomes very important for modern data lake use cases where usually the data is written in some kind of columnar format (Parquet or ORC) and larger files are recommended to amplify the read performance. A few examples are the Iceberg sink [1], Delta lake [2], or Hive. For Hive in particular we already have a sink that supports compaction but it is not generally applicable and only available in Flink’s Table API [3].

The goal of this document is to extend the unified Sink API to broaden the spectrum of supported scenarios and fix the small-file-compaction  problem.
To overcome the limitations of Sink V1 Flink offer different hooks to insert custom topologies into the sink.

![image](https://user-images.githubusercontent.com/59213263/178431734-02322a90-db46-4f54-9aea-4acc4e5bc597.png)

On the basis of FLIP-191, the structure of Iceberg Flink Sink will be similar to the above, except that it only uses one committer operator, that is, all the output of Sink should be written to one committer, and all the submission actions should be completed by it.

![image](https://user-images.githubusercontent.com/59213263/178431800-d5375113-16b0-4512-a149-a900a4af6134.png)


PostCommit gives us a portal to do things like asynchronous small file merges and index generation, where we can do some optimization without affecting stream data writing.
### The Advantage
Provides interfaces for small file merging and index
The structure is clearer, and fault tolerance is guaranteed by Flink itself

### Proposed Changes
The data writing action is converted from the transform operator to Sink
Establish a separate Commiter operator to commit the snapshot

Iceberg currently maintains three versions of Flink 1.13, 1.14 and 1.15, while Flip-191 was introduced in Flink 1.15, so we plan to complete the versions containing these two flips in Flink 1.15 first. The one containing only FLIP-141 will be migrated to 1.13 1.14

### immovable
The logic for writing data to a file
This proposal only modifies the timing&operator of data writing, it does not change the logic of writing

committer logic
Same with above, we don't change the action of commit, just put it into another operator.

### Compatibility, Deprecation, and Migration Plan
Java API
 	Deprecate old sink, and keep them at least until the next major version of Iceberg.
SQL API
 	Use new sink instead of the old one.

### To do
Small file merge
Index file generation





close #5119
