### PR TITLE
Infra - Fix API compatibility Github Action

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -37,19 +37,13 @@ jobs:
   revapi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@v3
         with:
           # fetch-depth of zero ensures that the tags are pulled in and we're not in a detached HEAD state
           # revapi depends on the tags, specifically the tag from git describe, to find the relevant override
           # in the .palantir/revapi.yml file
           #
           # See https://github.com/actions/checkout/issues/124
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/checkout@v2
-        if: github.event_name == 'push'
-        with:
           fetch-depth: 0
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -43,6 +43,8 @@ jobs:
           # fetch-depth of zero ensures that the tags are pulled in and we're not in a detached HEAD state
           # revapi depends on the tags, specifically the tag from git describe, to find the relevant override
           # in the .palantir/revapi.yml file
+          #
+          # See https://github.com/actions/checkout/issues/124
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/checkout@v2

--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -40,6 +40,9 @@ jobs:
       - uses: actions/checkout@v2
         if: github.event_name == 'pull_request'
         with:
+          # fetch-depth of zero ensures that the tags are pulled in and we're not in a detached HEAD state
+          # revapi depends on the tags, specifically the tag from git describe, to find the relevant override
+          # in the .palantir/revapi.yml file
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/checkout@v2
@@ -51,7 +54,7 @@ jobs:
           java-version: 11
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
-      - run: ./gradlew :iceberg-api:revapi --rerun-tasks --no-build-cache --no-daemon
+      - run: ./gradlew :iceberg-api:revapi --rerun-tasks
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -38,15 +38,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/checkout@v2
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - run: ./gradlew :iceberg-api:revapi
+      - run: |
+          echo "Using the old version tag, as per git describe, of $(git describe)";
+      - run: ./gradlew :iceberg-api:revapi --rerun-tasks --no-build-cache --no-daemon
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   revapi:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
The API Binary compatibility task `revapi`, was previously skipping or occasionally passing when it shouldn't be (and when it was _not_ passing for local gradle runs).

The issues were two:
1. The cache action was causing the action to be skipped.
2. The git checkout action checks out by default at a depth of 1, which is a detached head state. Therefore, the output of `git describe` or the first line of the output of `git tags` was not showing up. The action uses this tag to find the proper existing overrides and "old" version to pull from maven (currently iceberg-api:0.13.0) 

This removes the cache action, adds a step to output the `git describe` (so we can easily verify which tag is considered current, which corresponds to what's in `.palantir/revapi.yml`), and then runs the revapi task pretty aggressively (with --rerun-tasks, --no-build-cache, and --no-daemon).

We can try adding back in the `actions/cache` action as well as removing some of the aggressive flags for iceberg-api:revapi, but for now this is what I tested with in my fork and this will work. 🙂 