### PR TITLE
Open-api: RenameTableRequest props are required

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -869,6 +869,9 @@ components:
 
     RenameTableRequest:
       type: object
+      required:
+        - source
+        - destination
       properties:
         source:
           $ref: '#/components/schemas/TableIdentifier'


### PR DESCRIPTION
Currently, the properties are optional, which doesn't really make sense.

Also, in the Java code it throws an exception:
https://github.com/apache/iceberg/blob/master/core/src/test/java/org/apache/iceberg/rest/requests/TestRenameTableRequest.java#L106-L121

Therefore I would suggest making those required in the spec as well