### PR TITLE
Python: Bump pre-commit versions

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ files: ^python/
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -37,7 +37,7 @@ repos:
       - id: isort
         args: [ --settings-path=python/pyproject.toml ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.960
+    rev: v0.961
     hooks:
       - id: mypy
   - repo: https://github.com/hadialqattan/pycln
@@ -46,7 +46,7 @@ repos:
       - id: pycln
         args: [--config=python/pyproject.toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.34.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]


### PR DESCRIPTION
```
➜  python git:(fd-bump-pre-commit) pre-commit autoupdate
Updating https://github.com/pre-commit/pre-commit-hooks ... updating v4.2.0 -> v4.3.0.
Updating https://github.com/ambv/black ... already up to date.
Updating https://github.com/pre-commit/mirrors-isort ... already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... updating v0.960 -> v0.961.
Updating https://github.com/hadialqattan/pycln ... already up to date.
Updating https://github.com/asottile/pyupgrade ... updating v2.32.1 -> v2.34.0.
➜  python git:(fd-bump-pre-commit) ✗ pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check docstring is first.................................................Passed
debug statements (python)................................................Passed
check yaml...............................................................Passed
check python ast.........................................................Passed
black....................................................................Passed
isort....................................................................Passed
mypy.....................................................................Passed
pycln....................................................................Passed
pyupgrade................................................................Passed
```