### PR TITLE
Arrow: Avoid extra dictionary buffer copy

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -70,6 +70,10 @@ final class ArrowVectorAccessors {
 
     @Override
     public String ofByteBuffer(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return new String(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(),
+                byteBuffer.remaining(), StandardCharsets.UTF_8);
+      }
       return StandardCharsets.UTF_8.decode(byteBuffer).toString();
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -72,7 +72,7 @@ final class ArrowVectorAccessors {
     public String ofByteBuffer(ByteBuffer byteBuffer) {
       if (byteBuffer.hasArray()) {
         return new String(byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(),
-                byteBuffer.remaining(), StandardCharsets.UTF_8);
+            byteBuffer.remaining(), StandardCharsets.UTF_8);
       }
       return StandardCharsets.UTF_8.decode(byteBuffer).toString();
     }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.arrow.vectorized;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 import org.apache.arrow.vector.VarCharVector;
@@ -65,6 +66,11 @@ final class ArrowVectorAccessors {
     @Override
     public String ofBytes(byte[] bytes) {
       return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public String ofByteBuffer(ByteBuffer byteBuffer) {
+      return StandardCharsets.UTF_8.decode(byteBuffer).toString();
     }
   }
 }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -84,7 +84,7 @@ final class ArrowVectorAccessorFactory
     public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
       if (byteBuffer.hasArray()) {
         return UTF8String.fromBytes(
-                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+            byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
       }
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -76,6 +77,17 @@ final class ArrowVectorAccessorFactory
 
     @Override
     public UTF8String ofBytes(byte[] bytes) {
+      return UTF8String.fromBytes(bytes);
+    }
+
+    @Override
+    public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return UTF8String.fromBytes(
+                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+      }
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
       return UTF8String.fromBytes(bytes);
     }
   }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -84,7 +84,7 @@ final class ArrowVectorAccessorFactory
     public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
       if (byteBuffer.hasArray()) {
         return UTF8String.fromBytes(
-                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+            byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
       }
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -76,6 +77,17 @@ final class ArrowVectorAccessorFactory
 
     @Override
     public UTF8String ofBytes(byte[] bytes) {
+      return UTF8String.fromBytes(bytes);
+    }
+
+    @Override
+    public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return UTF8String.fromBytes(
+                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+      }
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
       return UTF8String.fromBytes(bytes);
     }
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -84,7 +84,7 @@ final class ArrowVectorAccessorFactory
     public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
       if (byteBuffer.hasArray()) {
         return UTF8String.fromBytes(
-                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+            byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
       }
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -76,6 +77,17 @@ final class ArrowVectorAccessorFactory
 
     @Override
     public UTF8String ofBytes(byte[] bytes) {
+      return UTF8String.fromBytes(bytes);
+    }
+
+    @Override
+    public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return UTF8String.fromBytes(
+                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+      }
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
       return UTF8String.fromBytes(bytes);
     }
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -84,7 +84,7 @@ final class ArrowVectorAccessorFactory
     public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
       if (byteBuffer.hasArray()) {
         return UTF8String.fromBytes(
-                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+            byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
       }
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessorFactory.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
@@ -76,6 +77,17 @@ final class ArrowVectorAccessorFactory
 
     @Override
     public UTF8String ofBytes(byte[] bytes) {
+      return UTF8String.fromBytes(bytes);
+    }
+
+    @Override
+    public UTF8String ofByteBuffer(ByteBuffer byteBuffer) {
+      if (byteBuffer.hasArray()) {
+        return UTF8String.fromBytes(
+                byteBuffer.array(), byteBuffer.arrayOffset() + byteBuffer.position(), byteBuffer.remaining());
+      }
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
       return UTF8String.fromBytes(bytes);
     }
   }


### PR DESCRIPTION
This PR changes the dictionary value accessors in the vectorized parquet reader so that the dictionary values are read from the underlying dictionary directly, rather than copying the values into a new buffer where relevant (this was already being done in the dictionary decimal accessor classes). The underlying parquet dictionary classes already load the values into a buffer, so copying them to a new buffer appears redundant in some cases.

This PR also makes a couple of changes to avoid binary buffer copies when building string values when possible.

In very limited testing, this shows a performance gain of over 20% in vectorized read performance in some scenarios, though more testing would be required to get more accurate metrics.