### PR TITLE
[WIP] Migrate Delta Lake tables to Iceberg

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/BaseMigrateDeltaLakeTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/BaseMigrateDeltaLakeTable.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.Map;
+
+/**
+ * Migrates a Delta Lake table to Iceberg format.
+ */
+public interface BaseMigrateDeltaLakeTable extends Action<BaseMigrateDeltaLakeTable, BaseMigrateDeltaLakeTable.Result> {
+
+  BaseMigrateDeltaLakeTable tableProperties(Map<String, String> properties);
+
+  interface Result {
+
+    boolean success();
+  }
+}


### PR DESCRIPTION
Work is in progress, but putting this out here for general feedback.

The idea will be to leverage the [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) library, rather than the DeltaCatalog, to read schema/partitioning/table metadata from the existing Delta Lake table. This simplifies the experience as users won't need to configure both a Delta Lake and Iceberg catalog as well as specify the mapping thereof.

A new action will be created to decouple the code behind this from the existing `migrate` action, which makes lots of assumptions about the incoming/exported catalog and relies on the `SparkSessionCatalog` to retrieve metadata about the state of the source table.