### PR TITLE
Build: Add iceberg-build.properties to Jars and release process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ try {
     gitPropertiesName = 'iceberg-build.properties'
     gitPropertiesResourceDir = file("${rootDir}/build")
     extProperty = 'gitProps'
-    failOnNoGitDirectory = false
+    failOnNoGitDirectory = true
   }
   generateGitProperties.outputs.upToDateWhen { false }
 } catch (Exception e) {

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -52,6 +52,10 @@ subprojects {
 
     // add LICENSE and NOTICE
     [jar, sourceJar, javadocJar, testJar].each { task ->
+      task.dependsOn rootProject.tasks.buildInfo
+      task.from("${rootDir}/build") {
+        include 'iceberg-build.properties'
+      }
       task.from(rootDir) {
         include 'LICENSE'
         include 'NOTICE'

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -87,11 +87,6 @@ tagrc="${tag}-rc${rc}"
 
 echo "Preparing source for $tagrc"
 
-echo "Generating version.txt and iceberg-build.properties..."
-echo $version > $projectdir/version.txt
-./gradlew generateGitProperties
-cp $projectdir/build/iceberg-build.properties $projectdir/iceberg-build.properties
-
 echo "Creating release candidate tag: $tagrc..."
 set_version_hash=`git rev-list HEAD 2> /dev/null | head -n 1 `
 git tag -am "Apache Iceberg $version" $tagrc $set_version_hash
@@ -105,6 +100,11 @@ if [ -z "$release_hash" ]; then
   echo "Cannot continue: unknown Git tag: $tag"
   exit
 fi
+
+echo "Generating version.txt and iceberg-build.properties..."
+echo $version > $projectdir/version.txt
+./gradlew generateGitProperties
+cp $projectdir/build/iceberg-build.properties $projectdir/iceberg-build.properties
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -89,7 +89,7 @@ echo "Preparing source for $tagrc"
 
 echo "Generating version.txt and iceberg-build.properties..."
 echo $version > $projectdir/version.txt
-./gradlew buildInfo
+./gradlew generateGitProperties
 cp $projectdir/build/iceberg-build.properties $projectdir/iceberg-build.properties
 
 echo "Creating release candidate tag: $tagrc..."

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -54,3 +54,15 @@ task deploySite(type: Exec) {
   workingDir 'site'
   commandLine('./deploy.sh')
 }
+
+if (file("${rootDir}/iceberg-build.properties").exists()) {
+  tasks.register('buildInfo', Exec) {
+    project.logger.info('Using build info from iceberg-build.properties')
+    commandLine 'cp', "${rootDir}/iceberg-build.properties", 'build/iceberg-build.properties'
+  }
+} else {
+  tasks.register('buildInfo') {
+    project.logger.info('Generating iceberg-build.properties from git')
+    dependsOn generateGitProperties
+  }
+}


### PR DESCRIPTION
This ensures that `iceberg-build.properties` is added to Jars produced by the Gradle build, even when building from a source tarball with no `.git` directory.

This builds on the `generateGitProperties` task added in #5228 and updates the build:
* A new task, `buildInfo` ensures that `build/iceberg-build.properties` exists, either by copying it from the source root or by calling `generateGitProperties` (change in `tasks.gradle`)
* All Jars will now include `iceberg-build.properties` from the root `build` folder (change in `deploy.gradle`)
* The source release script will generate `iceberg-build.properties` and add it to the root folder for the release candidate tarball (changes in `source-release.sh`)

Note that this also changes how release tarballs are created. Previously, the `source-release.sh` script would create `version.txt` and commit the file, then tag the commit with `version.txt`. This wasn't possible for adding `iceberg-build.properties` because `iceberg-build.properties` needs to describe the git commit in the source tarball (and can't be included in the commit itself). Instead of adding the file to git, this adds both `version.txt` and `iceberg-build.properties` directly to the archive using `git archive ... --add-file`. A side benefit is that we will no longer have release tags off of the master branch.