### PR TITLE
Checkstyle: fix reference of non canonical subclass

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
@@ -163,7 +163,7 @@ public abstract class BasePageIterator {
   IntIterator newRLEIterator(int maxLevel, BytesInput bytes) {
     try {
       if (maxLevel == 0) {
-        return new PageIterator.NullIntIterator();
+        return new NullIntIterator();
       }
       return new RLEIntIterator(
           new RunLengthBitPackingHybridDecoder(


### PR DESCRIPTION
```
BasePageIterator.java:166: warning: [NonCanonicalType] The type `BasePageIterator.NullIntIterator` was referred to by the non-canonical name `PageIterator.NullIntIterator`. This may be misleading.
        return new PageIterator.NullIntIterator();
                               ^
    (see https://errorprone.info/bugpattern/NonCanonicalType)
  Did you mean 'return new NullIntIterator();'?
```
Fix  reference of non canonical subclass as noted in this warning