### PR TITLE
StreamingDelete constructor can be called by subclasses

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.expressions.Expression;
  * This implementation will attempt to commit 5 times before throwing {@link CommitFailedException}.
  */
 public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
-  StreamingDelete(String tableName, TableOperations ops) {
+  protected StreamingDelete(String tableName, TableOperations ops) {
     super(tableName, ops);
   }
 


### PR DESCRIPTION
As a follow-up to https://github.com/apache/iceberg/pull/5148 we make sure that `StreamingDelete` can be sub-classed by marking its constructor as `protected`.