### PR TITLE
Docs: Fix broken link for `expiration properties`

### DIFF
--- a/docs/spark/spark-procedures.md
+++ b/docs/spark/spark-procedures.md
@@ -203,7 +203,7 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 | `stream_results` |    | boolean       | When true, deletion files will be sent to Spark driver by RDD partition (by default, all the files will be sent to Spark driver). This option is recommended to set to `true` to prevent Spark driver OOM from large file size |
 
-If `older_than` and `retain_last` are omitted, the table's [expiration properties](./configuration/#table-behavior-properties) will be used.
+If `older_than` and `retain_last` are omitted, the table's [expiration properties](../configuration/#table-behavior-properties) will be used.
 
 #### Output
 


### PR DESCRIPTION
This link is broken:
<img width="1356" alt="image" src="https://user-images.githubusercontent.com/29967142/171551157-85f4ddc8-5448-4562-9b5a-b87739c7603c.png">
