### PR TITLE
Python: Add py.typed file for annotations

### DIFF
--- a/python/py.typed
+++ b/python/py.typed
@@ -1,0 +1,18 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+# Marker file for PEP 561


### PR DESCRIPTION
Otherwise, the type annotations won't be used by other libraries. And that would be a pity of course :)

For more info: https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/