### PR TITLE
Python: Keep runtime typing

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -49,4 +49,4 @@ repos:
     rev: v2.32.1
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py38-plus, --keep-runtime-typing]


### PR DESCRIPTION
Pyupgrade would update `Dict[str, Any]` to `dict[str, Any]` which
isn't allowed in Python 3.8, breaking the tests with an obscure error:

```
ImportError while loading conftest '/Users/fokkodriesprong/Desktop/iceberg/python/tests/conftest.py'.
../conftest.py:34: in <module>
    from iceberg import schema
../../src/iceberg/schema.py:47: in <module>
    class Schema(IcebergBaseModel):
pydantic/main.py:188: in pydantic.main.ModelMetaclass.__new__
    ???
pydantic/typing.py:419: in pydantic.typing.resolve_annotations
    ???
/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/typing.py:270: in _eval_type
    return t._evaluate(globalns, localns)
/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/typing.py:518: in _evaluate
    eval(self.__forward_code__, globalns, localns),
E   TypeError: 'type' object is not subscriptable
```

Therefore we should disable them (until we go to Python 3.9 :)