### PR TITLE
Format: Clarify valid position delete file path

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -733,7 +733,7 @@ Position-based delete files store `file_position_delete`, a struct with the foll
 
 | Field id, name              | Type                       | Description |
 |-----------------------------|----------------------------|-------------|
-| **`2147483546  file_path`** | `string`                   | Full URI of a data file with FS scheme. This must match the `file_path` of the target data file in a manifest entry |
+| **`2147483546  file_path`** | `string`                   | Full URI of a data file with FS scheme. This must match a `file_path` of a target data file in a manifest entry with a sequence number less than or equal to the manifest entry containing this delete file. |
 | **`2147483545  pos`**       | `long`                     | Ordinal position of a deleted row in the target data file identified by `file_path`, starting at `0` |
 | **`2147483544  row`**       | `required struct<...>` [1] | Deleted row values. Omit the column when not storing deleted rows. |
 


### PR DESCRIPTION
Background: This was an outcome of thinking about RewritePositionDeleteFiles (minor compaction of position deletes), and what happens when rewriting position deletes with different sequence numbers.

Say we have the following (made-up) scenario:

| File Type | File Path | Sequence Number | Referenced File Paths |
| --- | --- | --- | --- |
| Position Delete |  | 1 |  /data_file |
| Data File | /data_file | 2|   |
| Position Delete |  | 3 |  /data_file |

When we rewrite the two position delete file into a combined one, we are in a bind.  We cannot choose 1 as the final sequence number, as then the position delete of sequence number 3 no longer apply (we apply position delete only to data files with less than or equal sequence number).  We also cannot choose 3 as the final sequence number, as then position delete with sequence number 1 which did not previously apply, now suddenly applies.

I think the spec should restrict this scenario, so a position delete can only reference file paths of data files with lesser or equal sequence numbers.  This way, they never start to suddenly apply, if their position delete file's sequence number gets bumped.  Then, in a RewritePositionDelete scenario , we should be safe to choose any greater sequence number for the final position delete file, as we are sure no new position deletes will start to suddenly apply, and that whatever applies now will continue to apply (as any position delete data file sequence number is still less than or equal to the new one). 