### PR TITLE
Infra - Add a GH Action to Mark and Close Stale Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -41,7 +41,8 @@ jobs:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has been open for 180 days
             with no activity. It will be closed in next 14 days if no further activity occurs. To
-            prevent this issue from being closed as stale, add the label 'not-stale'.
+            permanently prevent this issue from being considered stale, add the label 'not-stale',
+            but commenting on the issue is preferred when possible.
           close-issue-message: >
             This issue has been closed because it has not received any activity in the last 14 days
             since being marked as 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Close Stale Issues"
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  # All other permissions are set to none
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'not-stale'
+          days-before-issue-stale: 180
+          days-before-issue-close: 14
+          # Only close stale issues, leave PRs alone
+          days-before-pr-stale: -1
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has been open for 180 days
+            with no activity. It will be closed in next 14 days if no further activity occurs. To
+            prevent this issue from being closed as stale, add the label 'not-stale'.
+          close-issue-message: >
+            This issue has been closed because it has not received any activity in the last 14 days
+            since being marked as 'stale'


### PR DESCRIPTION
This closes issue https://github.com/apache/iceberg/issues/4948 

Adds a Github Action to mark issues as `stale` after the configured period of time (180 days), leaving the designated comment on those issues, and then closing them after 14 days if no activity occurs after that.

Issues can be marked as `not-stale` so that they will not be considered by the stale bot action. We'll need to create this label (whatever we wind up choosing).

Github Stale Action Docs / Configuration Options: https://github.com/actions/stale
Inspired By Airflow's usage of stale action: https://github.com/apache/airflow/blob/main/.github/workflows/stale.yml

cc @danielcweeks @Fokko 