### PR TITLE
Check getBloomFilterOffset() <= 0 for non bloom filter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -345,7 +345,7 @@ public class ParquetUtil {
   }
 
   public static boolean hasNoBloomFilterPages(ColumnChunkMetaData meta) {
-    return meta.getBloomFilterOffset() == -1;
+    return meta.getBloomFilterOffset() <= 0;
   }
 
   public static Dictionary readDictionary(ColumnDescriptor desc, PageReader pageSource) {


### PR DESCRIPTION
We saw parquet files (don't have bloom filters) with `bloomFilterOffset = 0`  :(

This is a known [bug](https://issues.apache.org/jira/browse/PARQUET-1979). It was fixed before the bloom filter was released in parquet-mr 1.12.0, but I guess it's possible people may use the unofficial released parquet-mr (which has the bloom filter support but doesn't have the offset bug fix), so change the check to be `getBloomFilterOffset() <= 0` to be safe.