### PR TITLE
Python: Disable autouse of the fixtures

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -46,7 +46,7 @@ class FooStruct:
         self.content[pos] = value
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def table_schema_simple():
     return schema.Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
@@ -57,7 +57,7 @@ def table_schema_simple():
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def table_schema_nested():
     return schema.Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), is_optional=False),
@@ -110,7 +110,7 @@ def table_schema_nested():
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def foo_struct():
     return FooStruct()
 


### PR DESCRIPTION
When debugging code, the fixtures get initialized when you run tests in PyCharm. This is a bit annoying since it will also hit all of the breakpoints that you have in the code

I don't think we really need to set those on autouse, we can just initialize on the first time we use them.`