### PR TITLE
Spark: Fixes NPE when convert NOT IN filter

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -178,6 +178,7 @@ public class SparkFilters {
             In childInFilter = (In) childFilter;
             Expression notIn = notIn(unquote(childInFilter.attribute()),
                 Stream.of(childInFilter.values())
+                    .filter(Objects::nonNull)
                     .map(SparkFilters::convertLiteral)
                     .collect(Collectors.toList()));
             return and(notNull(childInFilter.attribute()), notIn);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -148,4 +148,12 @@ public class TestSparkFilters {
     Expression expected = Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
     Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
   }
+
+  @Test
+  public void testNotInNull() {
+    Not filter = Not.apply(In.apply("col", new Integer[]{1, 2, null}));
+    Expression actual = SparkFilters.convert(filter);
+    Expression expected = Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
+    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+  }
 }


### PR DESCRIPTION
This pr fixes the following problems:
``` java
Cannot create expression literal from null
java.lang.NullPointerException: Cannot create expression literal from null
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:907)
	at org.apache.iceberg.expressions.Literals.from(Literals.java:62)
	at org.apache.iceberg.relocated.com.google.common.collect.Iterators$6.transform(Iterators.java:826)
	at org.apache.iceberg.relocated.com.google.common.collect.TransformedIterator.next(TransformedIterator.java:52)
	at org.apache.iceberg.relocated.com.google.common.collect.Iterators.addAll(Iterators.java:367)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.newArrayList(Lists.java:147)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.newArrayList(Lists.java:133)
	at org.apache.iceberg.expressions.UnboundPredicate.<init>(UnboundPredicate.java:55)
	at org.apache.iceberg.expressions.Expressions.predicate(Expressions.java:265)
	at org.apache.iceberg.expressions.Expressions.predicate(Expressions.java:254)
	at org.apache.iceberg.expressions.Expressions.notIn(Expressions.java:234)
	at org.apache.iceberg.spark.SparkFilters.convert(SparkFilters.java:179)
```

This happens when we convert `some_col NOT IN values` filter from spark to Iceberg and the `values` contains `null`.  For example: `DELETE FROM table WHERE id NOT IN (1, null)`.