### PR TITLE
Python: Don't use a metaclass for the Singleton

### DIFF
--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from enum import Enum, auto
 from functools import reduce, singledispatch
 from typing import Any, Generic, TypeVar
@@ -89,7 +89,7 @@ OPERATION_NEGATIONS = {
 }
 
 
-class Literal(Generic[T], metaclass=ABCMeta):
+class Literal(Generic[T], ABC):
     """Literal which has a value and can be converted between types"""
 
     def __init__(self, value: T, value_type: type):
@@ -130,7 +130,7 @@ class Literal(Generic[T], metaclass=ABCMeta):
         return self.value >= other.value
 
 
-class BooleanExpression(metaclass=ABCMeta):
+class BooleanExpression(ABC):
     """base class for all boolean expressions"""
 
     @abstractmethod
@@ -242,7 +242,7 @@ class Not(BooleanExpression):
         return f"(not {self.child})"
 
 
-class AlwaysTrue(BooleanExpression, metaclass=Singleton):
+class AlwaysTrue(BooleanExpression, ABC, Singleton):
     """TRUE expression"""
 
     def __invert__(self) -> "AlwaysFalse":
@@ -255,7 +255,7 @@ class AlwaysTrue(BooleanExpression, metaclass=Singleton):
         return "true"
 
 
-class AlwaysFalse(BooleanExpression, metaclass=Singleton):
+class AlwaysFalse(BooleanExpression, ABC, Singleton):
     """FALSE expression"""
 
     def __invert__(self) -> "AlwaysTrue":
@@ -349,7 +349,7 @@ class UnboundReference:
         return BoundReference(field=field, accessor=schema.accessor_for_field(field.field_id))
 
 
-class BooleanExpressionVisitor(Generic[T], metaclass=ABCMeta):
+class BooleanExpressionVisitor(Generic[T], ABC):
     @abstractmethod
     def visit_true(self) -> T:
         """Visit method for an AlwaysTrue boolean expression

--- a/python/src/iceberg/expressions/literals.py
+++ b/python/src/iceberg/expressions/literals.py
@@ -112,7 +112,7 @@ def _(value: Decimal) -> Literal[Decimal]:
     return DecimalLiteral(value)
 
 
-class AboveMax(metaclass=Singleton):
+class AboveMax(Singleton):
     @property
     def value(self):
         raise ValueError("AboveMax has no value")
@@ -127,7 +127,7 @@ class AboveMax(metaclass=Singleton):
         return "AboveMax"
 
 
-class BelowMin(metaclass=Singleton):
+class BelowMin(Singleton):
     def __init__(self):
         pass
 

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -29,6 +29,7 @@ Example:
 Notes:
   - https://iceberg.apache.org/#spec/#primitive-types
 """
+from abc import ABC
 from dataclasses import dataclass, field
 from functools import cached_property
 from typing import ClassVar, Optional, Tuple
@@ -37,7 +38,7 @@ from iceberg.utils.singleton import Singleton
 
 
 @dataclass(frozen=True)
-class IcebergType(metaclass=Singleton):
+class IcebergType(ABC, Singleton):
     """Base type for all Iceberg Types
 
     Example:

--- a/python/src/iceberg/utils/singleton.py
+++ b/python/src/iceberg/utils/singleton.py
@@ -14,15 +14,15 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-from abc import ABCMeta
+
 from typing import ClassVar, Dict
 
 
-class Singleton(ABCMeta):
+class Singleton:
     _instances: ClassVar[Dict] = {}
 
-    def __call__(cls, *args, **kwargs):
+    def __new__(cls, *args, **kwargs):
         key = (cls, args, tuple(sorted(kwargs.items())))
         if key not in cls._instances:
-            cls._instances[key] = super().__call__(*args, **kwargs)
+            cls._instances[key] = super().__new__(cls)
         return cls._instances[key]

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -64,7 +64,7 @@ def test_raise_on_no_negation_for_operation(operation):
     assert str(exc_info.value) == f"No negation defined for operation {operation}"
 
 
-class TestExpressionA(base.BooleanExpression, metaclass=Singleton):
+class TestExpressionA(base.BooleanExpression, Singleton):
     def __invert__(self):
         return TestExpressionB()
 
@@ -75,7 +75,7 @@ class TestExpressionA(base.BooleanExpression, metaclass=Singleton):
         return "testexpra"
 
 
-class TestExpressionB(base.BooleanExpression, metaclass=Singleton):
+class TestExpressionB(base.BooleanExpression, Singleton):
     def __invert__(self):
         return TestExpressionA()
 


### PR DESCRIPTION
Follow up PR of https://github.com/apache/iceberg/pull/5008

Metaclasses in Python don't mix very well, and when they cause conflicts then it breaks at initialization.
An example of metaclasses is the ABC, but also the Pydantic BaseModel. I tried to circumvent this by extending the Singleton from ABC but it is likely that we use different metaclasses in the future, and then it will bring us sadness and misery.