### PR TITLE
Use CatalogUtil classloader instead of context classloader for FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -60,7 +60,11 @@ public class AwsClientFactories {
   private static AwsClientFactory loadClientFactory(String impl, Map<String, String> properties) {
     DynConstructors.Ctor<AwsClientFactory> ctor;
     try {
-      ctor = DynConstructors.builder(AwsClientFactory.class).hiddenImpl(impl).buildChecked();
+      ctor =
+          DynConstructors.builder(AwsClientFactory.class)
+              .loader(AwsClientFactories.class.getClassLoader())
+              .hiddenImpl(impl)
+              .buildChecked();
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(String.format(
           "Cannot initialize AwsClientFactory, missing no-arg constructor: %s", impl), e);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -286,7 +286,10 @@ public class S3FileIO implements FileIO, SupportsBulkOperations, CredentialSuppl
     // Report Hadoop metrics if Hadoop is available
     try {
       DynConstructors.Ctor<MetricsContext> ctor =
-          DynConstructors.builder(MetricsContext.class).hiddenImpl(DEFAULT_METRICS_IMPL, String.class).buildChecked();
+          DynConstructors.builder(MetricsContext.class)
+              .loader(S3FileIO.class.getClassLoader())
+              .hiddenImpl(DEFAULT_METRICS_IMPL, String.class)
+              .buildChecked();
       MetricsContext context = ctor.newInstance("s3");
       context.initialize(properties);
       this.metrics = context;

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -245,11 +245,12 @@ public class CatalogUtil {
    * {@link FileIO#initialize(Map properties)} is called to complete the initialization.
    *
    * @param impl full class name of a custom FileIO implementation
+   * @param properties used to initialize the FileIO implementation
    * @param hadoopConf a hadoop Configuration
    * @return FileIO class
    * @throws IllegalArgumentException if class path not found or
    *  right constructor not found or
-   *  the loaded class cannot be casted to the given interface type
+   *  the loaded class cannot be cast to the given interface type
    */
   public static FileIO loadFileIO(
       String impl,
@@ -258,7 +259,8 @@ public class CatalogUtil {
     LOG.info("Loading custom FileIO implementation: {}", impl);
     DynConstructors.Ctor<FileIO> ctor;
     try {
-      ctor = DynConstructors.builder(FileIO.class).impl(impl).buildChecked();
+      ctor =
+          DynConstructors.builder(FileIO.class).loader(CatalogUtil.class.getClassLoader()).impl(impl).buildChecked();
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(String.format(
           "Cannot initialize FileIO, missing no-arg constructor: %s", impl), e);


### PR DESCRIPTION
Using the context classloader to dynamically load FileIO will cause problems in systems like Trino where the context classloader comes from a different plugin (e.g. information schema or describe table).

The classloader that loaded the `CatalogUtil` should have be the same classloader as the FileIO.