### PR TITLE
Core - Add build information to all requests sent by HTTPClient as headers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
@@ -22,6 +22,8 @@ package org.apache.iceberg.rest;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
@@ -32,13 +34,25 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  */
 public class HTTPClientFactory implements Function<Map<String, String>, RESTClient> {
 
+  @VisibleForTesting
+  static final String CLIENT_VERSION_HEADER = "X-Client-Version";
+  @VisibleForTesting
+  static final String CLIENT_GIT_COMMIT_SHORT_HEADER = "X-Client-Git-Commit-Short";
+
   @Override
   public RESTClient apply(Map<String, String> properties) {
     Preconditions.checkArgument(properties != null, "Invalid configuration: null");
     Preconditions.checkArgument(properties.containsKey(CatalogProperties.URI), "REST Catalog server URI is required");
 
     String baseURI = properties.get(CatalogProperties.URI).trim();
+    String clientVersion = IcebergBuild.fullVersion();
+    String gitCommitShortId = IcebergBuild.gitCommitShortId();
 
-    return HTTPClient.builder().uri(baseURI).build();
+    return HTTPClient
+        .builder()
+        .withHeader(CLIENT_VERSION_HEADER, clientVersion)
+        .withHeader(CLIENT_GIT_COMMIT_SHORT_HEADER, gitCommitShortId)
+        .uri(baseURI)
+        .build();
   }
 }


### PR DESCRIPTION
The HTTPClientFactory is used to build the HTTP Client that will be used by the REST Catalog.

This PR injects the following two headers into each request, for debugging purposes:
-   X-Client-Version  
-   X-Client-Git-Commit-Short

To test for these headers, `TestHTTPClient` was updated to use the `HTTPClientFactory`. The headers, with their expected values, are placed on each expected request, which is an assertion.

Notice that we don't have to add the headers onto the request that is sent, as they are default headers for each request.

This PR needs relies on work in #5237 and needs to be rebased once that is merged.