### PR TITLE
Prevent usage of @Test(expected = ...) and change existing tests

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -410,6 +410,11 @@
             <property name="format" value="(void setUp\(\))|(void setup\(\))|(void setupStatic\(\))|(void setUpStatic\(\))|(void beforeTest\(\))|(void teardown\(\))|(void tearDown\(\))|(void beforeStatic\(\))|(void afterStatic\(\))"/>
             <property name="message" value="Test setup/teardown methods are called before(), beforeClass(), after(), afterClass(), but not setUp, teardown, etc."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="ignoreComments" value="true"/>
+            <property name="format" value="@Test\(.*expected.*\)"/>
+            <property name="message" value="Prefer using Assertions.assertThatThrownBy(...).isInstanceOf(...) instead."/>
+        </module>
         <module name="RightCurly"> <!-- Java Style Guide: Nonempty blocks: K & R style -->
             <property name="option" value="same"/>
             <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -51,19 +51,17 @@ public class TestExpressionBinding {
   @Test
   public void testMissingReference() {
     Expression expr = and(equal("t", 5), equal("x", 7));
-    try {
-      Binder.bind(STRUCT, expr);
-      Assert.fail("Should not successfully bind to struct without field 't'");
-    } catch (ValidationException e) {
-      Assert.assertTrue("Should complain about missing field",
-          e.getMessage().contains("Cannot find field 't' in struct:"));
-    }
+    Assertions.assertThatThrownBy(() -> Binder.bind(STRUCT, expr))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 't' in struct");
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBoundExpressionFails() {
     Expression expr = not(equal("x", 7));
-    Binder.bind(STRUCT, Binder.bind(STRUCT, expr));
+    Assertions.assertThatThrownBy(() -> Binder.bind(STRUCT, Binder.bind(STRUCT, expr)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Found already bound predicate");
   }
 
   @Test
@@ -78,10 +76,12 @@ public class TestExpressionBinding {
     TestHelpers.assertAllReferencesBound("Single reference", Binder.bind(STRUCT, expr, false));
   }
 
-  @Test(expected = ValidationException.class)
+  @Test
   public void testCaseSensitiveReference() {
     Expression expr = not(equal("X", 7));
-    Binder.bind(STRUCT, expr, true);
+    Assertions.assertThatThrownBy(() -> Binder.bind(STRUCT, expr, true))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'X' in struct");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
@@ -31,6 +31,7 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.data.TimeConversions;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -159,18 +160,22 @@ public class TestStringLiteralConversions {
 
   }
 
-  @Test(expected = DateTimeException.class)
+  @Test
   public void testTimestampWithZoneWithoutZoneInLiteral() {
     // Zone must be present in literals when converting to timestamp with zone
     Literal<CharSequence> timestampStr = Literal.of("2017-08-18T14:21:01.919");
-    timestampStr.to(Types.TimestampType.withZone());
+    Assertions.assertThatThrownBy(() -> timestampStr.to(Types.TimestampType.withZone()))
+        .isInstanceOf(DateTimeException.class)
+        .hasMessageContaining("could not be parsed");
   }
 
-  @Test(expected = DateTimeException.class)
+  @Test
   public void testTimestampWithoutZoneWithZoneInLiteral() {
     // Zone must not be present in literals when converting to timestamp without zone
     Literal<CharSequence> timestampStr = Literal.of("2017-08-18T14:21:01.919+07:00");
-    timestampStr.to(Types.TimestampType.withoutZone());
+    Assertions.assertThatThrownBy(() -> timestampStr.to(Types.TimestampType.withoutZone()))
+        .isInstanceOf(DateTimeException.class)
+        .hasMessageContaining("could not be parsed");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.expressions.Predicate;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -129,7 +130,7 @@ public class TestResiduals {
     Assert.assertEquals("Residual should be alwaysFalse", alwaysFalse(), residual);
   }
 
-  @Test(expected = ValidationException.class)
+  @Test
   public void testCaseSensitiveIdentityTransformResiduals() {
     Schema schema = new Schema(
         Types.NestedField.optional(50, "dateint", Types.IntegerType.get()),
@@ -142,7 +143,9 @@ public class TestResiduals {
 
     ResidualEvaluator resEval = ResidualEvaluator.of(spec, lessThan("DATEINT", 20170815), true);
 
-    resEval.residualFor(Row.of(20170815));
+    Assertions.assertThatThrownBy(() -> resEval.residualFor(Row.of(20170815)))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'DATEINT' in struct");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types.IntegerType;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -427,7 +428,7 @@ public class TestTypeUtil {
     Assert.assertEquals(expected.asStruct(), actual.asStruct());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testReassignIdsIllegalArgumentException() {
     Schema schema = new Schema(
         required(1, "a", Types.IntegerType.get()),
@@ -436,10 +437,12 @@ public class TestTypeUtil {
     Schema sourceSchema = new Schema(
         required(1, "a", Types.IntegerType.get())
     );
-    TypeUtil.reassignIds(schema, sourceSchema);
+    Assertions.assertThatThrownBy(() -> TypeUtil.reassignIds(schema, sourceSchema))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Field b not found in source schema");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testValidateSchemaViaIndexByName() {
     Types.NestedField nestedType = Types.NestedField
         .required(1, "a", Types.StructType.of(
@@ -450,7 +453,9 @@ public class TestTypeUtil {
             )
         );
 
-    TypeUtil.indexByName(Types.StructType.of(nestedType));
+    Assertions.assertThatThrownBy(() -> TypeUtil.indexByName(Types.StructType.of(nestedType)))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("Invalid schema: multiple fields for name a.b.c");
   }
 
   @Test

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtilTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/DecimalVectorUtilTest.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.math.BigInteger;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -65,9 +66,11 @@ public class DecimalVectorUtilTest {
     assertEquals(BigInteger.ZERO, result);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testPadBigEndianBytesOverflow() {
     byte[] bytes = new byte[17];
-    DecimalVectorUtil.padBigEndianBytes(bytes, 16);
+    Assertions.assertThatThrownBy(() -> DecimalVectorUtil.padBigEndianBytes(bytes, 16))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Buffer size of 17 is larger than requested size of 16");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -51,8 +51,8 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   }
 
   /**
-   * The Hadoop implementation delegates to the Hadoop delegates to the
-   * FileSystem.Statistics implementation and therefore does not require
+   * The Hadoop implementation delegates to the FileSystem.Statistics
+   * implementation and therefore does not require
    * support for operations like unit() and count() as the counter
    * values are not directly consumed.
    *

--- a/pig/src/test/java/org/apache/iceberg/pig/SchemaUtilTest.java
+++ b/pig/src/test/java/org/apache/iceberg/pig/SchemaUtilTest.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.pig.ResourceSchema;
 import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -72,11 +73,13 @@ public class SchemaUtilTest {
     );
   }
 
-  @Test(expected = FrontendException.class)
-  public void invalidMap() throws IOException {
-    convertToPigSchema(new Schema(
-        optional(1, "invalid", MapType.ofOptional(2, 3, IntegerType.get(), DoubleType.get()))
-    ), "", "");
+  @Test
+  public void invalidMap() {
+    Assertions.assertThatThrownBy(() -> convertToPigSchema(new Schema(
+                    optional(1, "invalid", MapType.ofOptional(2, 3, IntegerType.get(), DoubleType.get()))
+            ), "", ""))
+            .isInstanceOf(FrontendException.class)
+            .hasMessageContaining("Unsupported map key type: int");
   }
 
   @Test

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.StructField;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,14 +160,18 @@ public class SchemaEvolutionTest {
         first.get().dataType() == LongType$.MODULE$);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void updateColumnTypeIntToString() {
-    table.updateSchema().updateColumn("price", Types.StringType.get()).commit();
+    Assertions.assertThatThrownBy(() -> table.updateSchema().updateColumn("price", Types.StringType.get()).commit())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot change column type: price: int -> string");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void updateColumnTypeStringToInt() {
-    table.updateSchema().updateColumn("author", Types.IntegerType.get()).commit();
+    Assertions.assertThatThrownBy(() -> table.updateSchema().updateColumn("author", Types.IntegerType.get()).commit())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot change column type: author: string -> int");
   }
 
   @Test

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -176,7 +177,7 @@ public class TestSnapshotSelection {
     Assert.assertEquals("Previous snapshot rows should match", firstBatchRecords, previousSnapshotRecords);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidSnapshotId() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -189,10 +190,12 @@ public class TestSnapshotSelection {
         .option("snapshot-id", -10)
         .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(df::collectAsList)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot find snapshot with ID -10");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidTimestamp() throws IOException {
     long timestamp = System.currentTimeMillis();
 
@@ -201,15 +204,15 @@ public class TestSnapshotSelection {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     tables.create(SCHEMA, spec, tableLocation);
 
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
-
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot find a snapshot older than");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionBySnapshotIdAndTimestamp() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -227,12 +230,14 @@ public class TestSnapshotSelection {
 
     long timestamp = System.currentTimeMillis();
     long snapshotId = table.currentSnapshot().snapshotId();
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot specify both snapshot-id")
+            .hasMessageContaining("and as-of-timestamp");
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -176,7 +177,7 @@ public class TestSnapshotSelection {
     Assert.assertEquals("Previous snapshot rows should match", firstBatchRecords, previousSnapshotRecords);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidSnapshotId() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -189,10 +190,12 @@ public class TestSnapshotSelection {
         .option("snapshot-id", -10)
         .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(df::collectAsList)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot find snapshot with ID -10");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidTimestamp() throws IOException {
     long timestamp = System.currentTimeMillis();
 
@@ -201,15 +204,15 @@ public class TestSnapshotSelection {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     tables.create(SCHEMA, spec, tableLocation);
 
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
-
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot find a snapshot older than");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionBySnapshotIdAndTimestamp() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -227,12 +230,14 @@ public class TestSnapshotSelection {
 
     long timestamp = System.currentTimeMillis();
     long snapshotId = table.currentSnapshot().snapshotId();
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot specify both snapshot-id")
+            .hasMessageContaining("and as-of-timestamp");
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class TestHadoopMetricsContextSerialization {
 
-  @Test(expected = Test.None.class)
+  @Test
   public void testHadoopMetricsContextKryoSerialization() throws IOException {
     MetricsContext metricsContext = new HadoopMetricsContext("s3");
 
@@ -41,7 +41,7 @@ public class TestHadoopMetricsContextSerialization {
         .increment();
   }
 
-  @Test(expected = Test.None.class)
+  @Test
   public void testHadoopMetricsContextJavaSerialization() throws IOException, ClassNotFoundException {
     MetricsContext metricsContext = new HadoopMetricsContext("s3");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -176,7 +177,7 @@ public class TestSnapshotSelection {
     Assert.assertEquals("Previous snapshot rows should match", firstBatchRecords, previousSnapshotRecords);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidSnapshotId() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -189,10 +190,12 @@ public class TestSnapshotSelection {
         .option("snapshot-id", -10)
         .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(df::collectAsList)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot find snapshot with ID -10");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidTimestamp() throws IOException {
     long timestamp = System.currentTimeMillis();
 
@@ -201,15 +204,15 @@ public class TestSnapshotSelection {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     tables.create(SCHEMA, spec, tableLocation);
 
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
-
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot find a snapshot older than");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionBySnapshotIdAndTimestamp() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -227,12 +230,14 @@ public class TestSnapshotSelection {
 
     long timestamp = System.currentTimeMillis();
     long snapshotId = table.currentSnapshot().snapshotId();
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot specify both snapshot-id")
+            .hasMessageContaining("and as-of-timestamp");
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class TestHadoopMetricsContextSerialization {
 
-  @Test(expected = Test.None.class)
+  @Test
   public void testHadoopMetricsContextKryoSerialization() throws IOException {
     MetricsContext metricsContext = new HadoopMetricsContext("s3");
 
@@ -41,7 +41,7 @@ public class TestHadoopMetricsContextSerialization {
         .increment();
   }
 
-  @Test(expected = Test.None.class)
+  @Test
   public void testHadoopMetricsContextJavaSerialization() throws IOException, ClassNotFoundException {
     MetricsContext metricsContext = new HadoopMetricsContext("s3");
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -176,7 +177,7 @@ public class TestSnapshotSelection {
     Assert.assertEquals("Previous snapshot rows should match", firstBatchRecords, previousSnapshotRecords);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidSnapshotId() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -189,10 +190,12 @@ public class TestSnapshotSelection {
         .option("snapshot-id", -10)
         .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(df::collectAsList)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot find snapshot with ID -10");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionByInvalidTimestamp() throws IOException {
     long timestamp = System.currentTimeMillis();
 
@@ -201,15 +204,15 @@ public class TestSnapshotSelection {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     tables.create(SCHEMA, spec, tableLocation);
 
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
-
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot find a snapshot older than");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testSnapshotSelectionBySnapshotIdAndTimestamp() throws IOException {
     String tableLocation = temp.newFolder("iceberg-table").toString();
 
@@ -227,12 +230,14 @@ public class TestSnapshotSelection {
 
     long timestamp = System.currentTimeMillis();
     long snapshotId = table.currentSnapshot().snapshotId();
-    Dataset<Row> df = spark.read()
-        .format("iceberg")
-        .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
-        .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
-        .load(tableLocation);
 
-    df.collectAsList();
+    Assertions.assertThatThrownBy(() -> spark.read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.SNAPSHOT_ID, snapshotId)
+                    .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
+                    .load(tableLocation))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Cannot specify both snapshot-id")
+            .hasMessageContaining("and as-of-timestamp");
   }
 }


### PR DESCRIPTION
We should avoid usage of `@Test(expected = ...)` because it is not
always clear from where exactly an exception is thrown. We should rather
promote using `Assertions.assertThatThrownBy(...).isInstanceOf(...).hasMessage(...)`
as that makes sure that we are in fact getting the right exception with
the appropriate error message.