### PR TITLE
Spark 3.2: Rename output columns in register_table procedure

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
@@ -43,9 +43,9 @@ class RegisterTableProcedure extends BaseProcedure {
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
-      new StructField("Current SnapshotId", DataTypes.LongType, true, Metadata.empty()),
-      new StructField("Rows", DataTypes.LongType, true, Metadata.empty()),
-      new StructField("Datafiles", DataTypes.LongType, true, Metadata.empty())
+      new StructField("current_snapshot_id", DataTypes.LongType, true, Metadata.empty()),
+      new StructField("total_records_count", DataTypes.LongType, true, Metadata.empty()),
+      new StructField("total_data_files_count", DataTypes.LongType, true, Metadata.empty())
   });
 
   private RegisterTableProcedure(TableCatalog tableCatalog) {


### PR DESCRIPTION
This is a change similar to #5253 but for Spark 3.2.