### PR TITLE
[Python] BindVisitor for binding a BooleanExpression to a Schema

### DIFF
--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -433,6 +433,12 @@ def _(obj: And, visitor: BooleanExpressionVisitor[T]) -> T:
     return visitor.visit_and(left_result=left_result, right_result=right_result)
 
 
+@visit.register(In)
+def _(obj: In, visitor: BooleanExpressionVisitor[T]) -> T:
+    """Visit an And boolean expression with a concrete BooleanExpressionVisitor"""
+    return visitor.visit_unbound_predicate(predicate=obj)
+
+
 @visit.register(Or)
 def _(obj: Or, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an Or boolean expression with a concrete BooleanExpressionVisitor"""
@@ -444,8 +450,8 @@ def _(obj: Or, visitor: BooleanExpressionVisitor[T]) -> T:
 class BindVisitor(BooleanExpressionVisitor[BooleanExpression]):
     """Rewrites a boolean expression by replacing unbound references with references to fields in a struct schema"""
 
-    def __init__(self, struct: StructType, case_sensitive: bool = True) -> None:
-        self._struct = struct
+    def __init__(self, schema: Schema, case_sensitive: bool = True) -> None:
+        self._schema = schema
         self._case_sensitive = case_sensitive
 
     def visit_true(self) -> BooleanExpression:
@@ -464,7 +470,7 @@ class BindVisitor(BooleanExpressionVisitor[BooleanExpression]):
         return Or(left=left_result, right=right_result)
 
     def visit_unbound_predicate(self, predicate) -> BooleanExpression:
-        return predicate.bind(self._struct)
+        return predicate.bind(self._schema, case_sensitive=self._case_sensitive)
 
     def visit_bound_predicate(self, predicate) -> BooleanExpression:
         raise TypeError(f"Found already bound predicate: {predicate}")

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -443,7 +443,12 @@ def _(obj: Or, visitor: BooleanExpressionVisitor[T]) -> T:
 
 
 class BindVisitor(BooleanExpressionVisitor[BooleanExpression]):
-    """Rewrites a boolean expression by replacing unbound references with references to fields in a struct schema"""
+    """Rewrites a boolean expression by replacing unbound references with references to fields in a struct schema
+
+    Args:
+      schema (Schema): A schema to use when binding the expression
+      case_sensitive (bool): Whether to consider case when binding a reference to a field in a schema, defaults to True
+    """
 
     def __init__(self, schema: Schema, case_sensitive: bool = True) -> None:
         self._schema = schema

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -211,7 +211,7 @@ def test_non_parameterized_type_equality(input_index, input_type, check_index, c
 # Examples based on https://iceberg.apache.org/spec/#appendix-c-json-serialization
 
 
-class TestType(IcebergBaseModel):
+class IcebergTestType(IcebergBaseModel):
     __root__: IcebergType
 
 
@@ -220,7 +220,7 @@ def test_serialization_boolean():
 
 
 def test_deserialization_boolean():
-    assert TestType.parse_raw('"boolean"') == BooleanType()
+    assert IcebergTestType.parse_raw('"boolean"') == BooleanType()
 
 
 def test_str_boolean():
@@ -236,7 +236,7 @@ def test_serialization_int():
 
 
 def test_deserialization_int():
-    assert TestType.parse_raw('"int"') == IntegerType()
+    assert IcebergTestType.parse_raw('"int"') == IntegerType()
 
 
 def test_str_int():
@@ -252,7 +252,7 @@ def test_serialization_long():
 
 
 def test_deserialization_long():
-    assert TestType.parse_raw('"long"') == LongType()
+    assert IcebergTestType.parse_raw('"long"') == LongType()
 
 
 def test_str_long():
@@ -268,7 +268,7 @@ def test_serialization_float():
 
 
 def test_deserialization_float():
-    assert TestType.parse_raw('"float"') == FloatType()
+    assert IcebergTestType.parse_raw('"float"') == FloatType()
 
 
 def test_str_float():
@@ -284,7 +284,7 @@ def test_serialization_double():
 
 
 def test_deserialization_double():
-    assert TestType.parse_raw('"double"') == DoubleType()
+    assert IcebergTestType.parse_raw('"double"') == DoubleType()
 
 
 def test_str_double():
@@ -300,7 +300,7 @@ def test_serialization_date():
 
 
 def test_deserialization_date():
-    assert TestType.parse_raw('"date"') == DateType()
+    assert IcebergTestType.parse_raw('"date"') == DateType()
 
 
 def test_str_date():
@@ -316,7 +316,7 @@ def test_serialization_time():
 
 
 def test_deserialization_time():
-    assert TestType.parse_raw('"time"') == TimeType()
+    assert IcebergTestType.parse_raw('"time"') == TimeType()
 
 
 def test_str_time():
@@ -332,7 +332,7 @@ def test_serialization_timestamp():
 
 
 def test_deserialization_timestamp():
-    assert TestType.parse_raw('"timestamp"') == TimestampType()
+    assert IcebergTestType.parse_raw('"timestamp"') == TimestampType()
 
 
 def test_str_timestamp():
@@ -348,7 +348,7 @@ def test_serialization_timestamptz():
 
 
 def test_deserialization_timestamptz():
-    assert TestType.parse_raw('"timestamptz"') == TimestamptzType()
+    assert IcebergTestType.parse_raw('"timestamptz"') == TimestamptzType()
 
 
 def test_str_timestamptz():
@@ -364,7 +364,7 @@ def test_serialization_string():
 
 
 def test_deserialization_string():
-    assert TestType.parse_raw('"string"') == StringType()
+    assert IcebergTestType.parse_raw('"string"') == StringType()
 
 
 def test_str_string():
@@ -380,7 +380,7 @@ def test_serialization_uuid():
 
 
 def test_deserialization_uuid():
-    assert TestType.parse_raw('"uuid"') == UUIDType()
+    assert IcebergTestType.parse_raw('"uuid"') == UUIDType()
 
 
 def test_str_uuid():
@@ -396,7 +396,7 @@ def test_serialization_fixed():
 
 
 def test_deserialization_fixed():
-    fixed = TestType.parse_raw('"fixed[22]"')
+    fixed = IcebergTestType.parse_raw('"fixed[22]"')
     assert fixed == FixedType(22)
 
     inner = fixed.__root__
@@ -417,7 +417,7 @@ def test_serialization_binary():
 
 
 def test_deserialization_binary():
-    assert TestType.parse_raw('"binary"') == BinaryType()
+    assert IcebergTestType.parse_raw('"binary"') == BinaryType()
 
 
 def test_str_binary():
@@ -433,7 +433,7 @@ def test_serialization_decimal():
 
 
 def test_deserialization_decimal():
-    decimal = TestType.parse_raw('"decimal(19, 25)"')
+    decimal = IcebergTestType.parse_raw('"decimal(19, 25)"')
     assert decimal == DecimalType(19, 25)
 
     inner = decimal.__root__
@@ -490,7 +490,9 @@ def test_deserialization_nestedfield():
 
 def test_deserialization_nestedfield_inner():
     expected = NestedField(1, "required_field", StringType(), True, "this is a doc")
-    actual = TestType.parse_raw('{"id": 1, "name": "required_field", "type": "string", "required": true, "doc": "this is a doc"}')
+    actual = IcebergTestType.parse_raw(
+        '{"id": 1, "name": "required_field", "type": "string", "required": true, "doc": "this is a doc"}'
+    )
     assert expected == actual.__root__
 
 


### PR DESCRIPTION
This adds `BindVisitor` which is an implementation of `BooleanExpressionVisitor` for binding all references in an expression. As an example, here's binding an expression along the lines of `'a' in ('foo', 'bar', 'baz')`.

```py
from pyiceberg.expressions.base import BindVisitor, In, Reference, visit
from pyiceberg.expressions.literals import literal
from pyiceberg.schema import Schema
from pyiceberg.types import NestedField, StringType

schema = Schema(
        NestedField(field_id=1, name="a", field_type=StringType(), required=True),
        NestedField(field_id=2, name="b", field_type=StringType(), required=True),
        NestedField(field_id=3, name="c", field_type=StringType(), required=False),
        schema_id=1,
        identifier_field_ids=[1],
   )

bind_visitor = BindVisitor(schema=schema)

unbound_expression = In(Reference("a"), (literal("foo"), literal("bar"), literal("baz")))

visit(unbound_expression, visitor=bind_visitor)
```
result:
```py
 BoundIn(
    term=BoundReference(
        field=NestedField(
            field_id=1, name='a', field_type=StringType(), required=True
        ),
        accessor=Accessor(position=0,inner=None)
    ),
    literals=(
        StringLiteral(foo),
        StringLiteral(bar),
        StringLiteral(baz)
    )
)
```