### PR TITLE
Python: Remove typing extension imports

### DIFF
--- a/python/src/iceberg/files.py
+++ b/python/src/iceberg/files.py
@@ -16,13 +16,7 @@
 # under the License.
 from abc import abstractmethod
 from enum import Enum, auto
-from typing import Any
-
-try:
-    from typing import Protocol, runtime_checkable
-except ImportError:  # pragma: no cover
-    from typing_extensions import Protocol  # type: ignore
-    from typing_extensions import runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 class FileContentType(Enum):

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -24,13 +24,7 @@ its location.
 """
 
 from abc import ABC, abstractmethod
-from typing import Union
-
-try:
-    from typing import Protocol, runtime_checkable
-except ImportError:  # pragma: no cover
-    from typing_extensions import Protocol  # type: ignore
-    from typing_extensions import runtime_checkable
+from typing import Protocol, Union, runtime_checkable
 
 
 @runtime_checkable


### PR DESCRIPTION
This is a Python 3.7 relic