### PR TITLE
Python: Consolidate types

### DIFF
--- a/python/src/iceberg/catalog/__init__.py
+++ b/python/src/iceberg/catalog/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from typing import Dict, Tuple
 
 Identifier = Tuple[str, ...]

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -27,11 +27,12 @@ Note:
     implementation, a concrete function is registered for each generic conversion function. For PrimitiveType
     implementations that share the same conversion logic, registrations can be stacked.
 """
+from __future__ import annotations
+
 import uuid
 from decimal import Decimal
 from functools import singledispatch
 from struct import Struct
-from typing import Union
 
 from iceberg.types import (
     BinaryType,
@@ -90,7 +91,7 @@ def partition_to_py(primitive_type, value_str: str):
 
 @partition_to_py.register(BooleanType)
 @handle_none
-def _(primitive_type, value_str: str) -> Union[int, float, str, uuid.UUID]:
+def _(primitive_type, value_str: str) -> int | float | str | uuid.UUID:
     return value_str.lower() == "true"
 
 
@@ -145,7 +146,7 @@ def _(primitive_type, value_str: str) -> Decimal:
 
 
 @singledispatch
-def to_bytes(primitive_type: PrimitiveType, value: Union[bool, bytes, Decimal, float, int, str, uuid.UUID]) -> bytes:
+def to_bytes(primitive_type: PrimitiveType, value: bool | bytes | Decimal | float | int | str | uuid.UUID) -> bytes:
     """A generic function which converts a built-in python value to bytes
 
     This conversion follows the serialization scheme for storing single values as individual binary values defined in the Iceberg specification that
@@ -236,7 +237,7 @@ def _(primitive_type: DecimalType, value: Decimal) -> bytes:
 
 
 @singledispatch
-def from_bytes(primitive_type: PrimitiveType, b: bytes) -> Union[bool, bytes, Decimal, float, int, str, uuid.UUID]:
+def from_bytes(primitive_type: PrimitiveType, b: bytes) -> bool | bytes | Decimal | float | int | str | uuid.UUID:
     """A generic function which converts bytes to a built-in python value
 
     Args:

--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from enum import Enum, auto
 from functools import reduce, singledispatch
@@ -62,7 +64,7 @@ class Operation(Enum):
     AND = auto()
     OR = auto()
 
-    def negate(self) -> "Operation":
+    def negate(self) -> Operation:
         """Returns the operation used when this is negated."""
 
         try:
@@ -134,7 +136,7 @@ class BooleanExpression(metaclass=ABCMeta):
     """base class for all boolean expressions"""
 
     @abstractmethod
-    def __invert__(self) -> "BooleanExpression":
+    def __invert__(self) -> BooleanExpression:
         ...
 
 
@@ -166,7 +168,7 @@ class And(BooleanExpression):
     def __eq__(self, other) -> bool:
         return id(self) == id(other) or (isinstance(other, And) and self.left == other.left and self.right == other.right)
 
-    def __invert__(self) -> "Or":
+    def __invert__(self) -> Or:
         return Or(~self.left, ~self.right)
 
     def __repr__(self) -> str:
@@ -204,7 +206,7 @@ class Or(BooleanExpression):
     def __eq__(self, other) -> bool:
         return id(self) == id(other) or (isinstance(other, Or) and self.left == other.left and self.right == other.right)
 
-    def __invert__(self) -> "And":
+    def __invert__(self) -> And:
         return And(~self.left, ~self.right)
 
     def __repr__(self) -> str:
@@ -245,7 +247,7 @@ class Not(BooleanExpression):
 class AlwaysTrue(BooleanExpression, metaclass=Singleton):
     """TRUE expression"""
 
-    def __invert__(self) -> "AlwaysFalse":
+    def __invert__(self) -> AlwaysFalse:
         return AlwaysFalse()
 
     def __repr__(self) -> str:
@@ -258,7 +260,7 @@ class AlwaysTrue(BooleanExpression, metaclass=Singleton):
 class AlwaysFalse(BooleanExpression, metaclass=Singleton):
     """FALSE expression"""
 
-    def __invert__(self) -> "AlwaysTrue":
+    def __invert__(self) -> AlwaysTrue:
         return AlwaysTrue()
 
     def __repr__(self) -> str:

--- a/python/src/iceberg/expressions/literals.py
+++ b/python/src/iceberg/expressions/literals.py
@@ -19,11 +19,11 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=W0613
+from __future__ import annotations
 
 import struct
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatch, singledispatchmethod
-from typing import Optional, Union
 from uuid import UUID
 
 from iceberg.expressions.base import Literal
@@ -170,7 +170,7 @@ class LongLiteral(Literal[int]):
         return self
 
     @to.register(IntegerType)
-    def _(self, type_var: IntegerType) -> Union[AboveMax, BelowMin, Literal[int]]:
+    def _(self, type_var: IntegerType) -> AboveMax | BelowMin | Literal[int]:
         if IntegerType.max < self.value:
             return AboveMax()
         elif IntegerType.min > self.value:
@@ -258,7 +258,7 @@ class DoubleLiteral(Literal[float]):
         return self
 
     @to.register(FloatType)
-    def _(self, type_var: FloatType) -> Union[AboveMax, BelowMin, Literal[float]]:
+    def _(self, type_var: FloatType) -> AboveMax | BelowMin | Literal[float]:
         if FloatType.max < self.value:
             return AboveMax()
         elif FloatType.min > self.value:
@@ -322,7 +322,7 @@ class DecimalLiteral(Literal[Decimal]):
         return None
 
     @to.register(DecimalType)
-    def _(self, type_var: DecimalType) -> Optional[Literal[Decimal]]:
+    def _(self, type_var: DecimalType) -> Literal[Decimal] | None:
         if type_var.scale == abs(self.value.as_tuple().exponent):
             return self
         return None
@@ -341,28 +341,28 @@ class StringLiteral(Literal[str]):
         return self
 
     @to.register(DateType)
-    def _(self, type_var: DateType) -> Optional[Literal[int]]:
+    def _(self, type_var: DateType) -> Literal[int] | None:
         try:
             return DateLiteral(date_to_days(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimeType)
-    def _(self, type_var: TimeType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimeType) -> Literal[int] | None:
         try:
             return TimeLiteral(time_to_micros(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimestampType)
-    def _(self, type_var: TimestampType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimestampType) -> Literal[int] | None:
         try:
             return TimestampLiteral(timestamp_to_micros(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimestamptzType)
-    def _(self, type_var: TimestamptzType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimestamptzType) -> Literal[int] | None:
         try:
             return TimestampLiteral(timestamptz_to_micros(self.value))
         except (TypeError, ValueError):
@@ -373,7 +373,7 @@ class StringLiteral(Literal[str]):
         return UUIDLiteral(UUID(self.value))
 
     @to.register(DecimalType)
-    def _(self, type_var: DecimalType) -> Optional[Literal[Decimal]]:
+    def _(self, type_var: DecimalType) -> Literal[Decimal] | None:
         dec = Decimal(self.value)
         if type_var.scale == abs(dec.as_tuple().exponent):
             return DecimalLiteral(dec)
@@ -403,7 +403,7 @@ class FixedLiteral(Literal[bytes]):
         return None
 
     @to.register(FixedType)
-    def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
+    def _(self, type_var: FixedType) -> Literal[bytes] | None:
         if len(self.value) == type_var.length:
             return self
         else:
@@ -427,7 +427,7 @@ class BinaryLiteral(Literal[bytes]):
         return self
 
     @to.register(FixedType)
-    def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
+    def _(self, type_var: FixedType) -> Literal[bytes] | None:
         if type_var.length == len(self.value):
             return FixedLiteral(self.value)
         else:

--- a/python/src/iceberg/files.py
+++ b/python/src/iceberg/files.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from abc import abstractmethod
 from enum import Enum, auto
 from typing import Any, Protocol, runtime_checkable

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -22,9 +22,10 @@ as check if a file exists. An implementation of the FileIO abstract base class i
 for returning an InputFile instance, an OutputFile instance, and deleting a file given
 its location.
 """
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Protocol, Union, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -187,7 +188,7 @@ class FileIO(ABC):
         """
 
     @abstractmethod
-    def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
+    def delete(self, location: str | InputFile | OutputFile) -> None:
         """Delete the file at the given path
 
         Args:

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -21,9 +21,9 @@ by PyArrow. It relies on PyArrow's `from_uri` method that infers the correct fil
 type to use. Theoretically, this allows the supported storage types to grow naturally
 with the pyarrow library.
 """
+from __future__ import annotations
 
 import os
-from typing import Union
 from urllib.parse import urlparse
 
 from pyarrow.fs import FileInfo, FileSystem, FileType
@@ -154,7 +154,7 @@ class PyArrowFile(InputFile, OutputFile):
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
         return output_file
 
-    def to_input_file(self) -> "PyArrowFile":
+    def to_input_file(self) -> PyArrowFile:
         """Returns a new PyArrowFile for the location of an existing PyArrowFile instance
 
         This method is included to abide by the OutputFile abstract base class. Since this implementation uses a single
@@ -187,7 +187,7 @@ class PyArrowFileIO(FileIO):
         """
         return PyArrowFile(location)
 
-    def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
+    def delete(self, location: str | InputFile | OutputFile) -> None:
         """Delete the file at the given location
 
         Args:

--- a/python/src/iceberg/schema.py
+++ b/python/src/iceberg/schema.py
@@ -409,7 +409,7 @@ def index_by_id(schema_or_type) -> dict[int, NestedField]:
         schema_or_type (Schema | IcebergType): A schema or type to index
 
     Returns:
-        Dict[int, NestedField]: An index of field IDs to NestedField instances
+        dict[int, NestedField]: An index of field IDs to NestedField instances
     """
     return visit(schema_or_type, _IndexById())
 
@@ -515,7 +515,7 @@ def index_by_name(schema_or_type: Schema | IcebergType) -> dict[str, int]:
         schema_or_type (Schema | IcebergType): A schema or type to index
 
     Returns:
-        Dict[str, int]: An index of field names to field IDs
+        dict[str, int]: An index of field names to field IDs
     """
     indexer = _IndexByName()
     visit(schema_or_type, indexer)
@@ -529,7 +529,7 @@ def index_name_by_id(schema_or_type: Schema | IcebergType) -> dict[int, str]:
         schema_or_type (Schema | IcebergType): A schema or type to index
 
     Returns:
-        Dict[str, int]: An index of field IDs to full names
+        dict[str, int]: An index of field IDs to full names
     """
     indexer = _IndexByName()
     visit(schema_or_type, indexer)
@@ -612,6 +612,6 @@ def build_position_accessors(schema_or_type: Schema | IcebergType) -> dict[int, 
         schema_or_type (Schema | IcebergType): A schema or type to index
 
     Returns:
-        Dict[int, Accessor]: An index of field IDs to accessors
+        dict[int, Accessor]: An index of field IDs to accessors
     """
     return visit(schema_or_type, _BuildPositionAccessors())

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -14,8 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
 
 from iceberg.schema import Schema
 from iceberg.transforms import Transform
@@ -59,9 +60,9 @@ class PartitionSpec:
 
     schema: Schema
     spec_id: int
-    fields: Tuple[PartitionField, ...]
+    fields: tuple[PartitionField, ...]
     last_assigned_field_id: int
-    source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False, repr=False)
+    source_id_to_fields_map: dict[int, list[PartitionField]] = field(init=False, repr=False)
 
     def __post_init__(self):
         source_id_to_fields_map = dict()
@@ -101,10 +102,10 @@ class PartitionSpec:
     def is_unpartitioned(self) -> bool:
         return not self.fields
 
-    def fields_by_source_id(self, field_id: int) -> List[PartitionField]:
+    def fields_by_source_id(self, field_id: int) -> list[PartitionField]:
         return self.source_id_to_fields_map[field_id]
 
-    def compatible_with(self, other: "PartitionSpec") -> bool:
+    def compatible_with(self, other: PartitionSpec) -> bool:
         """
         Produce a boolean to return True if two PartitionSpec are considered compatible
         """

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -29,9 +29,11 @@ Example:
 Notes:
   - https://iceberg.apache.org/#spec/#primitive-types
 """
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import ClassVar, Optional, Tuple
+from typing import ClassVar
 
 from iceberg.utils.singleton import Singleton
 
@@ -134,7 +136,7 @@ class NestedField(IcebergType):
     name: str = field()
     field_type: IcebergType = field()
     required: bool = field(default=True)
-    doc: Optional[str] = field(default=None, repr=False)
+    doc: str | None = field(default=None, repr=False)
 
     @property
     def optional(self) -> bool:
@@ -159,7 +161,7 @@ class StructType(IcebergType):
         'struct<1: required_field: optional string, 2: optional_field: optional int>'
     """
 
-    fields: Tuple[NestedField] = field()
+    fields: tuple[NestedField] = field()
 
     def __init__(self, *fields: NestedField, **kwargs):  # pylint: disable=super-init-not-called
         if not fields and "fields" in kwargs:

--- a/python/src/iceberg/utils/decimal.py
+++ b/python/src/iceberg/utils/decimal.py
@@ -14,11 +14,11 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-
 """Helper methods for working with Python Decimals
 """
+from __future__ import annotations
+
 from decimal import Decimal
-from typing import Union
 
 
 def decimal_to_unscaled(value: Decimal) -> int:
@@ -48,7 +48,7 @@ def unscaled_to_decimal(unscaled: int, scale: int) -> Decimal:
     return Decimal((sign, digits, -scale))
 
 
-def bytes_required(value: Union[int, Decimal]) -> int:
+def bytes_required(value: int | Decimal) -> int:
     """Returns the minimum number of bytes needed to serialize a decimal or unscaled value
 
     Args:

--- a/python/src/iceberg/utils/schema_conversion.py
+++ b/python/src/iceberg/utils/schema_conversion.py
@@ -107,7 +107,7 @@ class AvroSchemaConversion:
             True
 
         Args:
-            avro_schema (Dict[str, Any]): The JSON decoded Avro schema
+            avro_schema (dict[str, Any]): The JSON decoded Avro schema
 
         Returns:
             Equivalent Iceberg schema

--- a/python/src/iceberg/utils/singleton.py
+++ b/python/src/iceberg/utils/singleton.py
@@ -14,12 +14,14 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+from __future__ import annotations
+
 from abc import ABCMeta
-from typing import ClassVar, Dict
+from typing import ClassVar
 
 
 class Singleton(ABCMeta):
-    _instances: ClassVar[Dict] = {}
+    _instances: ClassVar[dict] = {}
 
     def __call__(cls, *args, **kwargs):
         key = (cls, args, tuple(sorted(kwargs.items())))


### PR DESCRIPTION
Move away from Types to the build in types.

When we add

```python
from __future__ import annotations
```

We can also use the buildin types in Python 3.8