### PR TITLE
Spark: Remove Usage of Sets.Union in Loop

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -74,8 +74,8 @@ public class RewriteDataFilesCommitManager {
     Set<DataFile> rewrittenDataFiles = Sets.newHashSet();
     Set<DataFile> addedDataFiles = Sets.newHashSet();
     for (RewriteFileGroup group : fileGroups) {
-      rewrittenDataFiles = Sets.union(rewrittenDataFiles, group.rewrittenFiles());
-      addedDataFiles = Sets.union(addedDataFiles, group.addedFiles());
+      rewrittenDataFiles.addAll(group.rewrittenFiles());
+      addedDataFiles.addAll(group.addedFiles());
     }
 
     RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);


### PR DESCRIPTION
Previously the repeated calls to union could create a very
large stack depth since each call ends up creating a view. This can lead
to StackOverflow issues with very large compaction jobs.