### PR TITLE
Include actual class name in class mismatch exception

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -119,7 +119,7 @@ class PartitionData
 
     throw new IllegalArgumentException(String.format(
         "Wrong class, %s, for object: %s",
-        javaClass.getName(), String.valueOf(value)));
+        javaClass.getName(), value));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -110,7 +110,6 @@ class PartitionData
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public <T> T get(int pos, Class<T> javaClass) {
     Object value = get(pos);
     if (value == null || javaClass.isInstance(value)) {

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -117,8 +117,8 @@ class PartitionData
     }
 
     throw new IllegalArgumentException(String.format(
-        "Wrong class, %s, for object: %s",
-        javaClass.getName(), value));
+        "Wrong class, expected %s, but was %s, for object: %s",
+        javaClass.getName(), value.getClass().getName(), value));
   }
 
   @Override


### PR DESCRIPTION
Include requested and actual class name in the exception message thrown
when `PartitionData` detects type mismatch.