### PR TITLE
Spark: Add the query ID to file names

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -320,9 +320,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
       OutputFileFactory dataFileFactory = OutputFileFactory.builderFor(table, partitionId, taskId)
           .format(context.dataFileFormat())
+          .operationId(context.queryId())
           .build();
       OutputFileFactory deleteFileFactory = OutputFileFactory.builderFor(table, partitionId, taskId)
           .format(context.deleteFileFormat())
+          .operationId(context.queryId())
           .build();
 
       SparkFileWriterFactory writerFactory = SparkFileWriterFactory.builderFor(table)
@@ -616,6 +618,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     private final FileFormat deleteFileFormat;
     private final long targetDeleteFileSize;
     private final boolean fanoutWriterEnabled;
+    private final String queryId;
 
     Context(Schema dataSchema, SparkWriteConf writeConf, ExtendedLogicalWriteInfo info) {
       this.dataSchema = dataSchema;
@@ -627,6 +630,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.targetDeleteFileSize = writeConf.targetDeleteFileSize();
       this.metadataSparkType = info.metadataSchema();
       this.fanoutWriterEnabled = writeConf.fanoutWriterEnabled();
+      this.queryId = info.queryId();
     }
 
     Schema dataSchema() {
@@ -663,6 +667,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     boolean fanoutWriterEnabled() {
       return fanoutWriterEnabled;
+    }
+
+    String queryId() {
+      return queryId;
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -320,9 +320,11 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
       OutputFileFactory dataFileFactory = OutputFileFactory.builderFor(table, partitionId, taskId)
           .format(context.dataFileFormat())
+          .operationId(context.queryId())
           .build();
       OutputFileFactory deleteFileFactory = OutputFileFactory.builderFor(table, partitionId, taskId)
           .format(context.deleteFileFormat())
+          .operationId(context.queryId())
           .build();
 
       SparkFileWriterFactory writerFactory = SparkFileWriterFactory.builderFor(table)
@@ -616,6 +618,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     private final FileFormat deleteFileFormat;
     private final long targetDeleteFileSize;
     private final boolean fanoutWriterEnabled;
+    private final String queryId;
 
     Context(Schema dataSchema, SparkWriteConf writeConf, ExtendedLogicalWriteInfo info) {
       this.dataSchema = dataSchema;
@@ -627,6 +630,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.targetDeleteFileSize = writeConf.targetDeleteFileSize();
       this.metadataSparkType = info.metadataSchema();
       this.fanoutWriterEnabled = writeConf.fanoutWriterEnabled();
+      this.queryId = info.queryId();
     }
 
     Schema dataSchema() {
@@ -663,6 +667,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
 
     boolean fanoutWriterEnabled() {
       return fanoutWriterEnabled;
+    }
+
+    String queryId() {
+      return queryId;
     }
   }
 }


### PR DESCRIPTION
Spark writes should use the query ID in filenames, but it was not correctly passed through, causing each writer to use a different UUID. Adding the UUID to filenames should allow identifying files from the same write.