### PR TITLE
[Infra] Add explicit call to revapi github action to ensure it's not skipped

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -46,7 +46,7 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - run: ./gradlew :iceberg-api:revapi
+      - run: ./gradlew clean :iceberg-api:revapi -x test -x integrationTest -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:


### PR DESCRIPTION
The revapi action is sometimes skipping.

This is possibly due to the cache (in which case we'd need to be more explicit about which dependencies are cached).

We can either try this or `./gradlew clean :iceberg-api:build -x test -x integrationTest -x javadoc` to try it out. I'm open to either.

I'll look into the revapi action upstream to see if there's a better way we can force it or if they have any guidance. This worked locally for me though as `clean` should force `iceberg-api:revapi` to invoke `build`.

cc @singhpk234 @ajantha-bhat