### PR TITLE
Spark: Provide size estimate for table broadcast

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -67,7 +67,7 @@ public class SerializableTable implements Table, Serializable {
   private transient volatile Map<Integer, PartitionSpec> lazySpecs = null;
   private transient volatile SortOrder lazySortOrder = null;
 
-  private SerializableTable(Table table) {
+  protected SerializableTable(Table table) {
     this.name = table.name();
     this.location = table.location();
     this.metadataFileLocation = metadataFileLocation(table);
@@ -346,11 +346,11 @@ public class SerializableTable implements Table, Serializable {
     return String.format("Operation %s is not supported after the table is serialized", operation);
   }
 
-  private static class SerializableMetadataTable extends SerializableTable {
+  public static class SerializableMetadataTable extends SerializableTable {
     private final MetadataTableType type;
     private final String baseTableName;
 
-    SerializableMetadataTable(BaseMetadataTable metadataTable) {
+    protected SerializableMetadataTable(BaseMetadataTable metadataTable) {
       super(metadataTable);
       this.type = metadataTable.metadataTableType();
       this.baseTableName = metadataTable.table().name();

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.BaseMetadataTable;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.spark.util.KnownSizeEstimation;
+
+/**
+ * This class provides a serializable table with a known size estimate. Spark calls
+ * its SizeEstimator class when broadcasting variables and this can be an expensive
+ * operation, so providing a known size estimate allows that operation to be skipped.
+ */
+public class SerializableTableWithSize extends SerializableTable implements KnownSizeEstimation {
+
+  private static final long SIZE_ESTIMATE = 32_768L;
+
+  protected SerializableTableWithSize(Table table) {
+    super(table);
+  }
+
+  @Override
+  public long estimatedSize() {
+    return SIZE_ESTIMATE;
+  }
+
+  public static Table copyOf(Table table) {
+    if (table instanceof BaseMetadataTable) {
+      return new SerializableMetadataTableWithSize((BaseMetadataTable) table);
+    } else {
+      return new SerializableTableWithSize(table);
+    }
+  }
+
+  public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
+      implements KnownSizeEstimation {
+
+    protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
+      super(metadataTable);
+    }
+
+    @Override
+    public long estimatedSize() {
+      return SIZE_ESTIMATE;
+    }
+  }
+}

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
@@ -135,7 +134,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
 
     // broadcast the table metadata as input partitions will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
 
     List<CombinedScanTask> scanTasks = tasks();
     InputPartition[] readTasks = new InputPartition[scanTasks.size()];

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.MicroBatches.MicroBatch;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
@@ -86,7 +85,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     this.caseSensitive = caseSensitive;
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
     this.localityPreferred = readConf.localityEnabled();
-    this.tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
@@ -161,7 +160,7 @@ class SparkWrite {
   // the writer factory works for both batch and streaming
   private WriterFactory createWriterFactory() {
     // broadcast the table metadata as the writer factory will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     return new WriterFactory(tableBroadcast, format, targetFileSize, writeSchema, dsSchema, partitionedFanoutEnabled);
   }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -82,7 +83,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
@@ -96,7 +97,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class TestTableSerialization {
 
   @Test
   public void testSerializableTableKryoSerialization() throws IOException {
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     TestHelpers.assertSerializedAndLoadedMetadata(table, KryoHelpers.roundTripSerialize(serializableTable));
   }
 
@@ -78,7 +79,7 @@ public class TestTableSerialization {
     for (MetadataTableType type : MetadataTableType.values()) {
       TableOperations ops = ((HasTableOperations) table).operations();
       Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, table.name(), "meta", type);
-      Table serializableMetadataTable = SerializableTable.copyOf(metadataTable);
+      Table serializableMetadataTable = SerializableTableWithSize.copyOf(metadataTable);
 
       TestHelpers.assertSerializedAndLoadedMetadata(
           metadataTable,
@@ -95,7 +96,7 @@ public class TestTableSerialization {
         .commit();
 
     Table txnTable = txn.table();
-    Table serializableTxnTable = SerializableTable.copyOf(txnTable);
+    Table serializableTxnTable = SerializableTableWithSize.copyOf(txnTable);
 
     TestHelpers.assertSerializedMetadata(txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
   }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -106,8 +105,8 @@ public class TestSparkCatalogHadoopOverrides extends SparkCatalogTestBase {
         configOverrideValue, actualCatalogOverride);
 
     // Now convert to SerializableTable and ensure overridden property is still present.
-    Table serializableTable = SerializableTable.copyOf(table);
-    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
+    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
     Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(configToOverride, "/whammies");
     Assert.assertEquals(

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.BaseMetadataTable;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.spark.util.KnownSizeEstimation;
+
+/**
+ * This class provides a serializable table with a known size estimate. Spark calls
+ * its SizeEstimator class when broadcasting variables and this can be an expensive
+ * operation, so providing a known size estimate allows that operation to be skipped.
+ */
+public class SerializableTableWithSize extends SerializableTable implements KnownSizeEstimation {
+
+  private static final long SIZE_ESTIMATE = 32_768L;
+
+  protected SerializableTableWithSize(Table table) {
+    super(table);
+  }
+
+  @Override
+  public long estimatedSize() {
+    return SIZE_ESTIMATE;
+  }
+
+  public static Table copyOf(Table table) {
+    if (table instanceof BaseMetadataTable) {
+      return new SerializableMetadataTableWithSize((BaseMetadataTable) table);
+    } else {
+      return new SerializableTableWithSize(table);
+    }
+  }
+
+  public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
+      implements KnownSizeEstimation {
+
+    protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
+      super(metadataTable);
+    }
+
+    @Override
+    public long estimatedSize() {
+      return SIZE_ESTIMATE;
+    }
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expression;
@@ -135,7 +134,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
 
     // broadcast the table metadata as input partitions will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
 
     List<CombinedScanTask> scanTasks = tasks();
     InputPartition[] readTasks = new InputPartition[scanTasks.size()];

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.MicroBatches.MicroBatch;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
@@ -86,7 +85,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     this.caseSensitive = caseSensitive;
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
     this.localityPreferred = readConf.localityEnabled();
-    this.tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
@@ -161,7 +160,7 @@ class SparkWrite {
   // the writer factory works for both batch and streaming
   private WriterFactory createWriterFactory() {
     // broadcast the table metadata as the writer factory will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     return new WriterFactory(tableBroadcast, format, targetFileSize, writeSchema, dsSchema, partitionedFanoutEnabled);
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -82,7 +83,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
@@ -96,7 +97,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class TestTableSerialization {
 
   @Test
   public void testSerializableTableKryoSerialization() throws IOException {
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     TestHelpers.assertSerializedAndLoadedMetadata(table, KryoHelpers.roundTripSerialize(serializableTable));
   }
 
@@ -78,7 +79,7 @@ public class TestTableSerialization {
     for (MetadataTableType type : MetadataTableType.values()) {
       TableOperations ops = ((HasTableOperations) table).operations();
       Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, table.name(), "meta", type);
-      Table serializableMetadataTable = SerializableTable.copyOf(metadataTable);
+      Table serializableMetadataTable = SerializableTableWithSize.copyOf(metadataTable);
 
       TestHelpers.assertSerializedAndLoadedMetadata(
           metadataTable,
@@ -95,7 +96,7 @@ public class TestTableSerialization {
         .commit();
 
     Table txnTable = txn.table();
-    Table serializableTxnTable = SerializableTable.copyOf(txnTable);
+    Table serializableTxnTable = SerializableTableWithSize.copyOf(txnTable);
 
     TestHelpers.assertSerializedMetadata(txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -106,8 +105,8 @@ public class TestSparkCatalogHadoopOverrides extends SparkCatalogTestBase {
         configOverrideValue, actualCatalogOverride);
 
     // Now convert to SerializableTable and ensure overridden property is still present.
-    Table serializableTable = SerializableTable.copyOf(table);
-    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
+    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
     Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(configToOverride, "/whammies");
     Assert.assertEquals(

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -45,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.JobGroupUtils;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -130,7 +130,7 @@ abstract class BaseSparkAction<ThisT, R> implements Action<ThisT, R> {
 
   // builds a DF of delete and data file path and type by reading all manifests
   protected Dataset<Row> buildValidContentFileWithTypeDF(Table table) {
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
 
     Dataset<ManifestFileBean> allManifests = loadMetadataTable(table, ALL_MANIFESTS)
         .selectExpr(

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.BaseMetadataTable;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.spark.util.KnownSizeEstimation;
+
+/**
+ * This class provides a serializable table with a known size estimate. Spark calls
+ * its SizeEstimator class when broadcasting variables and this can be an expensive
+ * operation, so providing a known size estimate allows that operation to be skipped.
+ */
+public class SerializableTableWithSize extends SerializableTable implements KnownSizeEstimation {
+
+  private static final long SIZE_ESTIMATE = 32_768L;
+
+  protected SerializableTableWithSize(Table table) {
+    super(table);
+  }
+
+  @Override
+  public long estimatedSize() {
+    return SIZE_ESTIMATE;
+  }
+
+  public static Table copyOf(Table table) {
+    if (table instanceof BaseMetadataTable) {
+      return new SerializableMetadataTableWithSize((BaseMetadataTable) table);
+    } else {
+      return new SerializableTableWithSize(table);
+    }
+  }
+
+  public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
+      implements KnownSizeEstimation {
+
+    protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
+      super(metadataTable);
+    }
+
+    @Override
+    public long estimatedSize() {
+      return SIZE_ESTIMATE;
+    }
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.source.SparkScan.ReadTask;
@@ -60,7 +59,7 @@ abstract class SparkBatch implements Batch {
   @Override
   public InputPartition[] planInputPartitions() {
     // broadcast the table metadata as input partitions will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
 
     InputPartition[] readTasks = new InputPartition[tasks().size()];

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.MicroBatches.MicroBatch;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
@@ -88,7 +87,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     this.caseSensitive = readConf.caseSensitive();
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
     this.localityPreferred = readConf.localityEnabled();
-    this.tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
@@ -151,7 +150,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     @Override
     public DeltaWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
       // broadcast the table metadata as the writer factory will be sent to executors
-      Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+      Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
       return new PositionDeltaWriteFactory(tableBroadcast, command, context);
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
@@ -179,7 +178,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   // the writer factory works for both batch and streaming
   private WriterFactory createWriterFactory() {
     // broadcast the table metadata as the writer factory will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     return new WriterFactory(tableBroadcast, format, targetFileSize, writeSchema, dsSchema, partitionedFanoutEnabled);
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOParser;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -84,7 +85,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
@@ -98,7 +99,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class TestTableSerialization {
 
   @Test
   public void testSerializableTableKryoSerialization() throws IOException {
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     TestHelpers.assertSerializedAndLoadedMetadata(table, KryoHelpers.roundTripSerialize(serializableTable));
   }
 
@@ -78,7 +79,7 @@ public class TestTableSerialization {
     for (MetadataTableType type : MetadataTableType.values()) {
       TableOperations ops = ((HasTableOperations) table).operations();
       Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, table.name(), "meta", type);
-      Table serializableMetadataTable = SerializableTable.copyOf(metadataTable);
+      Table serializableMetadataTable = SerializableTableWithSize.copyOf(metadataTable);
 
       TestHelpers.assertSerializedAndLoadedMetadata(
           metadataTable,
@@ -95,7 +96,7 @@ public class TestTableSerialization {
         .commit();
 
     Table txnTable = txn.table();
-    Table serializableTxnTable = SerializableTable.copyOf(txnTable);
+    Table serializableTxnTable = SerializableTableWithSize.copyOf(txnTable);
 
     TestHelpers.assertSerializedMetadata(txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -106,8 +105,8 @@ public class TestSparkCatalogHadoopOverrides extends SparkCatalogTestBase {
         configOverrideValue, actualCatalogOverride);
 
     // Now convert to SerializableTable and ensure overridden property is still present.
-    Table serializableTable = SerializableTable.copyOf(table);
-    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
+    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
     Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(configToOverride, "/whammies");
     Assert.assertEquals(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReachableFileUtil;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -45,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.JobGroupUtils;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -130,7 +130,7 @@ abstract class BaseSparkAction<ThisT, R> implements Action<ThisT, R> {
 
   // builds a DF of delete and data file path and type by reading all manifests
   protected Dataset<Row> buildValidContentFileWithTypeDF(Table table) {
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
 
     Dataset<ManifestFileBean> allManifests = loadMetadataTable(table, ALL_MANIFESTS)
         .selectExpr(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.BaseMetadataTable;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.spark.util.KnownSizeEstimation;
+
+/**
+ * This class provides a serializable table with a known size estimate. Spark calls
+ * its SizeEstimator class when broadcasting variables and this can be an expensive
+ * operation, so providing a known size estimate allows that operation to be skipped.
+ */
+public class SerializableTableWithSize extends SerializableTable implements KnownSizeEstimation {
+
+  private static final long SIZE_ESTIMATE = 32_768L;
+
+  protected SerializableTableWithSize(Table table) {
+    super(table);
+  }
+
+  @Override
+  public long estimatedSize() {
+    return SIZE_ESTIMATE;
+  }
+
+  public static Table copyOf(Table table) {
+    if (table instanceof BaseMetadataTable) {
+      return new SerializableMetadataTableWithSize((BaseMetadataTable) table);
+    } else {
+      return new SerializableTableWithSize(table);
+    }
+  }
+
+  public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
+      implements KnownSizeEstimation {
+
+    protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
+      super(metadataTable);
+    }
+
+    @Override
+    public long estimatedSize() {
+      return SIZE_ESTIMATE;
+    }
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.source.SparkScan.ReadTask;
@@ -60,7 +59,7 @@ abstract class SparkBatch implements Batch {
   @Override
   public InputPartition[] planInputPartitions() {
     // broadcast the table metadata as input partitions will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
 
     InputPartition[] readTasks = new InputPartition[tasks().size()];

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.MicroBatches.MicroBatch;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
@@ -88,7 +87,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     this.caseSensitive = readConf.caseSensitive();
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
     this.localityPreferred = readConf.localityEnabled();
-    this.tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    this.tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
@@ -151,7 +150,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     @Override
     public DeltaWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
       // broadcast the table metadata as the writer factory will be sent to executors
-      Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+      Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
       return new PositionDeltaWriteFactory(tableBroadcast, command, context);
     }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
@@ -179,7 +178,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   // the writer factory works for both batch and streaming
   private WriterFactory createWriterFactory() {
     // broadcast the table metadata as the writer factory will be sent to executors
-    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
     return new WriterFactory(tableBroadcast, format, targetFileSize, writeSchema, dsSchema, partitionedFanoutEnabled);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -82,7 +83,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 
@@ -96,7 +97,7 @@ public class TestFileIOSerialization {
     FileIO io = table.io();
     Configuration expectedConf = ((HadoopFileIO) io).conf();
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
     Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class TestTableSerialization {
 
   @Test
   public void testSerializableTableKryoSerialization() throws IOException {
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
     TestHelpers.assertSerializedAndLoadedMetadata(table, KryoHelpers.roundTripSerialize(serializableTable));
   }
 
@@ -78,7 +79,7 @@ public class TestTableSerialization {
     for (MetadataTableType type : MetadataTableType.values()) {
       TableOperations ops = ((HasTableOperations) table).operations();
       Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, table.name(), "meta", type);
-      Table serializableMetadataTable = SerializableTable.copyOf(metadataTable);
+      Table serializableMetadataTable = SerializableTableWithSize.copyOf(metadataTable);
 
       TestHelpers.assertSerializedAndLoadedMetadata(
           metadataTable,
@@ -95,7 +96,7 @@ public class TestTableSerialization {
         .commit();
 
     Table txnTable = txn.table();
-    Table serializableTxnTable = SerializableTable.copyOf(txnTable);
+    Table serializableTxnTable = SerializableTableWithSize.copyOf(txnTable);
 
     TestHelpers.assertSerializedMetadata(txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
-import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -106,8 +105,8 @@ public class TestSparkCatalogHadoopOverrides extends SparkCatalogTestBase {
         configOverrideValue, actualCatalogOverride);
 
     // Now convert to SerializableTable and ensure overridden property is still present.
-    Table serializableTable = SerializableTable.copyOf(table);
-    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
+    Table kryoSerializedTable = KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
     Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(configToOverride, "/whammies");
     Assert.assertEquals(


### PR DESCRIPTION
During query planning, Iceberg broadcasts table data, and Spark will run its size estimator tool on the object as part of the broadcast. This size estimation can be an expensive operation in some cases, for example, when the table uses `S3FileIO`, as the object graph being analyzed is large even if the data isn't being serialized. Ultimately this can cause performance problems in query planning. Also, the size estimate is not correct as it includes data that will not be serialized. For example, a table with an S3FileIO reference was being estimated at 16MB in size when the serialized size was only ~32KB.

This PR creates a subclass of `SerializableTable` that implements Spark's `KnownSizeEstimation` trait and uses that for broadcasts. By doing this, the expensive size estimation calculation is bypassed. The size is set to 32KB, as during testing the size of the serialized data was very roughly in this ballpark.

One side note - it appears as if the same table is being broadcast multiple times during query planning, so there are further opportunities for optimization in this area.

![Screen Shot 2022-07-07 at 4 03 28 PM](https://user-images.githubusercontent.com/5475421/177885613-b7999204-3414-4a90-831a-c5dfbd3b8f33.png)

