### PR TITLE
Build: Add iceberg-build.properties to RAT excludes

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,6 +1,7 @@
 version.txt
 versions.lock
 versions.props
+iceberg-build.properties
 .java-version
 books.json
 new-books.json


### PR DESCRIPTION
I hit this while verifying the 0.14.0-rc1 candidate.

It shouldn't fail the candidate since it is okay that the file doesn't have a license (it is generated metadata).