### PR TITLE
Python: Use taskipy for development task execution

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,3 +47,13 @@ ignore_missing_imports = true
 
 [tool.coverage.run]
 source = ['src/']
+
+[tool.taskipy.tasks]
+install = "pip install -e \".[dev,arrow]\""
+lint = "pre-commit run --all-files"
+test = """
+    coverage run --source=src/ -m pytest tests/ &&
+    coverage report -m --fail-under=90 &&
+    coverage html &&
+    coverage xml
+"""

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -52,8 +52,8 @@ source = ['src/']
 install = "pip install -e \".[dev,arrow]\""
 lint = "pre-commit run --all-files"
 test = """
-    coverage run --source=src/ -m pytest tests/ &&
-    coverage report -m --fail-under=90 &&
-    coverage html &&
-    coverage xml
+coverage run --source=src/ -m pytest tests/ &&
+coverage report -m --fail-under=90 &&
+coverage html &&
+coverage xml
 """

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -55,5 +55,6 @@ dev=
     pytest-checkdocs==2.7.1
     pyenchant==3.2.2
     pre-commit==2.19.0
+    taskipy==1.10.2
 [options.packages.find]
 where = src


### PR DESCRIPTION
Inspired by #4811 , instead of using introduce a new `Makefile` for defining arbitrary development task execution, we can actually leverage the `taskipy` and put task execution logic inside the `pyproject.toml`.

- It adds a new development dependency on `taskipy`, it defines custom logic in single source of truth `pyproject.toml` and it can also integrate with poetry nicely in upcoming #4844 
- It can potentially replace the Makefile (also version pinned in setup.cfg), instead of calling `make lint`, we can use `task lint`. With poetry it will become `poetry run task lint`.
- Task discovery is easier with 
```bash
$ task -l
install pip install -e ".[dev,arrow]"
lint    pre-commit run --all-files
test        coverage run --source=src/ -m pytest tests/ &&     coverage report -m --fail-under=90 &&     coverage html &&     coverage xml
```

---
Example Usage is similar to what we have today, once installed, we can just call
`task install`

`task lint` 


`task test`

Disclaim: 

It might be a bit dumb today, as to do `task install` we need to install the taskipy first. But I think it will get better once we adopt poetry 

CC @Fokko @samredai @rdblue 