### PR TITLE
Hive: Fix concurrent transactions overwriting commits by adding hive lock heartbeats.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
@@ -35,4 +35,8 @@ public class CommitStateUnknownException extends RuntimeException {
   public CommitStateUnknownException(Throwable cause) {
     super(cause.getMessage() + "\n" + COMMON_INFO, cause);
   }
+
+  public CommitStateUnknownException(String message, Throwable cause) {
+    super(message + "\n" + cause.getMessage() + "\n" + COMMON_INFO, cause);
+  }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -168,7 +168,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final FileIO fileIO;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
   private final ScheduledExecutorService exitingScheduledExecutorService;
-  private HiveLockHeartbeat hiveLockHeartbeat;
 
   protected HiveTableOperations(
       Configuration conf,
@@ -384,6 +383,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       if (hiveLockHeartbeat != null) {
         hiveLockHeartbeat.cancel();
       }
+
       cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
     }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -96,8 +96,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final String HIVE_LOCK_CHECK_MAX_WAIT_MS = "iceberg.hive.lock-check-max-wait-ms";
   private static final String HIVE_LOCK_HEARTBEAT_INTERVAL_MS =
       "iceberg.hive.lock-heartbeat-interval-ms";
-  private static final String HIVE_LOCK_HEARTBEAT_TIMEOUT_MS =
-      "iceberg.hive.lock-heartbeat-timeout-ms";
   private static final String HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES =
       "iceberg.hive.metadata-refresh-max-retries";
   private static final String HIVE_TABLE_LEVEL_LOCK_EVICT_MS =

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -49,16 +49,16 @@ public abstract class HiveMetastoreTest {
 
   public static void startMetastore(Map<String, String> hiveConfOverride) throws Exception {
     HiveMetastoreTest.metastore = new TestHiveMetastore();
-    HiveConf hiveConf = new HiveConf(new Configuration(), TestHiveMetastore.class);
+    HiveConf hiveConfWithOverrides = new HiveConf(new Configuration(), TestHiveMetastore.class);
     if (hiveConfOverride != null) {
       for (Map.Entry<String, String> kv : hiveConfOverride.entrySet()) {
-        hiveConf.set(kv.getKey(), kv.getValue());
+        hiveConfWithOverrides.set(kv.getKey(), kv.getValue());
       }
     }
 
-    metastore.start(hiveConf);
+    metastore.start(hiveConfWithOverrides);
     HiveMetastoreTest.hiveConf = metastore.hiveConf();
-    HiveMetastoreTest.metastoreClient = new HiveMetaStoreClient(hiveConf);
+    HiveMetastoreTest.metastoreClient = new HiveMetaStoreClient(hiveConfWithOverrides);
     String dbPath = metastore.getDatabasePath(DB_NAME);
     Database db = new Database(DB_NAME, "description", dbPath, Maps.newHashMap());
     metastoreClient.createDatabase(db);
@@ -70,7 +70,7 @@ public abstract class HiveMetastoreTest {
                 ImmutableMap.of(
                     CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS,
                     String.valueOf(EVICTION_INTERVAL)),
-                hiveConf);
+                hiveConfWithOverrides);
   }
 
   @AfterClass

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.hive;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -49,7 +48,7 @@ public abstract class HiveMetastoreTest {
 
   public static void startMetastore(Map<String, String> hiveConfOverride) throws Exception {
     HiveMetastoreTest.metastore = new TestHiveMetastore();
-    HiveConf hiveConfWithOverrides = new HiveConf(new Configuration(), TestHiveMetastore.class);
+    HiveConf hiveConfWithOverrides = new HiveConf(TestHiveMetastore.class);
     if (hiveConfOverride != null) {
       for (Map.Entry<String, String> kv : hiveConfOverride.entrySet()) {
         hiveConfWithOverrides.set(kv.getKey(), kv.getValue());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.hive;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -41,8 +44,19 @@ public abstract class HiveMetastoreTest {
 
   @BeforeClass
   public static void startMetastore() throws Exception {
+    startMetastore(Collections.emptyMap());
+  }
+
+  public static void startMetastore(Map<String, String> hiveConfOverride) throws Exception {
     HiveMetastoreTest.metastore = new TestHiveMetastore();
-    metastore.start();
+    HiveConf hiveConf = new HiveConf(new Configuration(), TestHiveMetastore.class);
+    if (hiveConfOverride != null) {
+      for (Map.Entry<String, String> kv : hiveConfOverride.entrySet()) {
+        hiveConf.set(kv.getKey(), kv.getValue());
+      }
+    }
+
+    metastore.start(hiveConf);
     HiveMetastoreTest.hiveConf = metastore.hiveConf();
     HiveMetastoreTest.metastoreClient = new HiveMetaStoreClient(hiveConf);
     String dbPath = metastore.getDatabasePath(DB_NAME);


### PR DESCRIPTION
When using Hive Metastore catalog, it is possible that longer transactions can take longer than [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) of the Hive Metastore (hive.txn.timeout or metastore.txn.timeout in the newer versions). In those cases, concurrent transactions can overwrite each other leading to data corruption. This change fixes concurrent transactions overwriting commits by adding hive lock heartbeats.