### PR TITLE
AWS: use pre-created IAM role for AssumeRole related integration tests

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
@@ -88,6 +88,10 @@ public class AwsIntegTestUtil {
     return System.getenv("AWS_TEST_ACCOUNT_ID");
   }
 
+  public static String testAssumeRoleArn() {
+    return System.getenv("AWS_TEST_ASSUME_ROLE_ARN");
+  }
+
   public static void cleanS3Bucket(S3Client s3, String bucketName, String prefix) {
     boolean hasContent = true;
     while (hasContent) {

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -26,87 +26,35 @@ import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.GlueException;
-import software.amazon.awssdk.services.iam.IamClient;
-import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
-import software.amazon.awssdk.services.iam.model.CreateRoleResponse;
-import software.amazon.awssdk.services.iam.model.DeleteRolePolicyRequest;
-import software.amazon.awssdk.services.iam.model.DeleteRoleRequest;
-import software.amazon.awssdk.services.iam.model.PutRolePolicyRequest;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetBucketAccelerateConfigurationRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 public class TestAssumeRoleAwsClientFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestAssumeRoleAwsClientFactory.class);
-
-  private IamClient iam;
-  private String roleName;
   private Map<String, String> assumeRoleProperties;
-  private String policyName;
 
   @Before
   public void before() {
-    roleName = UUID.randomUUID().toString();
-    iam = IamClient.builder()
-        .region(Region.AWS_GLOBAL)
-        .httpClientBuilder(UrlConnectionHttpClient.builder())
-        .build();
-    CreateRoleResponse response = iam.createRole(CreateRoleRequest.builder()
-        .roleName(roleName)
-        .assumeRolePolicyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Effect\":\"Allow\"," +
-            "\"Principal\":{" +
-            "\"AWS\":\"arn:aws:iam::" + AwsIntegTestUtil.testAccountId() + ":root\"}," +
-            "\"Action\": [\"sts:AssumeRole\"," +
-            "\"sts:TagSession\"]}]}")
-        .maxSessionDuration(3600)
-        .build());
     assumeRoleProperties = Maps.newHashMap();
     assumeRoleProperties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
     assumeRoleProperties.put(AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_APACHE);
-    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
-    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, response.role().arn());
+    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, AwsIntegTestUtil.testRegion());
+    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, AwsIntegTestUtil.testAssumeRoleArn());
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX + "key1", "value1");
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX + "key2", "value2");
-    policyName = UUID.randomUUID().toString();
-  }
-
-  @After
-  public void after() {
-    iam.deleteRolePolicy(DeleteRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
-    iam.deleteRole(DeleteRoleRequest.builder().roleName(roleName).build());
   }
 
   @Test
-  public void testAssumeRoleGlueCatalog() throws Exception {
-    String glueArnPrefix = "arn:aws:glue:*:" + AwsIntegTestUtil.testAccountId();
-    iam.putRolePolicy(PutRolePolicyRequest.builder()
-        .roleName(roleName)
-        .policyName(policyName)
-        .policyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Sid\":\"policy1\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":[\"glue:CreateDatabase\",\"glue:DeleteDatabase\",\"glue:GetDatabase\",\"glue:GetTables\"]," +
-            "\"Resource\":[\"" + glueArnPrefix + ":catalog\"," +
-            "\"" + glueArnPrefix + ":database/allowed_*\"," +
-            "\"" + glueArnPrefix + ":table/allowed_*/*\"," +
-            "\"" + glueArnPrefix + ":userDefinedFunction/allowed_*/*\"]}]}")
-        .build());
-    waitForIamConsistency();
-
+  public void testAssumeRoleGlueCatalog() {
     GlueCatalog glueCatalog = new GlueCatalog();
     assumeRoleProperties.put("warehouse", "s3://path");
     glueCatalog.initialize("test", assumeRoleProperties);
@@ -117,7 +65,7 @@ public class TestAssumeRoleAwsClientFactory {
       Assert.assertEquals(AccessDeniedException.class, e.getClass());
     }
 
-    Namespace namespace = Namespace.of("allowed_" + UUID.randomUUID().toString().replace("-", ""));
+    Namespace namespace = Namespace.of("iceberg_aws_ci_" + UUID.randomUUID().toString().replace("-", ""));
     try {
       glueCatalog.createNamespace(namespace);
     } catch (GlueException e) {
@@ -129,41 +77,20 @@ public class TestAssumeRoleAwsClientFactory {
   }
 
   @Test
-  public void testAssumeRoleS3FileIO() throws Exception {
-    String bucketArn = "arn:aws:s3:::" + AwsIntegTestUtil.testBucketName();
-    iam.putRolePolicy(PutRolePolicyRequest.builder()
-        .roleName(roleName)
-        .policyName(policyName)
-        .policyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Sid\":\"policy1\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":\"s3:ListBucket\"," +
-            "\"Resource\":[\"" + bucketArn + "\"]," +
-            "\"Condition\":{\"StringLike\":{\"s3:prefix\":[\"allowed/*\"]}}} ,{" +
-            "\"Sid\":\"policy2\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":\"s3:GetObject\"," +
-            "\"Resource\":[\"" + bucketArn + "/allowed/*\"]}]}")
-        .build());
-    waitForIamConsistency();
-
-    S3FileIO s3FileIO = new S3FileIO();
-    s3FileIO.initialize(assumeRoleProperties);
-    InputFile inputFile = s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file");
+  public void testAssumeRoleS3FileIO() {
+    S3Client s3Client = AwsClientFactories.from(assumeRoleProperties).s3();
     try {
-      inputFile.exists();
+      s3Client.getBucketAccelerateConfiguration(GetBucketAccelerateConfigurationRequest.builder()
+          .bucket(AwsIntegTestUtil.testBucketName())
+          .build());
       Assert.fail("Access to s3 should be denied");
     } catch (S3Exception e) {
       Assert.assertEquals("Should see 403 error code", 403, e.statusCode());
     }
 
-    inputFile = s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/allowed/file");
+    S3FileIO s3FileIO = new S3FileIO();
+    s3FileIO.initialize(assumeRoleProperties);
+    InputFile inputFile = s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/allowed/file");
     Assert.assertFalse("should be able to access file", inputFile.exists());
-  }
-
-  private void waitForIamConsistency() throws Exception {
-    Thread.sleep(10000); // sleep to make sure IAM up to date
   }
 }


### PR DESCRIPTION
as a part of AWS CI effort, remove IAM role that is created during tests and use a pre-created IAM role. The role creation and configuration step will be defined in a CDK stack for easy developer setup.

@amogh-jahagirdar @xiaoxuandev @rajarshisarkar @singhpk234