### PR TITLE
delegate sql text to spark parser with passThrough statement instead of regular expression

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.2/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,6 +73,7 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
+    | .*?                                                                                   #passThrough
     ;
 
 writeSpec

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -119,6 +119,11 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
   }
 
   /**
+   * passThrough
+   */
+  override def visitPassThrough(ctx: PassThroughContext): LogicalPlan = null
+
+  /**
    * Create a [[SetWriteDistributionAndOrdering]] for changing the write distribution and ordering.
    */
   override def visitSetWriteDistributionAndOrdering(


### PR DESCRIPTION
This PR uses a better way instead of regular expression to delegate sql text to spark parser, which is used in DeltaLake and Hudi. And if it's ok,  i will do it in other version spark extensions.