### PR TITLE
Spark: Spark SQL Extensions for tag

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -76,7 +76,7 @@ statement
     | ALTER TABLE multipartIdentifier CREATE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #createTag
     | ALTER TABLE multipartIdentifier REPLACE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #replaceTag
     | ALTER TABLE multipartIdentifier DROP TAG identifier #removeTag
-    | ALTER TABLE multipartIdentifier ALTER TAG identifier RETAIN snapshotRefRetain snapshotRefRetainTimeUnit #alterTagRetention
+    | ALTER TABLE multipartIdentifier ALTER TAG identifier RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit #alterTagRetention
     ;
 
 writeSpec

--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -75,7 +75,7 @@ statement
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
     | ALTER TABLE multipartIdentifier CREATE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #createTag
     | ALTER TABLE multipartIdentifier REPLACE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #replaceTag
-    | ALTER TABLE multipartIdentifier DROP TAG identifier #removeTag
+    | ALTER TABLE multipartIdentifier DROP TAG (IF EXISTS)? identifier #removeTag
     | ALTER TABLE multipartIdentifier ALTER TAG identifier RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit #alterTagRetention
     ;
 
@@ -174,7 +174,7 @@ fieldList
 nonReserved
     : ADD | ALTER | AS | ASC | BY | CALL | CREATE |  DESC | DROP | FIELD | FIRST | LAST | NULLS | OF | ORDERED
     | PARTITION | TABLE | WRITE | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | VERSION | WITH | IDENTIFIER_KW | FIELDS
-    | SET | TRUE | TAG | FALSE
+    | SET | TRUE | TAG | FALSE | IF | EXISTS
     | MAP
     ;
 
@@ -200,9 +200,11 @@ CREATE: 'CREATE';
 DESC: 'DESC';
 DISTRIBUTED: 'DISTRIBUTED';
 DROP: 'DROP';
+EXISTS: 'EXISTS';
 FIELD: 'FIELD';
 FIELDS: 'FIELDS';
 FIRST: 'FIRST';
+IF: 'IF';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 NULLS: 'NULLS';

--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,6 +73,10 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
+    | ALTER TABLE multipartIdentifier CREATE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #createTag
+    | ALTER TABLE multipartIdentifier REPLACE TAG identifier (AS OF VERSION snapshotId)?  (RETAIN FOR snapshotRefRetain snapshotRefRetainTimeUnit)? #replaceTag
+    | ALTER TABLE multipartIdentifier DROP TAG identifier #removeTag
+    | ALTER TABLE multipartIdentifier ALTER TAG identifier RETAIN snapshotRefRetain snapshotRefRetainTimeUnit #alterTagRetention
     ;
 
 writeSpec
@@ -168,10 +172,22 @@ fieldList
     ;
 
 nonReserved
-    : ADD | ALTER | AS | ASC | BY | CALL | DESC | DROP | FIELD | FIRST | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
-    | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | WITH | IDENTIFIER_KW | FIELDS | SET
-    | TRUE | FALSE
+    : ADD | ALTER | AS | ASC | BY | CALL | CREATE |  DESC | DROP | FIELD | FIRST | LAST | NULLS | OF | ORDERED
+    | PARTITION | TABLE | WRITE | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | VERSION | WITH | IDENTIFIER_KW | FIELDS
+    | SET | TRUE | TAG | FALSE
     | MAP
+    ;
+
+snapshotId
+    : number
+    ;
+
+snapshotRefRetain
+    : number
+    ;
+
+snapshotRefRetainTimeUnit
+    : identifier
     ;
 
 ADD: 'ADD';
@@ -180,6 +196,7 @@ AS: 'AS';
 ASC: 'ASC';
 BY: 'BY';
 CALL: 'CALL';
+CREATE: 'CREATE';
 DESC: 'DESC';
 DISTRIBUTED: 'DISTRIBUTED';
 DROP: 'DROP';
@@ -189,15 +206,21 @@ FIRST: 'FIRST';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 NULLS: 'NULLS';
+OF: 'OF';
 ORDERED: 'ORDERED';
 PARTITION: 'PARTITION';
 REPLACE: 'REPLACE';
+RETAIN: 'RETAIN';
+RETENTION: 'RETENTION';
 IDENTIFIER_KW: 'IDENTIFIER';
 SET: 'SET';
 TABLE: 'TABLE';
+TAG: 'TAG';
 UNORDERED: 'UNORDERED';
+VERSION: 'VERSION';
 WITH: 'WITH';
 WRITE: 'WRITE';
+FOR: 'FOR';
 
 TRUE: 'TRUE';
 FALSE: 'FALSE';

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -207,9 +207,9 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
             normalized.contains("set identifier fields") ||
             normalized.contains("drop identifier fields") ||
             normalized.contains("create tag") ||
-            normalized.contains("replace tag")) ||
+            normalized.contains("replace tag") ||
             normalized.contains("drop tag") ||
-            normalized.contains("alter tag"))
+            normalized.contains("alter tag")))
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -205,7 +205,11 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
             normalized.contains("write distributed by") ||
             normalized.contains("write unordered") ||
             normalized.contains("set identifier fields") ||
-            normalized.contains("drop identifier fields")))
+            normalized.contains("drop identifier fields") ||
+            normalized.contains("create tag") ||
+            normalized.contains("replace tag")) ||
+            normalized.contains("drop tag") ||
+            normalized.contains("alter tag"))
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -120,7 +120,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     val tagName = ctx.identifier().getText
     validateTag(tagName, Option.empty[Long], Option.empty[Long])
 
-    RemoveTag(typedVisit[Seq[String]](ctx.multipartIdentifier), ctx.identifier().getText)
+    RemoveTag(typedVisit[Seq[String]](ctx.multipartIdentifier), ctx.identifier().getText, ctx.EXISTS() != null)
   }
 
   /**

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -137,11 +137,11 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
 
   private def validateTag(tagName: String, snapshotId: Option[Long], snapshotRefRetain: Option[Long]): Unit = {
     if (StringUtils.isBlank(tagName)) {
-      throw new IllegalArgumentException("Tag name can not be empty or null.")
+      throw new IllegalArgumentException("Tag name can not be empty or null")
     }
 
     if (snapshotId.nonEmpty && snapshotId.get <= 0) {
-      throw new IllegalArgumentException("Snapshot ID:" + snapshotId.get + " must be greater than 0.")
+      throw new IllegalArgumentException("Snapshot id must be greater than 0")
     }
 
     if (snapshotRefRetain.nonEmpty && snapshotRefRetain.get <= 0) {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -19,10 +19,12 @@
 
 package org.apache.spark.sql.catalyst.parser.extensions
 
+import java.util.Locale
 import org.antlr.v4.runtime._
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.TerminalNode
+import org.apache.commons.lang3.StringUtils
 import org.apache.iceberg.DistributionMode
 import org.apache.iceberg.NullOrder
 import org.apache.iceberg.SortDirection
@@ -37,14 +39,18 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergParserUtils.withOrigin
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser._
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
+import org.apache.spark.sql.catalyst.plans.logical.AlterTagRefRetention
 import org.apache.spark.sql.catalyst.plans.logical.CallArgument
 import org.apache.spark.sql.catalyst.plans.logical.CallStatement
+import org.apache.spark.sql.catalyst.plans.logical.CreateTag
 import org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.NamedArgument
 import org.apache.spark.sql.catalyst.plans.logical.PositionalArgument
+import org.apache.spark.sql.catalyst.plans.logical.RemoveTag
 import org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTag
 import org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering
 import org.apache.spark.sql.catalyst.trees.CurrentOrigin
@@ -82,6 +88,68 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
   }
 
   /**
+   * Create an CREATE TAG logical command.
+   */
+  override def visitCreateTag(ctx: CreateTagContext): CreateTag = withOrigin(ctx) {
+    val tagName = ctx.identifier().getText
+    val snapshotId = Option(ctx.snapshotId()).map(_.getText.toLong)
+    val snapshotRefRetain =
+      Option(ctx.snapshotRefRetain()).map(_.getText.toLong * timeUnit(ctx.snapshotRefRetainTimeUnit().getText))
+    validateTag(tagName, snapshotId, snapshotRefRetain)
+
+    CreateTag(typedVisit[Seq[String]](ctx.multipartIdentifier), tagName, snapshotId, snapshotRefRetain)
+  }
+
+  /**
+   * Create an REPLACE TAG logical command.
+   */
+  override def visitReplaceTag(ctx: ReplaceTagContext): ReplaceTag = withOrigin(ctx) {
+    val tagName = ctx.identifier().getText
+    val snapshotId = Option(ctx.snapshotId()).map(_.getText.toLong)
+    val snapshotRefRetain =
+      Option(ctx.snapshotRefRetain()).map(_.getText.toLong * timeUnit(ctx.snapshotRefRetainTimeUnit().getText))
+    validateTag(tagName, snapshotId, snapshotRefRetain)
+
+    ReplaceTag(typedVisit[Seq[String]](ctx.multipartIdentifier), tagName, snapshotId, snapshotRefRetain)
+  }
+
+  /**
+   * Create an REMOVE TAG logical command.
+   */
+  override def visitRemoveTag(ctx: RemoveTagContext): RemoveTag = withOrigin(ctx) {
+    val tagName = ctx.identifier().getText
+    validateTag(tagName, Option.empty[Long], Option.empty[Long])
+
+    RemoveTag(typedVisit[Seq[String]](ctx.multipartIdentifier), ctx.identifier().getText)
+  }
+
+  /**
+   * Create an ALTER TAG RETENTION logical command.
+   */
+  override def visitAlterTagRetention(ctx: AlterTagRetentionContext): AlterTagRefRetention = withOrigin(ctx) {
+    val tagName = ctx.identifier().getText
+    val snapshotRefRetain =
+      Option(ctx.snapshotRefRetain()).map(_.getText.toLong * timeUnit(ctx.snapshotRefRetainTimeUnit().getText))
+    validateTag(tagName, Option.empty[Long], snapshotRefRetain)
+
+    AlterTagRefRetention(typedVisit[Seq[String]](ctx.multipartIdentifier()), tagName, snapshotRefRetain)
+  }
+
+  private def validateTag(tagName: String, snapshotId: Option[Long], snapshotRefRetain: Option[Long]): Unit = {
+    if (StringUtils.isBlank(tagName)) {
+      throw new IllegalArgumentException("Tag name can not be empty or null.")
+    }
+
+    if (snapshotId.nonEmpty && snapshotId.get <= 0) {
+      throw new IllegalArgumentException("Snapshot ID:" + snapshotId.get + " must be greater than 0.")
+    }
+
+    if (snapshotRefRetain.nonEmpty && snapshotRefRetain.get <= 0) {
+      throw new IllegalArgumentException("Max reference age must be greater than 0")
+    }
+  }
+
+  /**
    * Create a DROP PARTITION FIELD logical command.
    */
   override def visitDropPartitionField(ctx: DropPartitionFieldContext): DropPartitionField = withOrigin(ctx) {
@@ -89,7 +157,6 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
       typedVisit[Seq[String]](ctx.multipartIdentifier),
       typedVisit[Transform](ctx.transform))
   }
-
 
   /**
    * Create an REPLACE PARTITION FIELD logical command.
@@ -266,6 +333,16 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
 
   private def typedVisit[T](ctx: ParseTree): T = {
     ctx.accept(this).asInstanceOf[T]
+  }
+
+  private val timeUnit = (unit: String) => {
+    unit.toUpperCase(Locale.ENGLISH) match {
+      case "MONTHS" => 30 * 24 * 60 * 60 * 1000L
+      case "DAYS" => 24 * 60 * 60 * 1000L
+      case "HOURS" => 60 * 60 * 1000L
+      case "MINUTES" => 60 * 1000L
+      case _ => throw new IllegalArgumentException("Invalid time unit: " + unit)
+    }
   }
 }
 

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterTagRefRetention.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterTagRefRetention.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class AlterTagRefRetention(table: Seq[String], tag: String
+                                ,snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Alter tag:${tag} retention for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTag.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTag.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class CreateTag(table: Seq[String], tag: String, snapshotId: Option[Long],
+                     snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Create tag:${tag} for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveTag.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveTag.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.Attribute
 
-case class RemoveTag(table: Seq[String], tag: String) extends LeafCommand {
+case class RemoveTag(table: Seq[String], tag: String, ifExists: Boolean) extends LeafCommand {
 
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveTag.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveTag.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class RemoveTag(table: Seq[String], tag: String) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Remove tag:${tag} for table:${table.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceTag.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceTag.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class ReplaceTag(table: Seq[String], tag: String, snapshotId: Option[Long],
+                      snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Replace Tag:${tag} for table:${table.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTagRefRetentionExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterTagRefRetentionExec.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.AlterTagRefRetention
+import org.apache.spark.sql.connector.catalog._
+
+case class AlterTagRefRetentionExec(
+                             catalog: TableCatalog,
+                             ident: Identifier,
+                             alterTagRefRetention: AlterTagRefRetention) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        if(alterTagRefRetention.snapshotRefRetain.nonEmpty){
+          iceberg.table.manageSnapshots()
+            .setMaxRefAgeMs(alterTagRefRetention.tag, alterTagRefRetention.snapshotRefRetain.get)
+            .commit()
+        }
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot alter tag to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"alter tag:${alterTagRefRetention.tag} reference life cycle for table:${catalog.name}.${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTagExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTagExec.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.CreateTag
+import org.apache.spark.sql.connector.catalog._
+
+case class CreateTagExec(catalog: TableCatalog, ident: Identifier, createTag: CreateTag) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+
+        val snapshotId = createTag.snapshotId.getOrElse(iceberg.table.currentSnapshot().snapshotId())
+        iceberg.table.manageSnapshots()
+          .createTag(createTag.tag, snapshotId)
+          .setMaxRefAgeMs(createTag.tag, createTag.snapshotRefRetain.getOrElse(Long.MaxValue))
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot create tag to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Create tag: ${createTag.tag} for table: ${catalog.name}.${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -30,15 +30,19 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
+import org.apache.spark.sql.catalyst.plans.logical.AlterTagRefRetention
 import org.apache.spark.sql.catalyst.plans.logical.Call
+import org.apache.spark.sql.catalyst.plans.logical.CreateTag
 import org.apache.spark.sql.catalyst.plans.logical.DeleteFromIcebergTable
 import org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows
 import org.apache.spark.sql.catalyst.plans.logical.NoStatsUnaryNode
+import org.apache.spark.sql.catalyst.plans.logical.RemoveTag
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData
 import org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTag
 import org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.SetWriteDistributionAndOrdering
 import org.apache.spark.sql.catalyst.plans.logical.WriteDelta
@@ -60,6 +64,18 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
 
     case AddPartitionField(IcebergCatalogAndIdentifier(catalog, ident), transform, name) =>
       AddPartitionFieldExec(catalog, ident, transform, name) :: Nil
+
+    case CreateTag(IcebergCatalogAndIdentifier(catalog, ident), _, _, _) =>
+      CreateTagExec(catalog, ident, plan.asInstanceOf[CreateTag]) :: Nil
+
+    case ReplaceTag(IcebergCatalogAndIdentifier(catalog, ident), _, _, _) =>
+      ReplaceTagExec(catalog, ident, plan.asInstanceOf[ReplaceTag]) :: Nil
+
+    case RemoveTag(IcebergCatalogAndIdentifier(catalog, ident), _) =>
+      RemoveTagExec(catalog, ident, plan.asInstanceOf[RemoveTag]) :: Nil
+
+    case AlterTagRefRetention(IcebergCatalogAndIdentifier(catalog, ident),_,_) =>
+      AlterTagRefRetentionExec(catalog,ident,plan.asInstanceOf[AlterTagRefRetention]) :: Nil
 
     case DropPartitionField(IcebergCatalogAndIdentifier(catalog, ident), transform) =>
       DropPartitionFieldExec(catalog, ident, transform) :: Nil

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -71,7 +71,7 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
     case ReplaceTag(IcebergCatalogAndIdentifier(catalog, ident), _, _, _) =>
       ReplaceTagExec(catalog, ident, plan.asInstanceOf[ReplaceTag]) :: Nil
 
-    case RemoveTag(IcebergCatalogAndIdentifier(catalog, ident), _) =>
+    case RemoveTag(IcebergCatalogAndIdentifier(catalog, ident), _, _) =>
       RemoveTagExec(catalog, ident, plan.asInstanceOf[RemoveTag]) :: Nil
 
     case AlterTagRefRetention(IcebergCatalogAndIdentifier(catalog, ident),_,_) =>

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RemoveTagExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RemoveTagExec.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.RemoveTag
+import org.apache.spark.sql.connector.catalog._
+
+case class RemoveTagExec(catalog: TableCatalog, ident: Identifier, removeTag: RemoveTag) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        iceberg.table.manageSnapshots().removeTag(removeTag.tag).commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot remove tag to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"remove tag: ${removeTag.tag} for table: ${catalog.name}.${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceTagExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceTagExec.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceTag
+import org.apache.spark.sql.connector.catalog._
+
+case class ReplaceTagExec(catalog: TableCatalog, ident: Identifier, replaceTag: ReplaceTag) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+
+        val snapshotId = replaceTag.snapshotId.getOrElse(iceberg.table.currentSnapshot().snapshotId())
+        val manageSnapshots = iceberg.table.manageSnapshots()
+        if (replaceTag.snapshotId.nonEmpty) {
+          manageSnapshots.replaceTag(replaceTag.tag, snapshotId)
+        }
+        if (replaceTag.snapshotRefRetain.nonEmpty) {
+          manageSnapshots
+            .setMaxRefAgeMs(replaceTag.tag, replaceTag.snapshotRefRetain.getOrElse(Long.MaxValue))
+        }
+        manageSnapshots.commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot replace tag to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"replace tag: ${replaceTag.tag}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark.extensions;
 
 import java.util.List;
@@ -52,39 +51,55 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     long snapshotId = table.currentSnapshot().snapshotId();
     String tagName = "t1";
     long maxRefAge = 10L;
-    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+    sql(
+        "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
         tableName, tagName, snapshotId, maxRefAge);
     table.refresh();
     SnapshotRef ref = ((BaseTable) table).operations().current().ref(tagName);
     Assert.assertNotNull(ref);
     Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
 
-    AssertHelpers.assertThrows("Cannot create an exist tag",
-        IllegalArgumentException.class, "already exists",
-        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
-            tableName, tagName, snapshotId, maxRefAge));
+    AssertHelpers.assertThrows(
+        "Cannot create an exist tag",
+        IllegalArgumentException.class,
+        "already exists",
+        () ->
+            sql(
+                "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+                tableName, tagName, snapshotId, maxRefAge));
 
-    AssertHelpers.assertThrows("Tag name can not be empty or null.",
-        IllegalArgumentException.class, "Tag name can not be empty or null",
-        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
-            tableName, "` `", snapshotId, maxRefAge));
+    AssertHelpers.assertThrows(
+        "Tag name can not be empty or null.",
+        IllegalArgumentException.class,
+        "Tag name can not be empty or null",
+        () ->
+            sql(
+                "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+                tableName, "` `", snapshotId, maxRefAge));
 
     String tagName2 = "t2";
-    AssertHelpers.assertThrows("Snapshot Id must be greater than 0",
-        IllegalArgumentException.class, "must be greater than 0",
-        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
-            tableName, tagName2, -1, maxRefAge));
+    AssertHelpers.assertThrows(
+        "Snapshot Id must be greater than 0",
+        IllegalArgumentException.class,
+        "must be greater than 0",
+        () ->
+            sql(
+                "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+                tableName, tagName2, -1, maxRefAge));
     Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
 
-    AssertHelpers.assertThrows("Cannot set tag to unknown snapshot",
-        ValidationException.class, "unknown snapshot: 999",
-        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
-            tableName, tagName2, 999, maxRefAge));
+    AssertHelpers.assertThrows(
+        "Cannot set tag to unknown snapshot",
+        ValidationException.class,
+        "unknown snapshot: 999",
+        () ->
+            sql(
+                "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+                tableName, tagName2, 999, maxRefAge));
     Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
 
     String tagName3 = "t3";
-    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d",
-        tableName, tagName3, snapshotId);
+    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d", tableName, tagName3, snapshotId);
     table.refresh();
     SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(tagName3);
     Assert.assertEquals(Long.MAX_VALUE, ref3.maxRefAgeMs().longValue());
@@ -97,23 +112,23 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     long snapshotId = table.currentSnapshot().snapshotId();
     String tagName = "t1";
     long maxRefAge = 10L;
-    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+    sql(
+        "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
         tableName, tagName, snapshotId, maxRefAge);
     table.refresh();
     SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(tagName);
     Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref1.maxRefAgeMs().longValue());
     Assert.assertEquals(snapshotId, ref1.snapshotId());
 
-    List<SimpleRecord> records = ImmutableList.of(
-        new SimpleRecord(1, "a"),
-        new SimpleRecord(2, "b")
-    );
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
     Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
     df.writeTo(tableName).append();
     table.refresh();
     long snapshotId2 = table.currentSnapshot().snapshotId();
     maxRefAge = 9L;
-    sql("ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+    sql(
+        "ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
         tableName, tagName, snapshotId2, maxRefAge);
     table.refresh();
     SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
@@ -125,18 +140,18 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(tagName);
     Assert.assertEquals(snapshotId2, ref3.snapshotId());
 
-    AssertHelpers.assertThrows("Cannot set tag to unknown snapshot",
-        ValidationException.class, "unknown snapshot: 999",
-        () -> sql(
-            "ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d",
-            tableName, tagName, 999));
+    AssertHelpers.assertThrows(
+        "Cannot set tag to unknown snapshot",
+        ValidationException.class,
+        "unknown snapshot: 999",
+        () -> sql("ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d", tableName, tagName, 999));
 
     String tagName2 = "t2";
-    AssertHelpers.assertThrows("Cannot replace a tag that does not exist",
-        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName2),
-        () -> sql(
-            "ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d",
-            tableName, tagName2, 1));
+    AssertHelpers.assertThrows(
+        "Cannot replace a tag that does not exist",
+        IllegalArgumentException.class,
+        String.format("Tag does not exist: %s", tagName2),
+        () -> sql("ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d", tableName, tagName2, 1));
   }
 
   @Test
@@ -153,10 +168,13 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     ref = ((BaseTable) table).operations().current().ref(tagName);
     Assert.assertNull(ref);
 
-    AssertHelpers.assertThrows("Cannot drop tag that does not exists",
-        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName),
-        () -> sql("ALTER TABLE %s DROP TAG %s",
-            tableName, tagName));
+    sql("ALTER TABLE %s DROP TAG IF EXISTS %s", tableName, tagName);
+
+    AssertHelpers.assertThrows(
+        "Cannot drop tag that does not exists",
+        IllegalArgumentException.class,
+        String.format("Tag does not exist: %s", tagName),
+        () -> sql("ALTER TABLE %s DROP TAG %s", tableName, tagName));
   }
 
   @Test
@@ -165,10 +183,8 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
 
     long snapshotId = table.currentSnapshot().snapshotId();
 
-    List<SimpleRecord> records = ImmutableList.of(
-        new SimpleRecord(1, "a"),
-        new SimpleRecord(2, "b")
-    );
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
     Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
     df.writeTo(tableName).append();
 
@@ -183,34 +199,32 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     Assert.assertEquals(snapshotId, ref1.snapshotId());
 
     String tagName2 = "t2";
-    AssertHelpers.assertThrows("Cannot alter tag that does not exist",
-        IllegalArgumentException.class, String.format("does not exist: %s", tagName2),
-        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
-            tableName, "t2", maxRefAge));
+    AssertHelpers.assertThrows(
+        "Cannot alter tag that does not exist",
+        IllegalArgumentException.class,
+        String.format("does not exist: %s", tagName2),
+        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS", tableName, "t2", maxRefAge));
 
     long maxRefAge2 = 6L;
-    sql(
-        "ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
-        tableName, tagName, maxRefAge2);
+    sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS", tableName, tagName, maxRefAge2);
     table.refresh();
     SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
     Assert.assertEquals(maxRefAge2 * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
     Assert.assertEquals(snapshotId, ref2.snapshotId());
 
-    AssertHelpers.assertThrows("Max reference age must be greater than 0",
-        IllegalArgumentException.class, "Max reference age must be greater than 0",
-        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
-            tableName, tagName, -1));
+    AssertHelpers.assertThrows(
+        "Max reference age must be greater than 0",
+        IllegalArgumentException.class,
+        "Max reference age must be greater than 0",
+        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS", tableName, tagName, -1));
   }
 
   private Table createDefaultTableAndInsert2Row() throws NoSuchTableException {
     Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
     sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
 
-    List<SimpleRecord> records = ImmutableList.of(
-        new SimpleRecord(1, "a"),
-        new SimpleRecord(2, "b")
-    );
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
     Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
     df.writeTo(tableName).append();
     Table table = validationCatalog.loadTable(tableIdent);

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -65,7 +65,7 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
             tableName, tagName, snapshotId, maxRefAge));
 
     AssertHelpers.assertThrows("Tag name can not be empty or null.",
-        IllegalArgumentException.class, "Tag name can not be empty or null.",
+        IllegalArgumentException.class, "Tag name can not be empty or null",
         () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
             tableName, "` `", snapshotId, maxRefAge));
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -182,24 +182,24 @@ public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
     Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref1.maxRefAgeMs().longValue());
     Assert.assertEquals(snapshotId, ref1.snapshotId());
 
-    maxRefAge = 6L;
-    sql(
-        "ALTER TABLE %s ALTER TAG %s RETAIN %d DAYS",
-        tableName, tagName, maxRefAge);
-    table.refresh();
-    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
-    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
-    Assert.assertEquals(snapshotId, ref2.snapshotId());
-
     String tagName2 = "t2";
     AssertHelpers.assertThrows("Cannot alter tag that does not exist",
-        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName2),
-        () -> sql("ALTER TABLE %s DROP TAG %s",
-            tableName, tagName2));
+        IllegalArgumentException.class, String.format("does not exist: %s", tagName2),
+        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
+            tableName, "t2", maxRefAge));
+
+    long maxRefAge2 = 6L;
+    sql(
+        "ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
+        tableName, tagName, maxRefAge2);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(maxRefAge2 * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
+    Assert.assertEquals(snapshotId, ref2.snapshotId());
 
     AssertHelpers.assertThrows("Max reference age must be greater than 0",
         IllegalArgumentException.class, "Max reference age must be greater than 0",
-        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN %d DAYS",
+        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN FOR %d DAYS",
             tableName, tagName, -1));
   }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
+  public TestSnapshotRefSQL(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testCreateTag() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String tagName = "t1";
+    long maxRefAge = 10L;
+    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+        tableName, tagName, snapshotId, maxRefAge);
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertNotNull(ref);
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
+
+    AssertHelpers.assertThrows("Cannot create an exist tag",
+        IllegalArgumentException.class, "already exists",
+        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+            tableName, tagName, snapshotId, maxRefAge));
+
+    AssertHelpers.assertThrows("Tag name can not be empty or null.",
+        IllegalArgumentException.class, "Tag name can not be empty or null.",
+        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+            tableName, "` `", snapshotId, maxRefAge));
+
+    String tagName2 = "t2";
+    AssertHelpers.assertThrows("Snapshot Id must be greater than 0",
+        IllegalArgumentException.class, "must be greater than 0",
+        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+            tableName, tagName2, -1, maxRefAge));
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
+
+    AssertHelpers.assertThrows("Cannot set tag to unknown snapshot",
+        ValidationException.class, "unknown snapshot: 999",
+        () -> sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+            tableName, tagName2, 999, maxRefAge));
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000, ref.maxRefAgeMs().longValue());
+
+    String tagName3 = "t3";
+    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d",
+        tableName, tagName3, snapshotId);
+    table.refresh();
+    SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(tagName3);
+    Assert.assertEquals(Long.MAX_VALUE, ref3.maxRefAgeMs().longValue());
+  }
+
+  @Test
+  public void testReplaceTag() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String tagName = "t1";
+    long maxRefAge = 10L;
+    sql("ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+        tableName, tagName, snapshotId, maxRefAge);
+    table.refresh();
+    SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref1.maxRefAgeMs().longValue());
+    Assert.assertEquals(snapshotId, ref1.snapshotId());
+
+    List<SimpleRecord> records = ImmutableList.of(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+    df.writeTo(tableName).append();
+    table.refresh();
+    long snapshotId2 = table.currentSnapshot().snapshotId();
+    maxRefAge = 9L;
+    sql("ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+        tableName, tagName, snapshotId2, maxRefAge);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
+    Assert.assertEquals(snapshotId2, ref2.snapshotId());
+
+    sql("ALTER TABLE %s REPLACE TAG %s RETAIN FOR %d DAYS", tableName, tagName, maxRefAge);
+    table.refresh();
+    SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(snapshotId2, ref3.snapshotId());
+
+    AssertHelpers.assertThrows("Cannot set tag to unknown snapshot",
+        ValidationException.class, "unknown snapshot: 999",
+        () -> sql(
+            "ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d",
+            tableName, tagName, 999));
+
+    String tagName2 = "t2";
+    AssertHelpers.assertThrows("Cannot replace a tag that does not exist",
+        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName2),
+        () -> sql(
+            "ALTER TABLE %s REPLACE TAG %s AS OF VERSION %d",
+            tableName, tagName2, 1));
+  }
+
+  @Test
+  public void testDropTag() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    String tagName = "t1";
+    sql("ALTER TABLE %s CREATE TAG %s", tableName, tagName);
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertNotNull(ref);
+
+    sql("ALTER TABLE %s DROP TAG %s", tableName, tagName);
+    table.refresh();
+    ref = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertNull(ref);
+
+    AssertHelpers.assertThrows("Cannot drop tag that does not exists",
+        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName),
+        () -> sql("ALTER TABLE %s DROP TAG %s",
+            tableName, tagName));
+  }
+
+  @Test
+  public void testAlterTagRefRetention() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    List<SimpleRecord> records = ImmutableList.of(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+    df.writeTo(tableName).append();
+
+    String tagName = "t1";
+    long maxRefAge = 7L;
+    sql(
+        "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+        tableName, tagName, snapshotId, maxRefAge);
+    table.refresh();
+    SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref1.maxRefAgeMs().longValue());
+    Assert.assertEquals(snapshotId, ref1.snapshotId());
+
+    maxRefAge = 6L;
+    sql(
+        "ALTER TABLE %s ALTER TAG %s RETAIN %d DAYS",
+        tableName, tagName, maxRefAge);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(tagName);
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
+    Assert.assertEquals(snapshotId, ref2.snapshotId());
+
+    String tagName2 = "t2";
+    AssertHelpers.assertThrows("Cannot alter tag that does not exist",
+        IllegalArgumentException.class, String.format("Tag does not exist: %s", tagName2),
+        () -> sql("ALTER TABLE %s DROP TAG %s",
+            tableName, tagName2));
+
+    AssertHelpers.assertThrows("Max reference age must be greater than 0",
+        IllegalArgumentException.class, "Max reference age must be greater than 0",
+        () -> sql("ALTER TABLE %s ALTER TAG %s RETAIN %d DAYS",
+            tableName, tagName, -1));
+  }
+
+  private Table createDefaultTableAndInsert2Row() throws NoSuchTableException {
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    List<SimpleRecord> records = ImmutableList.of(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+    df.writeTo(tableName).append();
+    Table table = validationCatalog.loadTable(tableIdent);
+    return table;
+  }
+}


### PR DESCRIPTION
Co-authored-by: liliwei [liliwei14@huawei.com](mailto:liliwei14@huawei.com)
Co-authored-by: xuwei [xuwei132@huawei.com](mailto:xuwei132@huawei.com)
Co-authored-by: chidayong [chidayong2@h-partners.com](mailto:chidayong2@h-partners.com)

base on https://github.com/apache/iceberg/pull/5209#issuecomment-1184719859,  Split https://github.com/apache/iceberg/pull/5209 into TAG(#5281) and Branch(#5535)


## What is the purpose of the change
Implement the syntax in the following documents:
https://docs.google.com/document/d/1tbATFPrKF3vNlzkgZQdaW8CAJmbjvryfrlg6C2Ci_aA/edit

### DDLs for Tagging and Retention 


#### Creating and Replacing Tags
```sql
ALTER TABLE table {CREATE | REPLACE} TAG tagName
[AS OF {VERSION snapshotId}]
[RETAIN FOR interval {MONTHS | DAYS | HOURS | MINUTES}]

 
ALTER TABLE table 
CREATE TAG historical_annual_snapshot
AS OF VERSION 100
RETAIN FOR 12 MONTHS
```
#### Dropping  Tags



```sql
ALTER TABLE table DROP TAG { IF EXISTS} reference
```

#### Updating Retention for  Tags
```sql
ALTER TABLE table 
ALTER TAG refName
RETAIN interval {MONTHS | DAYS | HOURS | MINUTES}
```

