### PR TITLE
Build: Upgrade test dependencies to latest version

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.ConcurrentModificationException;
@@ -246,7 +245,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
       table.refresh();
       table.updateSchema().addColumn("newCol", Types.IntegerType.get()).commit();
       throw new RuntimeException("Datacenter on fire");
-    }).when(spyOperations).persistGlueTable(Matchers.any(), Matchers.anyMap(), Matchers.any());
+    }).when(spyOperations).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   @Test
@@ -344,7 +343,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
           i.getArgument(1, Map.class),
           i.getArgument(2, TableMetadata.class));
       throw new RuntimeException("Datacenter on fire");
-    }).when(spyOps).persistGlueTable(Matchers.any(), Matchers.anyMap(), Matchers.any());
+    }).when(spyOps).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   private void failCommitAndThrowException(GlueTableOperations spyOps) {
@@ -353,7 +352,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
   private void failCommitAndThrowException(GlueTableOperations spyOps, Exception exceptionToThrow) {
     Mockito.doThrow(exceptionToThrow)
-        .when(spyOps).persistGlueTable(Matchers.any(), Matchers.anyMap(), Matchers.any());
+        .when(spyOps).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   private void breakFallbackCatalogCommitCheck(GlueTableOperations spyOperations) {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -44,10 +44,10 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -37,8 +37,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;

--- a/versions.props
+++ b/versions.props
@@ -32,15 +32,15 @@ org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
 
 # test deps
-org.junit.vintage:junit-vintage-engine = 5.7.2
-org.junit.jupiter:* = 5.7.2
-org.mockito:* = 3.7.7
+org.junit.vintage:junit-vintage-engine = 5.8.2
+org.junit.jupiter:* = 5.8.2
+org.mockito:* = 4.6.1
 org.apache.tez:* = 0.8.4
 com.adobe.testing:s3mock-junit4 = 2.1.28
-org.assertj:assertj-core = 3.19.0
+org.assertj:assertj-core = 3.23.1
 org.xerial:sqlite-jdbc = 3.34.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-xml = 2.9.9
 org.springframework:* = 5.3.9
 org.springframework.boot:* = 2.5.4
-org.mock-server:mockserver-netty = 5.11.1
-org.mock-server:mockserver-client-java = 5.11.1
+org.mock-server:mockserver-netty = 5.13.2
+org.mock-server:mockserver-client-java = 5.13.2


### PR DESCRIPTION
- upgrade junit5 to 5.8.2
- upgrade assertj to 3.23.1
- upgrade mockserver to 5.13.2
- upgrade mockito to 4.6.1
- org.mockito.Matchers class was removed