### PR TITLE
[Specification] Clarify truncate for Iceberg strings is based on code points

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -349,7 +349,7 @@ Notes:
 
 1. The remainder, `v % W`, must be positive. For languages where `%` can produce negative values, the correct truncate function is: `v - (((v % W) + W) % W)`
 2. The width, `W`, used to truncate decimal values is applied using the scale of the decimal column to avoid additional (and potentially conflicting) parameters.
-3. Strings are truncated a valid UTF-8 string with no more than `W` codepoints.
+3. Strings are truncated to a valid UTF-8 string with no more than `W` code points.
 
 
 #### Partition Evolution

--- a/format/spec.md
+++ b/format/spec.md
@@ -349,7 +349,7 @@ Notes:
 
 1. The remainder, `v % W`, must be positive. For languages where `%` can produce negative values, the correct truncate function is: `v - (((v % W) + W) % W)`
 2. The width, `W`, used to truncate decimal values is applied using the scale of the decimal column to avoid additional (and potentially conflicting) parameters.
-3. Strings are truncated to a valid UTF-8 string with no more than `W` code points.
+3. Strings are truncated to a valid UTF-8 string with no more than `L` code points.
 
 
 #### Partition Evolution

--- a/format/spec.md
+++ b/format/spec.md
@@ -349,7 +349,7 @@ Notes:
 
 1. The remainder, `v % W`, must be positive. For languages where `%` can produce negative values, the correct truncate function is: `v - (((v % W) + W) % W)`
 2. The width, `W`, used to truncate decimal values is applied using the scale of the decimal column to avoid additional (and potentially conflicting) parameters.
-3. For strings truncation is based on on unicode code point length (not byte length).
+3. Strings are truncated a valid UTF-8 string with no more than `W` codepoints.
 
 
 #### Partition Evolution

--- a/format/spec.md
+++ b/format/spec.md
@@ -343,12 +343,13 @@ For hash function details by type, see Appendix B.
 | **`int`**     | `W`, width            | `v - (v % W)`	remainders must be positive	[1]                    | `W=10`: `1` ￫ `0`, `-1` ￫ `-10`  |
 | **`long`**    | `W`, width            | `v - (v % W)`	remainders must be positive	[1]                    | `W=10`: `1` ￫ `0`, `-1` ￫ `-10`  |
 | **`decimal`** | `W`, width (no scale) | `scaled_W = decimal(W, scale(v))` `v - (v % scaled_W)`		[1, 2] | `W=50`, `s=2`: `10.65` ￫ `10.50` |
-| **`string`**  | `L`, length           | Substring of length `L`: `v.substring(0, L)`                     | `L=3`: `iceberg` ￫ `ice`         |
+| **`string`**  | `L`, length           | Substring of length `L`: `v.substring(0, L)` [3]                    | `L=3`: `iceberg` ￫ `ice`         |
 
 Notes:
 
 1. The remainder, `v % W`, must be positive. For languages where `%` can produce negative values, the correct truncate function is: `v - (((v % W) + W) % W)`
 2. The width, `W`, used to truncate decimal values is applied using the scale of the decimal column to avoid additional (and potentially conflicting) parameters.
+3. For strings truncation is based on on unicode code point length (not byte length).
 
 
 #### Partition Evolution


### PR DESCRIPTION
The [java function](https://github.com/apache/iceberg/blob/5009949ba4377ac5a8572ff7ae70e886c9e33bec/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java#L42) seems to take this approach.  The [python](https://github.com/apache/iceberg/blob/6e1dfe965f51e58b6c2dd654c3481cfc803df52a/python_legacy/iceberg/api/transforms/truncate.py#L201) implementation seems to this also but requires the write type passed in to work 