### PR TITLE
Spark 3.3: Re-Enable TwoLevel Parquet List UT

### DIFF
--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -70,6 +70,7 @@ public abstract class SparkTestBase {
         .master("local[2]")
         .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+        .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
         .enableHiveSupport()
         .getOrCreate();
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -72,7 +72,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -634,8 +633,6 @@ public class TestCreateActions extends SparkCatalogTestBase {
     structOfThreeLevelLists(false);
   }
 
-  // TODO: revisit why Spark is no longer writing the legacy format.
-  @Ignore
   @Test
   public void testTwoLevelList() throws IOException {
     spark.conf().set("spark.sql.parquet.writeLegacyFormat", true);


### PR DESCRIPTION
### About the changes

Address https://github.com/apache/iceberg/pull/5094#discussion_r902008258
Spark was writing 3 level list rather than 2 level list which was expected in the [UT](https://github.com/apache/iceberg/blob/7e1ade80397a54c24db3634cb6015d539143e62d/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java#L640-L703). 

On debugging this more found that, since the schema was passed via  `spark.read().schema(sparkSchema).json` and as of spark 3.3 spark will not respect the nullability in the schema passed via above by default (ref. [this](https://github.com/apache/iceberg/pull/5094)). 

Now since the nullability is not respected (will be considered nullable) by spark by default the Parquet writer despite `writeLegacyParquetFormat` being true, will write in Three level list. [CodePointer](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetWriteSupport.scala#L376-L410)

This pr adds the conf to respect the nullability provided presently and hence preserves the existing behaviour. 

P.S : A good long term fix would be to get rid of this form of specifying schema from our test / test utils, can pick this in a follow-up.

----

### Testing Done
Re-enabled the UT, which was ignored in version upgrade.



cc @rdblue 