### PR TITLE
Write metadata-location instead of metadataLocation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.rest.requests.UpdateRequirementParser;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.JsonUtil;
 
@@ -77,7 +78,9 @@ public class RESTSerializers {
         .addSerializer(UpdateRequirement.class, new UpdateRequirementSerializer())
         .addDeserializer(UpdateRequirement.class, new UpdateRequirementDeserializer())
         .addSerializer(OAuthTokenResponse.class, new OAuthTokenResponseSerializer())
-        .addDeserializer(OAuthTokenResponse.class, new OAuthTokenResponseDeserializer());
+        .addDeserializer(OAuthTokenResponse.class, new OAuthTokenResponseDeserializer())
+        .addSerializer(LoadTableResponse.class, new LoadTableResponseSerializer())
+        .addDeserializer(LoadTableResponse.class, new LoadTableResponseDeserializer());
     mapper.registerModule(module);
   }
 
@@ -244,6 +247,22 @@ public class RESTSerializers {
     public OAuthTokenResponse deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return OAuth2Util.tokenResponseFromJson(jsonNode);
+    }
+  }
+
+  public static class LoadTableResponseSerializer extends JsonSerializer<LoadTableResponse> {
+    @Override
+    public void serialize(LoadTableResponse tokenResponse, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+      LoadTableResponse.toJson(tokenResponse, gen);
+    }
+  }
+
+  public static class LoadTableResponseDeserializer extends JsonDeserializer<LoadTableResponse> {
+    @Override
+    public LoadTableResponse deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return LoadTableResponse.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -102,12 +102,18 @@ public class LoadTableResponse implements RESTResponse {
       while (configNames.hasNext()) {
         String configKey = configNames.next();
         JsonNode configValue = config.get(configKey);
-        Preconditions.checkArgument(configValue.isTextual(), "Cannot parse config %s from non-string: %s", configKey, configValue);
+        Preconditions.checkArgument(
+                configValue.isTextual(), "Cannot parse config %s from non-string: %s", configKey, configValue);
         configEntries.put(configKey, configValue.textValue());
       }
     }
 
-    return LoadTableResponse.builder().withMetadataLocation(metadataLocation).withTableMetadata(metadata).addAllConfig(configEntries.build()).build();
+    return LoadTableResponse
+            .builder()
+            .withMetadataLocation(metadataLocation)
+            .withTableMetadata(metadata)
+            .addAllConfig(configEntries.build())
+            .build();
   }
 
   private String metadataLocation;
@@ -162,10 +168,10 @@ public class LoadTableResponse implements RESTResponse {
     private Builder() {
     }
 
-      public Builder withMetadataLocation(String metadataLocation) {
-          this.metadataLocation = metadataLocation;
-          return this;
-      }
+    public Builder withMetadataLocation(String location) {
+      this.metadataLocation = location;
+      return this;
+    }
 
     public Builder withTableMetadata(TableMetadata tableMetadata) {
       if (this.metadataLocation == null) {

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -90,9 +91,14 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
 
   @Override
   public LoadTableResponse deserialize(String json) throws JsonProcessingException {
-    LoadTableResponse resp = mapper().readValue(json, LoadTableResponse.class);
+    LoadTableResponse resp = LoadTableResponse.fromJson(json);
     resp.validate();
     return resp;
+  }
+
+  @Override
+  public String serialize(LoadTableResponse response) throws JsonProcessingException {
+    return LoadTableResponse.toJson(response);
   }
 
   @Test


### PR DESCRIPTION
While talking to the REST API I noticed that the API returns `metadataLocation`, instead of `metadata-location` as defined in the Open API Spec: https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1486