### PR TITLE
Spec: Sort-order order-id is mandatory

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1068,6 +1068,7 @@ components:
     SortOrder:
       type: object
       required:
+        - order-id
         - fields
       properties:
         order-id:


### PR DESCRIPTION
Looking at the code, we expect this field:

https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/SortOrderParser.java#L154

And we always write it on the Java side.

@rdblue Can you confirm this? I saw that you recently did some work on this.