### PR TITLE
Parquet: Fixes NPE when pruning columns

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -164,8 +164,8 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
     } else {
       GroupType groupType = field.asGroupType();
       LogicalTypeAnnotation logicalTypeAnnotation = groupType.getLogicalTypeAnnotation();
-      return !logicalTypeAnnotation.equals(LogicalTypeAnnotation.mapType()) &&
-          !logicalTypeAnnotation.equals(LogicalTypeAnnotation.listType());
+      return !LogicalTypeAnnotation.mapType().equals(logicalTypeAnnotation) &&
+          !LogicalTypeAnnotation.listType().equals(logicalTypeAnnotation);
     }
   }
 }


### PR DESCRIPTION
Fixes the following error when pruning columns. This is because the `LogicalTypeAnnotation` of `Struct` is null.
```
java.lang.NullPointerException
    at org.apache.iceberg.parquet.PruneColumns.isStruct(PruneColumns.java:167)
    at org.apache.iceberg.parquet.PruneColumns.message(PruneColumns.java:58)
    at org.apache.iceberg.parquet.PruneColumns.message(PruneColumns.java:35)
    at org.apache.iceberg.parquet.ParquetTypeVisitor.visit(ParquetTypeVisitor.java:37)
    at org.apache.iceberg.parquet.ParquetSchemaUtil.pruneColumns(ParquetSchemaUtil.java:80)
```

