### PR TITLE
Core: Fix ErrorProne Warnings

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -226,6 +226,7 @@ public class ManifestFiles {
     }
   }
 
+  @SuppressWarnings("Finally")
   private static ManifestFile copyManifestInternal(int formatVersion, ManifestReader<DataFile> reader,
                                                    OutputFile outputFile, long snapshotId,
                                                    SnapshotSummary.Builder summaryBuilder,

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -134,7 +133,7 @@ public class MetricsModes {
 
     @Override
     public int hashCode() {
-      return Objects.hash(length);
+      return Integer.hashCode(length);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -577,6 +577,7 @@ public class Avro {
     private org.apache.iceberg.Schema schema = null;
     private Function<Schema, DatumReader<?>> createReaderFunc = null;
     private BiFunction<org.apache.iceberg.Schema, Schema, DatumReader<?>> createReaderBiFunc = null;
+    @SuppressWarnings("UnnecessaryLambda")
     private final Function<Schema, DatumReader<?>> defaultCreateReaderFunc = readSchema -> {
       GenericAvroReader<?> reader = new GenericAvroReader<>(readSchema);
       reader.setClassLoader(loader);

--- a/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
@@ -43,6 +43,7 @@ public class InputFilesDecryptor {
         .map(entry -> EncryptedFiles.encryptedInput(io.newInputFile(entry.getKey()), entry.getValue()));
 
     // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
+    @SuppressWarnings("StreamToIterable")
     Iterable<InputFile> decryptedFiles = encryption.decrypt(encrypted::iterator);
 
     Map<String, InputFile> files = Maps.newHashMapWithExpectedSize(keyMetadata.size());

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -196,7 +196,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
         err -> {
           // SQLite doesn't set SQLState or throw SQLIntegrityConstraintViolationException
           if (err instanceof SQLIntegrityConstraintViolationException ||
-              err.getMessage() != null && err.getMessage().contains("constraint failed")) {
+              (err.getMessage() != null && err.getMessage().contains("constraint failed"))) {
             throw new AlreadyExistsException("Table already exists: %s", to);
           }
         },

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.rest;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,7 +167,7 @@ public class CatalogHandlers {
     }
 
     Map<String, String> properties = Maps.newHashMap();
-    properties.put("created-at", OffsetDateTime.now().toString());
+    properties.put("created-at", OffsetDateTime.now(ZoneOffset.UTC).toString());
     properties.putAll(request.properties());
 
     String location;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -352,6 +352,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
     return refreshExecutor;
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void scheduleTokenRefresh(
       AuthSession session, long startTimeMillis, long expiresIn, TimeUnit unit) {
     // convert expiration interval to milliseconds

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -569,6 +569,7 @@ public class Tasks {
     return new Builder<>(Arrays.asList(items));
   }
 
+  @SuppressWarnings("StreamToIterable")
   public static <I> Builder<I> foreach(Stream<I> items) {
     return new Builder<>(items::iterator);
   }

--- a/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
+++ b/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
@@ -123,6 +123,7 @@ public class ZOrderByteUtils {
    * This implementation just uses a set size to for all output byte representations. Truncating longer strings
    * and right padding 0 for shorter strings.
    */
+  @SuppressWarnings("ByteBufferBackingArray")
   public static ByteBuffer stringToOrderedBytes(String val, int length, ByteBuffer reuse, CharsetEncoder encoder) {
     Preconditions.checkArgument(encoder.charset().equals(StandardCharsets.UTF_8),
         "Cannot use an encoder not using UTF_8 as it's Charset");
@@ -140,6 +141,7 @@ public class ZOrderByteUtils {
    * Return a bytebuffer with the given bytes truncated to length, or filled with 0's to length depending on whether
    * the given bytes are larger or smaller than the given length.
    */
+  @SuppressWarnings("ByteBufferBackingArray")
   public static ByteBuffer byteTruncateOrFill(byte[] val, int length, ByteBuffer reuse) {
     ByteBuffer bytes = ByteBuffers.reuse(reuse, length);
     if (val.length < length) {
@@ -164,6 +166,7 @@ public class ZOrderByteUtils {
    * @param interleavedSize the number of bytes to use in the output
    * @return the columnbytes interleaved
    */
+  @SuppressWarnings("ByteBufferBackingArray")
   public static byte[] interleaveBits(byte[][] columnsBinary, int interleavedSize, ByteBuffer reuse) {
     byte[] interleavedBytes = reuse.array();
     Arrays.fill(interleavedBytes, 0, interleavedSize, (byte) 0x00);

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.data;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
@@ -200,7 +201,7 @@ public abstract class TestReadProjection {
     Record record = GenericRecord.create(writeSchema.asStruct());
     record.setField("id", 34L);
     record.setField("data", "test");
-    record.setField("time", OffsetDateTime.now());
+    record.setField("time", OffsetDateTime.now(ZoneOffset.UTC));
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())


### PR DESCRIPTION
The only warning that is left is this one from https://github.com/apache/iceberg/blob/2f8a09a8f81b27b8ba4025efaa328244ae0fc2a6/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java#L182-L183
which seems legit as we're doing a lossy cast that would fail compilation if I rewrite it (https://errorprone.info/bugpattern/NarrowingCompoundAssignment):

```
> Task :iceberg-core:compileJava
/home/nastra/Development/workspace/iceberg/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java:182: warning: [NarrowingCompoundAssignment] Compound assignments from int to byte hide lossy casts
      interleavedBytes[interleaveByte] |=
                                       ^
    (see https://errorprone.info/bugpattern/NarrowingCompoundAssignment)
  Did you mean 'interleavedBytes[interleaveByte] = (byte) (interleavedBytes[interleaveByte] | (columnsBinary[sourceColumn][sourceByte] & 1 << sourceBit) >>> sourceBit << interleaveBit);'?
```