### PR TITLE
Spec: Add sequence-number and parent-snapshot-id

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1087,19 +1087,17 @@ components:
         - manifest-list
         - summary
       properties:
-        sequence-number:
-          type: integer
         snapshot-id:
           type: integer
         parent-snapshot-id:
+          type: integer
+        sequence-number:
           type: integer
         timestamp-ms:
           type: integer
         manifest-list:
           type: string
           description: Location of the snapshot's manifest list file
-        schema-id:
-          type: integer
         summary:
           type: object
           required:
@@ -1110,6 +1108,8 @@ components:
               enum: ["append", "replace", "overwrite", "delete"]
             additionalProperties:
               type: string
+        schema-id:
+          type: integer
 
     SnapshotReference:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1087,7 +1087,11 @@ components:
         - manifest-list
         - summary
       properties:
+        sequence-number:
+          type: integer
         snapshot-id:
+          type: integer
+        parent-snapshot-id:
           type: integer
         timestamp-ms:
           type: integer


### PR DESCRIPTION
These fields are read/written by the Java reference implementation:
https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/SnapshotParser.java

And are part of the spec as well: https://iceberg.apache.org/spec/#snapshots