### PR TITLE
Core: Fix REST catalog metadata table loading.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.Locale;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 
@@ -93,6 +94,6 @@ public class MetadataTableUtils {
   }
 
   private static String metadataTableName(String tableName, MetadataTableType type) {
-    return tableName + (tableName.contains("/") ? "#" : ".") + type;
+    return tableName + (tableName.contains("/") ? "#" : ".") + type.name().toLowerCase(Locale.ROOT);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -225,8 +225,10 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
 
     MetadataTableType metadataType;
     LoadTableResponse response;
+    TableIdentifier loadedIdent;
     try {
       response = loadInternal(context, identifier);
+      loadedIdent = identifier;
       metadataType = null;
 
     } catch (NoSuchTableException original) {
@@ -236,6 +238,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
         TableIdentifier baseIdent = TableIdentifier.of(identifier.namespace().levels());
         try {
           response = loadInternal(context, baseIdent);
+          loadedIdent = baseIdent;
         } catch (NoSuchTableException ignored) {
           // the base table does not exist
           throw original;
@@ -248,9 +251,9 @@ public class RESTSessionCatalog extends BaseSessionCatalog implements Configurab
 
     AuthSession session = tableSession(response.config(), session(context));
     RESTTableOperations ops = new RESTTableOperations(
-        client, paths.table(identifier), session::headers, tableFileIO(response.config()), response.tableMetadata());
+        client, paths.table(loadedIdent), session::headers, tableFileIO(response.config()), response.tableMetadata());
 
-    BaseTable table = new BaseTable(ops, fullTableName(identifier));
+    BaseTable table = new BaseTable(ops, fullTableName(loadedIdent));
     if (metadataType != null) {
       return MetadataTableUtils.createMetadataTableInstance(table, metadataType);
     }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -635,6 +635,11 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table = catalog.loadTable(metaIdent);
     Assertions.assertThat(table).isNotNull();
     Assertions.assertThat(table).isInstanceOf(FilesTable.class);
+
+    // check that the table metadata can be refreshed
+    table.refresh();
+
+    Assertions.assertThat(table.name()).isEqualTo(catalog.name() + "." + metaIdent);
   }
 
   @Test


### PR DESCRIPTION
This fixes metadata table loading. Although the metadata table is correctly loaded, the `TableOperations` fails when it is first used because the path is based on the full table identifier (e.g. db.table.files) rather than the loaded table identifier (db.table). This fixes both the path and the table name.