### PR TITLE
Python: Pin bugbear in Python legacy

### DIFF
--- a/python_legacy/tox.ini
+++ b/python_legacy/tox.ini
@@ -51,7 +51,7 @@ skip_install = true
 deps =
     flake8>=3.8.4
     flake8-import-order>=0.9
-    flake8-bugbear
+    flake8-bugbear==22.6.22
 commands =
     flake8 iceberg setup.py tests
 


### PR DESCRIPTION
We got a new release on June 1st:
https://pypi.org/project/flake8-bugbear/22.7.1/

This introduced a new rule that actually broke the CI.

It is best to not do global lookups because of scoping and performance,
but I don't feel like rewriting the legacy code either.