### PR TITLE
Core: Update MetricsConfig to use a default for first 32 columns

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.slf4j.Logger;
@@ -45,9 +47,8 @@ public final class MetricsConfig implements Serializable {
   private static final Joiner DOT = Joiner.on('.');
 
   // Disable metrics by default for wide tables to prevent excessive metadata
-  private static final int MAX_COLUMNS = 32;
-  private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
-      MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
+  private static final MetricsMode DEFAULT_MODE = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+  private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(), DEFAULT_MODE);
 
   private final Map<String, MetricsMode> columnModes;
   private final MetricsMode defaultMode;
@@ -96,7 +97,7 @@ public final class MetricsConfig implements Serializable {
    **/
   @Deprecated
   public static MetricsConfig fromProperties(Map<String, String> props) {
-    return from(props, null, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+    return from(props, null, null);
   }
 
   /**
@@ -104,13 +105,7 @@ public final class MetricsConfig implements Serializable {
    * @param table iceberg table
    */
   public static MetricsConfig forTable(Table table) {
-    String defaultMode;
-    if (table.schema().columns().size() <= MAX_COLUMNS) {
-      defaultMode = DEFAULT_WRITE_METRICS_MODE_DEFAULT;
-    } else {
-      defaultMode = MetricsModes.None.get().toString();
-    }
-    return from(table.properties(), table.sortOrder(), defaultMode);
+    return from(table.properties(), table.schema(), table.sortOrder());
   }
 
   /**
@@ -136,50 +131,58 @@ public final class MetricsConfig implements Serializable {
   }
 
   /**
-   * Generate a MetricsConfig for all columns based on overrides, sortOrder, and defaultMode.
+   * Generate a MetricsConfig for all columns based on overrides, schema, and sort order.
+   *
    * @param props will be read for metrics overrides (write.metadata.metrics.column.*) and default
    *              (write.metadata.metrics.default)
+   * @param schema table schema
    * @param order sort order columns, will be promoted to truncate(16)
-   * @param defaultMode default, if not set by user property
    * @return metrics configuration
    */
-  private static MetricsConfig from(Map<String, String> props, SortOrder order, String defaultMode) {
+  private static MetricsConfig from(Map<String, String> props, Schema schema, SortOrder order) {
+    int maxInferredDefaultColumns = PropertyUtil.propertyAsInt(props,
+        TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS,
+        TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT);
     Map<String, MetricsMode> columnModes = Maps.newHashMap();
 
     // Handle user override of default mode
-    MetricsMode finalDefaultMode;
-    String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, defaultMode);
-    try {
-      finalDefaultMode = MetricsModes.fromString(defaultModeAsString);
-    } catch (IllegalArgumentException err) {
-      // User override was invalid, log the error and use the default
-      LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString, err);
-      finalDefaultMode = MetricsModes.fromString(defaultMode);
+    MetricsMode defaultMode;
+    String configuredDefault = props.get(DEFAULT_WRITE_METRICS_MODE);
+    if (configuredDefault != null) {
+      // a user-configured default mode is applied for all columns
+      defaultMode = parseMode(configuredDefault, DEFAULT_MODE, "default");
+
+    } else if (schema == null || schema.columns().size() <= maxInferredDefaultColumns) {
+      // there are less than the inferred limit, so the default is used everywhere
+      defaultMode = DEFAULT_MODE;
+
+    } else {
+      // a inferred default mode is applied to the first few columns, up to the limit
+      Schema subSchema = new Schema(schema.columns().subList(0, maxInferredDefaultColumns));
+      for (Integer id : TypeUtil.getProjectedIds(subSchema)) {
+        columnModes.put(subSchema.findColumnName(id), DEFAULT_MODE);
+      }
+
+      // all other columns don't use metrics
+      defaultMode = MetricsModes.None.get();
     }
 
     // First set sorted column with sorted column default (can be overridden by user)
-    MetricsMode sortedColDefaultMode = sortedColumnDefaultMode(finalDefaultMode);
+    MetricsMode sortedColDefaultMode = sortedColumnDefaultMode(defaultMode);
     Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
     sortedCols.forEach(sc -> columnModes.put(sc, sortedColDefaultMode));
 
     // Handle user overrides of defaults
-    MetricsMode finalDefaultModeVal = finalDefaultMode;
-    props.keySet().stream()
-        .filter(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))
-        .forEach(key -> {
-          String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
-          MetricsMode mode;
-          try {
-            mode = MetricsModes.fromString(props.get(key));
-          } catch (IllegalArgumentException err) {
-            // Mode was invalid, log the error and use the default
-            LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key), err);
-            mode = finalDefaultModeVal;
-          }
-          columnModes.put(columnAlias, mode);
-        });
+    MetricsMode finalDefaultModeVal = defaultMode;
+    for (String key : props.keySet()) {
+      if (key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX)) {
+        String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
+        MetricsMode mode = parseMode(props.get(key), finalDefaultModeVal, "column " + columnAlias);
+        columnModes.put(columnAlias, mode);
+      }
+    }
 
-    return new MetricsConfig(columnModes, finalDefaultMode);
+    return new MetricsConfig(columnModes, defaultMode);
   }
 
   /**
@@ -192,6 +195,16 @@ public final class MetricsConfig implements Serializable {
       return MetricsModes.Truncate.withLength(16);
     } else {
       return defaultMode;
+    }
+  }
+
+  private static MetricsMode parseMode(String modeString, MetricsMode fallback, String context) {
+    try {
+      return MetricsModes.fromString(modeString);
+    } catch (IllegalArgumentException err) {
+      // User override was invalid, log the error and use the default
+      LOG.warn("Ignoring invalid metrics mode ({}): {}", context, modeString, err);
+      return fallback;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -267,6 +267,10 @@ public class TableProperties {
   public static final String METADATA_DELETE_AFTER_COMMIT_ENABLED = "write.metadata.delete-after-commit.enabled";
   public static final boolean METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT = false;
 
+  public static final String METRICS_MAX_INFERRED_COLUMN_DEFAULTS =
+      "write.metadata.metrics.max-inferred-column-defaults";
+  public static final int METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT = 32;
+
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -238,22 +238,22 @@ public abstract class TestWriterMetrics<T> {
     DataFile dataFile = dataWriter.toDataFile();
 
     // start at 1 because IDs were reassigned in the table
-    int i = 1;
-    for (; i <= 32; i += 1) {
-      Assert.assertNotNull("Should have lower bound metrics", dataFile.lowerBounds().get(i));
-      Assert.assertNotNull("Should have upper bound metrics", dataFile.upperBounds().get(i));
-      Assert.assertNull("Should not have nan value metrics (not floating point)", dataFile.nanValueCounts().get(i));
-      Assert.assertNotNull("Should have null value metrics", dataFile.nullValueCounts().get(i));
-      Assert.assertNotNull("Should have value metrics", dataFile.valueCounts().get(i));
+    int id = 1;
+    for (; id <= 32; id += 1) {
+      Assert.assertNotNull("Should have lower bound metrics", dataFile.lowerBounds().get(id));
+      Assert.assertNotNull("Should have upper bound metrics", dataFile.upperBounds().get(id));
+      Assert.assertNull("Should not have nan value metrics (not floating point)", dataFile.nanValueCounts().get(id));
+      Assert.assertNotNull("Should have null value metrics", dataFile.nullValueCounts().get(id));
+      Assert.assertNotNull("Should have value metrics", dataFile.valueCounts().get(id));
     }
 
     // Remaining fields should not have metrics
-    for (; i <= numColumns; i += 1) {
-      Assert.assertNull("Should not have any lower bound metrics", dataFile.lowerBounds().get(i));
-      Assert.assertNull("Should not have any upper bound metrics", dataFile.upperBounds().get(i));
-      Assert.assertNull("Should not have any nan value metrics", dataFile.nanValueCounts().get(i));
-      Assert.assertNull("Should not have any null value metrics", dataFile.nullValueCounts().get(i));
-      Assert.assertNull("Should not have any value metrics", dataFile.valueCounts().get(i));
+    for (; id <= numColumns; id += 1) {
+      Assert.assertNull("Should not have any lower bound metrics", dataFile.lowerBounds().get(id));
+      Assert.assertNull("Should not have any upper bound metrics", dataFile.upperBounds().get(id));
+      Assert.assertNull("Should not have any nan value metrics", dataFile.nanValueCounts().get(id));
+      Assert.assertNull("Should not have any null value metrics", dataFile.nullValueCounts().get(id));
+      Assert.assertNull("Should not have any value metrics", dataFile.valueCounts().get(id));
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -237,12 +237,24 @@ public abstract class TestWriterMetrics<T> {
     dataWriter.close();
     DataFile dataFile = dataWriter.toDataFile();
 
-    // No field should have metrics
-    Assert.assertTrue("Should not have any lower bound metrics", dataFile.lowerBounds().isEmpty());
-    Assert.assertTrue("Should not have any upper bound metrics", dataFile.upperBounds().isEmpty());
-    Assert.assertTrue("Should not have any nan value metrics", dataFile.nanValueCounts().isEmpty());
-    Assert.assertTrue("Should not have any null value metrics", dataFile.nullValueCounts().isEmpty());
-    Assert.assertTrue("Should not have any value metrics", dataFile.valueCounts().isEmpty());
+    // start at 1 because IDs were reassigned in the table
+    int i = 1;
+    for (; i <= 32; i += 1) {
+      Assert.assertNotNull("Should have lower bound metrics", dataFile.lowerBounds().get(i));
+      Assert.assertNotNull("Should have upper bound metrics", dataFile.upperBounds().get(i));
+      Assert.assertNull("Should not have nan value metrics (not floating point)", dataFile.nanValueCounts().get(i));
+      Assert.assertNotNull("Should have null value metrics", dataFile.nullValueCounts().get(i));
+      Assert.assertNotNull("Should have value metrics", dataFile.valueCounts().get(i));
+    }
+
+    // Remaining fields should not have metrics
+    for (; i <= numColumns; i += 1) {
+      Assert.assertNull("Should not have any lower bound metrics", dataFile.lowerBounds().get(i));
+      Assert.assertNull("Should not have any upper bound metrics", dataFile.upperBounds().get(i));
+      Assert.assertNull("Should not have any nan value metrics", dataFile.nanValueCounts().get(i));
+      Assert.assertNull("Should not have any null value metrics", dataFile.nullValueCounts().get(i));
+      Assert.assertNull("Should not have any value metrics", dataFile.valueCounts().get(i));
+    }
   }
 
   @Test


### PR DESCRIPTION
#3959 updated `MetricsConfig` to stop writing metrics by default for tables with more than 32 columns. The intent was to avoid having too much metadata stored as stats in manifest files, but the implementation stopped writing metrics for all columns after a table reached 32 columns, which caused a large change in table performance after a table grows to 32+ columns.

This updates the logic so that the first 32 columns still have metrics, but no new metrics are stored for columns after that point unless the table has a global default set or columns are individually configured.