### PR TITLE
Hive: Fix an error when create external table in hive catalog

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -85,22 +85,22 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       // so that the table can be read by other engines like Impala
       hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
       hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
+    }
 
-      // If not using HiveCatalog check for existing table
-      try {
-        this.icebergTable = Catalogs.loadTable(conf, catalogProperties);
+    // Check for existing table
+    try {
+      this.icebergTable = Catalogs.loadTable(conf, catalogProperties);
 
-        Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
-            "Iceberg table already created - can not use provided schema");
-        Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.PARTITION_SPEC) == null,
-            "Iceberg table already created - can not use provided partition specification");
+      Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
+              "Iceberg table already created - can not use provided schema");
+      Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.PARTITION_SPEC) == null,
+              "Iceberg table already created - can not use provided partition specification");
 
-        LOG.info("Iceberg table already exists {}", icebergTable);
+      LOG.info("Iceberg table already exists {}", icebergTable);
 
-        return;
-      } catch (NoSuchTableException nte) {
-        // If the table does not exist we will create it below
-      }
+      return;
+    } catch (NoSuchTableException nte) {
+      // If the table does not exist we will create it below
     }
 
     // If the table does not exist collect data for table creation

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -91,10 +91,12 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     try {
       this.icebergTable = Catalogs.loadTable(conf, catalogProperties);
 
-      Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
-              "Iceberg table already created - can not use provided schema");
-      Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.PARTITION_SPEC) == null,
-              "Iceberg table already created - can not use provided partition specification");
+      if (!Catalogs.hiveCatalog(conf, catalogProperties)) {
+        Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
+                "Iceberg table already created - can not use provided schema");
+        Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.PARTITION_SPEC) == null,
+                "Iceberg table already created - can not use provided partition specification");
+      }
 
       LOG.info("Iceberg table already exists {}", icebergTable);
 


### PR DESCRIPTION
To access the iceberg table using CDH hive 2.1.1, we need to create an external table in CDH hive, and ensure that the database name and table name are consistent with those in iceberg. If they are inconsistent, no data can be queried. 

When creating the external table, an error that the table already exists will be reported, because when iceberg.mr creates the table, if it is hive catalog, it does not check whether the table exists.

`hive> CREATE EXTERNAL TABLE iceberg_db.test_eet(id int, chengshi string)  
          STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
          LOCATION 'hdfs://xx.x.xx.xx:9000/user/hive/warehouse/iceberg_db.db/test_eet'
          TBLPROPERTIES ('iceberg.catalog'='hive_catalog');
FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.DDLTask. org.apache.iceberg.exceptions.AlreadyExistsException: Table already exists: iceberg_db.test_eet
`


Like this:

cdh hiveA 2.1.1  
cdh          hmsA 

iceberg B
iceberg hmsB

Hive A want to read the iceberg table on iceberg B，so we must create a external table on hive A, when i create the external table on hive A , an error returned: Table already exists: iceberg_db.test_eet.