### PR TITLE
Core: Use table partitioning with manual sort order

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
@@ -49,7 +49,7 @@ public abstract class SortStrategy extends BinPackStrategy {
    * @return this for method chaining
    */
   public SortStrategy sortOrder(SortOrder order) {
-    Preconditions.checkArgument(!order.isUnsorted(), "Invalid sort order for sort strategy: unsorted");
+    Preconditions.checkArgument(!order.isUnsorted(), "Cannot set strategy sort order: unsorted");
     this.sortOrder = SortOrderUtil.buildSortOrder(table(), order);
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
@@ -49,6 +49,7 @@ public abstract class SortStrategy extends BinPackStrategy {
    * @return this for method chaining
    */
   public SortStrategy sortOrder(SortOrder order) {
+    Preconditions.checkArgument(!order.isUnsorted(), "Invalid sort order for sort strategy: unsorted");
     this.sortOrder = SortOrderUtil.buildSortOrder(table(), order);
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.util.SortOrderUtil;
 
 /**
  * A rewrite strategy for data files which aims to reorder data with data files to optimally lay them out
@@ -48,7 +49,7 @@ public abstract class SortStrategy extends BinPackStrategy {
    * @return this for method chaining
    */
   public SortStrategy sortOrder(SortOrder order) {
-    this.sortOrder = order;
+    this.sortOrder = SortOrderUtil.buildSortOrder(table(), order);
     return this;
   }
 

--- a/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
@@ -86,9 +86,6 @@ public class TestSortStrategy extends TableTestBase {
 
   @Test
   public void testInvalidSortOrder() {
-    AssertHelpers.assertThrows("Should not allow an unsorted Sort order", IllegalArgumentException.class,
-        () -> defaultSort().sortOrder(SortOrder.unsorted()).options(Collections.emptyMap()));
-
     AssertHelpers.assertThrows("Should not allow a Sort order with bad columns", ValidationException.class,
         () -> {
           Schema badSchema = new Schema(

--- a/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
@@ -86,6 +86,9 @@ public class TestSortStrategy extends TableTestBase {
 
   @Test
   public void testInvalidSortOrder() {
+    AssertHelpers.assertThrows("Should not allow an unsorted Sort order", IllegalArgumentException.class,
+        () -> defaultSort().sortOrder(SortOrder.unsorted()).options(Collections.emptyMap()));
+
     AssertHelpers.assertThrows("Should not allow a Sort order with bad columns", ValidationException.class,
         () -> {
           Schema badSchema = new Schema(


### PR DESCRIPTION
This is based on #4922, but adds a check for the unsorted order to make tests pass without modification.

Closes #4922.