### PR TITLE
Core, API: Add support for renaming tags

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
@@ -121,6 +121,16 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
   ManageSnapshots renameBranch(String name, String newName);
 
   /**
+   * Rename a tag
+   *
+   * @param name name of tag to rename
+   * @param newName the desired new name of the tag
+   * @throws IllegalArgumentException if the tag to rename does not exist or if there is already a reference
+   * with the same name as the desired new name.
+   */
+  ManageSnapshots renameTag(String name, String newName);
+
+  /**
    * Remove the tag with the given name.
    *
    * @param name tag name

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -131,6 +131,12 @@ public class SnapshotManager implements ManageSnapshots {
     return this;
   }
 
+  @Override
+  public ManageSnapshots renameTag(String name, String newName) {
+    updateSnapshotReferencesOperation().renameTag(name, newName);
+    return this;
+  }
+
   private UpdateSnapshotReferencesOperation updateSnapshotReferencesOperation() {
     if (updateSnapshotReferencesOperation == null) {
       this.updateSnapshotReferencesOperation = transaction.updateSnapshotReferencesOperation();


### PR DESCRIPTION
From discussion on https://docs.google.com/document/d/1tbATFPrKF3vNlzkgZQdaW8CAJmbjvryfrlg6C2Ci_aA/edit#, there's interest in renaming tags which is currently unsupported. 