### PR TITLE
Spark: Add `__metadata_col` metadata in metadata columns when doing Schema Conversion

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -31,6 +31,8 @@ public class MetadataColumns {
   private MetadataColumns() {
   }
 
+  public static final String METADATA_COL_ATTR_KEY = "__metadata_col";
+
   // IDs Integer.MAX_VALUE - (1-100) are used for metadata columns
   public static final NestedField FILE_PATH = NestedField.required(
       Integer.MAX_VALUE - 1, "_file", Types.StringType.get(), "Path of the file in which a row is stored");

--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -31,8 +31,6 @@ public class MetadataColumns {
   private MetadataColumns() {
   }
 
-  public static final String METADATA_COL_ATTR_KEY = "__metadata_col";
-
   // IDs Integer.MAX_VALUE - (1-100) are used for metadata columns
   public static final NestedField FILE_PATH = NestedField.required(
       Integer.MAX_VALUE - 1, "_file", Types.StringType.get(), "Path of the file in which a row is stored");

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
@@ -37,6 +38,7 @@ import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType$;
 import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType$;
@@ -59,8 +61,11 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
     for (int i = 0; i < fields.size(); i += 1) {
       Types.NestedField field = fields.get(i);
       DataType type = fieldResults.get(i);
-      StructField sparkField = StructField.apply(
-          field.name(), type, field.isOptional(), Metadata.empty());
+      Metadata metadata = Metadata.empty();
+      if (MetadataColumns.isMetadataColumn(field.name())) {
+        metadata = new MetadataBuilder().putBoolean(MetadataColumns.METADATA_COL_ATTR_KEY, true).build();
+      }
+      StructField sparkField = StructField.apply(field.name(), type, field.isOptional(), metadata);
       if (field.doc() != null) {
         sparkField = sparkField.withComment(field.doc());
       }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -71,11 +71,11 @@ public class TestSparkSchemaUtil {
     for (AttributeReference attrRef : attrRefs) {
       if (MetadataColumns.isMetadataColumn(attrRef.name())) {
         Assert.assertTrue("metadata columns should have __metadata_col in attribute metadata",
-            attrRef.metadata().contains(MetadataColumns.METADATA_COL_ATTR_KEY) &&
-                attrRef.metadata().getBoolean(MetadataColumns.METADATA_COL_ATTR_KEY));
+            attrRef.metadata().contains(TypeToSparkType.METADATA_COL_ATTR_KEY) &&
+                attrRef.metadata().getBoolean(TypeToSparkType.METADATA_COL_ATTR_KEY));
       } else {
         Assert.assertFalse("non metadata columns should not have __metadata_col in attribute metadata",
-            attrRef.metadata().contains(MetadataColumns.METADATA_COL_ATTR_KEY));
+            attrRef.metadata().contains(TypeToSparkType.METADATA_COL_ATTR_KEY));
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -20,8 +20,12 @@
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.types.StructType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,8 +37,15 @@ public class TestSparkSchemaUtil {
       optional(2, "data", Types.StringType.get())
   );
 
+  private static final Schema TEST_SCHEMA_WITH_METADATA_COLS = new Schema(
+      optional(1, "id", Types.IntegerType.get()),
+      optional(2, "data", Types.StringType.get()),
+      MetadataColumns.FILE_PATH,
+      MetadataColumns.ROW_POSITION
+  );
+
   @Test
-  public void testEstiamteSizeMaxValue() throws IOException {
+  public void testEstimateSizeMaxValue() throws IOException {
     Assert.assertEquals("estimateSize returns Long max value", Long.MAX_VALUE,
         SparkSchemaUtil.estimateSize(
             null,
@@ -42,14 +53,30 @@ public class TestSparkSchemaUtil {
   }
 
   @Test
-  public void testEstiamteSizeWithOverflow() throws IOException {
+  public void testEstimateSizeWithOverflow() throws IOException {
     long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), Long.MAX_VALUE - 1);
     Assert.assertEquals("estimateSize handles overflow", Long.MAX_VALUE, tableSize);
   }
 
   @Test
-  public void testEstiamteSize() throws IOException {
+  public void testEstimateSize() throws IOException {
     long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), 1);
     Assert.assertEquals("estimateSize matches with expected approximation", 24, tableSize);
+  }
+
+  @Test
+  public void testSchemaConversionWithMetaDataColumnSchema() {
+    StructType structType = SparkSchemaUtil.convert(TEST_SCHEMA_WITH_METADATA_COLS);
+    List<AttributeReference> attrRefs = scala.collection.JavaConverters.seqAsJavaList(structType.toAttributes());
+    for (AttributeReference attrRef : attrRefs) {
+      if (MetadataColumns.isMetadataColumn(attrRef.name())) {
+        Assert.assertTrue("metadata columns should have __metadata_col in attribute metadata",
+            attrRef.metadata().contains(MetadataColumns.METADATA_COL_ATTR_KEY) &&
+                attrRef.metadata().getBoolean(MetadataColumns.METADATA_COL_ATTR_KEY));
+      } else {
+        Assert.assertFalse("non metadata columns should not have __metadata_col in attribute metadata",
+            attrRef.metadata().contains(MetadataColumns.METADATA_COL_ATTR_KEY));
+      }
+    }
   }
 }


### PR DESCRIPTION
### About the change : 

Presently when doing schema conversion we were setting `metadata` for all the the columns, but we should add `____metadata_col` in metadata column which can be used by spark to check if the column is `metadata` col and drop it if required like, 
here : 
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala#L221-L225

Note : `MetadataAttribute` extractor uses the above key in attribute meta data to find if the attribute is metadata attribute or not.

This PR includes : 
(i) Fix for above 
(ii) Fix an existing minor typo in `TestSparkSchemaUtil`

---- 
### Testing Done
Added an UT for the same.

cc @rdblue @aokolnychyi @jackye1995 @RussellSpitzer 
