### PR TITLE
[CORE] Add Java Doc for LoadTableResponse and fix error prone warnings

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/RenameTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RenameTableRequest.java
@@ -43,6 +43,7 @@ public class RenameTableRequest implements RESTRequest {
     validate();
   }
 
+  @Override
   public void validate() {
     Preconditions.checkArgument(source != null, "Invalid source table: null");
     Preconditions.checkArgument(destination != null, "Invalid destination table: null");

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -28,7 +28,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RESTResponse;
 
 /**
- *
+ * A REST response that is used when a table is successfully loaded.
+ * <p>
+ * This class is used whenever the response to a request is a table's requested metadata and the associated location
+ * of its metadata, to reduce code duplication. This includes using this class as the response for
+ * {@link org.apache.iceberg.rest.requests.CreateTableRequest}, including when that request is used to commit
+ * an already staged table creation as part of a transaction.
  */
 public class LoadTableResponse implements RESTResponse {
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -80,6 +80,9 @@ public class OAuthTokenResponse implements RESTResponse {
     private Integer expiresInSeconds;
     private final List<String> scopes = Lists.newArrayList();
 
+    private Builder() {
+    }
+
     public Builder withToken(String token) {
       this.accessToken = token;
       return this;


### PR DESCRIPTION
The `LoadTableResponse` class is missing a java doc.

This class is used in multiple places, as outlined in the OpenAPI spec. Refer to
1. The responses that [use the `LoadTableResult` schema](https://github.com/apache/iceberg/blob/a7f7c1a9b78dd596c6c9eda1f0b621950b09f6f5/open-api/rest-catalog-open-api.yaml#L1929-L1959)
2. The [schema definition for `LoadTableResult`](https://github.com/apache/iceberg/blob/a7f7c1a9b78dd596c6c9eda1f0b621950b09f6f5/open-api/rest-catalog-open-api.yaml#L1461-L1482), which is part of this class.

I also took this opportunity to fix a few error prone warnings in the REST request / responses.