### PR TITLE
AWS: add skip name validation to isValidIdentifier

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -63,6 +63,7 @@ public class GlueTestBase {
   // iceberg
   static GlueCatalog glueCatalog;
   static GlueCatalog glueCatalogWithSkip;
+  static GlueCatalog glueCatalogWithSkipNameValidation;
 
   static Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
   static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
@@ -84,6 +85,11 @@ public class GlueTestBase {
     properties.setGlueCatalogSkipArchive(true);
     glueCatalogWithSkip = new GlueCatalog();
     glueCatalogWithSkip.initialize(catalogName, testBucketPath, properties, glue,
+            LockManagers.defaultLockManager(), fileIO);
+    glueCatalogWithSkipNameValidation = new GlueCatalog();
+    AwsProperties propertiesSkipNameValidation = new AwsProperties();
+    propertiesSkipNameValidation.setGlueCatalogSkipNameValidation(true);
+    glueCatalogWithSkipNameValidation.initialize(catalogName, testBucketPath, propertiesSkipNameValidation, glue,
             LockManagers.defaultLockManager(), fileIO);
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -67,7 +67,6 @@ public class GlueTestBase {
 
   static Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
   static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
-
   // table location properties
   static final Map<String, String> tableLocationProperties = ImmutableMap.of(
       TableProperties.WRITE_DATA_LOCATION, "s3://" + testBucketName + "/writeDataLoc",

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -304,7 +304,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
     namespaces.add(namespace);
     glueCatalogWithSkipNameValidation.createNamespace(Namespace.of(namespace));
     String tableName = "cc-cc";
-    glueCatalogWithSkipNameValidation.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
+    glueCatalogWithSkipNameValidation.createTable(
+            TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
     GetTableResponse response = glue.getTable(GetTableRequest.builder()
             .databaseName(namespace).name(tableName).build());
     Assert.assertEquals(namespace, response.table().databaseName());

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -299,6 +299,19 @@ public class TestGlueCatalogTable extends GlueTestBase {
   }
 
   @Test
+  public void testCommitTableSkipNameValidation() {
+    String namespace = "dd-dd";
+    namespaces.add(namespace);
+    glueCatalogWithSkipNameValidation.createNamespace(Namespace.of(namespace));
+    String tableName = "cc-cc";
+    glueCatalogWithSkipNameValidation.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
+    GetTableResponse response = glue.getTable(GetTableRequest.builder()
+            .databaseName(namespace).name(tableName).build());
+    Assert.assertEquals(namespace, response.table().databaseName());
+    Assert.assertEquals(tableName, response.table().name());
+  }
+
+  @Test
   public void testColumnCommentsAndParameters() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -497,6 +497,10 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
+    if (awsProperties.glueCatalogSkipNameValidation()) {
+      return true;
+    }
+
     return IcebergToGlueConverter.isValidNamespace(tableIdentifier.namespace()) &&
         IcebergToGlueConverter.isValidTableName(tableIdentifier.name());
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -479,4 +479,13 @@ public class TestGlueCatalog {
     Assert.assertTrue(properties.containsKey("table-override.key4"));
     Assert.assertEquals("catalog-override-key4", properties.get("table-override.key4"));
   }
+
+  @Test
+  public void testValidateIdentifierSkipNameValidation() {
+    AwsProperties props = new AwsProperties();
+    props.setGlueCatalogSkipNameValidation(true);
+    glueCatalog.initialize(CATALOG_NAME, WAREHOUSE_PATH, props, glue,
+        LockManagers.defaultLockManager(), null);
+    Assert.assertEquals(glueCatalog.isValidIdentifier(TableIdentifier.parse("db-1.a-1")), true);
+  }
 }


### PR DESCRIPTION
augment to: https://github.com/apache/iceberg/pull/5041

integration test passed
```
> Task :iceberg-aws:integrationTest
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Created namespace: dd-dd
[Test worker] INFO org.apache.iceberg.BaseMetastoreCatalog - Table properties set at catalog level through catalog properties: {}
[Test worker] INFO org.apache.iceberg.BaseMetastoreCatalog - Table properties enforced at catalog level through catalog properties: {}
[Test worker] INFO org.apache.iceberg.BaseMetastoreTableOperations - Successfully committed to table glue.dd-dd.cc-cc in 1992 ms
BUILD SUCCESSFUL in 21s
14 actionable tasks: 1 executed, 13 up-to-date
2:54:01 PM: Execution finished ':iceberg-aws:integrationTest --tests "org.apache.iceberg.aws.glue.TestGlueCatalogTable.testCommitTableSkipNameValidation"'.
```