### PR TITLE
Add InternalRecordWrapperFactory to generate InternalRecordWrapper

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -158,9 +158,11 @@ public abstract class DeleteFilter<T> {
       CloseableIterable<Record> records = CloseableIterable.transform(
           CloseableIterable.concat(deleteRecords), Record::copy);
 
+      InternalRecordWrapperFactory internalRecordWrapperFactory =
+              new InternalRecordWrapperFactory(deleteSchema.asStruct());
       StructLikeSet deleteSet = Deletes.toEqualitySet(
           CloseableIterable.transform(
-              records, record -> new InternalRecordWrapper(deleteSchema.asStruct()).wrap(record)),
+              records, record -> internalRecordWrapperFactory.generate().wrap(record)),
           deleteSchema.asStruct());
 
       Predicate<T> isInDeleteSet = record -> deleteSet.contains(projectRow.wrap(asStructLike(record)));

--- a/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapper.java
+++ b/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapper.java
@@ -42,7 +42,11 @@ public class InternalRecordWrapper implements StructLike {
         .toArray(length -> (Function<Object, Object>[]) Array.newInstance(Function.class, length));
   }
 
-  private static Function<Object, Object> converter(Type type) {
+  InternalRecordWrapper(Function<Object, Object>[] transforms) {
+    this.transforms = transforms;
+  }
+
+  public static Function<Object, Object> converter(Type type) {
     switch (type.typeId()) {
       case DATE:
         return date -> DateTimeUtil.daysFromDate((LocalDate) date);

--- a/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapperFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapperFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.lang.reflect.Array;
+import java.util.function.Function;
+import org.apache.iceberg.types.Types;
+
+public class InternalRecordWrapperFactory {
+  private final Function<Object, Object>[] transforms;
+
+  public InternalRecordWrapperFactory(Types.StructType struct) {
+    this.transforms = struct.fields().stream()
+            .map(field -> InternalRecordWrapper.converter(field.type()))
+            .toArray(length -> (Function<Object, Object>[]) Array.newInstance(Function.class, length));
+  }
+
+  public InternalRecordWrapper generate() {
+    return new InternalRecordWrapper(transforms);
+  }
+}


### PR DESCRIPTION
The cost of creating InternalRecord is very high, So the performance of MOR is low when have many delete files.