### PR TITLE
Add Makefile argument to pass-through args to pytest

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -23,7 +23,7 @@ lint:
 	poetry run pre-commit run --all-files
 
 test:
-	poetry run coverage run --source=pyiceberg/ -m pytest tests/
+	poetry run coverage run --source=pyiceberg/ -m pytest tests/ ${PYTEST_ARGS}
 	poetry run coverage report -m --fail-under=90
 	poetry run coverage html
 	poetry run coverage xml


### PR DESCRIPTION
This adds a `PYTEST_ARGS` argument to the `make test` command. This allows you to add arguments that Make will pass through to pytest. For example you can do `make test PYTEST_ARGS="-v"` to get verbose output, or `make test PYTEST_ARGS="--pdb"` to launch the pdb debugger on a failed test.

cc: @Fokko @rdblue