### PR TITLE
Python: Make the VoidTransform a singleton

### DIFF
--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -41,6 +41,7 @@ from iceberg.types import (
 )
 from iceberg.utils import datetime
 from iceberg.utils.decimal import decimal_to_bytes
+from src.iceberg.utils.singleton import Singleton
 
 S = TypeVar("S")
 T = TypeVar("T")
@@ -328,15 +329,8 @@ class UnknownTransform(Transform):
         return StringType()
 
 
-class VoidTransform(Transform):
+class VoidTransform(Transform, Singleton):
     """A transform that always returns None"""
-
-    _instance = None
-
-    def __new__(cls):  # pylint: disable=W0221
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
 
     def __init__(self):
         super().__init__("void", "transforms.always_null()")

--- a/python/tests/utils/test_singleton.py
+++ b/python/tests/utils/test_singleton.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from iceberg.avro.reader import BooleanReader, FixedReader
+from src.iceberg.transforms import VoidTransform
 
 
 def test_singleton():
@@ -22,3 +23,8 @@ def test_singleton():
     assert id(BooleanReader()) == id(BooleanReader())
     assert id(FixedReader(22)) == id(FixedReader(22))
     assert id(FixedReader(19)) != id(FixedReader(25))
+
+
+def test_singleton_transform():
+    """We want to reuse VoidTransform since it doesn't carry any state"""
+    assert id(VoidTransform()) == id(VoidTransform())


### PR DESCRIPTION
We want to reuse VoidTransform since it doesn't carry any state