### PR TITLE
[WIP][BUILD] Add Build Attributes to Generated Manifests for Jar Output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,15 @@ project(':iceberg-bundled-guava') {
   }
 
   jar {
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
     archiveClassifier = 'empty'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -200,15 +200,6 @@ project(':iceberg-bundled-guava') {
   }
 
   jar {
-    manifest {
-      attributes(
-        "Implementation-Title": project.name,
-        "Implementation-Version": project.version,
-        "Build-Timestamp": java.time.Instant.now().toString(),
-        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
-      )
-    }
     archiveClassifier = 'empty'
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencyRecommendations {
   propertiesFile file: file('versions.props')
 }
 
+project.ext {
+  buildSha = gitBuildSha()
+}
+
 allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
@@ -67,10 +71,6 @@ allprojects {
     mavenCentral()
     mavenLocal()
   }
-}
-
-def getCheckedOutGitCommitHash() {
-  'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
 subprojects {
@@ -159,7 +159,7 @@ subprojects {
       attributes(
         "Implementation-Title": project.name,
         "Implementation-Version": project.version,
-        "Build-SHA": getCheckedOutGitCommitHash(),
+        "Build-SHA": project.buildSha,
         "Build-Timestamp": java.time.Instant.now().toString(),
         "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
         "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
@@ -651,6 +651,10 @@ boolean versionFileExists() {
 @Memoized
 String getVersionFromFile() {
   return file('version.txt').text.trim()
+}
+
+String gitBuildSha() {
+  return 'git rev-parse --verify HEAD'.execute().text.trim()
 }
 
 String getProjectVersion() {

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ allprojects {
   }
 }
 
+def getCheckedOutGitCommitHash() {
+  'git rev-parse --verify --short HEAD'.execute().text.trim()
+}
+
 subprojects {
   apply plugin: 'nebula.dependency-recommender'
   apply plugin: 'java-library'
@@ -155,6 +159,7 @@ subprojects {
       attributes(
         "Implementation-Title": project.name,
         "Implementation-Version": project.version,
+        "Build-SHA": getCheckedOutGitCommitHash(),
         "Build-Timestamp": java.time.Instant.now().toString(),
         "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
         "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,18 @@ subprojects {
       exceptionFormat "full"
     }
   }
+
+  jar {
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
+  }
 }
 
 project(':iceberg-bundled-guava') {

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -21,6 +21,25 @@ String flinkVersion = '1.13.2'
 String flinkMajorVersion = '1.13'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
+def flinkProjects = [
+    project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
+    project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+]
+
+configure(flinkProjects) {
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
+}
+
+
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   dependencies {

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -22,8 +22,8 @@ String flinkMajorVersion = '1.13'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
 def flinkProjects = [
-  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
-  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+  project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}"),
+  project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}")
 ]
 
 configure(flinkProjects) {

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -22,8 +22,8 @@ String flinkMajorVersion = '1.13'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
 def flinkProjects = [
-    project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
-    project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
+  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
 ]
 
 configure(flinkProjects) {

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -22,8 +22,8 @@ String flinkMajorVersion = '1.14'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
 def flinkProjects = [
-    project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
-    project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
+  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
 ]
 
 configure(flinkProjects) {

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -22,8 +22,8 @@ String flinkMajorVersion = '1.14'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
 def flinkProjects = [
-  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
-  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+  project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}"),
+  project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}")
 ]
 
 configure(flinkProjects) {

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -21,6 +21,24 @@ String flinkVersion = '1.14.0'
 String flinkMajorVersion = '1.14'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
+def flinkProjects = [
+    project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
+    project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+]
+
+configure(flinkProjects) {
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
+}
+
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   dependencies {

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -21,6 +21,24 @@ String flinkVersion = '1.15.0'
 String flinkMajorVersion = '1.15'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
+def flinkProjects = [
+  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
+  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+]
+
+configure(flinkProjects) {
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
+}
+
 project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
   dependencies {

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -22,8 +22,8 @@ String flinkMajorVersion = '1.15'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
 def flinkProjects = [
-  project(':iceberg-flink:iceberg-flink-${flinkMajorVersion}'),
-  project(':iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}')
+  project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}"),
+  project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}")
 ]
 
 configure(flinkProjects) {

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -77,6 +77,18 @@ project(':iceberg-hive-runtime') {
     // relocate OrcSplit in order to avoid the conflict from Hive's OrcSplit
     relocate 'org.apache.hadoop.hive.ql.io.orc.OrcSplit', 'org.apache.iceberg.shaded.org.apache.hadoop.hive.ql.io.orc.OrcSplit'
 
+
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-SHA": project.buildSha,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
+
     classifier null
   }
 

--- a/hive3-orc-bundle/build.gradle
+++ b/hive3-orc-bundle/build.gradle
@@ -29,6 +29,17 @@ project(':iceberg-hive3-orc-bundle') {
     implementation {
       exclude group: 'com.github.luben'
     }
+
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-SHA": project.buildSha,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
   }
 
   dependencies {

--- a/hive3/build.gradle
+++ b/hive3/build.gradle
@@ -103,4 +103,17 @@ project(':iceberg-hive3') {
     // testJoinTables / testScanTable
     maxHeapSize '2500m'
   }
+
+  jar {
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-SHA": project.buildSha,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
+  }
 }

--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -35,6 +35,17 @@ configure(sparkProjects) {
       }
     }
   }
+
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
 }
 
 project(':iceberg-spark:iceberg-spark-2.4') {

--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -27,6 +27,7 @@ configure(sparkProjects) {
   project.ext {
     sparkVersion = '3.0.3'
   }
+
   configurations {
     all {
       resolutionStrategy {
@@ -35,6 +36,7 @@ configure(sparkProjects) {
       }
     }
   }
+
   manifest {
     attributes(
       "Implementation-Title": project.name,

--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -28,6 +28,17 @@ configure(sparkProjects) {
     sparkVersion = '3.0.3'
   }
 
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
+
   configurations {
     all {
       resolutionStrategy {

--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -27,7 +27,14 @@ configure(sparkProjects) {
   project.ext {
     sparkVersion = '3.0.3'
   }
-
+  configurations {
+    all {
+      resolutionStrategy {
+        force 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.11.4'
+        force 'com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4'
+      }
+    }
+  }
   manifest {
     attributes(
       "Implementation-Title": project.name,
@@ -37,15 +44,6 @@ configure(sparkProjects) {
       "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
       "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
     )
-  }
-
-  configurations {
-    all {
-      resolutionStrategy {
-        force 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.11.4'
-        force 'com.fasterxml.jackson.module:jackson-module-paranamer:2.11.4'
-      }
-    }
   }
 }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -260,6 +260,16 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    manifest {
+      attributes(
+        "Implementation-Title": project.name,
+        "Implementation-Version": project.version,
+        "Build-Timestamp": java.time.Instant.now().toString(),
+        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+      )
+    }
+
     classifier null
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -40,6 +40,7 @@ configure(sparkProjects) {
     attributes(
       "Implementation-Title": project.name,
       "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
       "Build-Timestamp": java.time.Instant.now().toString(),
       "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
       "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -269,16 +269,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
-    manifest {
-      attributes(
-        "Implementation-Title": project.name,
-        "Implementation-Version": project.version,
-        "Build-Timestamp": java.time.Instant.now().toString(),
-        "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
-      )
-    }
-
     classifier null
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -36,6 +36,15 @@ configure(sparkProjects) {
       }
     }
   }
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
 }
 
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -36,6 +36,7 @@ configure(sparkProjects) {
       }
     }
   }
+
   manifest {
     attributes(
       "Implementation-Title": project.name,

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -27,6 +27,19 @@ def sparkProjects = [
     project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
 ]
 
+configure(sparkProjects) {
+  manifest {
+    attributes(
+      "Implementation-Title": project.name,
+      "Implementation-Version": project.version,
+      "Build-SHA": project.buildSha,
+      "Build-Timestamp": java.time.Instant.now().toString(),
+      "Build-JDK": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+      "Build-OS": "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+  }
+}
+
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
   apply plugin: 'scala'
   apply plugin: 'com.github.alisiikh.scalastyle'


### PR DESCRIPTION
For debugging purposes, it would be beneficial to have the build information inside of each generated JAR.

This way, a JAR that is used on a cluster or within an application can be evaluated for its build SHA or true package name to help debug issues.

This adds some build metadata to the jars generated from projects in build.gradle and Spark jars etc.