### PR TITLE
Checkstyle: Add checkstyle rule for %d in Preconditions.checkArgument

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -71,6 +71,12 @@
         <property name="format" value="new LinkedHashSet&lt;&gt;\(.*\)"/>
         <property name="message" value="Prefer using Sets.newLinkedHashSet() instead."/>
     </module>
+    <module name="RegexpMultiline">
+        <property name="fileExtensions" value="java"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="Preconditions\.checkArgument\([^;]+%d[^;]+\);"/>
+        <property name="message" value="Preconditions.checkArgument does not support %d. use %s instead"/>
+    </module>
     <module name="SuppressionFilter"> <!-- baseline-gradle: README.md -->
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
@@ -51,7 +51,7 @@ class BaseIncrementalAppendScan extends BaseScan<IncrementalAppendScan> implemen
   @Override
   public IncrementalAppendScan fromSnapshotInclusive(long fromSnapshotId) {
     Preconditions.checkArgument(table().snapshot(fromSnapshotId) != null,
-        "Cannot find the starting snapshot: %d", fromSnapshotId);
+        "Cannot find the starting snapshot: %s", fromSnapshotId);
     return newRefinedScan(tableOps(), table(), schema(), context().fromSnapshotIdInclusive(fromSnapshotId));
   }
 
@@ -65,7 +65,7 @@ class BaseIncrementalAppendScan extends BaseScan<IncrementalAppendScan> implemen
   @Override
   public IncrementalAppendScan toSnapshot(long toSnapshotId) {
     Preconditions.checkArgument(table().snapshot(toSnapshotId) != null,
-        "Cannot find end snapshot: %d", toSnapshotId);
+        "Cannot find end snapshot: %s", toSnapshotId);
     return newRefinedScan(tableOps(), table(), schema(),  context().toSnapshotId(toSnapshotId));
   }
 

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -225,8 +225,8 @@ class AddFilesProcedure extends BaseProcedure {
       // Check to see there are sufficient partition columns to satisfy the filter
       Preconditions.checkArgument(partitionFields.size() >= partitionFilter.size(),
           "Cannot add data files to target table %s because that table is partitioned, " +
-              "but the number of columns in the provided partition filter (%d) " +
-              "is greater than the number of partitioned columns in table (%d)",
+              "but the number of columns in the provided partition filter (%s) " +
+              "is greater than the number of partitioned columns in table (%s)",
           table.name(), partitionFilter.size(), partitionFields.size());
 
       // Check for any filters of non existent columns

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -225,8 +225,8 @@ class AddFilesProcedure extends BaseProcedure {
       // Check to see there are sufficient partition columns to satisfy the filter
       Preconditions.checkArgument(partitionFields.size() >= partitionFilter.size(),
           "Cannot add data files to target table %s because that table is partitioned, " +
-              "but the number of columns in the provided partition filter (%d) " +
-              "is greater than the number of partitioned columns in table (%d)",
+              "but the number of columns in the provided partition filter (%s) " +
+              "is greater than the number of partitioned columns in table (%s)",
           table.name(), partitionFilter.size(), partitionFields.size());
 
       // Check for any filters of non existent columns

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -222,8 +222,8 @@ class AddFilesProcedure extends BaseProcedure {
       // Check to see there are sufficient partition columns to satisfy the filter
       Preconditions.checkArgument(partitionFields.size() >= partitionFilter.size(),
           "Cannot add data files to target table %s because that table is partitioned, " +
-              "but the number of columns in the provided partition filter (%d) " +
-              "is greater than the number of partitioned columns in table (%d)",
+              "but the number of columns in the provided partition filter (%s) " +
+              "is greater than the number of partitioned columns in table (%s)",
           table.name(), partitionFilter.size(), partitionFields.size());
 
       // Check for any filters of non existent columns


### PR DESCRIPTION
Closes #4618 

From the issue:
`Preconditions.checkArgument` only works with %s, as %d does not parse and returns a bad error message.

Created a multiline regex to prevent this.

The regex is as follows:
```regex
Preconditions\.checkArgument\([^;]+%d[^;]+\);
```
The logic behind it: Find the function call, then any characters (except `;`) until `%d`, and finally search until the function closes and a ';'.
* Used `[^;]*` instead of `.*`, because this is a multiline search and the dotall regex param (enabled by `matchAcrossLines` config) is aggressive and this is the best way to break its search.

Also, fixed %d usages that the Checkstyle rule found