### PR TITLE
Spark 3.3: [FOLLOWUP] Add TODO for TimeTravel via DataframeReader using timestamp in seconds and CatalogOptions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -88,8 +88,4 @@ public class DateTimeUtil {
   public static String formatTimestampMillis(long millis) {
     return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC));
   }
-
-  public static String formatTimestampMillisWithLocalTime(long millis) {
-    return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.systemDefault()));
-  }
 }

--- a/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -88,4 +88,8 @@ public class DateTimeUtil {
   public static String formatTimestampMillis(long millis) {
     return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC));
   }
+
+  public static String formatTimestampMillisWithLocalTime(long millis) {
+    return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.systemDefault()));
+  }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -28,7 +28,6 @@ import org.apache.iceberg.spark.PathIdentifier;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSessionCatalog;
-import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -174,19 +173,9 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
 
   @Override
   public Optional<String> extractTimeTravelTimestamp(CaseInsensitiveStringMap options) {
-    String timestampAsOf = PropertyUtil.propertyAsString(options, "timestampAsOf", null);
-    if (timestampAsOf == null) {
-      return Optional.empty();
-    }
-
-    try {
-      // timestamp provided should be at a seconds precision.
-      // TODO: remove once https://issues.apache.org/jira/browse/SPARK-39633 is resolved
-      long timestampAsOfAsLong = Long.parseLong(timestampAsOf);
-      return Optional.of(DateTimeUtil.formatTimestampMillisWithLocalTime(timestampAsOfAsLong * 1000));
-    } catch (NumberFormatException numberFormatException) {
-      return Optional.of(timestampAsOf);
-    }
+    // TODO: presently specifying timestamp in seconds for time-travel in not supported in dataframe reader,
+    //  remove when https://issues.apache.org/jira/browse/SPARK-39633 is available.
+    return Optional.ofNullable(PropertyUtil.propertyAsString(options, "timestampAsOf", null));
   }
 
   private static Long propertyAsLong(CaseInsensitiveStringMap options, String property) {


### PR DESCRIPTION
### About the changes

- Document limitation of TT via DataframeReader using timestamp in seconds and CatalogOptions.

### Testing Done

- Add an UT (in ignored mode) which would pass only when change for https://issues.apache.org/jira/browse/SPARK-39633 is available.

cc @rdblue