### PR TITLE
StreamingDelete becomes public class

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.expressions.Expression;
  * <p>
  * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
  */
-class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
+public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
   StreamingDelete(String tableName, TableOperations ops) {
     super(tableName, ops);
   }


### PR DESCRIPTION
Make `StreamingDelete` a public class so that it can be used on packages outside of `org.apache.iceberg`.

This is useful for whenever users want to subclass the default implementation for monitoring or to add custom snapshot properties.