### PR TITLE
Fix HTML javadoc warning

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/IdToOrcName.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.types.Types;
  * <p>
  * This visitor also enclose column names in backticks i.e. ` so that ORC can correctly parse column names with
  * special characters. A comparison of ORC convention with Iceberg convention is provided below
- * <pre><code>
+ * <pre>{@code
  *                                      Iceberg           ORC
  * field                                field             field
  * struct -> field                      struct.field      struct.field
@@ -46,7 +46,7 @@ import org.apache.iceberg.types.Types;
  * map -> value                         map.value         map._value
  * map -> struct key -> field           map.key.field     map._key.field
  * map -> struct value -> field         map.field         map._value.field
- * </code></pre>
+ * }</pre>
  */
 class IdToOrcName extends TypeUtil.SchemaVisitor<Map<Integer, String>> {
   private static final Joiner DOT = Joiner.on(".");


### PR DESCRIPTION
Simple fix for the warning received when currently building:

```
IdToOrcName.java:42: warning: [UnescapedEntity] This HTML entity is invalid. Enclosing the code in this <pre>/<code> tag with a {@code } block will force Javadoc to interpret HTML literally.
 * struct -> field                      struct.field      struct.field
           ^
(see https://errorprone.info/bugpattern/UnescapedEntity)
Did you mean '* <pre><code>{@code'?
```