### PR TITLE
Add additional options for catalog test implementations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -279,9 +279,10 @@ public class CatalogHandlers {
   }
 
   private static TableMetadata create(TableOperations ops, TableMetadata start, UpdateTableRequest request) {
-    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
-
     // the only valid requirement is that the table will be created
+    request.requirements().forEach(requirement -> requirement.validate(ops.current()));
+
+    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
     request.updates().forEach(update -> update.applyTo(builder));
 
     // create transactions do not retry. if the table exists, retrying is not a solution

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -384,22 +384,22 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testNamespaceWithSlash() {
-    if (supportsNamesWithSlashes()) {
-      C catalog = catalog();
+    Assume.assumeTrue(supportsNamesWithSlashes());
 
-      Namespace withSlash = Namespace.of("new/db");
+    C catalog = catalog();
 
-      Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
+    Namespace withSlash = Namespace.of("new/db");
 
-      catalog.createNamespace(withSlash);
-      Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withSlash));
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
 
-      Map<String, String> properties = catalog.loadNamespaceMetadata(withSlash);
-      Assert.assertNotNull("Properties should be accessible", properties);
+    catalog.createNamespace(withSlash);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withSlash));
 
-      Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withSlash));
-      Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
-    }
+    Map<String, String> properties = catalog.loadNamespaceMetadata(withSlash);
+    Assert.assertNotNull("Properties should be accessible", properties);
+
+    Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withSlash));
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
   }
 
   @Test
@@ -443,27 +443,27 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testTableNameWithSlash() {
-    if (supportsNamesWithSlashes()) {
-      C catalog = catalog();
+    Assume.assumeTrue(supportsNamesWithSlashes());
 
-      TableIdentifier ident = TableIdentifier.of("ns", "tab/le");
-      if (requiresNamespaceCreate()) {
-        catalog.createNamespace(Namespace.of("ns"));
-      }
+    C catalog = catalog();
 
-      Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
-
-      catalog.buildTable(ident, SCHEMA).create();
-      Assert.assertTrue("Table should exist", catalog.tableExists(ident));
-
-      Table loaded = catalog.loadTable(ident);
-      Assert.assertEquals("Schema should match expected ID assignment",
-              TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
-
-      catalog.dropTable(ident);
-
-      Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    TableIdentifier ident = TableIdentifier.of("ns", "tab/le");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(Namespace.of("ns"));
     }
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+
+    catalog.buildTable(ident, SCHEMA).create();
+    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+
+    Table loaded = catalog.loadTable(ident);
+    Assert.assertEquals("Schema should match expected ID assignment",
+            TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
+
+    catalog.dropTable(ident);
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -155,7 +155,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     return false;
   }
 
-  protected boolean supportsServerManagedLocation() {
+  protected boolean overridesRequestedLocation() {
     return false;
   }
 
@@ -1141,7 +1141,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assert.assertEquals("Table properties should be a superset of the requested properties",
         properties.entrySet(),
         Sets.intersection(properties.entrySet(), table.properties().entrySet()));
-    if (!supportsServerManagedLocation()) {
+    if (!overridesRequestedLocation()) {
       Assert.assertEquals("Table location should match requested", "file:/tmp/ns/table", table.location());
     }
     assertFiles(table, FILE_A);
@@ -1231,7 +1231,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assert.assertEquals("Table properties should be a superset of the requested properties",
         properties.entrySet(),
         Sets.intersection(properties.entrySet(), table.properties().entrySet()));
-    if (!supportsServerManagedLocation()) {
+    if (!overridesRequestedLocation()) {
       Assert.assertEquals("Table location should match requested", "file:/tmp/ns/table", table.location());
     }
     assertFiles(table, FILE_A);
@@ -1325,7 +1325,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assert.assertEquals("Table properties should be a superset of the requested properties",
         properties.entrySet(),
         Sets.intersection(properties.entrySet(), loaded.properties().entrySet()));
-    if (!supportsServerManagedLocation()) {
+    if (!overridesRequestedLocation()) {
       Assert.assertEquals("Table location should be replaced", "file:/tmp/ns/table", table.location());
     }
     assertUUIDsMatch(original, loaded);
@@ -1450,7 +1450,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assert.assertEquals("Table properties should be a superset of the requested properties",
         properties.entrySet(),
         Sets.intersection(properties.entrySet(), loaded.properties().entrySet()));
-    if (!supportsServerManagedLocation()) {
+    if (!overridesRequestedLocation()) {
       Assert.assertEquals("Table location should be replaced", "file:/tmp/ns/table", table.location());
     }
     assertUUIDsMatch(original, loaded);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -459,7 +459,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table loaded = catalog.loadTable(ident);
     Assert.assertEquals("Schema should match expected ID assignment",
-            TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
+        TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
 
     catalog.dropTable(ident);
 


### PR DESCRIPTION
This PR adds a couple of options to the catalog tests so it is more flexible for different catalog implementations. The first option is to support testing against catalogs that manage the table location. The second option is to support testing against catalogs that do not support slashes in the namespace or table name.