### PR TITLE
AWS: add retry logic to S3InputStream

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -354,6 +354,30 @@ public class AwsProperties implements Serializable {
   public static final boolean CLIENT_ENABLE_ETAG_CHECK_DEFAULT = false;
 
   /**
+   * Number of times to retry S3 read operation.
+   */
+  public static final String S3_READ_RETRY_NUM_RETRIES = "s3.read.retry.num-retries";
+  public static final int S3_READ_RETRY_NUM_RETRIES_DEFAULT = 7;
+
+  /**
+   * Minimum wait time to retry a S3 read operation
+   */
+  public static final String S3_READ_RETRY_MIN_WAIT_MS = "s3.read.retry.min-wait-ms";
+  public static final long S3_READ_RETRY_MIN_WAIT_MS_DEFAULT = 500; // 0.5 seconds
+
+  /**
+   * Maximum wait time to retry a S3 read operation
+   */
+  public static final String S3_READ_RETRY_MAX_WAIT_MS = "s3.read.retry.max-wait-ms";
+  public static final long S3_READ_RETRY_MAX_WAIT_MS_DEFAULT = 2 * 60 * 1000; // 2 minute
+
+  /**
+   * Total retry time for a S3 read operation
+   */
+  public static final String S3_READ_RETRY_TOTAL_TIMEOUT_MS = "s3.read.retry.total-timeout-ms";
+  public static final long S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT = 10 * 60 * 1000; // 10 minutes
+
+  /**
    * Used by {@link LakeFormationAwsClientFactory}.
    * The table name used as part of lake formation credentials request.
    */
@@ -380,6 +404,10 @@ public class AwsProperties implements Serializable {
   private int s3FileIoDeleteThreads;
   private boolean isS3DeleteEnabled;
   private final Map<String, String> s3BucketToAccessPointMapping;
+  private int s3ReadRetryNumRetries;
+  private long s3ReadRetryMinWaitMs;
+  private long s3ReadRetryMaxWaitMs;
+  private long s3ReadRetryTotalTimeoutMs;
 
   private String glueCatalogId;
   private boolean glueCatalogSkipArchive;
@@ -404,6 +432,10 @@ public class AwsProperties implements Serializable {
     this.s3FileIoDeleteThreads = Runtime.getRuntime().availableProcessors();
     this.isS3DeleteEnabled = S3_DELETE_ENABLED_DEFAULT;
     this.s3BucketToAccessPointMapping = ImmutableMap.of();
+    this.s3ReadRetryNumRetries = S3_READ_RETRY_NUM_RETRIES_DEFAULT;
+    this.s3ReadRetryMinWaitMs = S3_READ_RETRY_MIN_WAIT_MS_DEFAULT;
+    this.s3ReadRetryMaxWaitMs = S3_READ_RETRY_MAX_WAIT_MS_DEFAULT;
+    this.s3ReadRetryTotalTimeoutMs = S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT;
 
     this.glueCatalogId = null;
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
@@ -472,6 +504,14 @@ public class AwsProperties implements Serializable {
             Runtime.getRuntime().availableProcessors());
     this.isS3DeleteEnabled = PropertyUtil.propertyAsBoolean(properties, S3_DELETE_ENABLED, S3_DELETE_ENABLED_DEFAULT);
     this.s3BucketToAccessPointMapping = PropertyUtil.propertiesWithPrefix(properties, S3_ACCESS_POINTS_PREFIX);
+    this.s3ReadRetryNumRetries = PropertyUtil.propertyAsInt(properties, S3_READ_RETRY_NUM_RETRIES,
+        S3_READ_RETRY_NUM_RETRIES_DEFAULT);
+    this.s3ReadRetryMinWaitMs = PropertyUtil.propertyAsLong(properties, S3_READ_RETRY_MIN_WAIT_MS,
+        S3_READ_RETRY_MIN_WAIT_MS_DEFAULT);
+    this.s3ReadRetryMaxWaitMs = PropertyUtil.propertyAsLong(properties, S3_READ_RETRY_MAX_WAIT_MS,
+        S3_READ_RETRY_MAX_WAIT_MS_DEFAULT);
+    this.s3ReadRetryTotalTimeoutMs = PropertyUtil.propertyAsLong(properties, S3_READ_RETRY_TOTAL_TIMEOUT_MS,
+        S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT);
 
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
@@ -611,6 +651,38 @@ public class AwsProperties implements Serializable {
 
   public void setS3DeleteEnabled(boolean s3DeleteEnabled) {
     this.isS3DeleteEnabled = s3DeleteEnabled;
+  }
+
+  public int s3ReadRetryNumRetries() {
+    return s3ReadRetryNumRetries;
+  }
+
+  public void setS3ReadRetryNumRetries(int s3ReadRetryNumRetries) {
+    this.s3ReadRetryNumRetries = s3ReadRetryNumRetries;
+  }
+
+  public long s3ReadRetryMinWaitMs() {
+    return s3ReadRetryMinWaitMs;
+  }
+
+  public void setS3ReadRetryMinWaitMs(long s3ReadRetryMinWaitMs) {
+    this.s3ReadRetryMinWaitMs = s3ReadRetryMinWaitMs;
+  }
+
+  public long s3ReadRetryMaxWaitMs() {
+    return s3ReadRetryMaxWaitMs;
+  }
+
+  public void setS3ReadRetryMaxWaitMs(long s3ReadRetryMaxWaitMs) {
+    this.s3ReadRetryMaxWaitMs = s3ReadRetryMaxWaitMs;
+  }
+
+  public long s3ReadRetryTotalTimeoutMs() {
+    return s3ReadRetryTotalTimeoutMs;
+  }
+
+  public void setS3ReadRetryTotalTimeoutMs(long s3ReadRetryTotalTimeoutMs) {
+    this.s3ReadRetryTotalTimeoutMs = s3ReadRetryTotalTimeoutMs;
   }
 
   private Set<Tag> toTags(Map<String, String> properties, String prefix) {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3InputStream.java
@@ -1,0 +1,395 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.s3;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import javax.net.ssl.SSLException;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.aws.AwsProperties;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+@RunWith(Parameterized.class)
+public class TestFuzzyS3InputStream extends TestS3InputStream {
+
+  private final Exception exception;
+  private final boolean shouldRetry;
+
+  public TestFuzzyS3InputStream(Exception exception, boolean shouldRetry) {
+    this.exception = exception;
+    this.shouldRetry = shouldRetry;
+  }
+
+  @Parameterized.Parameters(name = "exception = {0}, shouldRetry = {1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        { new IOException("random failure"), true },
+        { new SSLException("client connection reset"), true },
+        { new SocketTimeoutException("client connection reset"), true },
+        { new EOFException("failure"), false },
+        { AwsServiceException.builder().statusCode(403).message("failure").build(), false },
+        { AwsServiceException.builder().statusCode(400).message("failure").build(), false },
+        { S3Exception.builder().statusCode(404).message("failure").build(), false },
+        { S3Exception.builder().statusCode(416).message("failure").build(), false }
+    };
+  }
+
+  @Test
+  public void testReadWithFuzzyClientRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRead(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @Test
+  public void testReadWithFuzzyStreamRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRead(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @Test
+  public void testReadWithFuzzyClientRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testRead(fuzzyClient(counter, exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testReadWithFuzzyStreamRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testRead(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testSeekWithFuzzyClientRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testSeek(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @Test
+  public void testSeekWithFuzzyStreamRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testSeek(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @Test
+  public void testSeekWithFuzzyClientRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testSeek(fuzzyClient(counter, exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testSeekWithFuzzyStreamRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testSeek(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testRangeReadWithFuzzyClientRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRangeRead(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @Test
+  public void testRangeReadWithFuzzyStreamRetrySucceed() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRangeRead(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @Test
+  public void testRangeReadWithFuzzyClientRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testRangeRead(fuzzyClient(counter, exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testRangeReadWithFuzzyStreamRetryFail() throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail((counter, awsProperties) -> {
+      try {
+        testRangeRead(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @Test
+  public void testExceptionNoRetry() throws Exception {
+    Assume.assumeFalse(shouldRetry);
+    testReadExceptionShouldNotRetry();
+  }
+
+  private void testRetryFail(BiConsumer<AtomicInteger, AwsProperties> runnable) throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(2);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    AtomicInteger counter = new AtomicInteger(4);
+    AssertHelpers.assertThrowsCause("Should fail after retries",
+        exception.getClass(),
+        exception.getMessage(),
+        () -> runnable.accept(counter, awsProperties));
+    Assert.assertEquals("Should have 3 invocations (1 initial call, 2 retries)", 3, 4 - counter.get());
+  }
+
+  private void testReadExceptionShouldNotRetry() throws Exception {
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    AtomicInteger counter = new AtomicInteger(3);
+    AssertHelpers.assertThrowsCause("Should fail without retry",
+        exception.getClass(),
+        exception.getMessage(),
+        () -> {
+          try {
+            testRead(fuzzyClient(counter, exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    Assert.assertEquals("Should have 1 invocation (1 initial call, no retry)", 1, 3 - counter.get());
+  }
+
+  private S3Client fuzzyClient(AtomicInteger counter, Exception failure) {
+    S3Client fuzzyClient = spy(new S3ClientWrapper(s3Client()));
+    int round = counter.get();
+
+    // for every round of n invocations, only the last call succeeds
+    doAnswer(invocation -> {
+      if (counter.decrementAndGet() == 0) {
+        counter.set(round);
+        return invocation.callRealMethod();
+      } else {
+        throw failure;
+      }
+    }).when(fuzzyClient).getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+    return fuzzyClient;
+  }
+
+  private S3Client  fuzzyStreamClient(AtomicInteger counter, IOException failure) {
+    S3Client fuzzyClient = spy(new S3ClientWrapper(s3Client()));
+    doAnswer(invocation -> new FuzzyResponseInputStream(invocation.callRealMethod(), counter, failure))
+        .when(fuzzyClient).getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+    return fuzzyClient;
+  }
+
+  /**
+   * Wrapper for S3 client, used to mock the final class DefaultS3Client
+   */
+  public static class S3ClientWrapper implements S3Client {
+
+    private final S3Client delegate;
+
+    public S3ClientWrapper(S3Client delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String serviceName() {
+      return delegate.serviceName();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public <ReturnT> ReturnT getObject(
+        GetObjectRequest getObjectRequest,
+        ResponseTransformer<GetObjectResponse, ReturnT> responseTransformer)
+        throws NoSuchKeyException, InvalidObjectStateException, AwsServiceException, SdkClientException, S3Exception {
+      return delegate.getObject(getObjectRequest, responseTransformer);
+    }
+
+    @Override
+    public HeadObjectResponse headObject(
+        HeadObjectRequest headObjectRequest)
+        throws NoSuchKeyException, AwsServiceException, SdkClientException, S3Exception {
+      return delegate.headObject(headObjectRequest);
+    }
+
+    @Override
+    public PutObjectResponse putObject(
+        PutObjectRequest putObjectRequest,
+        RequestBody requestBody)
+        throws AwsServiceException, SdkClientException, S3Exception {
+      return delegate.putObject(putObjectRequest, requestBody);
+    }
+
+    @Override
+    public CreateBucketResponse createBucket(
+        CreateBucketRequest createBucketRequest)
+        throws BucketAlreadyExistsException, BucketAlreadyOwnedByYouException,
+        AwsServiceException, SdkClientException, S3Exception {
+      return delegate.createBucket(createBucketRequest);
+    }
+  }
+
+  public static class FuzzyResponseInputStream extends InputStream {
+
+    private final ResponseInputStream<GetObjectResponse> delegate;
+    private final AtomicInteger counter;
+    private final int round;
+    private final IOException exception;
+
+    public FuzzyResponseInputStream(Object invocationResponse, AtomicInteger counter, IOException exception) {
+      this.delegate = (ResponseInputStream<GetObjectResponse>) invocationResponse;
+      this.counter = counter;
+      this.round = counter.get();
+      this.exception = exception;
+    }
+
+    private void checkCounter() throws IOException {
+      // for every round of n invocations, only the last call succeeds
+      if (counter.decrementAndGet() == 0) {
+        counter.set(round);
+      } else {
+        throw exception;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      checkCounter();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      checkCounter();
+      return delegate.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      checkCounter();
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      return delegate.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+      return delegate.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+      delegate.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return delegate.markSupported();
+    }
+  }
+}


### PR DESCRIPTION
@danielcweeks @rajarshisarkar @amogh-jahagirdar @xiaoxuandev @singhpk234 

Add retry for the `S3InputStream` so that when we encounter network failures (mostly `SSLException` for server side connection reset and `SocketTimoutException` for client side connection reset), we can quickly retry the read without failing the entire operation.