### PR TITLE
Python: Add flake8-comprehensions

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -60,4 +60,4 @@ repos:
     hooks:
       - id: flake8
         args: [ "--ignore=E501,W503,E203" ]
-        additional_dependencies: [ flake8-bugbear==22.4.25 ]
+        additional_dependencies: [ flake8-bugbear==22.4.25, flake8-comprehensions==3.10.0 ]

--- a/python/src/iceberg/table/partitioning.py
+++ b/python/src/iceberg/table/partitioning.py
@@ -64,7 +64,7 @@ class PartitionSpec:
     source_id_to_fields_map: Dict[int, List[PartitionField]] = field(init=False, repr=False)
 
     def __post_init__(self):
-        source_id_to_fields_map = dict()
+        source_id_to_fields_map = {}
         for partition_field in self.fields:
             source_column = self.schema.find_column_name(partition_field.source_id)
             if not source_column:

--- a/python/src/iceberg/utils/bin_packing.py
+++ b/python/src/iceberg/utils/bin_packing.py
@@ -23,7 +23,7 @@ class PackingIterator:
         self.lookback = lookback
         self.weight_func = weight_func
         self.largest_bin_first = largest_bin_first
-        self.bins = list()
+        self.bins = []
 
     def __iter__(self):
         return self
@@ -69,7 +69,7 @@ class PackingIterator:
         def __init__(self, target_weight: int):
             self.bin_weight = 0
             self.target_weight = target_weight
-            self.items: list = list()
+            self.items: list = []
 
         def weight(self) -> int:
             return self.bin_weight

--- a/python/tests/table/test_partitioning.py
+++ b/python/tests/table/test_partitioning.py
@@ -66,7 +66,7 @@ def test_partition_compatible_with(table_schema_simple: Schema):
 
 
 def test_unpartitioned(table_schema_simple: Schema):
-    unpartitioned = PartitionSpec(table_schema_simple, 1, tuple(), 1000)
+    unpartitioned = PartitionSpec(table_schema_simple, 1, (), 1000)
 
     assert not unpartitioned.fields
     assert unpartitioned.is_unpartitioned()

--- a/python/tests/utils/test_bin_packing.py
+++ b/python/tests/utils/test_bin_packing.py
@@ -80,4 +80,4 @@ def test_bin_packing_lookback(splits, target_weight, lookback, largest_bin_first
     def weight_func(x):
         return x
 
-    assert [item for item in PackingIterator(splits, target_weight, lookback, weight_func, largest_bin_first)] == expected_lists
+    assert list(PackingIterator(splits, target_weight, lookback, weight_func, largest_bin_first)) == expected_lists


### PR DESCRIPTION
It’s slower to call e.g. `dict()` than using the empty literal `{}`, because the name `dict` must be looked up in the global scope in case it has been rebound.