### PR TITLE
Flink: Support write options in the in-line insert SQL comments

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -562,6 +562,11 @@ FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SC
     .set("write-format", "orc")
     .set(FlinkWriteOptions.OVERWRITE_MODE, "true");
 ```
+For Flink SQL, write options can be passed in via SQL hints like this:
+```
+INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
+...
+```
 
 | Flink option           | Default                    | Description                                                                                                |
 |------------------------| -------------------------- |------------------------------------------------------------------------------------------------------------|

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -106,7 +106,7 @@ public class FlinkDynamicTableFactory
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
     CatalogTable catalogTable = context.getCatalogTable();
-    Map<String, String> tableProps = catalogTable.getOptions();
+    Map<String, String> writeProps = catalogTable.getOptions();
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
 
     TableLoader tableLoader;
@@ -115,10 +115,10 @@ public class FlinkDynamicTableFactory
     } else {
       tableLoader =
           createTableLoader(
-              catalogTable, tableProps, objectPath.getDatabaseName(), objectPath.getObjectName());
+              catalogTable, writeProps, objectPath.getDatabaseName(), objectPath.getObjectName());
     }
 
-    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration());
+    return new IcebergTableSink(tableLoader, tableSchema, context.getConfiguration(), writeProps);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -37,6 +37,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
   private final TableLoader tableLoader;
   private final TableSchema tableSchema;
   private final ReadableConfig readableConfig;
+  private final Map<String, String> writeProps;
 
   private boolean overwrite = false;
 
@@ -45,13 +46,18 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
     this.tableSchema = toCopy.tableSchema;
     this.overwrite = toCopy.overwrite;
     this.readableConfig = toCopy.readableConfig;
+    this.writeProps = toCopy.writeProps;
   }
 
   public IcebergTableSink(
-      TableLoader tableLoader, TableSchema tableSchema, ReadableConfig readableConfig) {
+      TableLoader tableLoader,
+      TableSchema tableSchema,
+      ReadableConfig readableConfig,
+      Map<String, String> writeProps) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
     this.readableConfig = readableConfig;
+    this.writeProps = writeProps;
   }
 
   @Override
@@ -70,6 +76,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
                 .tableSchema(tableSchema)
                 .equalityFieldColumns(equalityColumns)
                 .overwrite(overwrite)
+                .setAll(writeProps)
                 .flinkConf(readableConfig)
                 .append();
   }


### PR DESCRIPTION
Support write options in the in-line insert SQL comments:

```sql
insert into talbeName  /*+ OPTIONS('upsert-enabled'='true')*/ 
select 
…………

```

For properties like upsert, it is not recommended to enable it in the table props. Configuring it in table props is a bit strange.