### PR TITLE
Dell: Fix bugs during documenting

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/DellClientFactory.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/DellClientFactory.java
@@ -20,9 +20,10 @@
 package org.apache.iceberg.dell;
 
 import com.emc.object.s3.S3Client;
+import java.io.Serializable;
 import java.util.Map;
 
-public interface DellClientFactory {
+public interface DellClientFactory extends Serializable {
 
   /**
    * Create a Dell EMC ECS S3 client

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/PropertiesSerDesUtil.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/PropertiesSerDesUtil.java
@@ -58,7 +58,7 @@ public class PropertiesSerDesUtil {
    * @param version is the version of {@link PropertiesSerDesUtil}
    */
   public static Map<String, String> read(byte[] content, String version) {
-    Preconditions.checkArgument(version.equals(CURRENT_VERSION),
+    Preconditions.checkArgument(CURRENT_VERSION.equals(version),
         "Properties version is not match", version);
     Properties jdkProperties = new Properties();
     try (Reader reader = new InputStreamReader(new ByteArrayInputStream(content), StandardCharsets.UTF_8)) {


### PR DESCRIPTION
1. Make `DellClientFactory` serializable
2. To avoid the NPE when reading the table/namespace object which doesn't have the version field.