### PR TITLE
backport #5204 to Spark3.2

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -100,7 +100,13 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     List<Filter> pushed = Lists.newArrayListWithExpectedSize(filters.length);
 
     for (Filter filter : filters) {
-      Expression expr = SparkFilters.convert(filter);
+      Expression expr = null;
+      try {
+        expr = SparkFilters.convert(filter);
+      } catch (IllegalArgumentException e) {
+        // converting to Iceberg Expression failed, so this expression cannot be pushed down
+      }
+
       if (expr != null) {
         try {
           Binder.bind(schema.asStruct(), expr, caseSensitive);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -215,4 +215,18 @@ public class TestSelect extends SparkCatalogTestBase {
     assertEquals("Should return all expected rows", expected,
         sql("SELECT id, binary FROM %s where binary > X'11'", binaryTableName));
   }
+
+  @Test
+  public void testComplexTypeFilter() {
+    String complexTypeTableName = tableName("complex_table");
+    sql("CREATE TABLE %s (id INT, complex STRUCT<c1:INT,c2:STRING>) USING iceberg", complexTypeTableName);
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\"))", complexTypeTableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2, \"c2\", \"v2\"))", complexTypeTableName);
+
+    List<Object[]> result = sql("SELECT id FROM %s WHERE complex = named_struct(\"c1\", 3, \"c2\", \"v1\")",
+        complexTypeTableName);
+
+    assertEquals("Should return all expected rows", ImmutableList.of(row(1)), result);
+    sql("DROP TABLE IF EXISTS %s", complexTypeTableName);
+  }
 }


### PR DESCRIPTION
This PR backports the changes in https://github.com/apache/iceberg/pull/5204 to Spark 3.2