### PR TITLE
Drop table's root folder if the table owns it

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -345,4 +345,11 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  /**
+   * Table properties to be used when dropping a table. Contains a list of locations that are owned
+   * by the table and should also be dropped.
+   */
+  public static final String LOCATIONS_OWNED_BY_TABLE = "locations-owned-by-table";
+  public static final String LOCATIONS_OWNED_BY_TABLE_DEFAULT = null;
 }


### PR DESCRIPTION
Introducing a new Catalog level flag to indicate whether dropping a
table from HiveCatalog should also drop the whole location of the
table.

Testing:
  - Created a new test that verifies that the location of the table
    exists or not based on how the new flag is set.
  - Manually loaded the changed jars into Apache Impala and checked
    that setting the new flag will result the table location being
    dropped.