### PR TITLE
Spark: Add compute stats to scan builder also

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -39,14 +39,18 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
+public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns,
+    SupportsReportStatistics {
+
   private static final Filter[] NO_FILTERS = new Filter[0];
 
   private final SparkSession spark;
@@ -166,5 +170,15 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     return new SparkMergeScan(
         spark, table, readConf, caseSensitive, ignoreResiduals,
         schemaWithMetadataColumns(), filterExpressions, options);
+  }
+
+  @Override
+  public Statistics estimateStatistics() {
+    return ((SparkBatchScan) build()).estimateStatistics();
+  }
+
+  @Override
+  public StructType readSchema() {
+    return build().readSchema();
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -39,14 +39,18 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
+public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns,
+    SupportsReportStatistics {
+
   private static final Filter[] NO_FILTERS = new Filter[0];
 
   private final SparkSession spark;
@@ -166,5 +170,15 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     return new SparkMergeScan(
         spark, table, readConf, caseSensitive, ignoreResiduals,
         schemaWithMetadataColumns(), filterExpressions, options);
+  }
+
+  @Override
+  public Statistics estimateStatistics() {
+    return ((SparkBatchScan) build()).estimateStatistics();
+  }
+
+  @Override
+  public StructType readSchema() {
+    return build().readSchema();
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -44,14 +44,18 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns {
+public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, SupportsPushDownRequiredColumns,
+    SupportsReportStatistics {
+
   private static final Filter[] NO_FILTERS = new Filter[0];
 
   private final SparkSession spark;
@@ -277,5 +281,15 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     }
 
     return configuredScan;
+  }
+
+  @Override
+  public Statistics estimateStatistics() {
+    return ((SparkScan) build()).estimateStatistics();
+  }
+
+  @Override
+  public StructType readSchema() {
+    return build().readSchema();
   }
 }


### PR DESCRIPTION
This PR adds implementing the `SupportsReportStatistics` interface to the Spark v3.x scan builder classes. In Spark's `DataSourceV2Relation.computeStats()`, there is a [case that checks](https://github.com/apache/spark/blob/61dc08da34a405a61a77b0e173bf22bb9f11bcfd/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala#L83) if the scan builder implements `SupportsReportStatistics`, which currently is not implemented. This causes stats to fall back to `conf.defaultSizeInBytes`. With this change, stats are reported correctly, which allows systems such as EMR to properly apply optimizations such as join reordering.

Note that the case was [recently updated](https://github.com/apache/spark/blob/691b9c70bcaddf494e98617348dd18debd68cadf/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala#L83) in Spark to explicitly call `build()` on the builder, so this won't be needed in future versions of Spark (but appears to still be needed for v3.3 currently).