### PR TITLE
API: Introduce DefaultMetricsContext and Timer interface

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A default {@link MetricsContext} implementation that uses native Java counters/timers.
+ */
+public class DefaultMetricsContext implements MetricsContext {
+
+  @Override
+  public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+    if (Integer.class.equals(type)) {
+      return (Counter<T>) new IntCounter();
+    }
+
+    if (Long.class.equals(type)) {
+      return (Counter<T>) new LongCounter();
+    }
+    throw new IllegalArgumentException(String.format("Counter for type %s is not supported", type.getName()));
+  }
+
+  @Override
+  public Timer timer(String name, TimeUnit unit) {
+    return new DefaultTimer(unit);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultTimer.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultTimer.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Stopwatch;
+
+/**
+ * A default {@link Timer} implementation that uses a {@link Stopwatch} instance internally to measure time.
+ */
+public class DefaultTimer implements Timer {
+  private final TimeUnit defaultTimeUnit;
+  private final LongAdder count = new LongAdder();
+  private final LongAdder totalTime = new LongAdder();
+
+  public DefaultTimer(TimeUnit timeUnit) {
+    Preconditions.checkArgument(null != timeUnit, "TimeUnit must be non-null");
+    this.defaultTimeUnit = timeUnit;
+  }
+
+  @Override
+  public long count() {
+    return count.longValue();
+  }
+
+  @Override
+  public Duration totalDuration() {
+    return Duration.ofNanos(totalTime.longValue());
+  }
+
+  @Override
+  public Timed start() {
+    return new DefaultTimed(this, defaultTimeUnit);
+  }
+
+  @Override
+  public void record(long amount, TimeUnit unit) {
+    Preconditions.checkArgument(amount >= 0, "Cannot record %s %s: must be >= 0", amount, unit);
+    this.totalTime.add(TimeUnit.NANOSECONDS.convert(amount, unit));
+    this.count.increment();
+  }
+
+  @Override
+  public <T> T time(Supplier<T> supplier) {
+    Timed timed = start();
+    try {
+      return supplier.get();
+    } finally {
+      timed.stop();
+    }
+  }
+
+  @Override
+  public <T> T timeCallable(Callable<T> callable) throws Exception {
+    Timed timed = start();
+    try {
+      return callable.call();
+    } finally {
+      timed.stop();
+    }
+  }
+
+  @Override
+  public void time(Runnable runnable) {
+    Timed timed = start();
+    try {
+      runnable.run();
+    } finally {
+      timed.stop();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("defaultTimeUnit", defaultTimeUnit)
+        .add("count", count)
+        .add("duration", totalDuration())
+        .toString();
+  }
+
+  private static class DefaultTimed implements Timed {
+    private final Timer timer;
+    private final TimeUnit defaultTimeUnit;
+    private final AtomicReference<Stopwatch> stopwatchRef = new AtomicReference<>();
+
+    private DefaultTimed(Timer timer, TimeUnit defaultTimeUnit) {
+      this.timer = timer;
+      this.defaultTimeUnit = defaultTimeUnit;
+      stopwatchRef.compareAndSet(null, Stopwatch.createStarted());
+    }
+
+    @Override
+    public void stop() {
+      Stopwatch stopwatch = stopwatchRef.getAndSet(null);
+      Preconditions.checkState(null != stopwatch, "stop() called multiple times");
+      timer.record(stopwatch.stop().elapsed(defaultTimeUnit), defaultTimeUnit);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+/**
+ * A default {@link org.apache.iceberg.metrics.MetricsContext.Counter} implementation that uses an {@link Integer} to
+ * count events.
+ */
+class IntCounter implements MetricsContext.Counter<Integer> {
+  private final AtomicInteger counter;
+
+  IntCounter() {
+    this.counter = new AtomicInteger(0);
+  }
+
+  @Override
+  public void increment() {
+    increment(1);
+  }
+
+  @Override
+  public void increment(Integer amount) {
+    counter.updateAndGet(val -> Math.addExact(val, amount));
+  }
+
+  @Override
+  public Optional<Integer> count() {
+    return Optional.of(counter.get());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("counter", counter)
+        .toString();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+/**
+ * A default {@link org.apache.iceberg.metrics.MetricsContext.Counter} implementation that uses a {@link Long} to count
+ * events.
+ */
+class LongCounter implements MetricsContext.Counter<Long> {
+  private final AtomicLong counter;
+
+  LongCounter() {
+    this.counter = new AtomicLong(0L);
+  }
+
+  @Override
+  public void increment() {
+    increment(1L);
+  }
+
+  @Override
+  public void increment(Long amount) {
+    counter.updateAndGet(val -> Math.addExact(val, amount));
+  }
+
+  @Override
+  public Optional<Long> count() {
+    return Optional.of(counter.get());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("counter", counter)
+        .toString();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.metrics;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Generalized interface for creating telemetry related instances for tracking
@@ -89,12 +90,29 @@ public interface MetricsContext extends Serializable {
   }
 
   /**
+   * Get a named timer.
+   *
+   * @param name name of the metric
+   * @param unit the time unit designation of the metric
+   * @return a timer implementation
+   */
+  default Timer timer(String name, TimeUnit unit) {
+    throw new UnsupportedOperationException("Timer is not supported.");
+  }
+
+  /**
    * Utility method for producing no metrics.
    *
    * @return a non-recording metrics context
    */
   static MetricsContext nullMetrics() {
     return new MetricsContext() {
+
+      @Override
+      public Timer timer(String name, TimeUnit unit) {
+        return Timer.NOOP;
+      }
+
       @Override
       public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
         return new Counter<T>() {

--- a/api/src/main/java/org/apache/iceberg/metrics/Timer.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/Timer.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Generalized Timer interface for creating telemetry related instances for measuring duration of operations.
+ */
+public interface Timer {
+
+  /**
+   * The number of times {@link Timer#time(Duration)} was called.
+   *
+   * @return The number of times {@link Timer#time(Duration)} was called.
+   */
+  long count();
+
+  /**
+   * The total duration that was recorded.
+   *
+   * @return The total duration that was recorded.
+   */
+  Duration totalDuration();
+
+  /**
+   * Starts the timer and returns a {@link Timed} instance. Call {@link Timed#stop()} to complete the timing.
+   *
+   * @return A {@link Timed} instance with the start time recorded.
+   */
+  Timed start();
+
+  /**
+   * Records a custom amount in the given time unit.
+   *
+   * @param amount The amount to record
+   * @param unit   The time unit of the amount
+   */
+  void record(long amount, TimeUnit unit);
+
+  /**
+   * The duration to record
+   *
+   * @param duration The duration to record
+   */
+  default void time(Duration duration) {
+    record(duration.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  /**
+   * Executes and measures the given {@link Runnable} instance.
+   *
+   * @param runnable The {@link Runnable} to execute and measure.
+   */
+  void time(Runnable runnable);
+
+  /**
+   * Executes and measures the given {@link Callable} and returns its result.
+   *
+   * @param callable The {@link Callable} to execute and measure.
+   * @param <T>      The type of the {@link Callable}
+   * @return The result of the underlying {@link Callable}.
+   * @throws Exception In case the {@link Callable} fails.
+   */
+  <T> T timeCallable(Callable<T> callable) throws Exception;
+
+  /**
+   * Gets the result from the given {@link Supplier} and measures its execution time.
+   *
+   * @param supplier The {@link Supplier} to execute and measure.
+   * @param <T>      The type of the {@link Supplier}.
+   * @return The result of the underlying {@link Supplier}.
+   */
+  <T> T time(Supplier<T> supplier);
+
+  /**
+   * A timing sample that carries internal state about the Timer's start position. The timing can be completed by
+   * calling {@link Timed#stop()}.
+   */
+  interface Timed extends AutoCloseable {
+    /**
+     * Stops the timer and records the total duration up until {@link Timer#start()} was called.
+     */
+    void stop();
+
+    @Override
+    default void close() {
+      stop();
+    }
+
+    Timed NOOP = () -> { };
+  }
+
+  Timer NOOP = new Timer() {
+    @Override
+    public Timed start() {
+      return Timed.NOOP;
+    }
+
+    @Override
+    public long count() {
+      return 0;
+    }
+
+    @Override
+    public Duration totalDuration() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public void record(long amount, TimeUnit unit) {
+    }
+
+    @Override
+    public void time(Runnable runnable) {
+    }
+
+    @Override
+    public <T> T timeCallable(Callable<T> callable) throws Exception {
+      return callable.call();
+    }
+
+    @Override
+    public <T> T time(Supplier<T> supplier) {
+      return supplier.get();
+    }
+  };
+}

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestDefaultMetricsContext {
+
+  @Test
+  public void unsupportedCounter() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    Assertions.assertThatThrownBy(() -> metricsContext.counter("test", Double.class, MetricsContext.Unit.COUNT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Counter for type java.lang.Double is not supported");
+  }
+
+  @Test
+  public void intCounter() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MetricsContext.Counter<Integer> counter = metricsContext.counter("test", Integer.class, MetricsContext.Unit.COUNT);
+    counter.increment(5);
+    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(5);
+  }
+
+  @Test
+  public void intCounterOverflow() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MetricsContext.Counter<Integer> counter = metricsContext.counter("test", Integer.class, MetricsContext.Unit.COUNT);
+    counter.increment(Integer.MAX_VALUE);
+    Assertions.assertThatThrownBy(counter::increment)
+        .isInstanceOf(ArithmeticException.class)
+        .hasMessage("integer overflow");
+    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void longCounter() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MetricsContext.Counter<Long> counter = metricsContext.counter("test", Long.class, MetricsContext.Unit.COUNT);
+    counter.increment(5L);
+    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(5L);
+  }
+
+  @Test
+  public void longCounterOverflow() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MetricsContext.Counter<Long> counter = metricsContext.counter("test", Long.class, MetricsContext.Unit.COUNT);
+    counter.increment(Long.MAX_VALUE);
+    Assertions.assertThatThrownBy(counter::increment)
+        .isInstanceOf(ArithmeticException.class)
+        .hasMessage("long overflow");
+    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(Long.MAX_VALUE);
+  }
+
+  @Test
+  public void timer() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    Timer timer = metricsContext.timer("test", TimeUnit.MICROSECONDS);
+    timer.record(10, TimeUnit.MINUTES);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ofMinutes(10L));
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultTimer.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultTimer.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestDefaultTimer {
+
+  @Test
+  public void nullTimeUnit() {
+    Assertions.assertThatThrownBy(() -> new DefaultTimer(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("TimeUnit must be non-null");
+  }
+
+  @Test
+  public void recordNegativeAmount() {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThatThrownBy(() -> timer.record(-1, TimeUnit.NANOSECONDS))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot record -1 NANOSECONDS: must be >= 0");
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  public void multipleStops() {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Timer.Timed timed = timer.start();
+    timed.stop();
+    // we didn't start the timer again
+    Assertions.assertThatThrownBy(timed::stop)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("stop() called multiple times");
+  }
+
+  @Test
+  public void closeableTimer() throws InterruptedException {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+    try (Timer.Timed sample = timer.start()) {
+      Thread.sleep(500L);
+    }
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Assertions.assertThat(timer.totalDuration()).isGreaterThan(Duration.ZERO);
+  }
+
+  @Test
+  public void measureRunnable() {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Runnable runnable = () -> {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    };
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+
+    timer.time(runnable);
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Duration duration = timer.totalDuration();
+    Assertions.assertThat(duration).isGreaterThan(Duration.ZERO);
+
+    timer.time(runnable);
+    Assertions.assertThat(timer.count()).isEqualTo(2);
+    Duration secondDuration = timer.totalDuration();
+    Assertions.assertThat(secondDuration).isGreaterThan(duration);
+  }
+
+  @Test
+  public void measureCallable() throws Exception {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Callable<Boolean> callable = () -> {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return true;
+    };
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+
+    Assertions.assertThat(timer.timeCallable(callable).booleanValue()).isTrue();
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Duration duration = timer.totalDuration();
+    Assertions.assertThat(duration).isGreaterThan(Duration.ZERO);
+
+    Assertions.assertThat(timer.timeCallable(callable).booleanValue()).isTrue();
+    Assertions.assertThat(timer.count()).isEqualTo(2);
+    Duration secondDuration = timer.totalDuration();
+    Assertions.assertThat(secondDuration).isGreaterThan(duration);
+  }
+
+  @Test
+  public void measureSupplier() {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Supplier<Boolean> supplier = () -> {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return true;
+    };
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+
+    Assertions.assertThat(timer.time(supplier).booleanValue()).isTrue();
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Duration duration = timer.totalDuration();
+    Assertions.assertThat(duration).isGreaterThan(Duration.ZERO);
+
+    Assertions.assertThat(timer.time(supplier).booleanValue()).isTrue();
+    Assertions.assertThat(timer.count()).isEqualTo(2);
+    Duration secondDuration = timer.totalDuration();
+    Assertions.assertThat(secondDuration).isGreaterThan(duration);
+  }
+
+  @Test
+  public void measureNestedRunnables() {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Timer innerTimer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Runnable inner = () -> {
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Runnable outer = () -> {
+      try {
+        Thread.sleep(100);
+        innerTimer.time(inner);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    };
+
+    Assertions.assertThat(timer.count()).isEqualTo(0);
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
+    Assertions.assertThat(innerTimer.count()).isEqualTo(0);
+    Assertions.assertThat(innerTimer.totalDuration()).isEqualTo(Duration.ZERO);
+
+    timer.time(outer);
+    Assertions.assertThat(timer.count()).isEqualTo(1);
+    Duration outerDuration = timer.totalDuration();
+    Assertions.assertThat(outerDuration).isGreaterThan(Duration.ZERO);
+    Assertions.assertThat(innerTimer.count()).isEqualTo(1);
+    Duration innerDuration = innerTimer.totalDuration();
+    Assertions.assertThat(innerDuration).isGreaterThan(Duration.ZERO);
+    Assertions.assertThat(outerDuration).isGreaterThan(innerDuration);
+  }
+
+  @Test
+  public void multiThreadedStarts() throws InterruptedException {
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+
+    int threads = 10;
+    CyclicBarrier barrier = new CyclicBarrier(threads);
+    ExecutorService executor = newFixedThreadPool(threads);
+
+    List<Future<Duration>> futures = IntStream.range(0, threads)
+        .mapToObj(threadNumber -> executor.submit(() -> {
+          try {
+            barrier.await(30, SECONDS);
+            timer.record(5, TimeUnit.NANOSECONDS);
+            return timer.totalDuration();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }))
+        .collect(Collectors.toList());
+    futures.stream()
+        .map(f -> {
+          try {
+            return f.get(30, SECONDS);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }).forEach(d -> System.out.println("d = " + d));
+    executor.shutdownNow();
+    executor.awaitTermination(5, SECONDS);
+
+    Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ofNanos(5 * threads));
+    Assertions.assertThat(timer.count()).isEqualTo(threads);
+  }
+}

--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
@@ -96,6 +97,7 @@ public class GuavaClasses {
     Iterables.class.getName();
     CountingOutputStream.class.getName();
     Suppliers.class.getName();
+    Stopwatch.class.getName();
   }
 
 }


### PR DESCRIPTION
The idea here is that a `DefaultMetricsContext` can be used with native
Java Counters/Timers to measure things.

Additionally, this is introducing an API and a default implementation
for a Timer, which can be used to measure execution time.