### PR TITLE
Python: Add pyupgrade as a pre-commit hook

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -45,3 +45,8 @@ repos:
       hooks:
         - id: pycln
           args: [--config=python/pyproject.toml]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+      - id: pyupgrade
+        args: [--py38-plus]

--- a/python/src/iceberg/catalog/base.py
+++ b/python/src/iceberg/catalog/base.py
@@ -18,12 +18,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import (
-    List,
-    Optional,
-    Set,
-    Union,
-)
 
 from iceberg.catalog import Identifier, Properties
 from iceberg.schema import Schema
@@ -59,11 +53,11 @@ class Catalog(ABC):
     @abstractmethod
     def create_table(
         self,
-        identifier: Union[str, Identifier],
+        identifier: str | Identifier,
         schema: Schema,
-        location: Optional[str] = None,
-        partition_spec: Optional[PartitionSpec] = None,
-        properties: Optional[Properties] = None,
+        location: str | None = None,
+        partition_spec: PartitionSpec | None = None,
+        properties: Properties | None = None,
     ) -> Table:
         """Create a table
 
@@ -82,7 +76,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def load_table(self, identifier: Union[str, Identifier]) -> Table:
+    def load_table(self, identifier: str | Identifier) -> Table:
         """Loads the table's metadata and returns the table instance.
 
         You can also use this method to check for table existence using 'try catalog.table() except TableNotFoundError'
@@ -99,7 +93,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def drop_table(self, identifier: Union[str, Identifier]) -> None:
+    def drop_table(self, identifier: str | Identifier) -> None:
         """Drop a table.
 
         Args:
@@ -110,7 +104,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def purge_table(self, identifier: Union[str, Identifier]) -> None:
+    def purge_table(self, identifier: str | Identifier) -> None:
         """Drop a table and purge all data and metadata files.
 
         Args:
@@ -121,7 +115,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def rename_table(self, from_identifier: Union[str, Identifier], to_identifier: Union[str, Identifier]) -> Table:
+    def rename_table(self, from_identifier: str | Identifier, to_identifier: str | Identifier) -> Table:
         """Rename a fully classified table name
 
         Args:
@@ -136,7 +130,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def create_namespace(self, namespace: Union[str, Identifier], properties: Optional[Properties] = None) -> None:
+    def create_namespace(self, namespace: str | Identifier, properties: Properties | None = None) -> None:
         """Create a namespace in the catalog.
 
         Args:
@@ -148,7 +142,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def drop_namespace(self, namespace: Union[str, Identifier]) -> None:
+    def drop_namespace(self, namespace: str | Identifier) -> None:
         """Drop a namespace.
 
         Args:
@@ -160,7 +154,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def list_tables(self, namespace: Optional[Union[str, Identifier]] = None) -> List[Identifier]:
+    def list_tables(self, namespace: str | Identifier | None = None) -> list[Identifier]:
         """List tables under the given namespace in the catalog.
 
         If namespace not provided, will list all tables in the catalog.
@@ -176,7 +170,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def list_namespaces(self) -> List[Identifier]:
+    def list_namespaces(self) -> list[Identifier]:
         """List namespaces from the given namespace. If not given, list top-level namespaces from the catalog.
 
         Returns:
@@ -184,7 +178,7 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def load_namespace_properties(self, namespace: Union[str, Identifier]) -> Properties:
+    def load_namespace_properties(self, namespace: str | Identifier) -> Properties:
         """Get properties for a namespace.
 
         Args:
@@ -199,7 +193,7 @@ class Catalog(ABC):
 
     @abstractmethod
     def update_namespace_properties(
-        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Optional[Properties] = None
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties | None = None
     ) -> None:
         """Removes provided property keys and updates properties for a namespace.
 
@@ -214,7 +208,7 @@ class Catalog(ABC):
         """
 
     @staticmethod
-    def identifier_to_tuple(identifier: Union[str, Identifier]) -> Identifier:
+    def identifier_to_tuple(identifier: str | Identifier) -> Identifier:
         """Parses an identifier to a tuple.
 
         If the identifier is a string, it is split into a tuple on '.'. If it is a tuple, it is used as-is.
@@ -228,7 +222,7 @@ class Catalog(ABC):
         return identifier if isinstance(identifier, tuple) else tuple(str.split(identifier, "."))
 
     @staticmethod
-    def table_name_from(identifier: Union[str, Identifier]) -> str:
+    def table_name_from(identifier: str | Identifier) -> str:
         """Extracts table name from a table identifier
 
         Args:
@@ -240,7 +234,7 @@ class Catalog(ABC):
         return Catalog.identifier_to_tuple(identifier)[-1]
 
     @staticmethod
-    def namespace_from(identifier: Union[str, Identifier]) -> Identifier:
+    def namespace_from(identifier: str | Identifier) -> Identifier:
         """Extracts table namespace from a table identifier
 
         Args:

--- a/python/src/iceberg/table/base.py
+++ b/python/src/iceberg/table/base.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Union
 
 from iceberg.catalog.base import Identifier
 
@@ -29,7 +28,7 @@ class Table(ABC):
     To be implemented by https://github.com/apache/iceberg/issues/3227
     """
 
-    identifier: Union[str, Identifier]
+    identifier: str | Identifier
 
 
 class PartitionSpec:

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -258,7 +258,7 @@ class VoidTransform(Transform):
 
     def __new__(cls):  # pylint: disable=W0221
         if cls._instance is None:
-            cls._instance = super(VoidTransform, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
 
     def __init__(self):

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -44,7 +44,7 @@ class Singleton:
 
     def __new__(cls):
         if not isinstance(cls._instance, cls):
-            cls._instance = super(Singleton, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
 
 

--- a/python/src/iceberg/utils/schema_conversion.py
+++ b/python/src/iceberg/utils/schema_conversion.py
@@ -20,12 +20,7 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    Any,
-    Dict,
-    List,
-    Tuple,
-)
+from typing import Any
 
 from iceberg.schema import Schema
 from iceberg.types import (
@@ -52,7 +47,7 @@ from iceberg.types import (
 
 logger = logging.getLogger(__name__)
 
-PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
+PRIMITIVE_FIELD_TYPE_MAPPING: dict[str, PrimitiveType] = {
     "boolean": BooleanType(),
     "bytes": BinaryType(),
     "double": DoubleType(),
@@ -63,7 +58,7 @@ PRIMITIVE_FIELD_TYPE_MAPPING: Dict[str, PrimitiveType] = {
     "enum": StringType(),
 }
 
-LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
+LOGICAL_FIELD_TYPE_MAPPING: dict[tuple[str, str], PrimitiveType] = {
     ("date", "int"): DateType(),
     ("time-millis", "int"): TimeType(),
     ("timestamp-millis", "long"): TimestampType(),
@@ -74,7 +69,7 @@ LOGICAL_FIELD_TYPE_MAPPING: Dict[Tuple[str, str], PrimitiveType] = {
 
 
 class AvroSchemaConversion:
-    def avro_to_iceberg(self, avro_schema: Dict[str, Any]) -> Schema:
+    def avro_to_iceberg(self, avro_schema: dict[str, Any]) -> Schema:
         """Converts an Apache Avro into an Apache Iceberg schema equivalent
 
         This expects to have field id's to be encoded in the Avro schema::
@@ -119,7 +114,7 @@ class AvroSchemaConversion:
         """
         return Schema(*[self._convert_field(field) for field in avro_schema["fields"]], schema_id=1)
 
-    def _resolve_union(self, type_union: Dict | List | str) -> Tuple[str | Dict[str, Any], bool]:
+    def _resolve_union(self, type_union: dict | list | str) -> tuple[str | dict[str, Any], bool]:
         """
         Converts Unions into their type and resolves if the field is optional
 
@@ -142,7 +137,7 @@ class AvroSchemaConversion:
         Raises:
             TypeError: In the case non-optional union types are encountered
         """
-        avro_types: Dict | List
+        avro_types: dict | list
         if isinstance(type_union, str):
             # It is a primitive and required
             return type_union, False
@@ -160,7 +155,7 @@ class AvroSchemaConversion:
         # Filter the null value and return the type
         return list(filter(lambda t: t != "null", avro_types))[0], is_optional
 
-    def _convert_schema(self, avro_type: str | Dict[str, Any]) -> IcebergType:
+    def _convert_schema(self, avro_type: str | dict[str, Any]) -> IcebergType:
         """
         Resolves the Avro type
 
@@ -198,7 +193,7 @@ class AvroSchemaConversion:
         else:
             raise ValueError(f"Unknown type: {avro_type}")
 
-    def _convert_field(self, field: Dict[str, Any]) -> NestedField:
+    def _convert_field(self, field: dict[str, Any]) -> NestedField:
         """
         Converts an Avro field into an Iceberg equivalent field
         Args:
@@ -220,7 +215,7 @@ class AvroSchemaConversion:
             doc=field.get("doc"),
         )
 
-    def _convert_record_type(self, record_type: Dict[str, Any]) -> StructType:
+    def _convert_record_type(self, record_type: dict[str, Any]) -> StructType:
         """
         Converts the fields from a record into an Iceberg struct
 
@@ -274,7 +269,7 @@ class AvroSchemaConversion:
 
         return StructType(*[self._convert_field(field) for field in record_type["fields"]])
 
-    def _convert_array_type(self, array_type: Dict[str, Any]) -> ListType:
+    def _convert_array_type(self, array_type: dict[str, Any]) -> ListType:
         if "element-id" not in array_type:
             raise ValueError(f"Cannot convert array-type, missing element-id: {array_type}")
 
@@ -286,7 +281,7 @@ class AvroSchemaConversion:
             element_is_optional=element_is_optional,
         )
 
-    def _convert_map_type(self, map_type: Dict[str, Any]) -> MapType:
+    def _convert_map_type(self, map_type: dict[str, Any]) -> MapType:
         """
         Args:
             map_type: The dict that describes the Avro map type
@@ -322,7 +317,7 @@ class AvroSchemaConversion:
             value_is_optional=value_is_optional,
         )
 
-    def _convert_logical_type(self, avro_logical_type: Dict[str, Any]) -> IcebergType:
+    def _convert_logical_type(self, avro_logical_type: dict[str, Any]) -> IcebergType:
         """
         Convert a schema with a logical type annotation. For the decimal and map
         we need to fetch more keys from the dict, and for the simple ones we can just
@@ -358,7 +353,7 @@ class AvroSchemaConversion:
         else:
             raise ValueError(f"Unknown logical/physical type combination: {avro_logical_type}")
 
-    def _convert_logical_decimal_type(self, avro_type: Dict[str, Any]) -> DecimalType:
+    def _convert_logical_decimal_type(self, avro_type: dict[str, Any]) -> DecimalType:
         """
         Args:
             avro_type: The Avro type
@@ -384,7 +379,7 @@ class AvroSchemaConversion:
         """
         return DecimalType(precision=avro_type["precision"], scale=avro_type["scale"])
 
-    def _convert_logical_map_type(self, avro_type: Dict[str, Any]) -> MapType:
+    def _convert_logical_map_type(self, avro_type: dict[str, Any]) -> MapType:
         """
         In the case where a map hasn't a key as a type you can use a logical map to
         still encode this in Avro
@@ -436,7 +431,7 @@ class AvroSchemaConversion:
             value_is_optional=value.is_optional,
         )
 
-    def _convert_fixed_type(self, avro_type: Dict[str, Any]) -> FixedType:
+    def _convert_fixed_type(self, avro_type: dict[str, Any]) -> FixedType:
         """
         https://avro.apache.org/docs/current/spec.html#Fixed
 


### PR DESCRIPTION
The pyupgrade plugin will check the syntax, and make sure that you're using the latest version. For example, instead of Union[str, int] we have the str | int notation in Python 3.8.

This hook will not change any behavior of the code, but will just make sure that we're all using the same syntax.

More information on:
https://github.com/asottile/pyupgrade