### PR TITLE
BUILD - Fix gradle execution optimizations being disabled for iceberg-api:processTestResources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,7 @@ project(':iceberg-api') {
     testImplementation "org.apache.avro:avro"
   }
 
+  tasks.processTestResources.dependsOn rootProject.tasks.buildInfo
   tasks.test.dependsOn rootProject.tasks.buildInfo
 
   sourceSets {


### PR DESCRIPTION
When running iceberg-api gradle test tasks on master, a warning is printed that execution optimizations are disabled for `iceberg-api:processTestResources`.

This is because of an undeclared implicit dependency between `generateGitResources` and `iceberg-api:processTestResources`. This occurs despite an explicit dependency between `iceberg-api:test` and `:buildInfo`.

When running `./gradlew clean :iceberg-api:check -x test` the following warning is printed.

```bash
> Task :iceberg-api:processTestResources
Execution optimizations have been disabled for task ':iceberg-api:processTestResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/kylebendickson/repos/iceberg/build'. Reason: Task ':iceberg-api:processTestResources' uses this output of task ':generateGitProperties' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

This patch removes that warning.

cc @rdblue 


