### PR TITLE
Rest-catalog: Add flexibility to paths in rest catalog

### DIFF
--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Open-API"
+on:
+  push:
+    branches:
+      - 'master'
+      - '0.**'
+    tags:
+      - 'apache-iceberg-**'
+  pull_request:
+    paths:
+      - '.github/workflows/open-api.yml'
+      - 'open-api/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  tox:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Install
+        working-directory: ./open-api
+        run: pip install openapi-spec-validator && openapi-spec-validator rest-catalog-open-api.yaml

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -179,7 +179,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces:
+  /v1/{prefix}/namespaces:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
 
     get:
       tags:
@@ -268,8 +270,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces/{namespace}:
+  /v1/{prefix}/namespaces/{namespace}:
     parameters:
+      - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
 
     get:
@@ -333,8 +336,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces/{namespace}/properties:
+  /v1/{prefix}/namespaces/{namespace}/properties:
     parameters:
+      - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
 
     post:
@@ -394,8 +398,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces/{namespace}/tables:
+  /v1/{prefix}/namespaces/{namespace}/tables:
     parameters:
+      - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
 
     get:
@@ -486,8 +491,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces/{namespace}/tables/{table}:
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}:
     parameters:
+      - $ref: '#/components/parameters/prefix'
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
 
@@ -702,7 +708,9 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/tables/rename:
+  /v1/{prefix}/tables/rename:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
 
     post:
       tags:
@@ -781,6 +789,14 @@ components:
           value: "accounting"
         multipart_namespace:
           value: "accounting%1Ftax"
+
+    prefix:
+      name: prefix
+      in: path
+      schema:
+        type: string
+      required: true
+      description: An optional prefix in the path
 
     table:
       name: table
@@ -1415,19 +1431,19 @@ components:
         Assertions from the client that must be valid for the commit to succeed. Assertions are identified by `type` -
 
         - `assert-create` - the table must not already exist; used for create transactions
-        
+
         - `assert-table-uuid` - the table UUID must match the requirement's `uuid`
 
         - `assert-ref-snapshot-id` - the table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`; if `snapshot-id` is `null` or missing, the ref must not already exist
-        
+
         - `assert-last-assigned-field-id` - the table's last assigned column id must match the requirement's `last-assigned-field-id`
-        
+
         - `assert-current-schema-id` - the table's current schema id must match the requirement's `current-schema-id`
-        
+
         - `assert-last-assigned-partition-id` - the table's last assigned partition id must match the requirement's `last-assigned-partition-id`
-        
+
         - `assert-default-spec-id` - the table's default spec id must match the requirement's `default-spec-id`
-        
+
         - `assert-default-sort-order-id` - the table's default sort order id must match the requirement's `default-sort-order-id`
       type: object
       required:
@@ -1906,7 +1922,7 @@ components:
               - removed
             properties:
               updated:
-                description: List of property keys that were added or udpated
+                description: List of property keys that were added or updated
                 type: array
                 uniqueItems: true
                 items:


### PR DESCRIPTION
While generating Python code from the open-api spec to bootstrap the Python rest catalog implementation I noticed that the URLs were constructed differently than expected.

For our service the warehouse uuid is encoded as part of the path:
```
https://api.iceberg.io/ws/v1/oss/warehouses/8bcb0838-50fc-472d-9ddb-8feb89ef5f1e/namespaces
```

However, the open-api spec states that the `/v1/` comes after the base path:
```
/v1/namespaces/{namespace}/properties:
```
This would lead to:
```
https://api.iceberg.io/ws/oss/warehouses/8bcb0838-50fc-472d-9ddb-8feb89ef5f1e/v1/namespaces
```

where the base path is part of the server's definition:
```yaml
servers:
  - url: "{scheme}://{host}/{basePath}"
    description: Server URL when the port can be inferred from the scheme
    variables:
      scheme:
        description: The scheme of the URI, either http or https.
        default: https
      host:
        description: The host address for the specified server
        default: localhost
      basePath:
        description: Optional prefix to be appended to all routes
        default: ""
```
This will never allow us to construct an url with a prefix (the warehouse identifier). Therefore I suggest adding the prefix for the metadata-related endpoints (all except token and config). This way we can add v2 endpoints in the future to the same spec, and we also keep backward compatibility (just leaving the prefix empty)