### PR TITLE
Annotate selected FileScanTask attributes as not null

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/FileScanTask.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.apache.iceberg.expressions.Expression;
 
 /**
@@ -38,6 +39,7 @@ public interface FileScanTask extends ScanTask {
    *
    * @return a list of delete files to apply
    */
+  @Nonnull
   List<DeleteFile> deletes();
 
   /**
@@ -77,6 +79,7 @@ public interface FileScanTask extends ScanTask {
    * @param splitSize The size of a component scan task
    * @return an Iterable of {@link FileScanTask scan tasks}
    */
+  @Nonnull
   Iterable<FileScanTask> split(long splitSize);
 
   @Override

--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,7 @@ project(':iceberg-api') {
 
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    compileOnly "com.google.code.findbugs:jsr305"
     compileOnly "com.google.errorprone:error_prone_annotations"
     testImplementation "org.apache.avro:avro"
   }

--- a/versions.props
+++ b/versions.props
@@ -11,6 +11,7 @@ org.apache.spark:spark-hive_2.11 = 2.4.8
 org.apache.spark:spark-avro_2.11 = 2.4.8
 org.apache.pig:pig = 0.14.0
 com.fasterxml.jackson.*:* = 2.11.4
+com.google.code.findbugs:jsr305 = 3.0.0
 com.google.errorprone:error_prone_annotations = 2.3.3
 com.google.guava:guava = 31.0.1-jre
 com.github.ben-manes.caffeine:caffeine = 2.9.3


### PR DESCRIPTION
Within Iceberg API some attributes are nullable and some are not. We
should make clear to the user of the API which attributes do not require
a null check (are guaranteed to be non-null). This PR uses
`@NonNull` annotation for that purpose, but I am open to other suggestions.

cc @alexjo2144 