### PR TITLE
Spark 3.3: [FOLLOW UP] Support AS OF SPARK SQL syntax for TimeTravel E2E

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
@@ -161,9 +162,9 @@ public class SparkCatalog extends BaseCatalog {
   public SparkTable loadTable(Identifier ident, long timestamp) throws NoSuchTableException {
     try {
       Pair<Table, Long> icebergTable = load(ident);
-      // spark returns timestamp in nano seconds precision, convert it to milliseconds,
+      // spark returns timestamp in micro seconds precision, convert it to milliseconds,
       // as iceberg snapshot's are stored in millisecond precision.
-      long timestampMillis = timestamp / 1000_000;
+      long timestampMillis = TimeUnit.MICROSECONDS.toMillis(timestamp);
       Preconditions.checkArgument(icebergTable.second() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
       long snapshotIdAsOfTime = SnapshotUtil.snapshotIdAsOfTime(icebergTable.first(), timestampMillis);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -161,9 +161,12 @@ public class SparkCatalog extends BaseCatalog {
   public SparkTable loadTable(Identifier ident, long timestamp) throws NoSuchTableException {
     try {
       Pair<Table, Long> icebergTable = load(ident);
+      // spark returns timestamp in nano seconds precision, convert it to milliseconds,
+      // as iceberg snapshot's are stored in millisecond precision.
+      long timestampMillis = timestamp / 1000_000;
       Preconditions.checkArgument(icebergTable.second() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
-      long snapshotIdAsOfTime = SnapshotUtil.snapshotIdAsOfTime(icebergTable.first(), timestamp);
+      long snapshotIdAsOfTime = SnapshotUtil.snapshotIdAsOfTime(icebergTable.first(), timestampMillis);
       return new SparkTable(icebergTable.first(), snapshotIdAsOfTime, !cacheEnabled);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -137,6 +137,24 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
   }
 
   @Override
+  public Table loadTable(Identifier ident, String version) throws NoSuchTableException {
+    try {
+      return icebergCatalog.loadTable(ident, version);
+    } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
+      return getSessionCatalog().loadTable(ident, version);
+    }
+  }
+
+  @Override
+  public Table loadTable(Identifier ident, long timestamp) throws NoSuchTableException {
+    try {
+      return icebergCatalog.loadTable(ident, timestamp);
+    } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
+      return getSessionCatalog().loadTable(ident, timestamp);
+    }
+  }
+
+  @Override
   public void invalidateTable(Identifier ident) {
     // We do not need to check whether the table exists and whether
     // it is an Iceberg table to reduce remote service requests.

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -21,12 +21,14 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.PathIdentifier;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
@@ -162,6 +164,16 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
   @Override
   public String extractCatalog(CaseInsensitiveStringMap options) {
     return catalogAndIdentifier(options).catalog().name();
+  }
+
+  @Override
+  public Optional<String> extractTimeTravelVersion(CaseInsensitiveStringMap options) {
+    return Optional.ofNullable(PropertyUtil.propertyAsString(options, "versionAsOf", null));
+  }
+
+  @Override
+  public Optional<String> extractTimeTravelTimestamp(CaseInsensitiveStringMap options) {
+    return Optional.ofNullable(PropertyUtil.propertyAsString(options, "timestampAsOf", null));
   }
 
   private static Long propertyAsLong(CaseInsensitiveStringMap options, String property) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -19,8 +19,11 @@
 
 package org.apache.iceberg.spark.sql;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
@@ -192,22 +195,64 @@ public class TestSelect extends SparkCatalogTestBase {
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
 
     // read the table at the snapshot
-    List<Object[]> actual = sql("SELECT * FROM %s VERSION AS OF %s", tableName, snapshotId);
-    assertEquals("Snapshot at specific ID", expected, actual);
+    List<Object[]> actual1 = sql("SELECT * FROM %s VERSION AS OF %s", tableName, snapshotId);
+    assertEquals("Snapshot at specific ID", expected, actual1);
+
+    // read the table at the snapshot
+    // HIVE time travel syntax
+    List<Object[]> actual2 = sql("SELECT * FROM %s FOR SYSTEM_VERSION AS OF %s", tableName, snapshotId);
+    assertEquals("Snapshot at specific ID", expected, actual2);
+
+    // read the table using DataFrameReader option: versionAsOf
+    Dataset<Row> df = spark.read()
+        .format("iceberg")
+        .option("versionAsOf", snapshotId)
+        .load(tableName);
+    List<Object[]> fromDF = rowsToJava(df.collectAsList());
+    assertEquals("Snapshot at specific ID " + snapshotId, expected, fromDF);
   }
 
   @Test
   public void testTimestampAsOf() {
     long snapshotTs = validationCatalog.loadTable(tableIdent).currentSnapshot().timestampMillis();
-    long timestamp = waitUntilAfter(snapshotTs + 2);
+    long timestamp = waitUntilAfter(snapshotTs + 1000);
+    waitUntilAfter(timestamp + 1000);
+    // AS OF expects the timestamp if given in long format will be of seconds precision
+    long timestampInSeconds = TimeUnit.MILLISECONDS.toSeconds(timestamp);
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    String formattedDate = sdf.format(new Date(timestamp));
+
     List<Object[]> expected = sql("SELECT * FROM %s", tableName);
 
     // create a second snapshot
     sql("INSERT INTO %s VALUES (4, 'd', 4.0), (5, 'e', 5.0)", tableName);
 
-    // read the table at the snapshot
-    List<Object[]> actual = sql("SELECT * FROM %s TIMESTAMP AS OF %s", tableName, timestamp);
-    assertEquals("Snapshot at timestamp", expected, actual);
+    // read the table at the timestamp in long format i.e 1656507980463.
+    List<Object[]> actualWithLongFormat = sql("SELECT * FROM %s TIMESTAMP AS OF %s", tableName, timestampInSeconds);
+    assertEquals("Snapshot at timestamp", expected, actualWithLongFormat);
+
+    // read the table at the timestamp in date format i.e 2022-06-29 18:40:37
+    List<Object[]> actualWithDateFormat = sql("SELECT * FROM %s TIMESTAMP AS OF '%s'", tableName, formattedDate);
+    assertEquals("Snapshot at timestamp", expected, actualWithDateFormat);
+
+    // HIVE time travel syntax
+    // read the table at the timestamp in long format i.e 1656507980463.
+    List<Object[]> actualWithLongFormatInHiveSyntax = sql("SELECT * FROM %s FOR SYSTEM_TIME AS OF %s", tableName,
+        timestampInSeconds);
+    assertEquals("Snapshot at specific ID", expected, actualWithLongFormatInHiveSyntax);
+
+    // read the table at the timestamp in date format i.e 2022-06-29 18:40:37
+    List<Object[]> actualWithDateFormatInHiveSyntax = sql("SELECT * FROM %s FOR SYSTEM_TIME AS OF '%s'", tableName,
+        formattedDate);
+    assertEquals("Snapshot at specific ID", expected, actualWithDateFormatInHiveSyntax);
+
+    // read the table using DataFrameReader option
+    Dataset<Row> df = spark.read()
+        .format("iceberg")
+        .option("timestampAsOf", formattedDate)
+        .load(tableName);
+    List<Object[]> fromDF = rowsToJava(df.collectAsList());
+    assertEquals("Snapshot at timestamp " + timestamp, expected, fromDF);
   }
 
   @Test


### PR DESCRIPTION
Closes : 
1. https://github.com/apache/iceberg/issues/4365
2. https://github.com/apache/iceberg/issues/1405
3. https://github.com/apache/iceberg/issues/2618

---- 

### About the Changes : 
1. Make SparkSession Catalog implement newly introduced Catalog methods
2. respect newly added data frame reader options via SupportsCatalogOptions
3. Adapt the timestamp precision returned by spark to iceberg requirements.

P.S This change would not have been possible without the awesome work done by @huaxingao in spark to [support AS OF grammar in spark](https://issues.apache.org/jira/browse/SPARK-37219) natively. 

---- 

### Testing : 

Added new UT's 

----


cc @rdblue, @aokolnychyi , @RussellSpitzer , @jackye1995 , @huaxingao , @flyrain 
