### PR TITLE
Flink: reduce the scope and duration of holding checkpoint lock.

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -116,11 +116,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
   public void run(SourceContext<FlinkInputSplit> ctx) throws Exception {
     this.sourceContext = ctx;
     while (isRunning) {
-      synchronized (sourceContext.getCheckpointLock()) {
-        if (isRunning) {
-          monitorAndForwardSplits();
-        }
-      }
+      monitorAndForwardSplits();
       Thread.sleep(scanContext.monitorInterval().toMillis());
     }
   }
@@ -141,11 +137,15 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
       }
 
       FlinkInputSplit[] splits = FlinkSplitGenerator.createInputSplits(table, newScanContext);
-      for (FlinkInputSplit split : splits) {
-        sourceContext.collect(split);
-      }
 
-      lastSnapshotId = snapshotId;
+      // only need to hold the checkpoint lock when emitting the splits and updating lastSnapshotId
+      synchronized (sourceContext.getCheckpointLock()) {
+        for (FlinkInputSplit split : splits) {
+          sourceContext.collect(split);
+        }
+
+        lastSnapshotId = snapshotId;
+      }
     }
   }
 


### PR DESCRIPTION
Keep the expensive split planning outside the lock and only lock for emitting splits and update lastSnapshotId position.