### PR TITLE
[Spark][Test]: Check before creating default namespace to avoid noisy AlreadyExistsExceptions in test logs

### DIFF
--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -27,7 +27,6 @@ import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -69,13 +68,9 @@ public abstract class SparkTestBase {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -70,7 +70,10 @@ public abstract class SparkTestBase {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -87,7 +87,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.io.CloseableIterable;
@@ -86,13 +85,9 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -76,7 +76,10 @@ public abstract class SparkTestBase {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -249,9 +249,9 @@ public abstract class SparkTestBase {
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
   }
 
-  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    if (!catalog.namespaceExists(namespace)) {
-      catalog.createNamespace(namespace);
+  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+    if (!supportsNamespaces.namespaceExists(namespace)) {
+      supportsNamespaces.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -30,6 +30,7 @@ import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
@@ -75,14 +76,7 @@ public abstract class SparkTestBase {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    createNamespace(catalog, Namespace.of("default"));
   }
 
   @AfterClass
@@ -254,6 +248,16 @@ public abstract class SparkTestBase {
             .filter(x -> metricsIds.containsKey(x.getKey()))
             .collect(Collectors.toMap(x -> metricsIds.get(x.getKey()), x -> x.getValue()));
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
+  }
+
+  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
+    try {
+      if (!catalog.namespaceExists(namespace)) {
+        catalog.createNamespace(namespace);
+      }
+    } catch (AlreadyExistsException ignored) {
+      // the namespace already exists. ignore the create error
+    }
   }
 
   @FunctionalInterface

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -249,7 +249,8 @@ public abstract class SparkTestBase {
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
   }
 
-  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+  protected static void createNamespace(
+      SupportsNamespaces supportsNamespaces, Namespace namespace) {
     if (!supportsNamespaces.namespaceExists(namespace)) {
       supportsNamespaces.createNamespace(namespace);
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -251,12 +250,8 @@ public abstract class SparkTestBase {
   }
 
   protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    try {
-      if (!catalog.namespaceExists(namespace)) {
-        catalog.createNamespace(namespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the namespace already exists. ignore the create error
+    if (!catalog.namespaceExists(namespace)) {
+      catalog.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -77,8 +77,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     config.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    boolean isHadoopCatalog = config.get("type").equalsIgnoreCase("hadoop");
-    if (isHadoopCatalog) {
+    if (config.get("type").equalsIgnoreCase("hadoop")) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -92,10 +92,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     if (isHadoopCatalog) {
       sql("CREATE NAMESPACE IF NOT EXISTS default");
     } else {
-      boolean createNamespace = spark.sql("SHOW NAMESPACES IN " + catalogName)
-          .filter("namespace = 'default'")
-          .isEmpty();
-      if (createNamespace) {
+      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
         sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
       }
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -84,7 +84,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+    sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
   }
 
   protected String tableName(String name) {

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -85,6 +85,13 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
+    // "SHOW NAMESPACES IN <NAMESPACE>" command for HiveCatalog considers the catalog name as the first level in the
+    // namespace hierarchy. Thus, "SHOW NAMESPACES IN <hiveCatalogName>" returns a valid output.
+    // The same command "SHOW NAMESPACES IN <hadoopCatalogName>" fails for HadoopCatalog. This is because it expects
+    // "<hadoopCatalogName>" dir to exist and all its sub-dirs would be returned as the result. Since
+    // "<hadoopCatalogName>" dir does not exist, the command fails with
+    // "org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist" error. Thus skipping it for
+    // HadoopCatalog.
     boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
         .filter("namespace = 'default'")
         .isEmpty();

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -85,17 +85,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    // When Hive API is invoked to create Namespace/Database using CREATE IF NOT EXISTS, the standalone HMS logs an
-    // AlreadyExistsException exception in the test logs thereby generating unwanted error logs. Thus checking if a
-    // namespace exists before creating one to keep the test logs noise-free.
-    // HMS is not involved in case HadoopCatalog, thus skipping the check for HadoopCatalog.
-    if (isHadoopCatalog) {
-      sql("CREATE NAMESPACE IF NOT EXISTS default");
-    } else {
-      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
-        sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
-      }
-    }
+    createNamespace(validationNamespaceCatalog, Namespace.of("default"));
   }
 
   protected String tableName(String name) {

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -77,14 +77,20 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     config.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    if (config.get("type").equalsIgnoreCase("hadoop")) {
+    boolean isHadoopCatalog = config.get("type").equalsIgnoreCase("hadoop");
+    if (isHadoopCatalog) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+    boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
+        .filter("namespace = 'default'")
+        .isEmpty();
+    if (createNamespace) {
+      sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+    }
   }
 
   protected String tableName(String name) {

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -87,7 +87,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.io.CloseableIterable;
@@ -86,13 +85,9 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -142,20 +142,9 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
-    } else {
-      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals(
-          "Should have default and db namespaces",
-          ImmutableSet.of("default", "db"),
-          namespaceNames);
-    }
+    Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -143,8 +143,10 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
     Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
+    Set<String> namespaceNames =
+        namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals(
+        "Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -76,7 +76,10 @@ public abstract class SparkTestBase {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -249,9 +249,9 @@ public abstract class SparkTestBase {
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
   }
 
-  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    if (!catalog.namespaceExists(namespace)) {
-      catalog.createNamespace(namespace);
+  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+    if (!supportsNamespaces.namespaceExists(namespace)) {
+      supportsNamespaces.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -30,6 +30,7 @@ import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
@@ -75,14 +76,7 @@ public abstract class SparkTestBase {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    createNamespace(catalog, Namespace.of("default"));
   }
 
   @AfterClass
@@ -254,6 +248,16 @@ public abstract class SparkTestBase {
             .filter(x -> metricsIds.containsKey(x.getKey()))
             .collect(Collectors.toMap(x -> metricsIds.get(x.getKey()), x -> x.getValue()));
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
+  }
+
+  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
+    try {
+      if (!catalog.namespaceExists(namespace)) {
+        catalog.createNamespace(namespace);
+      }
+    } catch (AlreadyExistsException ignored) {
+      // the namespace already exists. ignore the create error
+    }
   }
 
   @FunctionalInterface

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -249,7 +249,8 @@ public abstract class SparkTestBase {
     Assert.assertEquals("Expected metric value not match", expectedMetrics, currentMetrics);
   }
 
-  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+  protected static void createNamespace(
+      SupportsNamespaces supportsNamespaces, Namespace namespace) {
     if (!supportsNamespaces.namespaceExists(namespace)) {
       supportsNamespaces.createNamespace(namespace);
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -251,12 +250,8 @@ public abstract class SparkTestBase {
   }
 
   protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    try {
-      if (!catalog.namespaceExists(namespace)) {
-        catalog.createNamespace(namespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the namespace already exists. ignore the create error
+    if (!catalog.namespaceExists(namespace)) {
+      catalog.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -77,8 +77,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     config.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    boolean isHadoopCatalog = config.get("type").equalsIgnoreCase("hadoop");
-    if (isHadoopCatalog) {
+    if (config.get("type").equalsIgnoreCase("hadoop")) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -92,10 +92,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     if (isHadoopCatalog) {
       sql("CREATE NAMESPACE IF NOT EXISTS default");
     } else {
-      boolean createNamespace = spark.sql("SHOW NAMESPACES IN " + catalogName)
-          .filter("namespace = 'default'")
-          .isEmpty();
-      if (createNamespace) {
+      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
         sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
       }
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -84,7 +84,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+    sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
   }
 
   protected String tableName(String name) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -85,6 +85,13 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
+    // "SHOW NAMESPACES IN <NAMESPACE>" command for HiveCatalog considers the catalog name as the first level in the
+    // namespace hierarchy. Thus, "SHOW NAMESPACES IN <hiveCatalogName>" returns a valid output.
+    // The same command "SHOW NAMESPACES IN <hadoopCatalogName>" fails for HadoopCatalog. This is because it expects
+    // "<hadoopCatalogName>" dir to exist and all its sub-dirs would be returned as the result. Since
+    // "<hadoopCatalogName>" dir does not exist, the command fails with
+    // "org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist" error. Thus skipping it for
+    // HadoopCatalog.
     boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
         .filter("namespace = 'default'")
         .isEmpty();

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -85,17 +85,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    // When Hive API is invoked to create Namespace/Database using CREATE IF NOT EXISTS, the standalone HMS logs an
-    // AlreadyExistsException exception in the test logs thereby generating unwanted error logs. Thus checking if a
-    // namespace exists before creating one to keep the test logs noise-free.
-    // HMS is not involved in case HadoopCatalog, thus skipping the check for HadoopCatalog.
-    if (isHadoopCatalog) {
-      sql("CREATE NAMESPACE IF NOT EXISTS default");
-    } else {
-      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
-        sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
-      }
-    }
+    createNamespace(validationNamespaceCatalog, Namespace.of("default"));
   }
 
   protected String tableName(String name) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -77,14 +77,20 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     config.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    if (config.get("type").equalsIgnoreCase("hadoop")) {
+    boolean isHadoopCatalog = config.get("type").equalsIgnoreCase("hadoop");
+    if (isHadoopCatalog) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+    boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
+        .filter("namespace = 'default'")
+        .isEmpty();
+    if (createNamespace) {
+      sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+    }
   }
 
   protected String tableName(String name) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -87,7 +87,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.io.CloseableIterable;
@@ -86,13 +85,9 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -142,20 +142,9 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
-    } else {
-      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals(
-          "Should have default and db namespaces",
-          ImmutableSet.of("default", "db"),
-          namespaceNames);
-    }
+    Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -143,8 +143,10 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
     Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
+    Set<String> namespaceNames =
+        namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals(
+        "Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -252,9 +252,9 @@ public abstract class SparkTestBase {
     return spark.read().schema(schema).json(jsonDF);
   }
 
-  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    if (!catalog.namespaceExists(namespace)) {
-      catalog.createNamespace(namespace);
+  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+    if (!supportsNamespaces.namespaceExists(namespace)) {
+      supportsNamespaces.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -252,7 +252,8 @@ public abstract class SparkTestBase {
     return spark.read().schema(schema).json(jsonDF);
   }
 
-  protected static void createNamespace(SupportsNamespaces supportsNamespaces, Namespace namespace) {
+  protected static void createNamespace(
+      SupportsNamespaces supportsNamespaces, Namespace namespace) {
     if (!supportsNamespaces.namespaceExists(namespace)) {
       supportsNamespaces.createNamespace(namespace);
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -254,12 +253,8 @@ public abstract class SparkTestBase {
   }
 
   protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
-    try {
-      if (!catalog.namespaceExists(namespace)) {
-        catalog.createNamespace(namespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the namespace already exists. ignore the create error
+    if (!catalog.namespaceExists(namespace)) {
+      catalog.createNamespace(namespace);
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
@@ -78,14 +79,7 @@ public abstract class SparkTestBase {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    createNamespace(catalog, Namespace.of("default"));
   }
 
   @AfterClass
@@ -257,6 +251,16 @@ public abstract class SparkTestBase {
   protected Dataset<Row> jsonToDF(String schema, String... records) {
     Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
     return spark.read().schema(schema).json(jsonDF);
+  }
+
+  protected static void createNamespace(SupportsNamespaces catalog, Namespace namespace) {
+    try {
+      if (!catalog.namespaceExists(namespace)) {
+        catalog.createNamespace(namespace);
+      }
+    } catch (AlreadyExistsException ignored) {
+      // the namespace already exists. ignore the create error
+    }
   }
 
   @FunctionalInterface

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -79,7 +79,10 @@ public abstract class SparkTestBase {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -89,6 +89,13 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
+    // "SHOW NAMESPACES IN <NAMESPACE>" command for HiveCatalog considers the catalog name as the first level in the
+    // namespace hierarchy. Thus, "SHOW NAMESPACES IN <hiveCatalogName>" returns a valid output.
+    // The same command "SHOW NAMESPACES IN <hadoopCatalogName>" fails for HadoopCatalog. This is because it expects
+    // "<hadoopCatalogName>" dir to exist and all its sub-dirs would be returned as the result. Since
+    // "<hadoopCatalogName>" dir does not exist, the command fails with
+    // "org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist" error. Thus skipping it for
+    // HadoopCatalog.
     boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
         .filter("namespace = 'default'")
         .isEmpty();

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -96,10 +96,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     if (isHadoopCatalog) {
       sql("CREATE NAMESPACE IF NOT EXISTS default");
     } else {
-      boolean createNamespace = spark.sql("SHOW NAMESPACES IN " + catalogName)
-              .filter("namespace = 'default'")
-              .isEmpty();
-      if (createNamespace) {
+      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
         sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
       }
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -81,8 +81,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     config.forEach(
         (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
 
-    boolean isHadoopCatalog = config.get("type").equalsIgnoreCase("hadoop");
-    if (isHadoopCatalog) {
+    if (config.get("type").equalsIgnoreCase("hadoop")) {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -89,17 +89,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    // When Hive API is invoked to create Namespace/Database using CREATE IF NOT EXISTS, the standalone HMS logs an
-    // AlreadyExistsException exception in the test logs thereby generating unwanted error logs. Thus checking if a
-    // namespace exists before creating one to keep the test logs noise-free.
-    // HMS is not involved in case HadoopCatalog, thus skipping the check for HadoopCatalog.
-    if (isHadoopCatalog) {
-      sql("CREATE NAMESPACE IF NOT EXISTS default");
-    } else {
-      if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
-        sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
-      }
-    }
+    createNamespace(validationNamespaceCatalog, Namespace.of("default"));
   }
 
   protected String tableName(String name) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -88,7 +88,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+    sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
   }
 
   protected String tableName(String name) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -89,18 +89,19 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    // "SHOW NAMESPACES IN <NAMESPACE>" command for HiveCatalog considers the catalog name as the first level in the
-    // namespace hierarchy. Thus, "SHOW NAMESPACES IN <hiveCatalogName>" returns a valid output.
-    // The same command "SHOW NAMESPACES IN <hadoopCatalogName>" fails for HadoopCatalog. This is because it expects
-    // "<hadoopCatalogName>" dir to exist and all its sub-dirs would be returned as the result. Since
-    // "<hadoopCatalogName>" dir does not exist, the command fails with
-    // "org.apache.iceberg.exceptions.NoSuchNamespaceException: Namespace does not exist" error. Thus skipping it for
-    // HadoopCatalog.
-    boolean createNamespace = isHadoopCatalog || spark.sql("SHOW NAMESPACES IN " + catalogName)
-        .filter("namespace = 'default'")
-        .isEmpty();
-    if (createNamespace) {
-      sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+    // When Hive API is invoked to create Namespace/Database using CREATE IF NOT EXISTS, the standalone HMS logs an
+    // AlreadyExistsException exception in the test logs thereby generating unwanted error logs. Thus checking if a
+    // namespace exists before creating one to keep the test logs noise-free.
+    // HMS is not involved in case HadoopCatalog, thus skipping the check for HadoopCatalog.
+    if (isHadoopCatalog) {
+      sql("CREATE NAMESPACE IF NOT EXISTS default");
+    } else {
+      boolean createNamespace = spark.sql("SHOW NAMESPACES IN " + catalogName)
+              .filter("namespace = 'default'")
+              .isEmpty();
+      if (createNamespace) {
+        sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+      }
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -109,7 +109,10 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
-      catalog.createNamespace(Namespace.of("default"));
+      Namespace defaultNamespace = Namespace.of("default");
+      if (!catalog.namespaceExists(defaultNamespace)) {
+        catalog.createNamespace(defaultNamespace);
+      }
     } catch (AlreadyExistsException ignored) {
       // the default namespace already exists. ignore the create error
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.io.CloseableIterable;
@@ -108,13 +107,9 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      Namespace defaultNamespace = Namespace.of("default");
-      if (!catalog.namespaceExists(defaultNamespace)) {
-        catalog.createNamespace(defaultNamespace);
-      }
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -142,20 +142,9 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
-    } else {
-      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals(
-          "Should have default and db namespaces",
-          ImmutableSet.of("default", "db"),
-          namespaceNames);
-    }
+    Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -143,8 +143,10 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
     Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-    Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-    Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
+    Set<String> namespaceNames =
+        namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals(
+        "Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -79,11 +79,7 @@ public abstract class SparkTestBase {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      catalog.createNamespace(Namespace.of("default"));
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
-    }
+    createNamespace(catalog, Namespace.of("default"));
   }
 
   @AfterClass
@@ -255,6 +251,13 @@ public abstract class SparkTestBase {
   protected Dataset<Row> jsonToDF(String schema, String... records) {
     Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
     return spark.read().schema(schema).json(jsonDF);
+  }
+
+  protected static void createNamespace(
+      SupportsNamespaces supportsNamespaces, Namespace namespace) {
+    if (!supportsNamespaces.namespaceExists(namespace)) {
+      supportsNamespaces.createNamespace(namespace);
+    }
   }
 
   @FunctionalInterface

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -88,7 +88,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+    createNamespace(validationNamespaceCatalog, Namespace.of("default"));
   }
 
   protected String tableName(String name) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.io.CloseableIterable;
@@ -108,10 +107,9 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             CatalogUtil.loadCatalog(
                 HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
-    try {
-      catalog.createNamespace(Namespace.of("default"));
-    } catch (AlreadyExistsException ignored) {
-      // the default namespace already exists. ignore the create error
+    Namespace defaultNamespace = Namespace.of("default");
+    if (!catalog.namespaceExists(defaultNamespace)) {
+      catalog.createNamespace(defaultNamespace);
     }
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -142,20 +142,11 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
 
     List<Object[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
 
-    if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
-    } else {
-      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
-      Set<String> namespaceNames =
-          namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
-      Assert.assertEquals(
-          "Should have default and db namespaces",
-          ImmutableSet.of("default", "db"),
-          namespaceNames);
-    }
+    Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+    Set<String> namespaceNames =
+        namespaces.stream().map(arr -> arr[0].toString()).collect(Collectors.toSet());
+    Assert.assertEquals(
+        "Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
 
     List<Object[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
 


### PR DESCRIPTION
This PR aims at removing the unwanted `AlreadyExistsException` stacktrace from the spark-iceberg test logs.

The test logs for spark tests are filled with `AlreadyExistsException(message:Database default already exists)` stacktrace even when all the tests pass.

These `AlreadyExistsException` exceptions are not from Spark per se but from HMS.

When "CREATE NAMESPACE IF NOT EXISTS default" SQL command is executed in Spark, Spark invokes `hive.createDatabase` command. 
https://github.com/apache/spark/blob/89fdb8a6fb6a669c458891b3abeba236e64b1e89/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala#L574

Hive client invokes internally invokes HMS API to create the database. If the DB already exists HMS throws `AlreadyExistsException`. When the `ifNotExist` flag is set to true, the Hive client simply ignores the exception.
https://github.com/apache/hive/blob/63326ff775206e59547b6b1332e25279e90ef5ee/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L608-L619

The HMS logs this exception to STDERR and for iceberg tests since a standalone HMS is running in the same JVM as that of the test, these logs are part of the info output of the tests.

This generates a lot of noise in the logs and might overshadow an actual exception.