### PR TITLE
Encapsulate public mutable field in IcebergSplit

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.util.SerializationUtil;
 // and v2 file formats.
 public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred.InputSplit, IcebergSplitContainer {
 
-  public static final String[] ANYWHERE = new String[]{"*"};
+  private static final String[] ANYWHERE = new String[]{"*"};
 
   private Table table;
   private CombinedScanTask task;
@@ -73,9 +73,9 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
     // getLocations() won't be accurate when called on worker nodes and will always return "*"
     if (locations == null && conf != null) {
       boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
-      locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE;
+      locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE.clone();
     } else {
-      locations = ANYWHERE;
+      locations = ANYWHERE.clone();
     }
 
     return locations;

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -337,7 +337,7 @@ public class TestIcebergInputFormats {
     helper.appendToTable(null, expectedRecords);
 
     for (InputSplit split : testInputFormat.create(builder.conf()).getSplits()) {
-      Assert.assertArrayEquals(IcebergSplit.ANYWHERE, split.getLocations());
+      Assert.assertArrayEquals(new String[]{"*"}, split.getLocations());
     }
 
     builder.preferLocality();


### PR DESCRIPTION
`IcebergSplit.ANYWHERE` was a mutable and publicly accessible field, so
someone could modify it. The modification could also be accidental, if
someone modified the array returned from `IcebergSplit.locations()`.