### PR TITLE
Core: In HadoopTableOperations, replace Util.getFs call with getFileSystem

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -307,7 +307,7 @@ public class HadoopTableOperations implements TableOperations {
   @VisibleForTesting
   int findVersion() {
     Path versionHintFile = versionHintFile();
-    FileSystem fs = Util.getFs(versionHintFile, conf);
+    FileSystem fs = getFileSystem(versionHintFile, conf);
 
     try (InputStreamReader fsr = new InputStreamReader(fs.open(versionHintFile), StandardCharsets.UTF_8);
          BufferedReader in = new BufferedReader(fsr)) {


### PR DESCRIPTION
In HadoopTableOperations, we use getFileSystem method to get FileSystem, which internally calls  Util.getFs but it was missing in some methods.
Using getFileSystem at all places in HadoopFileSystem allows to overriding method.
