### PR TITLE
API: Support computed comlumns

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -90,9 +90,9 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
       Types.NestedField field = fields.get(i);
       Type type = types.next();
       if (field.isOptional()) {
-        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type, field.doc()));
+        newFields.add(Types.NestedField.optional(newIds.get(i), field.name(), type, field.doc(), field.expr()));
       } else {
-        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type, field.doc()));
+        newFields.add(Types.NestedField.required(newIds.get(i), field.name(), type, field.doc(), field.expr()));
       }
     }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -415,27 +415,35 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type, null);
+      return new NestedField(true, id, name, type, null, null);
     }
 
     public static NestedField optional(int id, String name, Type type, String doc) {
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, null);
+    }
+
+    public static NestedField optional(int id, String name, Type type, String doc, String expr) {
+      return new NestedField(true, id, name, type, doc, expr);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type, null);
+      return new NestedField(false, id, name, type, null, null);
     }
 
     public static NestedField required(int id, String name, Type type, String doc) {
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, null);
+    }
+
+    public static NestedField required(int id, String name, Type type, String doc, String expr) {
+      return new NestedField(false, id, name, type, doc, expr);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
-      return new NestedField(isOptional, id, name, type, null);
+      return new NestedField(isOptional, id, name, type, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
-      return new NestedField(isOptional, id, name, type, doc);
+      return new NestedField(isOptional, id, name, type, doc, null);
     }
 
     private final boolean isOptional;
@@ -443,8 +451,9 @@ public class Types {
     private final String name;
     private final Type type;
     private final String doc;
+    private final String expr;
 
-    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+    private NestedField(boolean isOptional, int id, String name, Type type, String doc, String expr) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
       this.isOptional = isOptional;
@@ -452,6 +461,7 @@ public class Types {
       this.name = name;
       this.type = type;
       this.doc = doc;
+      this.expr = expr;
     }
 
     public boolean isOptional() {
@@ -462,7 +472,7 @@ public class Types {
       if (isOptional) {
         return this;
       }
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, doc, expr);
     }
 
     public boolean isRequired() {
@@ -473,7 +483,7 @@ public class Types {
       if (!isOptional) {
         return this;
       }
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, doc, expr);
     }
 
     public int fieldId() {
@@ -492,11 +502,16 @@ public class Types {
       return doc;
     }
 
+    public String expr() {
+      return expr;
+    }
+
     @Override
     public String toString() {
       return String.format("%d: %s: %s %s",
           id, name, isOptional ? "optional" : "required", type) +
-          (doc != null ? " (" + doc + ")" : "");
+          (doc != null ? " doc: (" + doc + ") " : "") +
+          (expr != null ? " expr:(" + expr + ")" : "");
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -51,6 +51,7 @@ public class SchemaParser {
   private static final String KEY = "key";
   private static final String VALUE = "value";
   private static final String DOC = "doc";
+  private static final String EXPR = "expr";
   private static final String NAME = "name";
   private static final String ID = "id";
   private static final String ELEMENT_ID = "element-id";
@@ -91,6 +92,9 @@ public class SchemaParser {
       toJson(field.type(), generator);
       if (field.doc() != null) {
         generator.writeStringField(DOC, field.doc());
+      }
+      if (field.expr() != null) {
+        generator.writeStringField(EXPR, field.expr());
       }
       generator.writeEndObject();
     }
@@ -213,11 +217,12 @@ public class SchemaParser {
       Type type = typeFromJson(field.get(TYPE));
 
       String doc = JsonUtil.getStringOrNull(DOC, field);
+      String expr = JsonUtil.getStringOrNull(EXPR, field);
       boolean isRequired = JsonUtil.getBool(REQUIRED, field);
       if (isRequired) {
-        fields.add(Types.NestedField.required(id, name, type, doc));
+        fields.add(Types.NestedField.required(id, name, type, doc, expr));
       } else {
-        fields.add(Types.NestedField.optional(id, name, type, doc));
+        fields.add(Types.NestedField.optional(id, name, type, doc, expr));
       }
     }
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -158,7 +158,7 @@ For the representations of these types in Avro, ORC, and Parquet file formats, s
 
 #### Nested Types
 
-A **`struct`** is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema. Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type. Fields may have an optional comment or doc string. Fields can have [default values](#default-values).
+A **`struct`** is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema. Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type. Fields may have an optional comment or doc string. Fields may be a computed column whose value is automatically computed using other columns values, or another deterministic expression. Fields can have [default values](#default-values).
 
 A **`list`** is a collection of values with some element type. The element field has an integer id that is unique in the table schema. Elements can be either optional or required. Element types may be any type.
 


### PR DESCRIPTION
We have put forward a proposal, which is mainly about supporting computed columns in iceberg.
the doc:
https://docs.google.com/document/d/1PICTSKK2yHgGtxgKAjChrKiF1GFDRVZtvcH9zW8gGcQ

Computed columns are commonly used in db, such as SQL Server, Oracle, and PostgreSQL etc.

On the basis of this, we can make Flink support `Time Attributes`, such AS `user_action_time AS PROCTIME()`.

We used this proposal internally. We hope that after community discussion and modification, it will become a viable proposal, and we are more than happy to continue the engine integration work.

We've seen some PR doing similar things, but it seems to have stalled for a long time. We raise it again here and hope to take it further.

cc @rdblue @kbendick @chenjunjiedada 