### PR TITLE
Flink: add an option to set monitoring snapshot number

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -184,6 +184,11 @@ public class FlinkSource {
       return this;
     }
 
+    public Builder monitorSnapshotNumber(int newMonitorSnapshotNumber) {
+      contextBuilder.monitorSnapshotNumber(newMonitorSnapshotNumber);
+      return this;
+    }
+
     public Builder flinkConf(ReadableConfig config) {
       this.readableConfig = config;
       return this;


### PR DESCRIPTION
This adds an option to control how many snapshots to monitor at once when using iceberg table as a Flink source. 

Currently, the monitor operator generates file splits from the last consumed snapshot to the latest snapshot, which may lead to backpressure when the consumer lag behind as follow image shows. We can reduce the checkpoint lock scope (https://github.com/apache/iceberg/pull/4911) or increase the network buffer to mitigate the situation while the problem still cannot be completely avoided since the number of the splits is unknown, especially when starting a consumer for the first time.
![image](https://user-images.githubusercontent.com/3960228/171612916-bfacf692-3e08-4161-9937-aa1fc93a602f.png)

With the option, the user can tune the monitoring flow according to backpressure and busy metrics. 
![image](https://user-images.githubusercontent.com/3960228/171615504-4d210b51-235a-4071-a547-8d463dc77385.png)

