### PR TITLE
API: Add generic FileIO JSON serialization

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -62,6 +62,15 @@ public interface FileIO extends Serializable, Closeable {
   }
 
   /**
+   * @return the property map used to configure this FileIO
+   * @throws UnsupportedOperationException if this FileIO does not expose its configuration properties
+   */
+  default Map<String, String> properties() {
+    throw new UnsupportedOperationException(String.format(
+        "%s does not expose configuration properties", this.getClass().toString()));
+  }
+
+  /**
    * Initialize File IO from catalog properties.
    * @param properties catalog properties
    */

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -22,8 +22,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -56,19 +54,7 @@ public class SortOrderParser {
   }
 
   public static String toJson(SortOrder sortOrder, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(sortOrder, generator);
-      generator.flush();
-      return writer.toString();
-
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(sortOrder, gen), pretty);
   }
 
   private static String toJson(SortDirection direction) {
@@ -105,19 +91,7 @@ public class SortOrderParser {
   }
 
   public static String toJson(UnboundSortOrder sortOrder, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(sortOrder, generator);
-      generator.flush();
-      return writer.toString();
-
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(sortOrder, gen), pretty);
   }
 
   private static void toJsonFields(UnboundSortOrder sortOrder, JsonGenerator generator) throws IOException {
@@ -142,11 +116,7 @@ public class SortOrderParser {
   }
 
   public static UnboundSortOrder fromJson(String json) {
-    try {
-      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return JsonUtil.parse(json, SortOrderParser::fromJson);
   }
 
   public static UnboundSortOrder fromJson(JsonNode json) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.hadoop;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -33,6 +34,7 @@ import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.util.SerializableSupplier;
 
@@ -79,6 +81,11 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to delete file: %s", path);
     }
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return ImmutableMap.of();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/FileIOParser.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileIOParser.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class FileIOParser {
+  private FileIOParser() {
+  }
+
+  private static final String FILE_IO_IMPL = "io-impl";
+  private static final String PROPERTIES = "properties";
+
+  public static String toJson(FileIO io) {
+    return toJson(io, false);
+  }
+
+  public static String toJson(FileIO io, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(io, gen), pretty);
+  }
+
+  private static void toJson(FileIO io, JsonGenerator generator) throws IOException {
+    String impl = io.getClass().getName();
+    Map<String, String> properties;
+    try {
+      properties = io.properties();
+    } catch (UnsupportedOperationException e) {
+      throw new IllegalArgumentException(String.format(
+          "Cannot serialize FileIO: %s does not expose configuration properties", impl));
+    }
+
+    Preconditions.checkArgument(properties != null,
+        "Cannot serialize FileIO: invalid configuration properties (null)", impl);
+
+    generator.writeStartObject();
+
+    generator.writeStringField(FILE_IO_IMPL, impl);
+    generator.writeObjectFieldStart(PROPERTIES);
+    for (Map.Entry<String, String> pair : properties.entrySet()) {
+      generator.writeStringField(pair.getKey(), pair.getValue());
+    }
+    generator.writeEndObject();
+
+    generator.writeEndObject();
+  }
+
+  public static FileIO fromJson(String json) {
+    return fromJson(json, null);
+  }
+
+  public static FileIO fromJson(String json, Object conf) {
+    return JsonUtil.parse(json, node -> fromJson(node, conf));
+  }
+
+  private static FileIO fromJson(JsonNode json, Object conf) {
+    Preconditions.checkArgument(json.isObject(), "Cannot parse FileIO from non-object: %s", json);
+    String impl = JsonUtil.getString(FILE_IO_IMPL, json);
+    Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, json);
+    return CatalogUtil.loadFileIO(impl, properties, conf);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -74,6 +74,11 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
   }
 
   @Override
+  public Map<String, String> properties() {
+    return properties;
+  }
+
+  @Override
   public void initialize(Map<String, String> newProperties) {
     close(); // close and discard any existing FileIO instances
     this.properties = newProperties;

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -90,8 +90,8 @@ public class JsonUtil {
    *
    * @param json a JSON string
    * @param parser a function that converts a JsonNode to a Java object
-   * @return the parsed Java object
    * @param <T> type of objects created by the parser
+   * @return the parsed Java object
    */
   public static <T> T parse(String json, FromJson<T> parser) {
     try {

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +50,55 @@ public class JsonUtil {
 
   public static ObjectMapper mapper() {
     return MAPPER;
+  }
+
+  @FunctionalInterface
+  public interface ToJson {
+    void generate(JsonGenerator gen) throws IOException;
+  }
+
+  /**
+   * Helper for writing JSON with a JsonGenerator.
+   *
+   * @param toJson a function to produce JSON using a JsonGenerator
+   * @param pretty whether to pretty-print JSON for readability
+   * @return a JSON string produced from the generator
+   */
+  public static String generate(ToJson toJson, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+      toJson.generate(generator);
+      generator.flush();
+      return writer.toString();
+
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @FunctionalInterface
+  public interface FromJson<T> {
+    T parse(JsonNode node);
+  }
+
+  /**
+   * Helper for parsing JSON from a String.
+   *
+   * @param json a JSON string
+   * @param parser a function that converts a JsonNode to a Java object
+   * @return the parsed Java object
+   * @param <T> type of objects created by the parser
+   */
+  public static <T> T parse(String json, FromJson<T> parser) {
+    try {
+      return parser.parse(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   public static int getInt(String property, JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -65,9 +65,8 @@ public class JsonUtil {
    * @return a JSON string produced from the generator
    */
   public static String generate(ToJson toJson, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+    try (StringWriter writer = new StringWriter();
+         JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
       if (pretty) {
         generator.useDefaultPrettyPrinter();
       }


### PR DESCRIPTION
This adds a JSON parser to serialize FileIO instances to and from JSON. The format is an object with an `io-impl` and configuration `properties`. Deserialization uses `CatalogUtil` to re-create an instance from an environment Hadoop Configuration (optional), the IO impl class, and the configuration used to create the original `FileIO`.