### PR TITLE
Spec: Snapshot summary is optional

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1085,7 +1085,6 @@ components:
         - snapshot-id
         - timestamp-ms
         - manifest-list
-        - summary
       properties:
         snapshot-id:
           type: integer


### PR DESCRIPTION
Looking at the Java reference implementation it is optional:
https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/SnapshotParser.java