### PR TITLE
Shutdown refresh token executor service during REST catalog client close

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -369,6 +369,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
       ScheduledExecutorService service = refreshExecutor;
       this.refreshExecutor = null;
 
+      service.shutdown();
       try {
         if (service.awaitTermination(1, TimeUnit.MINUTES)) {
           LOG.warn("Timed out waiting for refresh executor to terminate");


### PR DESCRIPTION
This PR adds a shutdown to the refresh token executor service when the REST catalog client is closed. Without shutting down the executor, refresh tasks continue to be scheduled (and fail because the REST client is closed).