### PR TITLE
Make VectorizedParquetDefinitionLevelReader work with off heap byte buffer

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -121,8 +121,7 @@ public class VectorizedDictionaryEncodedParquetValuesReader extends BaseVectoriz
     @Override
     protected void nextVal(FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
       ByteBuffer buffer = dict.decodeToBinary(currentVal).toByteBuffer();
-      vector.getDataBuffer()
-          .setBytes(idx, buffer.array(), buffer.position() + buffer.arrayOffset(), buffer.limit() - buffer.position());
+      vector.getDataBuffer().setBytes(idx, buffer);
     }
   }
 
@@ -134,8 +133,7 @@ public class VectorizedDictionaryEncodedParquetValuesReader extends BaseVectoriz
       System.arraycopy(decimalBytes, 0, vectorBytes, 0, typeWidth);
       ((DecimalVector) vector).setBigEndian(idx, vectorBytes);
       ByteBuffer buffer = dict.decodeToBinary(currentVal).toByteBuffer();
-      vector.getDataBuffer()
-          .setBytes(idx, buffer.array(), buffer.position() + buffer.arrayOffset(), buffer.limit() - buffer.position());
+      vector.getDataBuffer().setBytes(idx, buffer);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -415,8 +415,13 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
       int startOffset = ((BaseVariableWidthVector) vector).getStartOffset(idx);
       // It is possible that the data buffer was reallocated. So it is important to
       // not cache the data buffer reference but instead use vector.getDataBuffer().
-      vector.getDataBuffer().setBytes(startOffset, buffer.array(), buffer.position() + buffer.arrayOffset(),
-          buffer.limit() - buffer.position());
+      if (buffer.isDirect()) {
+        vector.getDataBuffer().setBytes(startOffset, buffer, buffer.position(),
+            buffer.limit() - buffer.position());
+      } else {
+        vector.getDataBuffer().setBytes(startOffset, buffer.array(), buffer.position() + buffer.arrayOffset(),
+            buffer.limit() - buffer.position());
+      }
       // Similarly, we need to get the latest reference to the validity buffer as well
       // since reallocation changes reference of the validity buffers as well.
       if (setArrowValidityVector) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -415,13 +415,9 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
       int startOffset = ((BaseVariableWidthVector) vector).getStartOffset(idx);
       // It is possible that the data buffer was reallocated. So it is important to
       // not cache the data buffer reference but instead use vector.getDataBuffer().
-      if (buffer.isDirect()) {
-        vector.getDataBuffer().setBytes(startOffset, buffer, buffer.position(),
-            buffer.limit() - buffer.position());
-      } else {
-        vector.getDataBuffer().setBytes(startOffset, buffer.array(), buffer.position() + buffer.arrayOffset(),
-            buffer.limit() - buffer.position());
-      }
+      vector.getDataBuffer().setBytes(startOffset, buffer, buffer.position(),
+          buffer.limit() - buffer.position());
+      buffer.arrayOffset();
       // Similarly, we need to get the latest reference to the validity buffer as well
       // since reallocation changes reference of the validity buffers as well.
       if (setArrowValidityVector) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -417,7 +417,6 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
       // not cache the data buffer reference but instead use vector.getDataBuffer().
       vector.getDataBuffer().setBytes(startOffset, buffer, buffer.position(),
           buffer.limit() - buffer.position());
-      buffer.arrayOffset();
       // Similarly, we need to get the latest reference to the validity buffer as well
       // since reallocation changes reference of the validity buffers as well.
       if (setArrowValidityVector) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -348,9 +348,7 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
             .nextBatch(vector, idx, numValuesToRead, dict, nullabilityHolder, typeWidth);
       } else if (Mode.PACKED.equals(mode)) {
         ByteBuffer buffer = dict.decodeToBinary(reader.readInteger()).toByteBuffer();
-        vector.getDataBuffer().setBytes(
-            (long) idx * typeWidth, buffer.array(),
-            buffer.position() + buffer.arrayOffset(), buffer.limit() - buffer.position());
+        vector.getDataBuffer().setBytes((long) idx * typeWidth, buffer);
       }
     }
   }
@@ -415,8 +413,7 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
       int startOffset = ((BaseVariableWidthVector) vector).getStartOffset(idx);
       // It is possible that the data buffer was reallocated. So it is important to
       // not cache the data buffer reference but instead use vector.getDataBuffer().
-      vector.getDataBuffer().setBytes(startOffset, buffer, buffer.position(),
-          buffer.limit() - buffer.position());
+      vector.getDataBuffer().setBytes(startOffset, buffer);
       // Similarly, we need to get the latest reference to the validity buffer as well
       // since reallocation changes reference of the validity buffers as well.
       if (setArrowValidityVector) {


### PR DESCRIPTION
Currently `VectorizedParquetDefinitionLevelReader` only works with `HeapByteBuffer`. When using off heap byte buffer, it throws Exception
```
org.apache.spark.SparkException: Job aborted due to stage failure: Task 0 in stage 5.0 failed 1 times, most recent failure: Lost task 0.0 in stage 5.0 (TID 5) (192.168.1.126 executor driver): java.lang.UnsupportedOperationException
	at java.base/java.nio.ByteBuffer.array(ByteBuffer.java:1049)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedParquetDefinitionLevelReader$VarWidthReader.nextVal(VectorizedParquetDefinitionLevelReader.java:418)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedParquetDefinitionLevelReader$BaseReader.nextBatch(VectorizedParquetDefinitionLevelReader.java:247)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedPageIterator$VarWidthTypePageReader.nextVal(VectorizedPageIterator.java:353)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedPageIterator$BagePageReader.nextBatch(VectorizedPageIterator.java:161)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedColumnIterator$VarWidthTypeBatchReader.nextBatchOf(VectorizedColumnIterator.java:191)
	at org.apache.iceberg.arrow.vectorized.parquet.VectorizedColumnIterator$BatchReader.nextBatch(VectorizedColumnIterator.java:74)
	at org.apache.iceberg.arrow.vectorized.VectorizedArrowReader.read(VectorizedArrowReader.java:151)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader$ColumnBatchLoader.readDataToColumnVectors(ColumnarBatchReader.java:101)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader$ColumnBatchLoader.loadDataToColumnBatch(ColumnarBatchReader.java:86)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader$ColumnBatchLoader.<init>(ColumnarBatchReader.java:81)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader.read(ColumnarBatchReader.java:69)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader.read(ColumnarBatchReader.java:44)
	at org.apache.iceberg.parquet.VectorizedParquetReader$FileIterator.next(VectorizedParquetReader.java:134)
	at org.apache.iceberg.spark.source.BaseDataReader.next(BaseDataReader.java:102)
	at org.apache.spark.sql.execution.datasources.v2.PartitionIterator.hasNext(DataSourceRDD.scala:93)
	at org.apache.spark.sql.execution.datasources.v2.MetricsIterator.hasNext(DataSourceRDD.scala:130)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.columnartorow_nextBatch_0$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.hasNext(WholeStageCodegenExec.scala:759)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anon$1.foreach(WholeStageCodegenExec.scala:757)
	at org.apache.spark.rdd.RDD.$anonfun$foreach$2(RDD.scala:1012)
	at org.apache.spark.rdd.RDD.$anonfun$foreach$2$adapted(RDD.scala:1012)
	at org.apache.spark.SparkContext.$anonfun$runJob$5(SparkContext.scala:2257)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:506)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1467)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:509)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```