### PR TITLE
AWS: Reduce TestS3FileIO prefix test scale factors. Replace with S3FileIO integration tests.

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -27,6 +27,7 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.List;
+import java.util.Random;
 import java.util.UUID;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -39,11 +40,13 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.PartitionMetadata;
@@ -65,8 +68,11 @@ import software.amazon.awssdk.services.s3control.S3ControlClient;
 import software.amazon.awssdk.utils.ImmutableMap;
 import software.amazon.awssdk.utils.IoUtils;
 
+import static org.junit.Assert.assertEquals;
+
 public class TestS3FileIOIntegration {
 
+  private final Random random = new Random(1);
   private static AwsClientFactory clientFactory;
   private static S3Client s3;
   private static S3ControlClient s3Control;
@@ -328,6 +334,38 @@ public class TestS3FileIOIntegration {
     testDeleteFiles(5, s3FileIO);
   }
 
+  @Test
+  public void testPrefixList() {
+    S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
+    List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
+    String listPrefix = String.format("s3://%s/%s", bucketName, "prefix-list-test");
+
+    scaleSizes.parallelStream().forEach(scale -> {
+      String scalePrefix = String.format("%s/%s/", prefix, scale);
+      createRandomObjects(scalePrefix, scale);
+      assertEquals((long) scale, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+    });
+
+    long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
+    Assertions.assertEquals(totalFiles, Streams.stream(s3FileIO.listPrefix(listPrefix)).count());
+  }
+
+  @Test
+  public void testPrefixDelete() {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoDeleteBatchSize(100);
+    S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
+    String deletePrefix = String.format("s3://%s/%s", bucketName, "prefix-delete-test");
+
+    List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1000, 2500);
+    scaleSizes.parallelStream().forEach(scale -> {
+      String scalePrefix = String.format("%s/%s/", deletePrefix, scale);
+      createRandomObjects(scalePrefix, scale);
+      s3FileIO.deletePrefix(scalePrefix);
+      assertEquals(0L, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+    });
+  }
+
   private AwsProperties getDeletionTestProperties() {
     AwsProperties properties = new AwsProperties();
     properties.setS3FileIoDeleteBatchSize(deletionBatchSize);
@@ -371,5 +409,12 @@ public class TestS3FileIOIntegration {
     // format: arn:aws:s3:region:account-id:accesspoint/resource
     return String.format("arn:%s:s3:%s:%s:accesspoint/%s",
         PartitionMetadata.of(Region.of(region)).id(), region, AwsIntegTestUtil.testAccountId(), accessPoint);
+  }
+
+  private void createRandomObjects(String objectPrefix, int count) {
+    S3URI s3URI = new S3URI(objectPrefix);
+    random.ints(count).parallel().forEach(i ->
+        s3.putObject(builder -> builder.bucket(s3URI.bucket()).key(s3URI.key() + i).build(), RequestBody.empty())
+    );
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -173,6 +173,7 @@ public class TestS3FileIO {
       for (int j = 1; j <= numObjects; j++) {
         String key = "object-" + j;
         paths.add("s3://" + bucketName + "/" + key);
+        s3mock.putObject(builder -> builder.bucket(bucketName).key(key).build(), RequestBody.empty());
       }
     }
     s3FileIO.deleteFiles(paths);
@@ -217,9 +218,9 @@ public class TestS3FileIO {
   @Test
   public void testPrefixDelete() {
     String prefix = "s3://bucket/path/to/delete";
-    List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1000, 2500);
+    List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1001);
 
-    scaleSizes.parallelStream().forEach(scale -> {
+    scaleSizes.forEach(scale -> {
       String scalePrefix = String.format("%s/%s/", prefix, scale);
 
       createRandomObjects(scalePrefix, scale);


### PR DESCRIPTION
Fix TestS3FileIO prefixDelete test and fix setup of S3 batch deletion tests. Sporadically the prefixDelete test fails with a 500 (see below). When debugging it looks appears as though for S3Mock there's some corruption of the file states when there's concurrent execution of deletes and lists. Still not entirely sure why this is, but serial execution of each of each of the "scale" prefix tests, leads to the test consistently passing. Though we really should be able to run these different scale tests in parallel without issue since the prefixes are isolated. The test fails during the validation step in the test where we list the prefix to validate the objects were deleted.


If this is truly a S3Mock issue (which debugging seems to point to), then for the prefix tests another way is just to remove the unit tests and write integration tests which validate against S3. @danielcweeks @rdblue @jackye1995 let me know your thoughts.


Also fixed the setup step for the batch deletion tested. I noticed we aren't actually putting the objects. The tests were passing before because we just validate at the end if the objects no longer exist (and they were never put it in the first place). 

```
org.apache.iceberg.aws.s3.TestS3FileIO > testPrefixDelete FAILED
    software.amazon.awssdk.services.s3.model.S3Exception: null (Service: S3, Status Code: 500, Request ID: null)
        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156)
        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:108)
        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:85)
        at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:43)
        at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:95)
        at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$6(BaseClientHandler.java:234)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56)
        at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:48)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:31)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37)
        at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26)
        at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:193)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:167)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:175)
        at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76)
        at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45)
        at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56)
        at software.amazon.awssdk.services.s3.DefaultS3Client.listObjectsV2(DefaultS3Client.java:6148)
        at software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable$ListObjectsV2ResponseFetcher.nextPage(ListObjectsV2Iterable.java:153)
        at software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable$ListObjectsV2ResponseFetcher.nextPage(ListObjectsV2Iterable.java:144)
        at software.amazon.awssdk.core.pagination.sync.PaginatedResponsesIterator.next(PaginatedResponsesIterator.java:58)
        at java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1812)
        at java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:295)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:207)
        at java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:162)
        at java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:301)
```