### PR TITLE
Core,API: Add table property transform to support stateful property update.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -47,12 +47,10 @@ acceptedBreaks:
       justification: "Allow adding a new method to the interface - old method is deprecated"
     - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedEqualityDeleteFilesCount()"
-      justification: "Interface is backward compatible, very unlikely anyone implements\
-        \ this Result bean interface"
+      justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"
     - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedPositionDeleteFilesCount()"
-      justification: "Interface is backward compatible, very unlikely anyone implements\
-        \ this Result bean interface"
+      justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"
     - code: "java.method.addedToInterface"
       new: "method org.apache.iceberg.ExpireSnapshots org.apache.iceberg.ExpireSnapshots::planWith(java.util.concurrent.ExecutorService)"
       justification: "Accept all changes prior to introducing API compatibility checks"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -47,10 +47,12 @@ acceptedBreaks:
       justification: "Allow adding a new method to the interface - old method is deprecated"
     - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedEqualityDeleteFilesCount()"
-      justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"
+      justification: "Interface is backward compatible, very unlikely anyone implements\
+        \ this Result bean interface"
     - code: "java.method.addedToInterface"
       new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedPositionDeleteFilesCount()"
-      justification: "Interface is backward compatible, very unlikely anyone implements this Result bean interface"
+      justification: "Interface is backward compatible, very unlikely anyone implements\
+        \ this Result bean interface"
     - code: "java.method.addedToInterface"
       new: "method org.apache.iceberg.ExpireSnapshots org.apache.iceberg.ExpireSnapshots::planWith(java.util.concurrent.ExecutorService)"
       justification: "Accept all changes prior to introducing API compatibility checks"
@@ -109,6 +111,10 @@ acceptedBreaks:
     - code: "java.method.addedToInterface"
       new: "method org.apache.iceberg.ReplacePartitions org.apache.iceberg.ReplacePartitions::validateNoConflictingDeletes()"
       justification: "Accept all changes prior to introducing API compatibility checks"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.UpdateProperties org.apache.iceberg.UpdateProperties::transform(java.lang.String,\
+        \ java.util.function.Function<java.lang.String, java.lang.String>)"
+      justification: "A new method is added to the Interface, and the implementation is provided in its only subclass."
     - code: "java.method.numberOfParametersChanged"
       old: "method void org.apache.iceberg.events.IncrementalScanEvent::<init>(java.lang.String,\
         \ long, long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.Schema)"

--- a/api/src/main/java/org/apache/iceberg/UpdateProperties.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateProperties.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * API for updating table properties.
@@ -40,6 +41,18 @@ public interface UpdateProperties extends PendingUpdate<Map<String, String>> {
    * @throws NullPointerException If either the key or value is null
    */
   UpdateProperties set(String key, String value);
+
+  /**
+   * Apply a transform to a table property based on the "current" value.
+   *
+   * If the key doesn't exit but transformFunc produces a non-null value, it will add the key/value
+   * to table property, so the transformFunc is expected to handle null as input.
+   *
+   * @param key a String key
+   * @return this for method chaining
+   * @throws NullPointerException If either the key or transformFunc is null
+   */
+  UpdateProperties transform(String key, Function<String, String> transformFunc);
 
   /**
    * Remove the given property key from the table.

--- a/api/src/main/java/org/apache/iceberg/UpdateProperties.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateProperties.java
@@ -45,7 +45,7 @@ public interface UpdateProperties extends PendingUpdate<Map<String, String>> {
   /**
    * Apply a transform to a table property based on the "current" value.
    *
-   * If the key doesn't exit but transformFunc produces a non-null value, it will add the key/value
+   * If the key doesn't exist but transformFunc produces a non-null value, it will add the key/value
    * to table property, so the transformFunc is expected to handle null as input.
    *
    * @param key a String key

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -68,7 +68,7 @@ class PropertiesUpdate implements UpdateProperties {
     Preconditions.checkNotNull(key, "Key cannot be null");
     Preconditions.checkNotNull(transformFunc, "Transform function cannot be null");
     Preconditions.checkArgument(!updates.containsKey(key),
-        "Cannot updates and transform the same key: %s", key);
+        "Cannot update and transform the same key: %s", key);
     Preconditions.checkArgument(!removals.contains(key),
         "Cannot remove and transform the same key: %s", key);
     transforms.put(key, transformFunc);

--- a/core/src/test/java/org/apache/iceberg/TestUpdateProperties.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateProperties.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestUpdateProperties extends TableTestBase {
+  @Parameterized.Parameters(name = "formatVersion = {0}")
+  public static Object[] parameters() {
+    return new Object[] {1, 2};
+  }
+
+  private static final Function<String, String> plusOneTransform = new Function<String, String>() {
+    @Override
+    public String apply(String s) {
+      if (s == null) {
+        return "1";
+      }
+      return String.valueOf((Integer.parseInt(s) + 1));
+    }
+  };
+
+  public TestUpdateProperties(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Test
+  public void testPropertyTransform() {
+    TableMetadata base = readMetadata();
+    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+
+    String counter = "counter";
+    Assert.assertFalse("Counter key should not exist initially", table.properties().containsKey(counter));
+    table.updateProperties().transform(counter, plusOneTransform).commit();
+    Assert.assertEquals("Counter value should be 1", "1", table.properties().get(counter));
+    table.updateProperties().transform(counter, plusOneTransform).commit();
+    Assert.assertEquals("Counter value should be 2", "2", table.properties().get(counter));
+  }
+
+  @Test
+  public void testConcurrentPropertyTransform() throws InterruptedException {
+    TableMetadata base = readMetadata();
+    Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
+    Assert.assertEquals("Last sequence number should be 0", 0, base.lastSequenceNumber());
+
+    String counter = "counter";
+    Assert.assertFalse("Counter key should not exist initially", table.properties().containsKey(counter));
+
+    ExecutorService executorService = MoreExecutors.getExitingExecutorService(
+        (ThreadPoolExecutor) Executors.newFixedThreadPool(7));
+    for (int i = 0; i < 7; i++) {
+      executorService.submit(() -> table.updateProperties().transform(counter, plusOneTransform).commit());
+    }
+    executorService.shutdown();
+
+    Assert.assertTrue("Timeout", executorService.awaitTermination(3, TimeUnit.MINUTES));
+    Assert.assertEquals("Counter value should be 7", "7", table.properties().get(counter));
+  }
+}


### PR DESCRIPTION
This PR adds a transform API to table properties update, and the transforms will be re-applied based on refreshed properties when there's a conflict, and this make it possible for truly stateful and transactional property updates.

Currently, the table property update commit is basically "last commit wins", and the property value update happens out side of iceberg library so it will not be re-applied during commit retries when there's a conflict, that can cause some commits "effectively" being overwritten when the property update is supposed to be based on existing value.

Consider below example use case: 
Table property "subscribers" is used to track who should be notified whenever there's a new data write, and "subscribers" is a set of users and we do add/remove to manage users.

Steps for a value update loss:
1. initially there's only 1 user, subscribers value = \<u1>
2. commit A attempts to add user u2 to subscribers: set value to  <u1,u2>
3. commit B attempts to add user u3 to subscribers: set value to  <u1,u3>
4. commit B succeeded first, now subscribers value is: <u1,u3>
5. Commit A failed, and retry succeeded, setting new value to: <u1,u2>
6. now both A and B succeeded, final value: <u1,u2>    =>   commit B is effectively lost.

With transform API, commits can request a transform like "add user u2 to existing set" instead of "set it to <u1,u2>", and no commit will be lost because transform is re-applied for commit retries.
