### PR TITLE
Core: Add length arg to FileIO.newInputFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -38,6 +38,13 @@ public interface FileIO extends Serializable, Closeable {
   InputFile newInputFile(String path);
 
   /**
+   * Get a {@link InputFile} instance to read bytes from the file at the given path, with a known file length.
+   */
+  default InputFile newInputFile(String path, long length) {
+    return newInputFile(path);
+  }
+
+  /**
    * Get a {@link OutputFile} instance to write bytes to the file at the given path.
    */
   OutputFile newOutputFile(String path);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -120,6 +120,11 @@ public class S3FileIO implements FileIO, SupportsBulkOperations, SupportsPrefixO
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return S3InputFile.fromLocation(path, length, client(), awsProperties, metrics);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return S3OutputFile.fromLocation(path, client(), awsProperties, metrics);
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -29,15 +29,23 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryptedFile {
   private NativeFileCryptoParameters nativeDecryptionParameters;
+  private Long length;
 
   public static S3InputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
       MetricsContext metrics) {
-    return new S3InputFile(client, new S3URI(location, awsProperties.s3BucketToAccessPointMapping()),
+    return new S3InputFile(client, new S3URI(location, awsProperties.s3BucketToAccessPointMapping()), null,
         awsProperties, metrics);
   }
 
-  S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
+  public static S3InputFile fromLocation(String location, long length, S3Client client, AwsProperties awsProperties,
+                                         MetricsContext metrics) {
+    return new S3InputFile(client, new S3URI(location, awsProperties.s3BucketToAccessPointMapping()),
+        length > 0 ? length : null, awsProperties, metrics);
+  }
+
+  S3InputFile(S3Client client, S3URI uri, Long length, AwsProperties awsProperties, MetricsContext metrics) {
     super(client, uri, awsProperties, metrics);
+    this.length = length;
   }
 
   /**
@@ -47,7 +55,11 @@ public class S3InputFile extends BaseS3File implements InputFile, NativelyEncryp
    */
   @Override
   public long getLength() {
-    return getObjectMetadata().contentLength();
+    if (length == null) {
+      this.length = getObjectMetadata().contentLength();
+    }
+
+    return length;
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -70,7 +70,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile, NativelyEncr
 
   @Override
   public InputFile toInputFile() {
-    return new S3InputFile(client(), uri(), awsProperties(), metrics());
+    return new S3InputFile(client(), uri(), null, awsProperties(), metrics());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -82,7 +82,7 @@ public class ManifestFiles {
   public static ManifestReader<DataFile> read(ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
     Preconditions.checkArgument(manifest.content() == ManifestContent.DATA,
         "Cannot read a delete manifest with a ManifestReader: %s", manifest);
-    InputFile file = io.newInputFile(manifest.path());
+    InputFile file = io.newInputFile(manifest.path(), manifest.length());
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.fromManifest(manifest);
     return new ManifestReader<>(file, specsById, inheritableMetadata, FileType.DATA_FILES);
   }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -68,6 +68,11 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return HadoopInputFile.fromLocation(path, length, hadoopConf.get());
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return HadoopOutputFile.fromPath(new Path(path), hadoopConf.get());
   }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -61,7 +61,11 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
   public static HadoopInputFile fromLocation(CharSequence location, long length,
                                              Configuration conf) {
     FileSystem fs = Util.getFs(new Path(location.toString()), conf);
-    return new HadoopInputFile(fs, location.toString(), length, conf);
+    if (length > 0) {
+      return new HadoopInputFile(fs, location.toString(), length, conf);
+    } else {
+      return new HadoopInputFile(fs, location.toString(), conf);
+    }
   }
 
   public static HadoopInputFile fromLocation(CharSequence location, FileSystem fs) {

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -64,6 +64,11 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
   }
 
   @Override
+  public InputFile newInputFile(String location, long length) {
+    return io(location).newInputFile(location, length);
+  }
+
+  @Override
   public OutputFile newOutputFile(String location) {
     return io(location).newOutputFile(location);
   }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -81,6 +81,11 @@ public class GCSFileIO implements FileIO {
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return GCSInputFile.fromLocation(path, length, client(), gcpProperties, metrics);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return GCSOutputFile.fromLocation(path, client(), gcpProperties, metrics);
   }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
@@ -27,19 +27,31 @@ import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
 class GCSInputFile extends BaseGCSFile implements InputFile {
+  private Long length;
 
   static GCSInputFile fromLocation(String location, Storage storage,
-      GCPProperties gcpProperties, MetricsContext metrics) {
-    return new GCSInputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties, metrics);
+                                   GCPProperties gcpProperties, MetricsContext metrics) {
+    return new GCSInputFile(storage, BlobId.fromGsUtilUri(location), null, gcpProperties, metrics);
   }
 
-  GCSInputFile(Storage storage, BlobId blobId, GCPProperties gcpProperties, MetricsContext metrics) {
+  static GCSInputFile fromLocation(String location, long length, Storage storage,
+      GCPProperties gcpProperties, MetricsContext metrics) {
+    return new GCSInputFile(
+        storage, BlobId.fromGsUtilUri(location), length > 0 ? length : null, gcpProperties, metrics);
+  }
+
+  GCSInputFile(Storage storage, BlobId blobId, Long length, GCPProperties gcpProperties, MetricsContext metrics) {
     super(storage, blobId, gcpProperties, metrics);
+    this.length = length;
   }
 
   @Override
   public long getLength() {
-    return getBlob().getSize();
+    if (length == null) {
+      this.length = getBlob().getSize();
+    }
+
+    return length;
   }
 
   @Override

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
@@ -67,6 +67,6 @@ class GCSOutputFile extends BaseGCSFile implements OutputFile {
 
   @Override
   public InputFile toInputFile() {
-    return new GCSInputFile(storage(), blobId(), gcpProperties(), metrics());
+    return new GCSInputFile(storage(), blobId(), null, gcpProperties(), metrics());
   }
 }


### PR DESCRIPTION
While investigating #5206, I found that a lot of time is spent in `InputFile#getLength()` for manifest files during job planning. This isn't necessary because `ManifestFile` stored in a manifest list has the manifest file length. This PR avoids round-trip calls to get object lengths by passing the length into `FileIO.newInputFile`. This implements the improvement for S3, GCP, and Hadoop.