### PR TITLE
[WIP] Core: Fix drop table without purge for hadoop catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -254,8 +254,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
           // Since the data files and the metadata files may store in different locations,
           // so it has to call dropTableData to force delete the data file.
           CatalogUtil.dropTableData(ops.io(), lastMetadata);
+          return fs.delete(tablePath, true /* recursive */);
+        } else {
+          // just drop the version-hint.txt file
+          return fs.delete(((HadoopTableOperations) ops).versionHintFile(), false /* recursive */);
         }
-        return fs.delete(tablePath, true /* recursive */);
       }
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to delete file: %s", tablePath);


### PR DESCRIPTION
When `dropTable()` is called with `purge=false` it is `deleting the data and metadata files`.

The expected behaviour for `purge = false` is that it should not clean the data files and metadata files. Only catalog's entries should be deleted. 