### PR TITLE
Python: Bump pre-commit hooks

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -37,11 +37,11 @@ repos:
       - id: isort
         args: [ --settings-path=python/pyproject.toml ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.960
     hooks:
       - id: mypy
   -   repo: https://github.com/hadialqattan/pycln
-      rev: v1.3.2
+      rev: v1.3.3
       hooks:
         - id: pycln
           args: [--config=python/pyproject.toml]

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -34,6 +34,8 @@ Pre-commit will automatically fix the violations such as import orders, formatti
 
 In contrast to the name, it doesn't run on the git pre-commit hook by default. If this is something that you like, you can set this up by running `pre-commit install`.
 
+You can bump the integrations to the latest version using `pre-commit autoupdate`. This will check if there is a newer version of `{black,mypy,isort,...}` and update the yaml.
+
 ## Testing
 
 For Python, we use pytest in combination with coverage to maintain 90% code coverage


### PR DESCRIPTION
More as an example, since nothing really changed in the lint tools.

Using pre-commit you can easily bump the integrations to the latest version using `pre-commit autoupdate`.

```bash
➜  python git:(master) pre-commit autoupdate
Updating https://github.com/pre-commit/pre-commit-hooks ... already up to date.
Updating https://github.com/ambv/black ... already up to date.
Updating https://github.com/pre-commit/mirrors-isort ... already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... updating v0.950 -> v0.960.
Updating https://github.com/hadialqattan/pycln ... updating v1.3.2 -> v1.3.3.
```