### PR TITLE
Spark-3.3: Support Zorder option for rewrite_data_files stored procedure

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -93,6 +93,10 @@ callArgument
     | identifier '=>' expression    #namedArgument
     ;
 
+singleOrder
+    : order EOF
+    ;
+
 order
     : fields+=orderField (',' fields+=orderField)*
     | '(' fields+=orderField (',' fields+=orderField)* ')'

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -26,6 +26,8 @@ import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.TerminalNodeImpl
 import org.apache.iceberg.common.DynConstructors
+import org.apache.iceberg.spark.ExtendedParser
+import org.apache.iceberg.spark.ExtendedParser.RawOrderField
 import org.apache.iceberg.spark.Spark3Util
 import org.apache.iceberg.spark.source.SparkTable
 import org.apache.spark.sql.AnalysisException
@@ -57,7 +59,7 @@ import org.apache.spark.sql.types.StructType
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface {
+class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInterface with ExtendedParser {
 
   import IcebergSparkSqlExtensionsParser._
 
@@ -110,6 +112,14 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
    */
   override def parseTableSchema(sqlText: String): StructType = {
     delegate.parseTableSchema(sqlText)
+  }
+
+  override def parseSortOrder(sqlText: String): java.util.List[RawOrderField] = {
+    val fields = parse(sqlText) { parser => astBuilder.visitSingleOrder(parser.singleOrder()) }
+    fields.map { field =>
+      val (term, direction, order) = field
+      new RawOrderField(term, direction, order)
+    }.asJava
   }
 
   /**

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -26,6 +26,8 @@ import org.antlr.v4.runtime.tree.TerminalNode
 import org.apache.iceberg.DistributionMode
 import org.apache.iceberg.NullOrder
 import org.apache.iceberg.SortDirection
+import org.apache.iceberg.SortOrder
+import org.apache.iceberg.UnboundSortOrder
 import org.apache.iceberg.expressions.Term
 import org.apache.iceberg.spark.Spark3Util
 import org.apache.spark.sql.AnalysisException
@@ -215,6 +217,10 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
    */
   override def visitMultipartIdentifier(ctx: MultipartIdentifierContext): Seq[String] = withOrigin(ctx) {
     toSeq(ctx.parts).map(_.getText)
+  }
+
+  override def visitSingleOrder(ctx: SingleOrderContext): Seq[(Term, SortDirection, NullOrder)] = withOrigin(ctx) {
+    toSeq(ctx.order.fields).map(typedVisit[(Term, SortDirection, NullOrder)])
   }
 
   /**

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ExtendedParser.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ExtendedParser.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.expressions.Term;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.parser.ParserInterface;
+
+public interface ExtendedParser extends ParserInterface {
+  class RawOrderField {
+    private final Term term;
+    private final SortDirection direction;
+    private final NullOrder nullOrder;
+
+    public RawOrderField(Term term, SortDirection direction, NullOrder nullOrder) {
+      this.term = term;
+      this.direction = direction;
+      this.nullOrder = nullOrder;
+    }
+
+    public Term term() {
+      return term;
+    }
+
+    public SortDirection direction() {
+      return direction;
+    }
+
+    public NullOrder nullOrder() {
+      return nullOrder;
+    }
+  }
+
+  static List<RawOrderField> parseSortOrder(SparkSession spark, String orderString) {
+    if (spark.sessionState().sqlParser() instanceof ExtendedParser) {
+      ExtendedParser parser = (ExtendedParser) spark.sessionState().sqlParser();
+      try {
+        return parser.parseSortOrder(orderString);
+      } catch (AnalysisException e) {
+        throw new IllegalArgumentException(String.format("Unable to parse sortOrder: %s", orderString), e);
+      }
+    } else {
+      throw new IllegalStateException("Cannot parse order: parser is not an Iceberg ExtendedParser");
+    }
+  }
+
+  List<RawOrderField> parseSortOrder(String orderString) throws AnalysisException;
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -141,6 +141,8 @@ public class BaseRewriteDataFilesSparkAction
 
   @Override
   public RewriteDataFiles zOrder(String... columnNames) {
+    Preconditions.checkArgument(this.strategy == null,
+        "Cannot set strategy to zorder, it has already been set to %s", this.strategy);
     this.strategy = zOrderStrategy(columnNames);
     return this;
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
@@ -133,7 +133,21 @@ public class SparkZOrderStrategy extends SparkSortStrategy {
           "Cannot perform ZOrdering, all columns provided were identity partition columns and cannot be used.");
     }
 
+    validateColumnsExistence(table, spark, zOrderColNames);
+
     this.zOrderColNames = zOrderColNames;
+  }
+
+  private void validateColumnsExistence(Table table, SparkSession spark, List<String> colNames) {
+    boolean caseSensitive = Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+    Schema schema = table.schema();
+    colNames.forEach(col -> {
+      NestedField nestedField = caseSensitive ? schema.findField(col) : schema.caseInsensitiveFindField(col);
+      if (nestedField == null) {
+        throw new IllegalArgumentException(
+            String.format("Cannot find column '%s' in table schema: %s", col, schema.asStruct()));
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
This is just a port of #4902 (from spark-3.2)