### PR TITLE
Core: Assign main branch to table's current snapshot if there is no main but there is a current table state

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -174,7 +174,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   protected void refreshFromMetadataLocation(String newLocation, Predicate<Exception> shouldRetry,
                                              int numRetries) {
     refreshFromMetadataLocation(newLocation, shouldRetry, numRetries,
-        metadataLocation -> TableMetadataParser.read(io(), metadataLocation));
+        metadataLocation -> TableMetadata.buildFromLocation(io(), metadataLocation).build());
   }
 
   protected void refreshFromMetadataLocation(String newLocation, Predicate<Exception> shouldRetry,

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -31,6 +31,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -755,6 +756,10 @@ public class TableMetadata implements Serializable {
     return new Builder(base);
   }
 
+  static Builder buildFromLocation(FileIO io, String location) {
+    return buildFrom(TableMetadataParser.read(io, location));
+  }
+
   public static class Builder {
     private static final int LAST_ADDED = -1;
 
@@ -1165,6 +1170,11 @@ public class TableMetadata implements Serializable {
     }
 
     public TableMetadata build() {
+      if (refs.isEmpty() && currentSnapshotId != -1) {
+        SnapshotRef main = SnapshotRef.branchBuilder(currentSnapshotId).build();
+        setRef(SnapshotRef.MAIN_BRANCH, main);
+      }
+
       if (!hasChanges()) {
         return base;
       }


### PR DESCRIPTION
As part of https://github.com/apache/iceberg/pull/4428/files#r884916051 and other PRs, a common theme has been around checking if main even exists in different API implementations. In this PR, main will always be set in a table metadata's refs. If refs don't exist or the main ref does not exist for some reason when parsing, it will be set to the table's current snapshot. 

This change also allows -1 to be set on different table metadata builder APIs to allow main to be created when there is no current table snapshot.

I'm still mulling over the implications of this change, the benefit is that this change allows different operations to be implemented with the assumption that main exists. However, I think the real long term solution is that we produce a snapshot upon table creation and assign main at that point. In this change, we only allow -1 for main, but this prevents the ability to create a branch before a snapshot is produced on main, which is a bit awkward but I think is needed until we produce a snapshot upon table creation. 

@rdblue @jackye1995 let me know your thoughts! If we determine that it makes more sense to just explicitly handle the non-existing main branch cases, then I will just close this PR. 