### PR TITLE
API/Core: Initial Table Scan Reporting support

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
@@ -73,6 +74,36 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
     };
   }
 
+  /**
+   * Will run the given runnable when {@link CloseableIterable#close()} has been called.
+   *
+   * @param iterable The underlying {@link CloseableIterable} to iterate over
+   * @param onCompletionRunnable The runnable to run after the underlying iterable was closed
+   * @param <E> The type of the underlying iterable
+   * @return A new {@link CloseableIterable} where the runnable will be executed as the final step
+   *     after {@link CloseableIterable#close()} has been called
+   */
+  static <E> CloseableIterable<E> whenComplete(
+      CloseableIterable<E> iterable, Runnable onCompletionRunnable) {
+    Preconditions.checkNotNull(
+        onCompletionRunnable, "Cannot execute a null Runnable after completion");
+    return new CloseableIterable<E>() {
+      @Override
+      public void close() throws IOException {
+        try {
+          iterable.close();
+        } finally {
+          onCompletionRunnable.run();
+        }
+      }
+
+      @Override
+      public CloseableIterator<E> iterator() {
+        return CloseableIterator.withClose(iterable.iterator());
+      }
+    };
+  }
+
   static <E> CloseableIterable<E> filter(CloseableIterable<E> iterable, Predicate<E> pred) {
     return combine(
         () ->
@@ -83,6 +114,65 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
               }
             },
         iterable);
+  }
+
+  /**
+   * Filters the given {@link CloseableIterable} and counts the number of elements that do not match
+   * the predicate by incrementing the {@link MetricsContext.Counter}.
+   *
+   * @param skipCounter The {@link MetricsContext.Counter} instance to increment on each skipped
+   *     item during filtering.
+   * @param iterable The underlying {@link CloseableIterable} to filter.
+   * @param <E> The underlying type to be iterated.
+   * @return A filtered {@link CloseableIterable} where the given skipCounter is incremented
+   *     whenever the predicate does not match.
+   */
+  static <E> CloseableIterable<E> filter(
+      MetricsContext.Counter<?> skipCounter, CloseableIterable<E> iterable, Predicate<E> pred) {
+    Preconditions.checkArgument(null != skipCounter, "Invalid counter: null");
+    Preconditions.checkArgument(null != iterable, "Invalid iterable: null");
+    Preconditions.checkArgument(null != pred, "Invalid predicate: null");
+    return combine(
+        () ->
+            new FilterIterator<E>(iterable.iterator()) {
+              @Override
+              protected boolean shouldKeep(E item) {
+                boolean matches = pred.test(item);
+                if (!matches) {
+                  skipCounter.increment();
+                }
+                return matches;
+              }
+            },
+        iterable);
+  }
+
+  /**
+   * Counts the number of elements in the given {@link CloseableIterable} by incrementing the {@link
+   * MetricsContext.Counter} instance for each {@link Iterator#next()} call.
+   *
+   * @param counter The {@link MetricsContext.Counter} instance to increment on each {@link
+   *     Iterator#next()} call.
+   * @param iterable The underlying {@link CloseableIterable} to count
+   * @param <T> The underlying type to be iterated.
+   * @return A {@link CloseableIterable} that increments the given counter on each {@link
+   *     Iterator#next()} call.
+   */
+  static <T> CloseableIterable<T> count(
+      MetricsContext.Counter<?> counter, CloseableIterable<T> iterable) {
+    Preconditions.checkArgument(null != counter, "Invalid counter: null");
+    Preconditions.checkArgument(null != iterable, "Invalid iterable: null");
+    return new CloseableIterable<T>() {
+      @Override
+      public CloseableIterator<T> iterator() {
+        return CloseableIterator.count(counter, iterable.iterator());
+      }
+
+      @Override
+      public void close() throws IOException {
+        iterable.close();
+      }
+    };
   }
 
   static <I, O> CloseableIterable<O> transform(

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.function.Function;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
@@ -74,6 +75,28 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
       @Override
       public O next() {
         return transform.apply(iterator.next());
+      }
+    };
+  }
+
+  static <T> CloseableIterator<T> count(
+      MetricsContext.Counter<?> counter, CloseableIterator<T> iterator) {
+    return new CloseableIterator<T>() {
+      @Override
+      public void close() throws IOException {
+        iterator.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public T next() {
+        T next = iterator.next();
+        counter.increment();
+        return next;
       }
     };
   }

--- a/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
@@ -27,6 +27,25 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * {@link Integer} to count events.
  */
 class IntCounter implements MetricsContext.Counter<Integer> {
+  static final IntCounter NOOP =
+      new IntCounter("NOOP", MetricsContext.Unit.UNDEFINED) {
+        @Override
+        public void increment() {}
+
+        @Override
+        public void increment(Integer amount) {}
+
+        @Override
+        public Optional<Integer> count() {
+          return Optional.of(value());
+        }
+
+        @Override
+        public Integer value() {
+          return 0;
+        }
+      };
+
   private final AtomicInteger counter;
   private final String name;
   private final MetricsContext.Unit unit;

--- a/api/src/main/java/org/apache/iceberg/metrics/LoggingScanReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LoggingScanReporter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A default {@link ScanReporter} implementation that logs the {@link ScanReport} to the log file.
+ */
+public class LoggingScanReporter implements ScanReporter {
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingScanReporter.class);
+
+  @Override
+  public void reportScan(ScanReport scanReport) {
+    Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
+    LOG.info("Completed scan planning: {}", scanReport);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
@@ -27,6 +27,25 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * {@link Long} to count events.
  */
 class LongCounter implements MetricsContext.Counter<Long> {
+  static final LongCounter NOOP =
+      new LongCounter("NOOP", MetricsContext.Unit.UNDEFINED) {
+        @Override
+        public void increment() {}
+
+        @Override
+        public void increment(Long amount) {}
+
+        @Override
+        public Optional<Long> count() {
+          return Optional.of(value());
+        }
+
+        @Override
+        public Long value() {
+          return 0L;
+        }
+      };
+
   private final AtomicLong counter;
   private final String name;
   private final MetricsContext.Unit unit;

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -135,13 +135,16 @@ public interface MetricsContext extends Serializable {
 
       @Override
       public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
-        return new Counter<T>() {
-          @Override
-          public void increment() {}
+        if (Integer.class.equals(type)) {
+          return (Counter<T>) IntCounter.NOOP;
+        }
 
-          @Override
-          public void increment(T amount) {}
-        };
+        if (Long.class.equals(type)) {
+          return (Counter<T>) LongCounter.NOOP;
+        }
+
+        throw new IllegalArgumentException(
+            String.format("Counter for type %s is not supported", type.getName()));
       }
     };
   }

--- a/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/** A Table Scan report that contains all relevant information from a Table Scan. */
+public class ScanReport implements Serializable {
+
+  private final String tableName;
+  private final long snapshotId;
+  private final Expression filter;
+  private final Schema projection;
+  private final ScanMetrics scanMetrics;
+
+  private ScanReport(
+      String tableName,
+      long snapshotId,
+      Expression filter,
+      Schema projection,
+      ScanMetrics scanMetrics) {
+    this.tableName = tableName;
+    this.snapshotId = snapshotId;
+    this.filter = filter;
+    this.projection = projection;
+    this.scanMetrics = scanMetrics;
+  }
+
+  public String tableName() {
+    return tableName;
+  }
+
+  public long snapshotId() {
+    return snapshotId;
+  }
+
+  public Expression filter() {
+    return filter;
+  }
+
+  public Schema projection() {
+    return projection;
+  }
+
+  public ScanMetrics scanMetrics() {
+    return scanMetrics;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("tableName", tableName)
+        .add("snapshotId", snapshotId)
+        .add("filter", filter)
+        .add("projection", projection)
+        .add("scanMetrics", scanMetrics)
+        .toString();
+  }
+
+  public static class Builder {
+    private String tableName;
+    private long snapshotId = -1L;
+    private Expression filter;
+    private Schema projection;
+    private ScanMetrics scanMetrics;
+
+    private Builder() {}
+
+    public Builder withTableName(String newTableName) {
+      this.tableName = newTableName;
+      return this;
+    }
+
+    public Builder withSnapshotId(long newSnapshotId) {
+      this.snapshotId = newSnapshotId;
+      return this;
+    }
+
+    public Builder withFilter(Expression newFilter) {
+      this.filter = newFilter;
+      return this;
+    }
+
+    public Builder withProjection(Schema newProjection) {
+      this.projection = newProjection;
+      return this;
+    }
+
+    public Builder fromScanMetrics(ScanMetrics newScanMetrics) {
+      this.scanMetrics = newScanMetrics;
+      return this;
+    }
+
+    public ScanReport build() {
+      Preconditions.checkArgument(null != tableName, "Invalid table name: null");
+      Preconditions.checkArgument(null != filter, "Invalid expression filter: null");
+      Preconditions.checkArgument(null != projection, "Invalid schema projection: null");
+      Preconditions.checkArgument(null != scanMetrics, "Invalid scan metrics: null");
+      return new ScanReport(tableName, snapshotId, filter, projection, scanMetrics);
+    }
+  }
+
+  /** Carries all metrics for a particular scan */
+  public static class ScanMetrics {
+    public static final ScanMetrics NOOP = new ScanMetrics(MetricsContext.nullMetrics());
+    private final Timer totalPlanningDuration;
+    private final Counter<Integer> resultDataFiles;
+    private final Counter<Integer> resultDeleteFiles;
+    private final Counter<Integer> totalDataManifests;
+    private final Counter<Integer> totalDeleteManifests;
+    private final Counter<Integer> scannedDataManifests;
+    private final Counter<Integer> skippedDataManifests;
+    private final Counter<Long> totalFileSizeInBytes;
+    private final Counter<Long> totalDeleteFileSizeInBytes;
+
+    public ScanMetrics(MetricsContext metricsContext) {
+      Preconditions.checkArgument(null != metricsContext, "Invalid metrics context: null");
+      this.totalPlanningDuration =
+          metricsContext.timer("totalPlanningDuration", TimeUnit.NANOSECONDS);
+      this.resultDataFiles =
+          metricsContext.counter("resultDataFiles", Integer.class, MetricsContext.Unit.COUNT);
+      this.resultDeleteFiles =
+          metricsContext.counter("resultDeleteFiles", Integer.class, MetricsContext.Unit.COUNT);
+      this.scannedDataManifests =
+          metricsContext.counter("scannedDataManifests", Integer.class, MetricsContext.Unit.COUNT);
+      this.totalDataManifests =
+          metricsContext.counter("totalDataManifests", Integer.class, MetricsContext.Unit.COUNT);
+      this.totalDeleteManifests =
+          metricsContext.counter("totalDeleteManifests", Integer.class, MetricsContext.Unit.COUNT);
+      this.totalFileSizeInBytes =
+          metricsContext.counter("totalFileSizeInBytes", Long.class, MetricsContext.Unit.BYTES);
+      this.totalDeleteFileSizeInBytes =
+          metricsContext.counter(
+              "totalDeleteFileSizeInBytes", Long.class, MetricsContext.Unit.BYTES);
+      this.skippedDataManifests =
+          metricsContext.counter("skippedDataManifests", Integer.class, MetricsContext.Unit.COUNT);
+    }
+
+    public Timer totalPlanningDuration() {
+      return totalPlanningDuration;
+    }
+
+    public Counter<Integer> resultDataFiles() {
+      return resultDataFiles;
+    }
+
+    public Counter<Integer> resultDeleteFiles() {
+      return resultDeleteFiles;
+    }
+
+    public Counter<Integer> scannedDataManifests() {
+      return scannedDataManifests;
+    }
+
+    public Counter<Integer> totalDataManifests() {
+      return totalDataManifests;
+    }
+
+    public Counter<Integer> totalDeleteManifests() {
+      return totalDeleteManifests;
+    }
+
+    public Counter<Long> totalFileSizeInBytes() {
+      return totalFileSizeInBytes;
+    }
+
+    public Counter<Long> totalDeleteFileSizeInBytes() {
+      return totalDeleteFileSizeInBytes;
+    }
+
+    public Counter<Integer> skippedDataManifests() {
+      return skippedDataManifests;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .addValue(totalPlanningDuration)
+          .addValue(resultDataFiles)
+          .addValue(resultDeleteFiles)
+          .addValue(scannedDataManifests)
+          .addValue(skippedDataManifests)
+          .addValue(totalDataManifests)
+          .addValue(totalDeleteManifests)
+          .addValue(totalFileSizeInBytes)
+          .addValue(totalDeleteFileSizeInBytes)
+          .toString();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/ScanReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/ScanReporter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import org.apache.iceberg.metrics.ScanReport.ScanMetrics;
+
+/**
+ * This interface defines the basic API for a Table Scan Reporter that can be used to report
+ * different metrics after a Table scan is done.
+ */
+@FunctionalInterface
+public interface ScanReporter {
+
+  /**
+   * Indicates that a Scan is done by reporting a {@link ScanReport}. A {@link ScanReport} is
+   * usually directly derived from a {@link ScanMetrics} instance.
+   *
+   * @param scanReport The {@link ScanReport} to report.
+   */
+  void reportScan(ScanReport scanReport);
+}

--- a/api/src/test/java/org/apache/iceberg/metrics/TestScanReport.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestScanReport.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.True;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestScanReport {
+
+  @Test
+  public void missingFields() {
+    Assertions.assertThatThrownBy(() -> ScanReport.builder().build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid table name: null");
+
+    Assertions.assertThatThrownBy(() -> ScanReport.builder().withTableName("x").build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid expression filter: null");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanReport.builder()
+                    .withTableName("x")
+                    .withFilter(Expressions.alwaysTrue())
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid schema projection: null");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ScanReport.builder()
+                    .withTableName("x")
+                    .withFilter(Expressions.alwaysTrue())
+                    .withProjection(
+                        new Schema(
+                            Types.NestedField.required(1, "c1", Types.StringType.get(), "c1")))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scan metrics: null");
+  }
+
+  @Test
+  public void fromEmptyScanMetrics() {
+    String tableName = "x";
+    True filter = Expressions.alwaysTrue();
+    Schema projection =
+        new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
+    ScanReport scanReport =
+        ScanReport.builder()
+            .withTableName(tableName)
+            .withFilter(filter)
+            .withProjection(projection)
+            .fromScanMetrics(ScanReport.ScanMetrics.NOOP)
+            .build();
+
+    Assertions.assertThat(scanReport.tableName()).isEqualTo(tableName);
+    Assertions.assertThat(scanReport.projection()).isEqualTo(projection);
+    Assertions.assertThat(scanReport.filter()).isEqualTo(filter);
+    Assertions.assertThat(scanReport.snapshotId()).isEqualTo(-1);
+    Assertions.assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isEqualTo(Duration.ZERO);
+    Assertions.assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(0);
+    Assertions.assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(0);
+    Assertions.assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(0);
+    Assertions.assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(0L);
+  }
+
+  @Test
+  public void fromScanMetrics() {
+    ScanReport.ScanMetrics scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
+    scanMetrics.resultDataFiles().increment(5);
+    scanMetrics.resultDeleteFiles().increment(5);
+    scanMetrics.scannedDataManifests().increment(5);
+    scanMetrics.totalFileSizeInBytes().increment(1024L);
+    scanMetrics.totalDataManifests().increment(5);
+
+    String tableName = "x";
+    True filter = Expressions.alwaysTrue();
+    Schema projection =
+        new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
+    ScanReport scanReport =
+        ScanReport.builder()
+            .withTableName(tableName)
+            .withFilter(filter)
+            .withProjection(projection)
+            .withSnapshotId(23L)
+            .fromScanMetrics(scanMetrics)
+            .build();
+
+    Assertions.assertThat(scanReport.tableName()).isEqualTo(tableName);
+    Assertions.assertThat(scanReport.projection()).isEqualTo(projection);
+    Assertions.assertThat(scanReport.filter()).isEqualTo(filter);
+    Assertions.assertThat(scanReport.snapshotId()).isEqualTo(23L);
+    Assertions.assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isEqualTo(Duration.ofMinutes(10L));
+    Assertions.assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(5);
+    Assertions.assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(5);
+    Assertions.assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(5);
+    Assertions.assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(5);
+    Assertions.assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(1024L);
+  }
+
+  @Test
+  public void nullScanMetrics() {
+    Assertions.assertThatThrownBy(() -> new ScanReport.ScanMetrics(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid metrics context: null");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.metrics.LoggingScanReporter;
+import org.apache.iceberg.metrics.ScanReporter;
 
 /**
  * Base {@link Table} implementation.
@@ -37,10 +39,18 @@ import org.apache.iceberg.io.LocationProvider;
 public class BaseTable implements Table, HasTableOperations, Serializable {
   private final TableOperations ops;
   private final String name;
+  private final ScanReporter scanReporter;
 
   public BaseTable(TableOperations ops, String name) {
     this.ops = ops;
     this.name = name;
+    this.scanReporter = new LoggingScanReporter();
+  }
+
+  public BaseTable(TableOperations ops, String name, ScanReporter scanReporter) {
+    this.ops = ops;
+    this.name = name;
+    this.scanReporter = scanReporter;
   }
 
   @Override
@@ -60,12 +70,13 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public TableScan newScan() {
-    return new DataTableScan(ops, this);
+    return new DataTableScan(ops, this, schema(), new TableScanContext().reportWith(scanReporter));
   }
 
   @Override
   public IncrementalAppendScan newIncrementalAppendScan() {
-    return new BaseIncrementalAppendScan(ops, this);
+    return new BaseIncrementalAppendScan(
+        ops, this, schema(), new TableScanContext().reportWith(scanReporter));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -25,6 +25,9 @@ import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.Timer;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -37,6 +40,7 @@ import org.slf4j.LoggerFactory;
 abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedScanTask>
     implements TableScan {
   private static final Logger LOG = LoggerFactory.getLogger(BaseTableScan.class);
+  private ScanReport.ScanMetrics scanMetrics;
 
   protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
     this(ops, table, schema, new TableScanContext());
@@ -68,6 +72,14 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
   }
 
   protected abstract CloseableIterable<FileScanTask> doPlanFiles();
+
+  protected ScanReport.ScanMetrics scanMetrics() {
+    if (scanMetrics == null) {
+      this.scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    }
+
+    return scanMetrics;
+  }
 
   @Override
   public Table table() {
@@ -121,9 +133,22 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
           ExpressionUtil.toSanitizedString(filter()));
 
       Listeners.notifyAll(new ScanEvent(table().name(), snapshot.snapshotId(), filter(), schema()));
+      Timer.Timed scanDuration = scanMetrics().totalPlanningDuration().start();
 
-      return doPlanFiles();
-
+      return CloseableIterable.whenComplete(
+          doPlanFiles(),
+          () -> {
+            scanDuration.stop();
+            ScanReport scanReport =
+                ScanReport.builder()
+                    .withFilter(ExpressionUtil.sanitize(filter()))
+                    .withProjection(schema())
+                    .withTableName(table().name())
+                    .withSnapshotId(snapshot.snapshotId())
+                    .fromScanMetrics(scanMetrics())
+                    .build();
+            context().scanReporter().reportScan(scanReport);
+          });
     } else {
       LOG.info("Scanning empty table {}", table());
       return CloseableIterable.empty();

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -363,6 +364,7 @@ class DeleteFileIndex {
     private PartitionSet partitionSet = null;
     private boolean caseSensitive = true;
     private ExecutorService executorService = null;
+    private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.NOOP;
 
     Builder(FileIO io, Set<ManifestFile> deleteManifests) {
       this.io = io;
@@ -401,6 +403,11 @@ class DeleteFileIndex {
 
     Builder planWith(ExecutorService newExecutorService) {
       this.executorService = newExecutorService;
+      return this;
+    }
+
+    Builder scanMetrics(ScanReport.ScanMetrics newScanMetrics) {
+      this.scanMetrics = newScanMetrics;
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -92,6 +93,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   private Schema fileProjection = null;
   private Collection<String> columns = null;
   private boolean caseSensitive = true;
+  private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.NOOP;
 
   // lazily initialized
   private Evaluator lazyEvaluator = null;
@@ -183,6 +185,11 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
   public ManifestReader<F> caseSensitive(boolean isCaseSensitive) {
     this.caseSensitive = isCaseSensitive;
+    return this;
+  }
+
+  ManifestReader<F> scanMetrics(ScanReport.ScanMetrics newScanMetrics) {
+    this.scanMetrics = newScanMetrics;
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -24,6 +24,8 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.metrics.LoggingScanReporter;
+import org.apache.iceberg.metrics.ScanReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.ThreadPools;
@@ -42,6 +44,7 @@ final class TableScanContext {
   private final Long toSnapshotId;
   private final ExecutorService planExecutor;
   private final boolean fromSnapshotInclusive;
+  private final ScanReporter scanReporter;
 
   TableScanContext() {
     this.snapshotId = null;
@@ -56,6 +59,7 @@ final class TableScanContext {
     this.toSnapshotId = null;
     this.planExecutor = null;
     this.fromSnapshotInclusive = false;
+    this.scanReporter = new LoggingScanReporter();
   }
 
   private TableScanContext(
@@ -70,7 +74,8 @@ final class TableScanContext {
       Long fromSnapshotId,
       Long toSnapshotId,
       ExecutorService planExecutor,
-      boolean fromSnapshotInclusive) {
+      boolean fromSnapshotInclusive,
+      ScanReporter scanReporter) {
     this.snapshotId = snapshotId;
     this.rowFilter = rowFilter;
     this.ignoreResiduals = ignoreResiduals;
@@ -83,6 +88,7 @@ final class TableScanContext {
     this.toSnapshotId = toSnapshotId;
     this.planExecutor = planExecutor;
     this.fromSnapshotInclusive = fromSnapshotInclusive;
+    this.scanReporter = scanReporter;
   }
 
   Long snapshotId() {
@@ -102,7 +108,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   Expression rowFilter() {
@@ -122,7 +129,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   boolean ignoreResiduals() {
@@ -142,7 +150,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   boolean caseSensitive() {
@@ -162,7 +171,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   boolean returnColumnStats() {
@@ -182,7 +192,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   Collection<String> selectedColumns() {
@@ -204,7 +215,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   Schema projectedSchema() {
@@ -226,7 +238,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   Map<String, String> options() {
@@ -249,7 +262,8 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   Long fromSnapshotId() {
@@ -269,7 +283,8 @@ final class TableScanContext {
         id,
         toSnapshotId,
         planExecutor,
-        false);
+        false,
+        scanReporter);
   }
 
   TableScanContext fromSnapshotIdInclusive(long id) {
@@ -285,7 +300,8 @@ final class TableScanContext {
         id,
         toSnapshotId,
         planExecutor,
-        true);
+        true,
+        scanReporter);
   }
 
   boolean fromSnapshotInclusive() {
@@ -309,7 +325,8 @@ final class TableScanContext {
         fromSnapshotId,
         id,
         planExecutor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
   }
 
   ExecutorService planExecutor() {
@@ -333,6 +350,28 @@ final class TableScanContext {
         fromSnapshotId,
         toSnapshotId,
         executor,
-        fromSnapshotInclusive);
+        fromSnapshotInclusive,
+        scanReporter);
+  }
+
+  ScanReporter scanReporter() {
+    return scanReporter;
+  }
+
+  TableScanContext reportWith(ScanReporter reporter) {
+    return new TableScanContext(
+        snapshotId,
+        rowFilter,
+        ignoreResiduals,
+        caseSensitive,
+        colStats,
+        projectedSchema,
+        selectedColumns,
+        options,
+        fromSnapshotId,
+        toSnapshotId,
+        planExecutor,
+        fromSnapshotInclusive,
+        reporter);
   }
 }

--- a/data/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
+++ b/data/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.metrics.LoggingScanReporter;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.ScanReporter;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+
+public class TestScanPlanningAndReporting extends TableTestBase {
+
+  private final TestScanReporter reporter = new TestScanReporter();
+
+  public TestScanPlanningAndReporting() {
+    super(2);
+  }
+
+  @Test
+  public void testScanPlanningWithReport() throws IOException {
+    String tableName = "simple-scan-planning";
+    Table table = createTableWithCustomRecords(tableName);
+    TableScan tableScan = table.newScan();
+
+    // should be 3 files
+    try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+      fileScanTasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+    assertThat(scanReport.snapshotId()).isEqualTo(1L);
+    assertThat(scanReport.filter()).isEqualTo(Expressions.alwaysTrue());
+    assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isGreaterThan(Duration.ZERO);
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(3);
+    assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().skippedDataManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().totalDeleteManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(1850L);
+    assertThat(scanReport.scanMetrics().totalDeleteFileSizeInBytes().value()).isEqualTo(0L);
+
+    // should be 1 file
+    try (CloseableIterable<FileScanTask> fileScanTasks =
+        tableScan.filter(Expressions.lessThan("x", "30")).planFiles()) {
+      fileScanTasks.forEach(task -> {});
+    }
+
+    scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+    assertThat(scanReport.snapshotId()).isEqualTo(1L);
+    assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isGreaterThan(Duration.ZERO);
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().skippedDataManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().totalDeleteManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(616L);
+    assertThat(scanReport.scanMetrics().totalDeleteFileSizeInBytes().value()).isEqualTo(0L);
+  }
+
+  private Table createTableWithCustomRecords(String tableName) throws IOException {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()), required(2, "x", Types.StringType.get()));
+
+    Table table =
+        TestTables.create(
+            tableDir,
+            tableName,
+            schema,
+            PartitionSpec.builderFor(schema).build(),
+            SortOrder.unsorted(),
+            formatVersion,
+            reporter);
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("id", 1);
+    record.setField("x", "23");
+
+    GenericRecord record2 = record.copy(ImmutableMap.of("id", 2, "x", "30"));
+    GenericRecord record3 = record.copy(ImmutableMap.of("id", 3, "x", "45"));
+    GenericRecord record4 = record.copy(ImmutableMap.of("id", 4, "x", "51"));
+
+    DataFile dataFile = writeParquetFile(table, Arrays.asList(record, record3));
+    DataFile dataFile2 = writeParquetFile(table, Arrays.asList(record2));
+    DataFile dataFile3 = writeParquetFile(table, Arrays.asList(record4));
+    table.newFastAppend().appendFile(dataFile).appendFile(dataFile2).appendFile(dataFile3).commit();
+    return table;
+  }
+
+  @Test
+  public void deleteScanning() throws IOException {
+    Table table =
+        TestTables.create(
+            tableDir,
+            "scan-planning-with-deletes",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            reporter);
+
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).appendFile(FILE_C).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_B_DELETES).commit();
+    TableScan tableScan = table.newScan();
+
+    try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+      fileScanTasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo("scan-planning-with-deletes");
+    assertThat(scanReport.snapshotId()).isEqualTo(2L);
+    assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isGreaterThan(Duration.ZERO);
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(3);
+    assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(2);
+    assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().skippedDataManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().totalDeleteManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(30L);
+    assertThat(scanReport.scanMetrics().totalDeleteFileSizeInBytes().value()).isEqualTo(20L);
+  }
+
+  @Test
+  public void multipleDataManifests() throws IOException {
+    Table table =
+        TestTables.create(
+            tableDir,
+            "multiple-data-manifests",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            reporter);
+
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newAppend().appendFile(FILE_C).appendFile(FILE_D).commit();
+
+    TableScan tableScan = table.newScan();
+
+    try (CloseableIterable<FileScanTask> fileScanTasks = tableScan.planFiles()) {
+      fileScanTasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo("multiple-data-manifests");
+    assertThat(scanReport.snapshotId()).isEqualTo(2L);
+    assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isGreaterThan(Duration.ZERO);
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(4);
+    assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(2);
+    assertThat(scanReport.scanMetrics().skippedDataManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(2);
+    assertThat(scanReport.scanMetrics().totalDeleteManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(40L);
+    assertThat(scanReport.scanMetrics().totalDeleteFileSizeInBytes().value()).isEqualTo(0L);
+
+    // we should hit only a single data manifest and only a single data file
+    try (CloseableIterable<FileScanTask> fileScanTasks =
+        tableScan.filter(Expressions.equal("data", "1")).planFiles()) {
+      fileScanTasks.forEach(task -> {});
+    }
+
+    scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo("multiple-data-manifests");
+    assertThat(scanReport.snapshotId()).isEqualTo(2L);
+    assertThat(scanReport.scanMetrics().totalPlanningDuration().totalDuration())
+        .isGreaterThan(Duration.ZERO);
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().resultDeleteFiles().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().scannedDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().skippedDataManifests().value()).isEqualTo(1);
+    assertThat(scanReport.scanMetrics().totalDataManifests().value()).isEqualTo(2);
+    assertThat(scanReport.scanMetrics().totalDeleteManifests().value()).isEqualTo(0);
+    assertThat(scanReport.scanMetrics().totalFileSizeInBytes().value()).isEqualTo(10L);
+    assertThat(scanReport.scanMetrics().totalDeleteFileSizeInBytes().value()).isEqualTo(0L);
+  }
+
+  private DataFile writeParquetFile(Table table, List<GenericRecord> records) throws IOException {
+    File parquetFile = temp.newFile();
+    assertTrue(parquetFile.delete());
+    FileAppender<GenericRecord> appender =
+        Parquet.write(Files.localOutput(parquetFile))
+            .schema(table.schema())
+            .createWriterFunc(GenericParquetWriter::buildWriter)
+            .build();
+    try {
+      appender.addAll(records);
+    } finally {
+      appender.close();
+    }
+
+    return DataFiles.builder(table.spec())
+        .withInputFile(localInput(parquetFile))
+        .withMetrics(appender.metrics())
+        .withFormat(FileFormat.PARQUET)
+        .build();
+  }
+
+  private static class TestScanReporter implements ScanReporter {
+    private final List<ScanReport> reports = Lists.newArrayList();
+    // this is mainly so that we see scan reports being logged during tests
+    private final LoggingScanReporter delegate = new LoggingScanReporter();
+
+    @Override
+    public void reportScan(ScanReport scanReport) {
+      reports.add(scanReport);
+      delegate.reportScan(scanReport);
+    }
+
+    public ScanReport lastReport() {
+      if (reports.isEmpty()) {
+        return null;
+      }
+      return reports.get(reports.size() - 1);
+    }
+  }
+}


### PR DESCRIPTION
The idea here is that we collect metrics during Table scans so that we
can better understand what exactly happens during a Table scan.

This is just an initial implementation that gathers/records a few metrics. The idea is to get early feedback on this approach.

## Overview of proposed changes

* a `ScanReport` that contains all relevant metrics from a Scan
* a `ScanReporter` interface that can be used to collect and report different metrics during a Table scant. Engines can implement this API to customize how a `ScanReport` is being reported
* a `LoggingScanReporter` is introduced that logs a `ScanReport` to the log file. We can think about defaulting to that one or using a **no-op** scan reporter
* a new Catalog Property `scan-reporter-impl` is introduced, allowing a Catalog to specify which `ScanReporter` to use
* a `ScanMetrics` that carries all relevant metrics during a Table scan. This class should be seen as something that is only used during a scan. At the end of a scan we'll want to create a `ScanReport` based on the collected metrics
* a `Timer` and a `DefaultTimer` were introduced so that we can measure spent time for a table scan
* some other changes, such as `DefaultScanMetrics` that use native Java Integer/Long counters and a `DefaultTimer`
