### PR TITLE
Docs: add missing table properties for update and merge write distrib…

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,8 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.delete.target-file-size-bytes| 67108864 (64 MB)   | Controls the size of delete files generated to target about this many bytes |
 | write.distribution-mode            | none               | Defines distribution of write data: __none__: don't shuffle rows; __hash__: hash distribute by partition key ; __range__: range distribute by partition key or sort key if table has an SortOrder |
 | write.delete.distribution-mode     | hash               | Defines distribution of write delete data          |
+| write.update.distribution-mode     | hash               | Defines distribution of write update data          |
+| write.merge.distribution-mode      | none               | Defines distribution of write merge data           |
 | write.wap.enabled                  | false              | Enables write-audit-publish writes |
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |


### PR DESCRIPTION
Add missing documentation for `write.update.distribution-mode`

I believe
- `write.delete.distribution-mode`
- `write.update.distribution-mode`
- `write.merge.distribution-mode` (not super sure about this one, deducted from https://github.com/apache/iceberg/blob/master/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java#L228-L240)

are all introduced in #3511 but only one of them is shown up on documentation site. 


CC @aokolnychyi @samredai 