### PR TITLE
Spec: Add string ↔ binary promotion

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -218,6 +218,8 @@ Valid type promotions are:
 * `int` to `long`
 * `float` to `double`
 * `decimal(P, S)` to `decimal(P', S)` if `P' > P` -- widen the precision of decimal types.
+* `bytes` to `string`
+* `string` to `bytes`
 
 Any struct, including a top-level schema, can evolve through deleting fields, adding new fields, renaming existing fields, reordering existing fields, or promoting a primitive using the valid type promotions. Adding a new field assigns a new ID for that field and for any nested fields. Renaming an existing field must change the name, but not the field ID. Deleting a field removes it from the current schema. Field deletion cannot be rolled back unless the field was nullable or if the current snapshot has not changed.
 

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -23,6 +23,7 @@ import mmh3 as mmh3
 import pytest
 
 from iceberg import transforms
+from iceberg.transforms import BucketBytesTransform, BucketStringTransform
 from iceberg.types import (
     BinaryType,
     BooleanType,
@@ -199,3 +200,11 @@ def test_void_transform():
     assert not void_transform.satisfies_order_of(transforms.bucket(DateType(), 100))
     assert void_transform.to_human_string("test") == "null"
     assert void_transform.dedup_name == "void"
+
+
+def test_string_and_binary_equal_hashcode():
+    """The hash of the string and the raw bytes should be equal"""
+    input_string = "iceberg"
+    lhs = BucketStringTransform(100).hash(input_string)
+    rhs = BucketBytesTransform(BinaryType(), 100).hash(input_string.encode())
+    assert lhs == rhs


### PR DESCRIPTION
Inspired by Avro and Ryan: https://github.com/apache/iceberg/pull/5116#discussion_r907858442

<img width="1330" alt="Screenshot 2022-06-28 at 22 02 50" src="https://user-images.githubusercontent.com/1134248/176274565-bfa8e8a6-5e9e-455e-8822-cdbc1b39273e.png">

By promoting string to bytes back and forth, we can just read the string as bytes. I've added a test for Python, to make sure that the hashing functions are equal. It might be a bit overkill, but just to make sure. I don't think this is necessary for Java since it is already tested: https://github.com/apache/iceberg/blob/master/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java#L207-L216

