### PR TITLE
Docs: Add reference to Apache Impala documentation

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -22,7 +22,7 @@ weight: 0
 
 ![Iceberg](./img/Iceberg-logo.png)
 
-**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink and Hive using a high-performance table format that works just like a SQL table.
+**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink, Hive and Impala using a high-performance table format that works just like a SQL table.
 
 ### User experience
 
@@ -52,4 +52,3 @@ Iceberg was designed to solve correctness problems in eventually-consistent clou
 Iceberg has been designed and developed to be an open community standard with a [specification](../../spec) to ensure compatibility across languages and implementations.
 
 [Apache Iceberg is open source](../../community), and is developed at the [Apache Software Foundation](https://www.apache.org/).
-


### PR DESCRIPTION
This brings over the change to this page in iceberg-docs from [this](https://github.com/apache/iceberg-docs/pull/94/files#diff-5d9ba8bc1a568741b44ccc852748ca739d71f89dc1ac05a9f8d3787a064a549d) PR. This file is pending removal from iceberg-docs and going forward will only be source controlled here in the iceberg repo.