### PR TITLE
Hive: Print db and table name while acquiring hive meta-store lock

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -74,6 +74,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -512,6 +513,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
     AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
     long lockId = lockResponse.getLockid();
+    Pair<Long, String> lockDetails = Pair.of(lockId, String.format("%s.%s", database, tableName));
 
     final long start = System.currentTimeMillis();
     long duration = 0;
@@ -524,7 +526,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         // upper bound of retries. So it is just reasonable to set a large retry count. However, if we set
         // Integer.MAX_VALUE, the above logic of `retries + 1` would overflow into Integer.MIN_VALUE. Hence,
         // the retry is set conservatively as `Integer.MAX_VALUE - 100` so it doesn't hit any boundary issues.
-        Tasks.foreach(lockId)
+        Tasks.foreach(lockDetails)
             .retry(Integer.MAX_VALUE - 100)
             .exponentialBackoff(
                 lockCheckMinWaitTime,
@@ -533,17 +535,17 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
                 1.5)
             .throwFailureWhenFinished()
             .onlyRetryOn(WaitingForLockException.class)
-            .run(id -> {
+            .run(lockInfo -> {
               try {
-                LockResponse response = metaClients.run(client -> client.checkLock(id));
+                LockResponse response = metaClients.run(client -> client.checkLock(lockInfo.first()));
                 LockState newState = response.getState();
                 state.set(newState);
                 if (newState.equals(LockState.WAITING)) {
-                  throw new WaitingForLockException("Waiting for lock.");
+                  throw new WaitingForLockException(String.format("Waiting for lock on table %s", lockInfo.second()));
                 }
               } catch (InterruptedException e) {
                 Thread.interrupted(); // Clear the interrupt status flag
-                LOG.warn("Interrupted while waiting for lock.", e);
+                LOG.warn("Interrupted while waiting for lock on table {}", lockInfo.second(), e);
               }
             }, TException.class);
       }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -513,7 +513,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
     AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
     long lockId = lockResponse.getLockid();
-    Pair<Long, String> lockDetails = Pair.of(lockId, String.format("%s.%s", database, tableName));
+    final Pair<Long, String> lockDetails = Pair.of(lockId, String.format("%s.%s", database, tableName));
 
     final long start = System.currentTimeMillis();
     long duration = 0;


### PR DESCRIPTION
While acquiring hive-metastore lock on an Iceberg table, after every timeout, below [log line](https://github.com/apache/iceberg/blob/98dc9fe8724375e8b932e7e8afdb925c897b4695/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L542) is printed, which doesn't have database and table name information. 

`org.apache.iceberg.hive.HiveTableOperations$WaitingForLockException: Waiting for lock.`

After exhausting all the re-try attempt, finally below [log line](https://github.com/apache/iceberg/blob/98dc9fe8724375e8b932e7e8afdb925c897b4695/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L561) prints database and table name.

`Retrying task after failure: Timed out after 180133 ms waiting for lock on database.table`

Here we are adding the database and table name in first log line to speed up investigation related with locking.

cc : @szehon-ho @dramaticlly 