### PR TITLE
Spark: fix regression from scan refactor

### DIFF
--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -1147,7 +1147,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
       checkExpirationResults(1L, 0L, 0L, 1L, 2L, results);
 
       Assert.assertEquals("Expected total number of jobs with stream-results should match the expected number",
-          5L, jobsRunDuringStreamResults);
+          4L, jobsRunDuringStreamResults);
     });
   }
 }


### PR DESCRIPTION
A performance regression was introduced with the refactoring of the Spark batch classes. One problem that surfaced was that `BatchScanExec` does an equality check on the batch object. However with the refactoring, a new batch object was created for each call to `toBatch()` so the equality check returned false for the same scan instance (because the batch objects were different). The end result is that filters weren't being pushed down in some cases.

Creating only one batch object per scan partially fixed the performance problems, but other issues remained. So this PR makes the scan class implement the Batch interface as before the refactor, for now, until all of the issues can be addressed.