### PR TITLE
Core - Update JavaDoc for CreateTableRequest

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
@@ -33,7 +33,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RESTRequest;
 
 /**
- * A REST request to create a namespace, with an optional set of properties.
+ * A REST request to create a table, either via direct commit or staging the creation
+ * of the table as part of a transaction.
  */
 public class CreateTableRequest implements RESTRequest {
 


### PR DESCRIPTION
The JavaDoc for `CreateTableRequest` appears to be copied over from the `CreateNamespaceRequest` class.

Updating it to reflect `CreateTableRequest` instead.