### PR TITLE
only log error message(not the stack trace) if filter conversion/bind expression fail

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,7 +108,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}.{}",
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}. {}",
             filter, e.getMessage());
       }
 
@@ -119,7 +119,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}.{}",
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}. {}",
               filter, e.getMessage());
         }
       }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,8 +108,8 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.warn("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}",
-            filter, e);
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {} {}",
+            filter, e.getMessage());
       }
 
       if (expr != null) {
@@ -119,8 +119,8 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.warn("Failed to bind expression to table schema, skipping push down for this expression: {}",
-              filter, e);
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {} {}",
+              filter, e.getMessage());
         }
       }
     }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,7 +108,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {} {}",
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}.{}",
             filter, e.getMessage());
       }
 
@@ -119,7 +119,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {} {}",
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}.{}",
               filter, e.getMessage());
         }
       }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,7 +108,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}.{}",
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}. {}",
             filter, e.getMessage());
       }
 
@@ -119,7 +119,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}.{}",
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}. {}",
               filter, e.getMessage());
         }
       }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,8 +108,8 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.warn("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}",
-            filter, e);
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {} {}",
+            filter, e.getMessage());
       }
 
       if (expr != null) {
@@ -119,8 +119,8 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.warn("Failed to bind expression to table schema, skipping push down for this expression: {}",
-              filter, e);
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {} {}",
+              filter, e.getMessage());
         }
       }
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -108,7 +108,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
         expr = SparkFilters.convert(filter);
       } catch (IllegalArgumentException e) {
         // converting to Iceberg Expression failed, so this expression cannot be pushed down
-        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {} {}",
+        LOG.info("Failed to convert filter to Iceberg expression, skipping push down for this expression: {}.{}",
             filter, e.getMessage());
       }
 
@@ -119,7 +119,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
           pushed.add(filter);
         } catch (ValidationException e) {
           // binding to the table schema failed, so this expression cannot be pushed down
-          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {} {}",
+          LOG.info("Failed to bind expression to table schema, skipping push down for this expression: {}.{}",
               filter, e.getMessage());
         }
       }


### PR DESCRIPTION
This is a follow up to https://github.com/apache/iceberg/pull/5254. When filter conversion/bind expression fail, we will only log the error message instead of the whole stack trace.