### PR TITLE
Python: Reenable mypy

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
     rev: v0.961
     hooks:
       - id: mypy
+        args: [--config=python/pyproject.toml]
   - repo: https://github.com/hadialqattan/pycln
     rev: v1.3.4
     hooks:

--- a/python/pyiceberg/io/base.py
+++ b/python/pyiceberg/io/base.py
@@ -22,7 +22,6 @@ as check if a file exists. An implementation of the FileIO abstract base class i
 for returning an InputFile instance, an OutputFile instance, and deleting a file given
 its location.
 """
-
 from abc import ABC, abstractmethod
 from io import SEEK_SET
 from typing import Protocol, Union, runtime_checkable
@@ -41,16 +40,11 @@ class InputStream(Protocol):
         ...
 
     @abstractmethod
-    def seek(self, offset: int, whence: int = SEEK_SET) -> None:
+    def seek(self, offset: int, whence: int = SEEK_SET) -> int:
         ...
 
     @abstractmethod
     def tell(self) -> int:
-        ...
-
-    @property
-    @abstractmethod
-    def closed(self) -> bool:
         ...
 
     @abstractmethod
@@ -67,12 +61,7 @@ class OutputStream(Protocol):  # pragma: no cover
     """
 
     @abstractmethod
-    def write(self, b: bytes) -> None:
-        ...
-
-    @property
-    @abstractmethod
-    def closed(self) -> bool:
+    def write(self, b: bytes) -> int:
         ...
 
     @abstractmethod

--- a/python/pyiceberg/io/base.py
+++ b/python/pyiceberg/io/base.py
@@ -48,6 +48,7 @@ class InputStream(Protocol):
     def tell(self) -> int:
         ...
 
+    @property
     @abstractmethod
     def closed(self) -> bool:
         ...
@@ -69,6 +70,7 @@ class OutputStream(Protocol):  # pragma: no cover
     def write(self, b: bytes) -> None:
         ...
 
+    @property
     @abstractmethod
     def closed(self) -> bool:
         ...

--- a/python/pyiceberg/io/memory.py
+++ b/python/pyiceberg/io/memory.py
@@ -36,7 +36,7 @@ class MemoryInputStream(InputStream):
         >>> stream.read(4)
         b'1925'
         >>> stream.close()
-        >>> stream.closed()
+        >>> stream.closed
         True
     """
 
@@ -67,6 +67,7 @@ class MemoryInputStream(InputStream):
     def tell(self) -> int:
         return self.pos
 
+    @property
     def closed(self) -> bool:
         return not hasattr(self, "buffer")
 

--- a/python/pyiceberg/io/memory.py
+++ b/python/pyiceberg/io/memory.py
@@ -36,8 +36,6 @@ class MemoryInputStream(InputStream):
         >>> stream.read(4)
         b'1925'
         >>> stream.close()
-        >>> stream.closed
-        True
     """
 
     buffer: bytes
@@ -54,7 +52,7 @@ class MemoryInputStream(InputStream):
         self.pos += size
         return b
 
-    def seek(self, offset: int, whence: int = SEEK_SET) -> None:
+    def seek(self, offset: int, whence: int = SEEK_SET) -> int:
         if whence == SEEK_SET:
             self.pos = offset
         elif whence == SEEK_CUR:
@@ -64,12 +62,10 @@ class MemoryInputStream(InputStream):
         else:
             raise ValueError(f"Unknown whence {offset}")
 
-    def tell(self) -> int:
         return self.pos
 
-    @property
-    def closed(self) -> bool:
-        return not hasattr(self, "buffer")
+    def tell(self) -> int:
+        return self.pos
 
     def close(self) -> None:
         del self.buffer

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -84,15 +84,31 @@ warn_redundant_casts = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = "mypy-pyarrow.*"
+module = "pyarrow.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "mypy-snappy.*"
+module = "snappy.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = "mypy-zstandard.*"
+module = "zstandard.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pydantic.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "pytest.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fastavro.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "mmh3.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -112,8 +112,9 @@ class OneByteAtATimeInputStream(InputStream):
     def tell(self) -> int:
         pass
 
+    @property
     def closed(self) -> bool:
-        pass
+        return False
 
     def close(self) -> None:
         pass

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -106,7 +106,7 @@ class OneByteAtATimeInputStream(InputStream):
         self.pos += 1
         return int.to_bytes(1, self.pos, byteorder="little")
 
-    def seek(self, offset: int, whence: int = SEEK_SET) -> None:
+    def seek(self, offset: int, whence: int = SEEK_SET) -> int:
         pass
 
     def tell(self) -> int:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -828,9 +828,9 @@ class LocalOutputFile(OutputFile):
 
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self._path, "wb" if overwrite else "xb")
-        if not isinstance(output_file, OutputStream):
-            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
-        return output_file
+        # if not issubclass(type(output_file), OutputStream):
+        #    raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
+        return output_file  # type: ignore
 
 
 class LocalFileIO(FileIO):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -828,9 +828,9 @@ class LocalOutputFile(OutputFile):
 
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self._path, "wb" if overwrite else "xb")
-        # if not issubclass(type(output_file), OutputStream):
-        #    raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
-        return output_file  # type: ignore
+        if not issubclass(type(output_file), OutputStream):
+            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
+        return output_file
 
 
 class LocalFileIO(FileIO):

--- a/python/tests/io/test_io_base.py
+++ b/python/tests/io/test_io_base.py
@@ -64,9 +64,9 @@ class LocalInputFile(InputFile):
 
     def open(self) -> InputStream:
         input_file = open(self.parsed_location.path, "rb")
-        if not isinstance(input_file, InputStream):
-            raise TypeError("Object returned from LocalInputFile.open() does not match the OutputStream protocol.")
-        return input_file
+        # if not isinstance(input_file, InputStream):
+        #    raise TypeError("Object returned from LocalInputFile.open() does not match the OutputStream protocol.")
+        return input_file  # type: ignore
 
 
 class LocalOutputFile(OutputFile):
@@ -104,9 +104,9 @@ class LocalOutputFile(OutputFile):
 
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self.parsed_location.path, "wb" if overwrite else "xb")
-        if not isinstance(output_file, OutputStream):
-            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
-        return output_file
+        # if not issubclass(type(output_file), OutputStream):
+        #    raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
+        return output_file  # type: ignore
 
 
 class LocalFileIO(FileIO):

--- a/python/tests/io/test_io_base.py
+++ b/python/tests/io/test_io_base.py
@@ -64,9 +64,9 @@ class LocalInputFile(InputFile):
 
     def open(self) -> InputStream:
         input_file = open(self.parsed_location.path, "rb")
-        # if not isinstance(input_file, InputStream):
-        #    raise TypeError("Object returned from LocalInputFile.open() does not match the OutputStream protocol.")
-        return input_file  # type: ignore
+        if not isinstance(input_file, InputStream):
+            raise TypeError("Object returned from LocalInputFile.open() does not match the OutputStream protocol.")
+        return input_file
 
 
 class LocalOutputFile(OutputFile):
@@ -104,9 +104,9 @@ class LocalOutputFile(OutputFile):
 
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self.parsed_location.path, "wb" if overwrite else "xb")
-        # if not issubclass(type(output_file), OutputStream):
-        #    raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
-        return output_file  # type: ignore
+        if not issubclass(type(output_file), OutputStream):
+            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
+        return output_file
 
 
 class LocalFileIO(FileIO):

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from textwrap import dedent
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -388,7 +388,7 @@ def test_build_position_accessors(table_schema_nested):
 
 def test_build_position_accessors_with_struct(table_schema_nested: Schema):
     class TestStruct(StructProtocol):
-        def __init__(self, pos: Dict[int, Any] = None):
+        def __init__(self, pos: Optional[Dict[int, Any]] = None):
             self._pos: Dict[int, Any] = pos or {}
 
         def set(self, pos: int, value) -> None:


### PR DESCRIPTION
Mypy was so quiet, that I got a bit suspicious.

The path to the config file was incorrect, therefore it was not working.

I fixed all the violations, but also ran into some other issues:

It looks like that open() returns an incompatible type:
```
python/tests/conftest.py:833: error: Incompatible return value type (got "BufferedWriter", expected "OutputStream")
python/tests/conftest.py:833: note: Following member(s) of "BufferedWriter" have conflicts:
python/tests/conftest.py:833: note:     Expected:
python/tests/conftest.py:833: note:         def write(self, b: bytes) -> None
python/tests/conftest.py:833: note:     Got:
python/tests/conftest.py:833: note:         def write(self, Union[bytes, Union[bytearray, memoryview, array[Any], mmap, _CData, PickleBuffer]]) -> int
```

When fixing the type to the awkward signature, and converting `closed()` to `closed` (a property). I got the following:
```
python/tests/conftest.py:831: error: Only protocols that don't have non-method members can be used with issubclass()
python/tests/conftest.py:831: note: Protocol "OutputStream" has non-method member(s): closed
```

Which basically tells us that we can't include `closed` in the protocol because I had to change it to a property to conform it to `IOBase`.

My suggestion would be to get rid of the InputStream/OutputStream and just use the internal IOBase which is a bit richer, but we don't have to implement everything.

I also stumbled upon this when trying to integrate the Avro library, but this wasn't an issue in the end because we vendor'ed it because we replaced the Avro schema with the iceberg one. Therefore we just could tailor the interfaces to our liking.

WDYT?