### PR TITLE
Arrow: Fix for dictionary encoded fixed length binary decimals

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
@@ -592,8 +592,8 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
 
     @Override
     protected DecimalT decode(int dictId, int precision, int scale) {
-      BigDecimal value = DecimalUtility.getBigDecimalFromByteBuffer(
-          parquetDictionary.decodeToBinary(dictId).toByteBuffer(), scale, DecimalVector.TYPE_WIDTH);
+      ByteBuffer byteBuffer = parquetDictionary.decodeToBinary(dictId).toByteBuffer();
+      BigDecimal value = DecimalUtility.getBigDecimalFromByteBuffer(byteBuffer, scale, byteBuffer.remaining());
       return decimalFactory.ofBigDecimal(value, precision, scale);
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.arrow.vectorized;
 
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.function.IntFunction;
 import java.util.function.Supplier;
@@ -556,9 +555,9 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
       DictionaryDecimalAccessor<DecimalT, Utf8StringT, ArrayT, ChildVectorT extends AutoCloseable>
           extends ArrowVectorAccessor<DecimalT, Utf8StringT, ArrayT, ChildVectorT> {
     private final DecimalT[] cache;
-    private final DecimalFactory<DecimalT> decimalFactory;
-    private final Dictionary parquetDictionary;
     private final IntVector offsetVector;
+    protected final DecimalFactory<DecimalT> decimalFactory;
+    protected final Dictionary parquetDictionary;
 
     private DictionaryDecimalAccessor(
             IntVector vector,
@@ -571,28 +570,16 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
       this.cache = genericArray(decimalFactory.getGenericClass(), dictionary.getMaxId() + 1);
     }
 
-    protected long decodeToBinary(int dictId) {
-      return new BigInteger(parquetDictionary.decodeToBinary(dictId).getBytesUnsafe()).longValue();
-    }
-
-    protected long decodeToLong(int dictId) {
-      return parquetDictionary.decodeToLong(dictId);
-    }
-
-    protected int decodeToInt(int dictId) {
-      return parquetDictionary.decodeToInt(dictId);
-    }
-
     @Override
     public final DecimalT getDecimal(int rowId, int precision, int scale) {
       int offset = offsetVector.get(rowId);
       if (cache[offset] == null) {
-        cache[offset] = decimalFactory.ofLong(decode(offset), precision, scale);
+        cache[offset] = decode(offset, precision, scale);
       }
       return cache[offset];
     }
 
-    protected abstract long decode(int dictId);
+    protected abstract DecimalT decode(int dictId, int precision, int scale);
   }
 
   private static class
@@ -604,8 +591,10 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
     }
 
     @Override
-    protected long decode(int dictId) {
-      return decodeToBinary(dictId);
+    protected DecimalT decode(int dictId, int precision, int scale) {
+      BigDecimal value = DecimalUtility.getBigDecimalFromByteBuffer(
+          parquetDictionary.decodeToBinary(dictId).toByteBuffer(), scale, DecimalVector.TYPE_WIDTH);
+      return decimalFactory.ofBigDecimal(value, precision, scale);
     }
   }
 
@@ -617,8 +606,8 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
     }
 
     @Override
-    protected long decode(int dictId) {
-      return decodeToLong(dictId);
+    protected DecimalT decode(int dictId, int precision, int scale) {
+      return decimalFactory.ofLong(parquetDictionary.decodeToLong(dictId), precision, scale);
     }
   }
 
@@ -630,8 +619,8 @@ public class GenericArrowVectorAccessorFactory<DecimalT, Utf8StringT, ArrayT, Ch
     }
 
     @Override
-    protected long decode(int dictId) {
-      return decodeToInt(dictId);
+    protected DecimalT decode(int dictId, int precision, int scale) {
+      return decimalFactory.ofLong(parquetDictionary.decodeToInt(dictId), precision, scale);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtil.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtil.java
@@ -20,10 +20,17 @@
 package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.util.Arrays;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 
 public class DecimalVectorUtil {
 
   private DecimalVectorUtil() {
+  }
+
+  public static void setBigEndian(DecimalVector vector, int idx, byte[] value) {
+    byte[] paddedBytes = DecimalVectorUtil.padBigEndianBytes(value, DecimalVector.TYPE_WIDTH);
+    vector.setBigEndian(idx, paddedBytes);
   }
 
   /**
@@ -37,7 +44,8 @@ public class DecimalVectorUtil {
    * @param newLength      The length of the byte array to return
    * @return The new byte array
    */
-  public static byte[] padBigEndianBytes(byte[] bigEndianBytes, int newLength) {
+  @VisibleForTesting
+  static byte[] padBigEndianBytes(byte[] bigEndianBytes, int newLength) {
     if (bigEndianBytes.length == newLength) {
       return bigEndianBytes;
     } else if (bigEndianBytes.length < newLength) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -128,11 +128,8 @@ public class VectorizedDictionaryEncodedParquetValuesReader extends BaseVectoriz
   class FixedLengthDecimalDictEncodedReader extends BaseDictEncodedReader {
     @Override
     protected void nextVal(FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
-      byte[] vectorBytes =
-          DecimalVectorUtil.padBigEndianBytes(
-              dict.decodeToBinary(currentVal).getBytesUnsafe(),
-              DecimalVector.TYPE_WIDTH);
-      ((DecimalVector) vector).setBigEndian(idx, vectorBytes);
+      byte[] bytes = dict.decodeToBinary(currentVal).getBytesUnsafe();
+      DecimalVectorUtil.setBigEndian((DecimalVector) vector, idx, bytes);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -358,8 +358,7 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
     protected void nextVal(
         FieldVector vector, int idx, ValuesAsBytesReader valuesReader, int typeWidth, byte[] byteArray) {
       valuesReader.getBuffer(typeWidth).get(byteArray, 0, typeWidth);
-      byte[] vectorBytes = DecimalVectorUtil.padBigEndianBytes(byteArray, DecimalVector.TYPE_WIDTH);
-      ((DecimalVector) vector).setBigEndian(idx, vectorBytes);
+      DecimalVectorUtil.setBigEndian((DecimalVector) vector, idx, byteArray);
     }
 
     @Override
@@ -370,11 +369,8 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
         reader.fixedLengthDecimalDictEncodedReader()
             .nextBatch(vector, idx, numValuesToRead, dict, nullabilityHolder, typeWidth);
       } else if (Mode.PACKED.equals(mode)) {
-        byte[] vectorBytes =
-            DecimalVectorUtil.padBigEndianBytes(
-                dict.decodeToBinary(reader.readInteger()).getBytesUnsafe(),
-                DecimalVector.TYPE_WIDTH);
-        ((DecimalVector) vector).setBigEndian(idx, vectorBytes);
+        byte[] bytes = dict.decodeToBinary(reader.readInteger()).getBytesUnsafe();
+        DecimalVectorUtil.setBigEndian((DecimalVector) vector, idx, bytes);
       }
     }
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -59,9 +59,10 @@ public abstract class AvroDataTest {
       // required(111, "uuid", Types.UUIDType.get()),
       required(112, "fixed", Types.FixedType.ofLength(7)),
       optional(113, "bytes", Types.BinaryType.get()),
-      required(114, "dec_9_0", Types.DecimalType.of(9, 0)),
-      required(115, "dec_11_2", Types.DecimalType.of(11, 2)),
-      required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // spark's maximum precision
+      required(114, "dec_9_0", Types.DecimalType.of(9, 0)), // int encoded
+      required(115, "dec_11_2", Types.DecimalType.of(11, 2)), // long encoded
+      required(116, "dec_20_5", Types.DecimalType.of(20, 5)), // requires padding
+      required(117, "dec_38_10", Types.DecimalType.of(38, 10)) // Spark's maximum precision
   );
 
   @Rule

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -279,10 +279,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
   @Test
   public void testSupportedReadsForParquetV2() throws Exception {
-    // Only float and double column types are written using plain encoding with Parquet V2
+    // Float and double column types are written using plain encoding with Parquet V2,
+    // also Parquet V2 will dictionary encode decimals that use fixed length binary
+    // (i.e. decimals > 8 bytes)
     Schema schema = new Schema(
             optional(102, "float_data", Types.FloatType.get()),
-            optional(103, "double_data", Types.DoubleType.get()));
+            optional(103, "double_data", Types.DoubleType.get()),
+            optional(104, "decimal_data", Types.DecimalType.of(25, 5))
+    );
 
     File dataFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", dataFile.delete());


### PR DESCRIPTION
This PR fixes the vectorized reader for decimals that are fixed length binary and dictionary-encoded. Before these decimals would be downcast to 8 byte (long) precision. This only affects Parquet V2, as fixed length binary decimals aren't dictionary-encoded in Parquet V1. The Spark vectorized reader test for Parquet V2 was modified so this is now tested.

Also included is a minor refactor of the big endian padding to share some common logic and make it easier to enhance later.

In addition, the Spark benchmark test for the vectorized reader was enhanced to include both long encoded and fixed width binary encoded decimals.