### PR TITLE
Spark: Show metadata.json path in `DESC TABLE EXTENDED`

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -168,6 +168,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
     if (icebergTable instanceof BaseTable) {
       TableOperations ops = ((BaseTable) icebergTable).operations();
       propsBuilder.put(FORMAT_VERSION, String.valueOf(ops.current().formatVersion()));
+      propsBuilder.put("metadata_location", String.valueOf(ops.current().metadataFileLocation()));
     }
 
     if (!icebergTable.sortOrder().isUnsorted()) {


### PR DESCRIPTION
### About Change
The change attempts to show metadata location in `DESC TABLE EXTENDED`, this adds `metadata-location` to the table properties.

### Why this change is Required

We can use this to figure out  the metadata pointer this table points to and use it to register table via [StoredProcedure](https://github.com/apache/iceberg/pull/4810) recently introduced. This could be convenient for users who *only* want to use SPARK-SQL.

### Testing

Added a UT.
Add one more UT for path validation