### PR TITLE
Update REST namespace separator to use unit separator char

### DIFF
--- a/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
@@ -34,7 +34,7 @@ import org.apache.iceberg.util.JsonUtil;
  * <p>
  * For TableIdentifier.of("dogs", "owners.and.handlers", "food"), we'd have
  * the following JSON representation, where the dot character of an
- * individual level is in the namespace is replaced by the null byte character.
+ * individual level is in the namespace is replaced by the unit separator byte character.
  * <pre>
  * {
  *   "namespace": ["dogs", "owners.and.handlers"],

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -88,8 +87,6 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
   private static final List<String> TOKEN_PREFERENCE_ORDER = ImmutableList.of(
       OAuth2Properties.ID_TOKEN_TYPE, OAuth2Properties.ACCESS_TOKEN_TYPE, OAuth2Properties.JWT_TOKEN_TYPE,
       OAuth2Properties.SAML2_TOKEN_TYPE, OAuth2Properties.SAML1_TOKEN_TYPE);
-  private static final char NAMESPACE_SEPARATOR = '\u001f';
-  private static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
 
   private final Function<Map<String, String>, RESTClient> clientBuilder;
   private Cache<String, AuthSession> sessions = null;
@@ -282,7 +279,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
       queryParams = ImmutableMap.of();
     } else {
       // query params should be unescaped
-      queryParams = ImmutableMap.of("parent", NAMESPACE_JOINER.join(namespace.levels()));
+      queryParams = ImmutableMap.of("parent", RESTUtil.NAMESPACE_JOINER.join(namespace.levels()));
     }
 
     ListNamespacesResponse response = client.get(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -88,7 +88,8 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
   private static final List<String> TOKEN_PREFERENCE_ORDER = ImmutableList.of(
       OAuth2Properties.ID_TOKEN_TYPE, OAuth2Properties.ACCESS_TOKEN_TYPE, OAuth2Properties.JWT_TOKEN_TYPE,
       OAuth2Properties.SAML2_TOKEN_TYPE, OAuth2Properties.SAML1_TOKEN_TYPE);
-  private static final Joiner NULL_BYTE = Joiner.on('\u0000');
+  private static final char NAMESPACE_SEPARATOR = '\u001f';
+  private static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
 
   private final Function<Map<String, String>, RESTClient> clientBuilder;
   private Cache<String, AuthSession> sessions = null;
@@ -281,7 +282,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
       queryParams = ImmutableMap.of();
     } else {
       // query params should be unescaped
-      queryParams = ImmutableMap.of("parent", NULL_BYTE.join(namespace.levels()));
+      queryParams = ImmutableMap.of("parent", NAMESPACE_JOINER.join(namespace.levels()));
     }
 
     ListNamespacesResponse response = client.get(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -34,12 +34,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class RESTUtil {
-  public static final char NAMESPACE_SEPARATOR = '\u001f';
+  private static final char NAMESPACE_SEPARATOR = '\u001f';
   public static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
   public static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR);
-  public static final String NAMESPACE_ESCAPED_SEPARATOR = "%1F";
-  public static final Joiner NAMESPACE_ESCAPED_JOINER = Joiner.on(NAMESPACE_ESCAPED_SEPARATOR);
-  public static final Splitter NAMESPACE_ESCAPED_SPLITTER = Splitter.on(NAMESPACE_ESCAPED_SEPARATOR);
+  private static final String NAMESPACE_ESCAPED_SEPARATOR = "%1F";
+  private static final Joiner NAMESPACE_ESCAPED_JOINER = Joiner.on(NAMESPACE_ESCAPED_SEPARATOR);
+  private static final Splitter NAMESPACE_ESCAPED_SPLITTER = Splitter.on(NAMESPACE_ESCAPED_SEPARATOR);
 
   private RESTUtil() {
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -34,8 +34,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class RESTUtil {
-  private static final Joiner NULL_JOINER = Joiner.on("%00");
-  private static final Splitter NULL_SPLITTER = Splitter.on("%00");
+  public static final char NAMESPACE_SEPARATOR = '\u001f';
+  public static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR);
+  public static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR);
+  public static final String NAMESPACE_ESCAPED_SEPARATOR = "%1F";
+  public static final Joiner NAMESPACE_ESCAPED_JOINER = Joiner.on(NAMESPACE_ESCAPED_SEPARATOR);
+  public static final Splitter NAMESPACE_ESCAPED_SPLITTER = Splitter.on(NAMESPACE_ESCAPED_SEPARATOR);
 
   private RESTUtil() {
   }
@@ -169,7 +173,7 @@ public class RESTUtil {
       encodedLevels[i] = encodeString(levels[i]);
     }
 
-    return NULL_JOINER.join(encodedLevels);
+    return NAMESPACE_ESCAPED_JOINER.join(encodedLevels);
   }
 
   /**
@@ -183,7 +187,7 @@ public class RESTUtil {
    */
   public static Namespace decodeNamespace(String encodedNs) {
     Preconditions.checkArgument(encodedNs != null, "Invalid namespace: null");
-    String[] levels = Iterables.toArray(NULL_SPLITTER.split(encodedNs), String.class);
+    String[] levels = Iterables.toArray(NAMESPACE_ESCAPED_SPLITTER.split(encodedNs), String.class);
 
     // Decode levels in place
     for (int i = 0; i < levels.length; i++) {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -56,7 +56,7 @@ import org.apache.iceberg.util.Pair;
  */
 public class RESTCatalogAdapter implements RESTClient {
   private static final Splitter SLASH = Splitter.on('/');
-  private static final Splitter NULL = Splitter.on('\u0000');
+  private static final Splitter NAMESPACE_SPLITTER = Splitter.on('\u001f');
 
   private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES = ImmutableMap
       .<Class<? extends Exception>, Integer>builder()
@@ -194,7 +194,7 @@ public class RESTCatalogAdapter implements RESTClient {
         if (asNamespaceCatalog != null) {
           Namespace ns;
           if (vars.containsKey("parent")) {
-            ns = Namespace.of(NULL.splitToStream(vars.get("parent")).toArray(String[]::new));
+            ns = Namespace.of(NAMESPACE_SPLITTER.splitToStream(vars.get("parent")).toArray(String[]::new));
           } else {
             ns = Namespace.empty();
           }

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.util.Pair;
  */
 public class RESTCatalogAdapter implements RESTClient {
   private static final Splitter SLASH = Splitter.on('/');
-  private static final Splitter NAMESPACE_SPLITTER = Splitter.on('\u001f');
 
   private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES = ImmutableMap
       .<Class<? extends Exception>, Integer>builder()
@@ -194,7 +193,8 @@ public class RESTCatalogAdapter implements RESTClient {
         if (asNamespaceCatalog != null) {
           Namespace ns;
           if (vars.containsKey("parent")) {
-            ns = Namespace.of(NAMESPACE_SPLITTER.splitToStream(vars.get("parent")).toArray(String[]::new));
+            ns = Namespace.of(
+                RESTUtil.NAMESPACE_SPLITTER.splitToStream(vars.get("parent")).toArray(String[]::new));
           } else {
             ns = Namespace.empty();
           }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -71,10 +71,10 @@ public class TestRESTUtil {
         new Object[] {new String[] {"dogs"}, "dogs"},
         new Object[] {new String[] {"dogs.named.hank"}, "dogs.named.hank"},
         new Object[] {new String[] {"dogs/named/hank"}, "dogs%2Fnamed%2Fhank"},
-        new Object[] {new String[] {"dogs", "named", "hank"}, "dogs%00named%00hank"},
+        new Object[] {new String[] {"dogs", "named", "hank"}, "dogs%1Fnamed%1Fhank"},
         new Object[] {
             new String[] {"dogs.and.cats", "named", "hank.or.james-westfall"},
-            "dogs.and.cats%00named%00hank.or.james-westfall"
+            "dogs.and.cats%1Fnamed%1Fhank.or.james-westfall"
         }
     };
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -59,8 +59,8 @@ public class TestResourcePaths {
   @Test
   public void testNamespaceWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s", withPrefix.namespace(ns));
-    Assert.assertEquals("v1/namespaces/n%00s", withoutPrefix.namespace(ns));
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%1Fs", withPrefix.namespace(ns));
+    Assert.assertEquals("v1/namespaces/n%1Fs", withoutPrefix.namespace(ns));
   }
 
   @Test
@@ -80,8 +80,8 @@ public class TestResourcePaths {
   @Test
   public void testNamespacePropertiesWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/properties", withPrefix.namespaceProperties(ns));
-    Assert.assertEquals("v1/namespaces/n%00s/properties", withoutPrefix.namespaceProperties(ns));
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%1Fs/properties", withPrefix.namespaceProperties(ns));
+    Assert.assertEquals("v1/namespaces/n%1Fs/properties", withoutPrefix.namespaceProperties(ns));
   }
 
   @Test
@@ -101,8 +101,8 @@ public class TestResourcePaths {
   @Test
   public void testTablesWithMultipartNamespace() {
     Namespace ns = Namespace.of("n", "s");
-    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/tables", withPrefix.tables(ns));
-    Assert.assertEquals("v1/namespaces/n%00s/tables", withoutPrefix.tables(ns));
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%1Fs/tables", withPrefix.tables(ns));
+    Assert.assertEquals("v1/namespaces/n%1Fs/tables", withoutPrefix.tables(ns));
   }
 
   @Test
@@ -122,7 +122,7 @@ public class TestResourcePaths {
   @Test
   public void testTableWithMultipartNamespace() {
     TableIdentifier ident = TableIdentifier.of("n", "s", "table");
-    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/tables/table", withPrefix.table(ident));
-    Assert.assertEquals("v1/namespaces/n%00s/tables/table", withoutPrefix.table(ident));
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%1Fs/tables/table", withPrefix.table(ident));
+    Assert.assertEquals("v1/namespaces/n%1Fs/tables/table", withoutPrefix.table(ident));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -72,7 +72,7 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
 
   @Test
   public void testDeserializeInvalidRequest() {
-    String jsonIncorrectTypeForNamespace = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    String jsonIncorrectTypeForNamespace = "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
     AssertHelpers.assertThrows(
         "A JSON request with incorrect types for fields should fail to deserialize and validate",
         JsonProcessingException.class,

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -76,7 +76,7 @@ public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateN
 
   @Test
   public void testDeserializeInvalidResponse() {
-    String jsonResponseMalformedNamespaceValue = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    String jsonResponseMalformedNamespaceValue = "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
     AssertHelpers.assertThrows(
         "A JSON response with the wrong type for the namespace field should fail to deserialize",
         JsonProcessingException.class,

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -61,7 +61,7 @@ public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespa
 
   @Test
   public void testDeserializeInvalidResponse() {
-    String jsonNamespaceHasWrongType = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    String jsonNamespaceHasWrongType = "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
     AssertHelpers.assertThrows(
         "A JSON response with the wrong type for a field should fail to deserialize",
         JsonProcessingException.class,

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -47,7 +47,7 @@ public class TestListTablesResponse extends RequestResponseTestBase<ListTablesRe
 
   @Test
   public void testDeserializeInvalidResponsesThrows() {
-    String identifiersHasWrongType = "{\"identifiers\":\"accounting%00tax\"}";
+    String identifiersHasWrongType = "{\"identifiers\":\"accounting%1Ftax\"}";
     AssertHelpers.assertThrows(
         "A JSON response with the incorrect type for the field identifiers should fail to parse",
         JsonProcessingException.class,

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -202,7 +202,7 @@ paths:
           allowEmptyValue: true
           schema:
             type: string
-          example: "accounting%00tax"
+          example: "accounting%1Ftax"
       responses:
         200:
           $ref: '#/components/responses/ListNamespacesResponse'
@@ -780,7 +780,7 @@ components:
         singlepart_namespace:
           value: "accounting"
         multipart_namespace:
-          value: "accounting%00tax"
+          value: "accounting%1Ftax"
 
     table:
       name: table
@@ -1995,7 +1995,7 @@ components:
 
     MultipartNamespaceAsPathVariable:
       summary: A multi-part namespace, as represented in a path parameter
-      value: "accounting%00tax"
+      value: "accounting%1Ftax"
 
     NamespaceAsPathVariable:
       summary: A single part namespace, as represented in a path paremeter

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -197,7 +197,7 @@ paths:
           description:
             An optional namespace, underneath which to list namespaces.
             If not provided or empty, all top-level namespaces should be listed.
-            If parent is a multipart namespace, the parts must be separated by the null byte.
+            If parent is a multipart namespace, the parts must be separated by the unit separator (`0x1F`) byte.
           required: false
           allowEmptyValue: true
           schema:
@@ -773,7 +773,7 @@ components:
       required: true
       description:
         A namespace identifier as a single string.
-        Multipart namespace parts should be separated by the null byte.
+        Multipart namespace parts should be separated by the unit separator (`0x1F`) byte.
       schema:
         type: string
       examples:


### PR DESCRIPTION
The null byte character is not generally considered safe for use in REST paths even when url encoded due to various forms of null byte injection attacks.  This will cause problems with many frameworks that detect and reject requests using this character in the path.

The unit separator character (`0x1F`) is a safer and more meaningful alternative.