### PR TITLE
Core: Resolve environment variables in REST catalog config

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -74,6 +74,7 @@ import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.ThreadPools;
@@ -109,8 +110,11 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
   }
 
   @Override
-  public void initialize(String name, Map<String, String> props) {
-    Preconditions.checkArgument(props != null, "Invalid configuration: null");
+  public void initialize(String name, Map<String, String> unresolved) {
+    Preconditions.checkArgument(unresolved != null, "Invalid configuration: null");
+    // resolve any configuration that is supplied by environment variables
+    // note that this is only done for local config properties and not for properties from the catalog service
+    Map<String, String> props = EnvironmentUtil.resolveAll(unresolved);
 
     long startTimeMillis = System.currentTimeMillis(); // keep track of the init start time for token refresh
     String initToken = props.get(OAuth2Properties.TOKEN);

--- a/core/src/main/java/org/apache/iceberg/util/EnvironmentUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/EnvironmentUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class EnvironmentUtil {
+  private EnvironmentUtil() {
+  }
+
+  private static final String ENVIRONMENT_VARIABLE_PREFIX = "env:";
+
+  public static Map<String, String> resolveAll(Map<String, String> properties) {
+    return resolveAll(System.getenv(), properties);
+  }
+
+  @VisibleForTesting
+  static Map<String, String> resolveAll(Map<String, String> env, Map<String, String> properties) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    properties.forEach((name, value) -> {
+      if (value.startsWith(ENVIRONMENT_VARIABLE_PREFIX)) {
+        String resolved = env.get(value.substring(ENVIRONMENT_VARIABLE_PREFIX.length()));
+        if (resolved != null) {
+          builder.put(name, resolved);
+        }
+      } else {
+        builder.put(name, value);
+      }
+    });
+
+    return builder.build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestEnvironmentUtil {
+  @Test
+  public void testEnvironmentSubstitution() {
+    Assertions.assertEquals(
+        ImmutableMap.of("user-test", System.getenv().get("USER")),
+        EnvironmentUtil.resolveAll(ImmutableMap.of("user-test", "env:USER")),
+        "Should get the user from the environment");
+  }
+
+  @Test
+  public void testMultipleEnvironmentSubstitutions() {
+    Map<String, String> result = EnvironmentUtil.resolveAll(
+        ImmutableMap.of("USER", "u", "VAR", "value"),
+        ImmutableMap.of("user-test", "env:USER", "other", "left-alone", "var", "env:VAR"));
+
+    Assertions.assertEquals(
+        ImmutableMap.of("user-test", "u", "other", "left-alone", "var", "value"),
+        result,
+        "Should resolve all values starting with env:");
+  }
+
+  @Test
+  public void testEnvironmentSubstitutionWithMissingVar() {
+    Map<String, String> result = EnvironmentUtil.resolveAll(
+        ImmutableMap.of(),
+        ImmutableMap.of("user-test", "env:USER"));
+
+    Assertions.assertEquals(
+        ImmutableMap.of(),
+        result,
+        "Should not contain values with missing environment variables");
+  }
+}


### PR DESCRIPTION
The REST catalog has support for access tokens that are used with Bearer authentication. To help protect these access tokens, some deployments may prefer to set them from environment variables. This adds support for resolving REST catalog configuration values using the JVM environment (`System.getenv()`). If a catalog config value is `env:SOME_VAR`, the value will be replaced with the value of the environment variable `SOME_VAR`. If the environment variable is missing, the value will be null.