### PR TITLE
Don't throw from finally block

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -135,8 +135,7 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
           io().deleteFile(newMetadataLocation);
         }
       } catch (RuntimeException e) {
-        LOG.error("Fail to cleanup metadata file at {}", newMetadataLocation, e);
-        throw e;
+        LOG.error("Failed to cleanup metadata file at {}", newMetadataLocation, e);
       }
     }
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -247,8 +247,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
         io().deleteFile(metadataLocation);
       }
     } catch (RuntimeException e) {
-      LOG.error("Fail to cleanup metadata file at {}", metadataLocation, e);
-      throw e;
+      LOG.error("Failed to cleanup metadata file at {}", metadataLocation, e);
     } finally {
       if (lockManager != null) {
         lockManager.release(commitLockEntityId, metadataLocation);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -578,8 +578,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         io().deleteFile(metadataLocation);
       }
     } catch (RuntimeException e) {
-      LOG.error("Fail to cleanup metadata file at {}", metadataLocation, e);
-      throw e;
+      LOG.error("Failed to cleanup metadata file at {}", metadataLocation, e);
     } finally {
       unlock(lockId);
       tableLevelMutex.unlock();


### PR DESCRIPTION
Any exception coming from the try-catch block will be swallowed and the user will only see the exception from the finally block.
Note that `cleanupMetadataAndUnlock()` is being called from a `finally` block.

It seems enough to just log the error but not throw an exception when
metadata cleanup failed.