### PR TITLE
Build: unify github action versions

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -45,13 +45,14 @@ jobs:
           #
           # See https://github.com/actions/checkout/issues/124
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: zulu
           java-version: 11
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
       - run: ./gradlew :iceberg-api:revapi --rerun-tasks
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: test logs


### PR DESCRIPTION
since https://github.com/apache/iceberg/pull/4851 a new workflow was added that did not use the upgraded versions

before:
```
~/code/iceberg$ rg --no-filename -o 'uses:.*$' .github | sort | uniq -c
      9 uses: actions/cache@v3
     17 uses: actions/checkout@v3
      1 uses: actions/labeler@v4
      1 uses: actions/setup-java@v1
     12 uses: actions/setup-java@v3
      2 uses: actions/setup-python@v3
      1 uses: actions/upload-artifact@v2
      9 uses: actions/upload-artifact@v3
```

after:
```
~/code/iceberg$ rg --no-filename -o 'uses:.*$' .github | sort | uniq -c
      9 uses: actions/cache@v3
     17 uses: actions/checkout@v3
      1 uses: actions/labeler@v4
     13 uses: actions/setup-java@v3
      2 uses: actions/setup-python@v3
     10 uses: actions/upload-artifact@v3
```