### PR TITLE
Build: Use Google Java Format for spotless

### DIFF
--- a/.baseline/copyright/copyright-header-java.txt
+++ b/.baseline/copyright/copyright-header-java.txt
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -42,22 +42,15 @@ subprojects {
   apply plugin: 'com.palantir.baseline-release-compatibility'
   apply plugin: 'com.diffplug.spotless'
 
-  // Can't use the built-in Baseline spotless format because it's opinionated about the import
-  // order of having static imports after non-static imports, and this cannot be overridden.
-
-  // So we apply Spotless manually to get a similar effect to baseline-format, but change the
-  // import order.
   pluginManager.withPlugin('com.diffplug.spotless') {
     spotless {
       // don't run spotlessCheck during gradle check task
       enforceCheck = false
       java {
         target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/jmh/java/**/*.java'
+        googleJavaFormat()
         removeUnusedImports()
-        importOrder '', 'static '
-        trimTrailingWhitespace()
-        indentWithSpaces 2
-        endWithNewline()
+        licenseHeaderFile "$rootDir/.baseline/copyright/copyright-header-java.txt"
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
     classpath 'com.palantir.baseline:gradle-baseline-java:4.0.0'
     classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
-    classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.2.2'
+    classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.8.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
     classpath 'me.champeau.jmh:jmh-gradle-plugin:0.6.6'
     classpath "com.github.alisiikh:gradle-scalastyle-plugin:3.4.1"


### PR DESCRIPTION
This PR is the first step towards automatic code formatting.

It configures Spotless to use the Google Java format and applies the copyright header automatically when running `./gradlew spotlessApply`.

Once this PR is merged, the next steps would be:
1. removing conflicting Checkstyle rules that are not in line with the Google format
2. formatting the entire code base via `./gradlew spotlessApply`
3. setting `enforceCheck` to `true` in https://github.com/apache/iceberg/blob/80318d8cfbeb0d96d0afc27c84bc3dbddde35344/baseline.gradle#L48
4. updating docs around the current Formatter usage and how to configure Eclipse/IntelliJ

