### PR TITLE
[API] Fix throwing null exception and add error prone suppression to runSafely functions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
@@ -78,6 +78,7 @@ public class ExceptionUtil {
     return runSafely(block, catchBlock, finallyBlock, e1Class, e2Class, RuntimeException.class);
   }
 
+  @SuppressWarnings("Finally")
   public static <R, E1 extends Exception, E2 extends Exception, E3 extends Exception> R runSafely(
       Block<R, E1, E2, E3> block,
       CatchBlock catchBlock,
@@ -113,15 +114,15 @@ public class ExceptionUtil {
         try {
           finallyBlock.run();
         } catch (Exception e) {
-          LOG.warn("Suppressing failure in finally block", e);
           if (failure != null) {
+            LOG.warn("Suppressing failure in finally block", e);
             failure.addSuppressed(e);
           } else {
             tryThrowAs(e, e1Class);
             tryThrowAs(e, e2Class);
             tryThrowAs(e, e3Class);
             tryThrowAs(e, RuntimeException.class);
-            throw new RuntimeException("Unknown exception in finally block", failure);
+            throw new RuntimeException("Unknown exception in finally block", e);
           }
         }
       }


### PR DESCRIPTION
The `runSafely` function gives an error prone warning for throwing from a finally block.

Originally, we fixed this via suppression in https://github.com/apache/iceberg/pull/5190, but I noticed this function was unused and so chose to deprecate it instead in https://github.com/apache/iceberg/pull/5205.

@rdblue wanted to keep the function, as it's tested and could be useful in the future.

So this PR:
- fixes the issue discovered in #5190 of throwing `failure` when it's null
- attempts to throw `failure` after adding `e` as a suppressed error when it's non-null
- adds the `@Finally` suppression to remove the error prone log from the build.

Warning that is logged on build:
```
iceberg/api/src/main/java/org/apache/iceberg/util/ExceptionUtil.java:124: warning: [Finally] If you return or throw from a finally, then values returned or thrown from the try-catch block will be ignored. Consider using try-with-resources instead.
            throw new RuntimeException("Unknown exception in finally block", failure);
            ^
    (see https://errorprone.info/bugpattern/Finally)
``` 

