### PR TITLE
Build - Add Git Build Properties File via Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ try {
   // git properties file for the root project for adding to the source tarball
   gitProperties {
     gitPropertiesName = 'iceberg-build.properties'
-    gitPropertiesResourceDir = 'build'
+    gitPropertiesResourceDir = file("${rootDir}/build")
     extProperty = 'gitProps'
     failOnNoGitDirectory = false
   }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
     classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.6'
     classpath "com.github.alisiikh:gradle-scalastyle-plugin:3.4.1"
     classpath 'com.palantir.gradle.revapi:gradle-revapi:1.7.0'
+    classpath 'com.gorylenko.gradle-git-properties:gradle-git-properties:2.4.1'
   }
 }
 
@@ -42,8 +43,16 @@ plugins {
 }
 
 try {
-  // apply this plugin in a try-catch block so that we can handle cases without .git directory
+  // apply these plugins in a try-catch block so that we can handle cases without .git directory
   apply plugin: 'com.palantir.git-version'
+  apply plugin: 'com.gorylenko.gradle-git-properties'
+  // git properties file for the root project for adding to the source tarball
+  gitProperties {
+    gitPropertiesName = 'iceberg-build.properties'
+    extProperty = 'gitProps'
+    failOnNoGitDirectory = false
+  }
+  generateGitProperties.outputs.upToDateWhen { false }
 } catch (Exception e) {
   project.logger.error(e.getMessage())
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ try {
   // git properties file for the root project for adding to the source tarball
   gitProperties {
     gitPropertiesName = 'iceberg-build.properties'
+    gitPropertiesResourceDir = 'build'
     extProperty = 'gitProps'
     failOnNoGitDirectory = false
   }


### PR DESCRIPTION
This adds a git properties file, generated using the https://github.com/n0mer/gradle-git-properties (many thanks to @nastra) for both the top level project.

The top level project file is needed so that the source tarball has a file that it can add to the tarball before releasing in `dev/source-release.sh`.

This is an alternative implementation to https://github.com/apache/iceberg/pull/5186

I've tested this, and we might want to remove some of the git property information but otherwise this generates the file `build/iceberg-build.properties` as described in the output comments below.

Note that [`build/**` is in the `.gitattributes` file as `export-ignore`](https://github.com/apache/iceberg/blob/b0937a4951a2d4a40b67eda484d49c4a4d32566e/.gitattributes#L26-L27), so this file won't be added to the tarball unless we add it in `dev/source-release.sh` or move it elsewhere.