### PR TITLE
Core, API: Replace unnecessary hash uses with hashCode

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -172,7 +172,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(wrapperSet);
+    return Objects.hashCode(wrapperSet);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/mapping/MappedFields.java
+++ b/core/src/main/java/org/apache/iceberg/mapping/MappedFields.java
@@ -113,7 +113,7 @@ public class MappedFields implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(fields);
+    return Objects.hashCode(fields);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
@@ -176,6 +176,6 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
 
   @Override
   public int hashCode() {
-    return Objects.hash(type) + wrapperSet.stream().mapToInt(StructLikeWrapper::hashCode).sum();
+    return Objects.hashCode(type) + wrapperSet.stream().mapToInt(StructLikeWrapper::hashCode).sum();
   }
 }


### PR DESCRIPTION
Observed some build warnings:

`warning: [ObjectsHashCodeUnnecessaryVarargs] java.util.Objects.hash(non-varargs) should be replaced with java.util.Objects.hashCode(value) to avoid unnecessary varargs array allocations.
    return Objects.hash(fields);
                       ^
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
  Did you mean 'return Objects.hashCode(fields)`

In some hashCode implementations we unnecessarily use Objects.hash which accepts variadic arguments. Under the hood, this will create an array and do Arrays.hash. However, in these cases since we're passing in a single object reference, hashCode suffices, and we can avoid ant unnecessary array allocations,
