### PR TITLE
Spark: Validate HMS uri in SparkSessionCatalog

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -290,8 +290,7 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
     }
 
     Preconditions.checkArgument(catalogHmsUri.equals(envHmsUri),
-        "The environment Hive metastore uri(%s) doesn't match with Spark session catalog uri(%s). " +
-            "Please make sure they are the same, or keep a valid one and unset the other.",
+        "Inconsistent Hive metastore URIs: %s (Spark session) != %s (spark_catalog)",
         envHmsUri, catalogHmsUri);
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark;
 
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -43,8 +44,6 @@ import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
-
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 
 /**
  * A Spark catalog that can also load non-Iceberg tables.
@@ -285,7 +284,7 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
     }
 
     Configuration conf = SparkSession.active().sessionState().newHadoopConf();
-    String envHmsUri = conf.get(METASTOREURIS.varname, null);
+    String envHmsUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, null);
     if (envHmsUri == null) {
       return;
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -42,9 +42,14 @@ public class TestSparkSessionCatalog extends SparkTestBase {
 
     // HMS uris doesn't match
     spark.sessionState().catalogManager().reset();
+    String catalogHmsUri = "RandomString";
     spark.conf().set(envHmsUriKey, hmsUri);
-    spark.conf().set(catalogHmsUriKey, "RandomString");
-    Assert.assertThrows(IllegalArgumentException.class, () -> spark.sessionState().catalogManager().v2SessionCatalog());
+    spark.conf().set(catalogHmsUriKey, catalogHmsUri);
+    IllegalArgumentException exception = Assert.assertThrows(IllegalArgumentException.class,
+        () -> spark.sessionState().catalogManager().v2SessionCatalog());
+    String errorMessage = String.format("Inconsistent Hive metastore URIs: %s (Spark session) != %s (spark_catalog)",
+        hmsUri, catalogHmsUri);
+    Assert.assertEquals(errorMessage, exception.getMessage());
 
     // no env HMS uri, only catalog HMS uri
     spark.sessionState().catalogManager().reset();

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+
+public class TestSparkSessionCatalog extends SparkTestBase {
+  @Test
+  public void testValidateHmsUri() {
+    String envHmsUriKey = "spark.hadoop." + METASTOREURIS.varname;
+    String catalogHmsUriKey = "spark.sql.catalog.spark_catalog.uri";
+    String hmsUri = hiveConf.get(METASTOREURIS.varname);
+
+    spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
+    spark.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
+
+    // HMS uris match
+    spark.sessionState().catalogManager().reset();
+    spark.conf().set(envHmsUriKey, hmsUri);
+    spark.conf().set(catalogHmsUriKey, hmsUri);
+    Assert.assertTrue(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0].equals("default"));
+
+    // HMS uris doesn't match
+    spark.sessionState().catalogManager().reset();
+    spark.conf().set(envHmsUriKey, hmsUri);
+    spark.conf().set(catalogHmsUriKey, "RandomString");
+    Assert.assertThrows(IllegalArgumentException.class, () -> spark.sessionState().catalogManager().v2SessionCatalog());
+
+    // no env HMS uri, only catalog HMS uri
+    spark.sessionState().catalogManager().reset();
+    spark.conf().set(catalogHmsUriKey, hmsUri);
+    spark.conf().unset(envHmsUriKey);
+    Assert.assertTrue(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0].equals("default"));
+
+    // no catalog HMS uri, only env HMS uri
+    spark.sessionState().catalogManager().reset();
+    spark.conf().set(envHmsUriKey, hmsUri);
+    spark.conf().unset(catalogHmsUriKey);
+    Assert.assertTrue(spark.sessionState().catalogManager().v2SessionCatalog().defaultNamespace()[0].equals("default"));
+  }
+}


### PR DESCRIPTION
To close https://github.com/apache/iceberg/issues/2488. Open a new PR since #3126 isn't active for a while.
All comments in #3126 are resolved. Please take a look. @RussellSpitzer @rdblue @kbendick @szehon-ho @karuppayya @aokolnychyi 
