### PR TITLE
Python: Replace vars with cached_property decorator

### DIFF
--- a/python/src/iceberg/expressions/base.py
+++ b/python/src/iceberg/expressions/base.py
@@ -346,7 +346,12 @@ class UnboundReference:
         if not field:
             raise ValueError(f"Cannot find field '{self.name}' in schema: {schema}")
 
-        return BoundReference(field=field, accessor=schema.accessor_for_field(field.field_id))
+        accessor = schema.accessor_for_field(field.field_id)
+
+        if not accessor:
+            raise ValueError(f"Cannot find accessor for field '{self.name}' in schema: {schema}")
+
+        return BoundReference(field=field, accessor=accessor)
 
 
 class BooleanExpressionVisitor(Generic[T], ABC):


### PR DESCRIPTION
Instead of doing the caching ourselves, functools has a nice decorator that can do that for us. I also removed the type ignore to avoid having an accidental None.