### PR TITLE
AWS: Dynamo Catalog: Pass CommitFailedException up the stack without wrapping

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -114,6 +114,9 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       commitStatus = CommitStatus.SUCCESS;
     } catch (ConditionalCheckFailedException e) {
       throw new CommitFailedException(e, "Cannot commit %s: concurrent update detected", tableName());
+    } catch (CommitFailedException e) {
+      // any explicit commit failures are passed up and out to the retry handler
+      throw e;
     } catch (RuntimeException persistFailure) {
       LOG.error("Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
           fullTableName, persistFailure);


### PR DESCRIPTION
This resolves a bug that doesn't let the commit retry mechanism kick in. In the dynamo catalog, `checkMetadataLocation` can throw a CommitFailedException.  If this happens, it's caught in
```
} catch (RuntimeException persistFailure) {
```

and the commit state is repeatedly checked via `checkCommitStatus`. The only observable case is that checkCommitStatus fails and wraps the CommitFailedException into a CommitStateUnknownException. 

This PR catches explicit CommitFailedException (we know we didn't successfully commit) and bubbles it up to the more comprehensive retry logic that checks if the new commit touches partitions that have been recently modified. 

@jackye1995 would appreciate the review on this. 