### PR TITLE
API: Support registering filesystem tables to metastore based catalogs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -151,7 +151,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     this.shouldRefresh = false;
   }
 
-  protected String writeNewMetadata(TableMetadata metadata, int newVersion) {
+  public String writeNewMetadata(TableMetadata metadata, int newVersion) {
     String newTableMetadataFilePath = newTableMetadataFilePath(metadata, newVersion);
     OutputFile newMetadataLocation = io().newOutputFile(newTableMetadataFilePath);
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -151,7 +151,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     this.shouldRefresh = false;
   }
 
-  public String writeNewMetadata(TableMetadata metadata, int newVersion) {
+  protected String writeNewMetadata(TableMetadata metadata, int newVersion) {
     String newTableMetadataFilePath = newTableMetadataFilePath(metadata, newVersion);
     OutputFile newMetadataLocation = io().newOutputFile(newTableMetadataFilePath);
 
@@ -336,7 +336,10 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     int versionEnd = metadataLocation.indexOf('-', versionStart);
     try {
       return Integer.valueOf(metadataLocation.substring(versionStart, versionEnd));
-    } catch (NumberFormatException e) {
+    } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
+      // As per the spec, metastore tables and filesystem tables
+      // will have different representation for metadata file names.
+      // So, StringIndexOutOfBoundsException can happen when parsing a filesystem based metadata file name.
       LOG.warn("Unable to parse version from metadata location: {}", metadataLocation, e);
       return -1;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -331,15 +331,24 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     return metadataFileLocation(meta, String.format("%05d-%s%s", newVersion, UUID.randomUUID(), fileExtension));
   }
 
+  /**
+   * Parse the version from table metadata file name.
+   *
+   * @param metadataLocation table metadata file location
+   * @return version of the table metadata file in success case and
+   * -1 if the version is not parsable (as a sign that the metadata is not part of this catalog)
+   */
   private static int parseVersion(String metadataLocation) {
     int versionStart = metadataLocation.lastIndexOf('/') + 1; // if '/' isn't found, this will be 0
     int versionEnd = metadataLocation.indexOf('-', versionStart);
+    if (versionEnd < 0) {
+      // found filesystem table's metadata
+      return -1;
+    }
+
     try {
       return Integer.valueOf(metadataLocation.substring(versionStart, versionEnd));
-    } catch (NumberFormatException | StringIndexOutOfBoundsException e) {
-      // As per the spec, metastore tables and filesystem tables
-      // will have different representation for metadata file names.
-      // So, StringIndexOutOfBoundsException can happen when parsing a filesystem based metadata file name.
+    } catch (NumberFormatException e) {
       LOG.warn("Unable to parse version from metadata location: {}", metadataLocation, e);
       return -1;
     }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -246,24 +246,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
     TableOperations ops = newTableOps(identifier);
     InputFile metadataFile = fileIO.newInputFile(metadataFileLocation);
     TableMetadata metadata = TableMetadataParser.read(ops.io(), metadataFile);
-
-    if (!isMetastoreTable(metadataFileLocation)) {
-      // Metastore table and filesystem tables will have different naming conventions as per the spec.
-      // So, to support importing filesystem tables to metastore catalog,
-      // create a new metadata file with contents of filesystem table but with a metastore table naming convention.
-      BaseMetastoreTableOperations baseOps = (BaseMetastoreTableOperations) ops;
-      String newFileName = baseOps.writeNewMetadata(metadata, baseOps.currentVersion() + 1);
-      metadataFile = fileIO.newInputFile(newFileName);
-      metadata = TableMetadataParser.read(ops.io(), metadataFile);
-    }
-
     ops.commit(null, metadata);
 
     return new BaseTable(ops, identifier.toString());
-  }
-
-  private boolean isMetastoreTable(String metadataFileLocation) {
-    return metadataFileLocation.substring(metadataFileLocation.lastIndexOf("/") + 1).contains("-");
   }
 
   @Override


### PR DESCRIPTION
Filesystem tables and metastore tables have different naming conventions for TableMetadata file as per spec.
So, when a filesystem table is registered to hive catalog (or any metastore based catalog), the register was successful but loading the table used to fail in `parseVersion` as it was expecting the naming convention of metastore table.

Fixed it by using metastore table naming convention while registering. 

Fixes #4794 