### PR TITLE
REST: Create commit catalog handler fix

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -127,7 +127,6 @@ public class TableMetadata implements Serializable {
         .setDefaultSortOrder(freshSortOrder)
         .setLocation(location)
         .setProperties(properties)
-        .discardChanges()
         .build();
   }
 
@@ -1245,7 +1244,7 @@ public class TableMetadata implements Serializable {
           ImmutableList.copyOf(newSnapshotLog),
           ImmutableList.copyOf(metadataHistory),
           ImmutableMap.copyOf(refs),
-          discardChanges ? ImmutableList.of() : ImmutableList.copyOf(changes)
+          discardChanges || base == null ? ImmutableList.of() : ImmutableList.copyOf(changes)
       );
     }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1012,10 +1012,12 @@ public class TableMetadata implements Serializable {
         return this;
       }
 
+      ValidationException.check(!schemas.isEmpty(), "Attempting to add a snapshot before a schema is added");
+      ValidationException.check(!specs.isEmpty(), "Attempting to add a snapshot before a partition spec is added");
+      ValidationException.check(!sortOrders.isEmpty(), "Attempting to add a snapshot before a sort order is added");
       ValidationException.check(!snapshotsById.containsKey(snapshot.snapshotId()),
           "Snapshot already exists for id: %s",
           snapshot.snapshotId());
-
       ValidationException.check(formatVersion == 1 || snapshot.sequenceNumber() > lastSequenceNumber,
           "Cannot add snapshot with sequence number %s older than last sequence number %s",
           snapshot.sequenceNumber(), lastSequenceNumber);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -120,13 +120,15 @@ public class TableMetadata implements Serializable {
     // break existing tables.
     MetricsConfig.fromProperties(properties).validateReferencedColumns(schema);
 
-    return new TableMetadata(null, formatVersion, UUID.randomUUID().toString(), location,
-        INITIAL_SEQUENCE_NUMBER, System.currentTimeMillis(),
-        lastColumnId.get(), freshSchema.schemaId(), ImmutableList.of(freshSchema),
-        freshSpec.specId(), ImmutableList.of(freshSpec), freshSpec.lastAssignedFieldId(),
-        freshSortOrderId, ImmutableList.of(freshSortOrder),
-        ImmutableMap.copyOf(properties), -1, ImmutableList.of(),
-        ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), ImmutableList.of());
+    return new Builder()
+        .upgradeFormatVersion(formatVersion)
+        .setCurrentSchema(freshSchema, lastColumnId.get())
+        .setDefaultPartitionSpec(freshSpec)
+        .setDefaultSortOrder(freshSortOrder)
+        .setLocation(location)
+        .setProperties(properties)
+        .discardChanges()
+        .build();
   }
 
   public static class SnapshotLogEntry implements HistoryEntry {
@@ -755,6 +757,10 @@ public class TableMetadata implements Serializable {
     return new Builder(base);
   }
 
+  public static Builder buildFromEmpty() {
+    return new Builder();
+  }
+
   public static class Builder {
     private static final int LAST_ADDED = -1;
 
@@ -796,6 +802,28 @@ public class TableMetadata implements Serializable {
     private final Map<Integer, Schema> schemasById;
     private final Map<Integer, PartitionSpec> specsById;
     private final Map<Integer, SortOrder> sortOrdersById;
+
+    private Builder() {
+      this.base = null;
+      this.formatVersion = DEFAULT_TABLE_FORMAT_VERSION;
+      this.lastSequenceNumber = INITIAL_SEQUENCE_NUMBER;
+      this.uuid = UUID.randomUUID().toString();
+      this.schemas = Lists.newArrayList();
+      this.specs = Lists.newArrayList();
+      this.sortOrders = Lists.newArrayList();
+      this.properties = Maps.newHashMap();
+      this.snapshots = Lists.newArrayList();
+      this.currentSnapshotId = -1;
+      this.changes = Lists.newArrayList();
+      this.startingChangeCount = 0;
+      this.snapshotLog = Lists.newArrayList();
+      this.previousFiles = Lists.newArrayList();
+      this.refs = Maps.newHashMap();
+      this.snapshotsById = Maps.newHashMap();
+      this.schemasById = Maps.newHashMap();
+      this.specsById = Maps.newHashMap();
+      this.sortOrdersById = Maps.newHashMap();
+    }
 
     private Builder(TableMetadata base) {
       this.base = base;
@@ -1187,8 +1215,13 @@ public class TableMetadata implements Serializable {
       PartitionSpec.checkCompatibility(specsById.get(defaultSpecId), schema);
       SortOrder.checkCompatibility(sortOrdersById.get(defaultSortOrderId), schema);
 
-      List<MetadataLogEntry> metadataHistory = addPreviousFile(
-          previousFiles, previousFileLocation, base.lastUpdatedMillis(), properties);
+      List<MetadataLogEntry> metadataHistory;
+      if (base == null) {
+        metadataHistory = Lists.newArrayList();
+      } else {
+        metadataHistory = addPreviousFile(
+            previousFiles, previousFileLocation, base.lastUpdatedMillis(), properties);
+      }
       List<HistoryEntry> newSnapshotLog = updateSnapshotLog(snapshotLog, snapshotsById, currentSnapshotId, changes);
 
       return new TableMetadata(

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1015,9 +1015,11 @@ public class TableMetadata implements Serializable {
       ValidationException.check(!schemas.isEmpty(), "Attempting to add a snapshot before a schema is added");
       ValidationException.check(!specs.isEmpty(), "Attempting to add a snapshot before a partition spec is added");
       ValidationException.check(!sortOrders.isEmpty(), "Attempting to add a snapshot before a sort order is added");
+
       ValidationException.check(!snapshotsById.containsKey(snapshot.snapshotId()),
           "Snapshot already exists for id: %s",
           snapshot.snapshotId());
+
       ValidationException.check(formatVersion == 1 || snapshot.sequenceNumber() > lastSequenceNumber,
           "Cannot add snapshot with sequence number %s older than last sequence number %s",
           snapshot.sequenceNumber(), lastSequenceNumber);
@@ -1246,7 +1248,7 @@ public class TableMetadata implements Serializable {
           ImmutableList.copyOf(newSnapshotLog),
           ImmutableList.copyOf(metadataHistory),
           ImmutableMap.copyOf(refs),
-          discardChanges || base == null ? ImmutableList.of() : ImmutableList.copyOf(changes)
+          discardChanges ? ImmutableList.of() : ImmutableList.copyOf(changes)
       );
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -244,7 +244,7 @@ public class CatalogHandlers {
       Transaction transaction = catalog.buildTable(ident, EMPTY_SCHEMA).createOrReplaceTransaction();
       if (transaction instanceof BaseTransaction) {
         BaseTransaction baseTransaction = (BaseTransaction) transaction;
-        finalMetadata = create(baseTransaction.underlyingOps(), baseTransaction.startMetadata(), request);
+        finalMetadata = create(baseTransaction.underlyingOps(), request);
       } else {
         throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTransaction");
       }
@@ -283,15 +283,15 @@ public class CatalogHandlers {
     return isCreate;
   }
 
-  private static TableMetadata create(TableOperations ops, TableMetadata start, UpdateTableRequest request) {
+  private static TableMetadata create(TableOperations ops, UpdateTableRequest request) {
     // the only valid requirement is that the table will be created
     request.requirements().forEach(requirement -> requirement.validate(ops.current()));
 
-    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
+    TableMetadata.Builder builder = TableMetadata.buildFromEmpty();
     request.updates().forEach(update -> update.applyTo(builder));
 
     // create transactions do not retry. if the table exists, retrying is not a solution
-    ops.commit(null, builder.build());
+    ops.commit(null, builder.discardChanges().build());
 
     return ops.current();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -291,7 +291,7 @@ public class CatalogHandlers {
     request.updates().forEach(update -> update.applyTo(builder));
 
     // create transactions do not retry. if the table exists, retrying is not a solution
-    ops.commit(null, builder.discardChanges().build());
+    ops.commit(null, builder.build());
 
     return ops.current();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -579,14 +579,18 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
     PartitionSpec spec = meta.spec();
     if (spec != null && spec.isPartitioned()) {
       changes.add(new MetadataUpdate.AddPartitionSpec(spec));
-      changes.add(new MetadataUpdate.SetDefaultPartitionSpec(-1));
+    } else {
+      changes.add(new MetadataUpdate.AddPartitionSpec(PartitionSpec.unpartitioned()));
     }
+    changes.add(new MetadataUpdate.SetDefaultPartitionSpec(-1));
 
     SortOrder order = meta.sortOrder();
     if (order != null && order.isSorted()) {
       changes.add(new MetadataUpdate.AddSortOrder(order));
-      changes.add(new MetadataUpdate.SetDefaultSortOrder(-1));
+    } else {
+      changes.add(new MetadataUpdate.AddSortOrder(SortOrder.unsorted()));
     }
+    changes.add(new MetadataUpdate.SetDefaultSortOrder(-1));
 
     String location = meta.location();
     if (location != null) {

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -1261,10 +1261,22 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
     Table table = catalog.loadTable(TABLE);
 
+    // initial IDs taken from TableMetadata constants
+    final int initialSchemaId = 0;
+    final int initialSpecId = 0;
+    final int initialOrderId = 1;
+    final int updateSchemaId = initialSchemaId + 1;
+    final int updateSpecId = initialSpecId + 1;
+    final int updateOrderId = initialOrderId + 1;
+
     Assert.assertEquals("Table schema should match the new schema",
         newSchema.asStruct(), table.schema().asStruct());
-    Assert.assertEquals("Table should have create partition spec", newSpec.fields(), table.spec().fields());
-    Assert.assertEquals("Table should have create sort order", newSortOrder.fields(), table.sortOrder().fields());
+    Assert.assertEquals("Table schema should match the new schema ID",
+        updateSchemaId, table.schema().schemaId());
+    Assert.assertEquals("Table should have updated partition spec", newSpec.fields(), table.spec().fields());
+    Assert.assertEquals("Table should have updated partition spec ID", updateSpecId, table.spec().specId());
+    Assert.assertEquals("Table should have updated sort order", newSortOrder.fields(), table.sortOrder().fields());
+    Assert.assertEquals("Table should have updated sort order ID", updateOrderId, table.sortOrder().orderId());
     Assert.assertEquals("Table properties should be a superset of the requested properties",
         properties.entrySet(),
         Sets.intersection(properties.entrySet(), table.properties().entrySet()));
@@ -1272,8 +1284,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       Assert.assertEquals("Table location should match requested", "file:/tmp/ns/table", table.location());
     }
     assertFiles(table, FILE_A, anotherFile);
-    assertFilePartitionSpec(table, FILE_A, 0);
-    assertFilePartitionSpec(table, anotherFile, 1);
+    assertFilePartitionSpec(table, FILE_A, initialSpecId);
+    assertFilePartitionSpec(table, anotherFile, updateSpecId);
     assertPreviousMetadataFileCount(table, 0);
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -78,6 +78,7 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
         TableMetadata
             .buildFrom(
                 TableMetadata.newTableMetadata(SCHEMA_7, SPEC_5, SORT_ORDER_3, TEST_TABLE_LOCATION, TABLE_PROPS))
+            .discardChanges()
             .withMetadataLocation(TEST_METADATA_LOCATION)
             .build();
 


### PR DESCRIPTION
Currently in the REST catalog handler, during a CTAS, the files will be written and associated with the partition spec ID from the initial create request. When the commit occurs, an empty table metadata object is created and updates are applied to that. However, applying the updates will increment the partition spec ID, so the files will be associated with the empty spec ID, and thus partition pruning will not be available for these files.

This PR adds the ability to build on top of an empty TableMetadata so the initial IDs will match the initial files. It also moves `TableMetadata.newTableMetadata` to use the builder to instantiate a new instance so it can reuse functionality from the builder and to be consistent with `buildReplacement()`.
