### PR TITLE
Add interface for FileIO prefix operations and implementations 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileInfo.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.time.Instant;
+
+public class FileInfo {
+  private final String location;
+  private final long size;
+  private final Instant created;
+
+  public FileInfo(String location, long size, Instant created) {
+    this.location = location;
+    this.size = size;
+    this.created = created;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public Instant getCreated() {
+    return created;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/SupportsPrefixOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsPrefixOperations.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.stream.Stream;
+
+/**
+ * This interface is intended as an extension for FileIO implementations
+ * to provide additional prefix based operations that may be useful in
+ * performing supporting operations.
+ */
+public interface SupportsPrefixOperations {
+
+  /**
+   * Return a stream of all files under a prefix.
+   *
+   * Hierarchical file systems (e.g. HDFS) may impose additional restrictions
+   * like the prefix mush fully match a directory whereas key/value object
+   * stores may allow for arbitrary prefixes.
+   *
+   * @param prefix prefix to list
+   * @return stream of file information
+   */
+  Stream<FileInfo> listPrefix(String prefix);
+
+  /**
+   * Delete all files under a prefix.
+   *
+   * Hierarchical file systems (e.g. HDFS) may impose additional restrictions
+   * like the prefix mush fully match a directory whereas key/value object
+   * stores may allow for arbitrary prefixes.
+   *
+   * @param prefix prefix to delete
+   */
+  void deletePrefix(String prefix);
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Random;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class HadoopFileIOTest {
+  private final Random random = new Random(1);
+
+  private FileSystem fs;
+  private HadoopFileIO hadoopFileIO;
+
+  @TempDir
+  static File tempDir;
+
+  @BeforeEach
+  public void before() throws Exception {
+    Configuration conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+
+    hadoopFileIO = new HadoopFileIO(conf);
+  }
+
+  @Test
+  public void testListPrefix() {
+    Path parent = new Path(tempDir.toURI());
+
+    List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
+
+    scaleSizes.parallelStream().forEach(scale -> {
+      Path scalePath = new Path(parent, Integer.toString(scale));
+
+      createRandomFiles(scalePath, scale);
+      assertEquals((long) scale, hadoopFileIO.listPrefix(scalePath.toUri().toString()).count());
+    });
+
+    long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
+    assertEquals(totalFiles, hadoopFileIO.listPrefix(parent.toUri().toString()).count());
+  }
+
+  @Test
+  public void testDeletePrefix() {
+    Path parent = new Path(tempDir.toURI());
+
+    List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
+
+    scaleSizes.parallelStream().forEach(scale -> {
+      Path scalePath = new Path(parent, Integer.toString(scale));
+
+      createRandomFiles(scalePath, scale);
+      hadoopFileIO.deletePrefix(scalePath.toUri().toString());
+
+      // Hadoop filesystem will throw if the path does not exist
+      assertThrows(UncheckedIOException.class, () -> hadoopFileIO.listPrefix(scalePath.toUri().toString()));
+    });
+
+    hadoopFileIO.deletePrefix(parent.toUri().toString());
+    // Hadoop filesystem will throw if the path does not exist
+    assertThrows(UncheckedIOException.class, () -> hadoopFileIO.listPrefix(parent.toUri().toString()));
+  }
+
+  private void createRandomFiles(Path parent, int count) {
+    random.ints(count).parallel().forEach(i -> {
+          try {
+            fs.createNewFile(new Path(parent, "file-" + i));
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        }
+    );
+  }
+}


### PR DESCRIPTION
This adds an interface for FileIO implementations to support prefix based operations for listing and deleting.

The primary motivation is to enable supporting maintenance activities (like cleaning path directories or listing table locations) without the need to fall back to Hadoop FileSystem. 

There are some notable behavioral differences between directory based and object based storage systems (e.g. for directory based storage, a the prefix must denote a directory).  