### PR TITLE
INFRA: Avoid running engine tests on LICENSE and NOTICE update

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -46,6 +46,8 @@ on:
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'
+    - 'LICENSE'
+    - 'NOTICE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -44,6 +44,8 @@ on:
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'
+    - 'LICENSE'
+    - 'NOTICE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -41,6 +41,8 @@ on:
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'
+    - 'LICENSE'
+    - 'NOTICE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -46,6 +46,8 @@ on:
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'
+    - 'LICENSE'
+    - 'NOTICE'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Presently on updating LICENSE / NOTICE we trigger complete engine suite, As per my understanding it should not be required, and hence like ignored running tests README / CONTRIBUTING .md we should avoid running it for them.
