### PR TITLE
Build: Exclude unnecessary git properties from iceberg-build.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ gitProperties {
   gitPropertiesResourceDir = file("${rootDir}/build")
   extProperty = 'gitProps'
   failOnNoGitDirectory = true
-  keys = ['git.branch', 'git.build.version', 'git.commit.id.abbrev', 'git.commit.id', 'git.commit.message.short',
-          'git.commit.time', 'git.tags']
+  keys = ['git.branch', 'git.build.version', 'git.closest.tag.name','git.commit.id.abbrev', 'git.commit.id',
+          'git.commit.message.short', 'git.commit.time', 'git.tags']
 }
 generateGitProperties.outputs.upToDateWhen { false }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,8 @@ gitProperties {
   gitPropertiesResourceDir = file("${rootDir}/build")
   extProperty = 'gitProps'
   failOnNoGitDirectory = true
+  keys = ['git.branch', 'git.build.version', 'git.commit.id.abbrev', 'git.commit.id', 'git.commit.message.short',
+          'git.commit.time', 'git.tags']
 }
 generateGitProperties.outputs.upToDateWhen { false }
 


### PR DESCRIPTION
### About the change

presently by default `gradle-git-properties` plugin add all the git properties as below : 

```
git.branch
git.build.host
git.build.user.email
git.build.user.name
git.build.version
git.closest.tag.commit.count
git.closest.tag.name
git.commit.id
git.commit.id.abbrev
git.commit.id.describe
git.commit.message.full
git.commit.message.short
git.commit.time
git.commit.user.email
git.commit.user.name
git.dirty
git.remote.origin.url
git.tags
git.total.commit.count
```
[[ref](https://github.com/n0mer/gradle-git-properties)]

This includes sensitive properties like `git.build.host` & `git.remote.origin.url`.

This changes avoid exposing all props, by only exposing the properties required by Iceberg Build Info.


----- 

Testing Done : 

Exsiting UT.

cc @rdblue @kbendick @nastra