### PR TITLE
Python: Extend the use of the singleton

### DIFF
--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from abc import ABC, abstractmethod
+from abc import ABCMeta, abstractmethod
 from enum import Enum, auto
 from functools import reduce, singledispatch
 from typing import Any, Generic, TypeVar
 
 from iceberg.files import StructProtocol
 from iceberg.schema import Accessor, Schema
-from iceberg.types import NestedField, Singleton
+from iceberg.types import NestedField
+from iceberg.utils.singleton import Singleton
 
 T = TypeVar("T")
 
@@ -88,7 +89,7 @@ OPERATION_NEGATIONS = {
 }
 
 
-class Literal(Generic[T], ABC):
+class Literal(Generic[T], metaclass=ABCMeta):
     """Literal which has a value and can be converted between types"""
 
     def __init__(self, value: T, value_type: type):
@@ -129,7 +130,7 @@ class Literal(Generic[T], ABC):
         return self.value >= other.value
 
 
-class BooleanExpression(ABC):
+class BooleanExpression(metaclass=ABCMeta):
     """base class for all boolean expressions"""
 
     @abstractmethod
@@ -241,7 +242,7 @@ class Not(BooleanExpression):
         return f"(not {self.child})"
 
 
-class AlwaysTrue(BooleanExpression, Singleton):
+class AlwaysTrue(BooleanExpression, metaclass=Singleton):
     """TRUE expression"""
 
     def __invert__(self) -> "AlwaysFalse":
@@ -254,7 +255,7 @@ class AlwaysTrue(BooleanExpression, Singleton):
         return "true"
 
 
-class AlwaysFalse(BooleanExpression, Singleton):
+class AlwaysFalse(BooleanExpression, metaclass=Singleton):
     """FALSE expression"""
 
     def __invert__(self) -> "AlwaysTrue":
@@ -348,7 +349,7 @@ class UnboundReference:
         return BoundReference(field=field, accessor=schema.accessor_for_field(field.field_id))
 
 
-class BooleanExpressionVisitor(Generic[T], ABC):
+class BooleanExpressionVisitor(Generic[T], metaclass=ABCMeta):
     @abstractmethod
     def visit_true(self) -> T:
         """Visit method for an AlwaysTrue boolean expression

--- a/python/src/iceberg/expressions/literals.py
+++ b/python/src/iceberg/expressions/literals.py
@@ -37,7 +37,6 @@ from iceberg.types import (
     FloatType,
     IntegerType,
     LongType,
-    Singleton,
     StringType,
     TimestampType,
     TimestamptzType,
@@ -51,6 +50,7 @@ from iceberg.utils.datetime import (
     timestamp_to_micros,
     timestamptz_to_micros,
 )
+from iceberg.utils.singleton import Singleton
 
 
 @singledispatch
@@ -112,7 +112,7 @@ def _(value: Decimal) -> Literal[Decimal]:
     return DecimalLiteral(value)
 
 
-class AboveMax(Singleton):
+class AboveMax(metaclass=Singleton):
     @property
     def value(self):
         raise ValueError("AboveMax has no value")
@@ -127,7 +127,7 @@ class AboveMax(Singleton):
         return "AboveMax"
 
 
-class BelowMin(Singleton):
+class BelowMin(metaclass=Singleton):
     def __init__(self):
         pass
 

--- a/python/src/iceberg/utils/singleton.py
+++ b/python/src/iceberg/utils/singleton.py
@@ -1,0 +1,28 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+from abc import ABCMeta
+from typing import ClassVar, Dict
+
+
+class Singleton(ABCMeta):
+    _instances: ClassVar[Dict] = {}
+
+    def __call__(cls, *args, **kwargs):
+        key = (cls, args, tuple(sorted(kwargs.items())))
+        if key not in cls._instances:
+            cls._instances[key] = super().__call__(*args, **kwargs)
+        return cls._instances[key]

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -22,7 +22,8 @@ from typing import List
 import pytest
 
 from iceberg.expressions import base
-from iceberg.types import NestedField, Singleton, StringType
+from iceberg.types import NestedField, StringType
+from iceberg.utils.singleton import Singleton
 
 
 @pytest.mark.parametrize(
@@ -63,7 +64,7 @@ def test_raise_on_no_negation_for_operation(operation):
     assert str(exc_info.value) == f"No negation defined for operation {operation}"
 
 
-class TestExpressionA(base.BooleanExpression, Singleton):
+class TestExpressionA(base.BooleanExpression, metaclass=Singleton):
     def __invert__(self):
         return TestExpressionB()
 
@@ -74,7 +75,7 @@ class TestExpressionA(base.BooleanExpression, Singleton):
         return "testexpra"
 
 
-class TestExpressionB(base.BooleanExpression, Singleton):
+class TestExpressionB(base.BooleanExpression, metaclass=Singleton):
     def __invert__(self):
         return TestExpressionA()
 

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -204,3 +204,10 @@ def test_non_parameterized_type_equality(input_index, input_type, check_index, c
         assert input_type() == check_type()
     else:
         assert input_type() != check_type()
+
+
+def test_types_singleton():
+    """The types are immutable so we can return the same instance multiple times"""
+    assert id(BooleanType()) == id(BooleanType())
+    assert id(FixedType(22)) == id(FixedType(22))
+    assert id(FixedType(19)) != id(FixedType(25))


### PR DESCRIPTION
Instead of having a specialized caching mechanism per class, we can generalize it as a singleton metaclass that we can reuse across different classes.

This moves the `Singleton` out of the `types.py` and implements it as a singleton.

Changing `Class(ABC)` to `Class(metaclass=ABCMeta)` is equivalent, but nicer since it more explicitly shows that we're setting a metaclass. From abc:
```python
class ABC(metaclass=ABCMeta):
    """Helper class that provides a standard way to create an ABC using
    inheritance.
    """
    __slots__ = ()
```