### PR TITLE
Add StructLikeWrapperFactory to generate StructLikeWrapper

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
@@ -38,9 +38,11 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
   private final Types.StructType type;
   private final Set<StructLikeWrapper> wrapperSet;
   private final ThreadLocal<StructLikeWrapper> wrappers;
+  private final StructLikeWrapperFactory structLikeWrapperFactory;
 
   private StructLikeSet(Types.StructType type) {
     this.type = type;
+    this.structLikeWrapperFactory = new StructLikeWrapperFactory(type);
     this.wrapperSet = Sets.newHashSet();
     this.wrappers = ThreadLocal.withInitial(() -> StructLikeWrapper.forType(type));
   }
@@ -100,7 +102,7 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
 
   @Override
   public boolean add(StructLike struct) {
-    return wrapperSet.add(StructLikeWrapper.forType(type).set(struct));
+    return wrapperSet.add(structLikeWrapperFactory.generate().set(struct));
   }
 
   @Override
@@ -126,7 +128,7 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
   public boolean addAll(Collection<? extends StructLike> structs) {
     if (structs != null) {
       return Iterables.addAll(wrapperSet,
-          Iterables.transform(structs, struct -> StructLikeWrapper.forType(type).set(struct)));
+          Iterables.transform(structs, struct -> structLikeWrapperFactory.generate().set(struct)));
     }
     return false;
   }

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
@@ -45,6 +45,11 @@ public class StructLikeWrapper {
     this.hashCode = null;
   }
 
+  StructLikeWrapper(Comparator<StructLike> comparator, JavaHash<StructLike> structHash) {
+    this.comparator = comparator;
+    this.structHash = structHash;
+  }
+
   public StructLikeWrapper set(StructLike newStruct) {
     this.struct = newStruct;
     this.hashCode = null;

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeWrapperFactory.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeWrapperFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Comparator;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.JavaHash;
+import org.apache.iceberg.types.Types;
+
+public class StructLikeWrapperFactory {
+
+  private final Comparator<StructLike> comparator;
+
+  private final JavaHash<StructLike> structHash;
+
+  public StructLikeWrapperFactory(Types.StructType type) {
+    this.comparator = Comparators.forType(type);
+    this.structHash = JavaHash.forType(type);
+  }
+
+  public StructLikeWrapper generate() {
+    return new StructLikeWrapper(comparator, structHash);
+  }
+}


### PR DESCRIPTION
The cost of creating StructLikeWrapper is very high, So the performance of MOR is very low when have many delete files