### PR TITLE
Core: Add base implementations for changelog tasks

### DIFF
--- a/api/src/main/java/org/apache/iceberg/AddedRowsScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/AddedRowsScanTask.java
@@ -50,4 +50,14 @@ public interface AddedRowsScanTask extends ChangelogScanTask, ContentScanTask<Da
   default ChangelogOperation operation() {
     return ChangelogOperation.INSERT;
   }
+
+  @Override
+  default long sizeBytes() {
+    return length() + deletes().stream().mapToLong(ContentFile::fileSizeInBytes).sum();
+  }
+
+  @Override
+  default int filesCount() {
+    return 1 + deletes().size();
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DeletedDataFileScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/DeletedDataFileScanTask.java
@@ -49,4 +49,14 @@ public interface DeletedDataFileScanTask extends ChangelogScanTask, ContentScanT
   default ChangelogOperation operation() {
     return ChangelogOperation.DELETE;
   }
+
+  @Override
+  default long sizeBytes() {
+    return length() + existingDeletes().stream().mapToLong(ContentFile::fileSizeInBytes).sum();
+  }
+
+  @Override
+  default int filesCount() {
+    return 1 + existingDeletes().size();
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DeletedRowsScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/DeletedRowsScanTask.java
@@ -59,4 +59,16 @@ public interface DeletedRowsScanTask extends ChangelogScanTask, ContentScanTask<
   default ChangelogOperation operation() {
     return ChangelogOperation.DELETE;
   }
+
+  @Override
+  default long sizeBytes() {
+    return length() +
+        addedDeletes().stream().mapToLong(ContentFile::fileSizeInBytes).sum() +
+        existingDeletes().stream().mapToLong(ContentFile::fileSizeInBytes).sum();
+  }
+
+  @Override
+  default int filesCount() {
+    return 1 + addedDeletes().size() + existingDeletes().size();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
@@ -59,14 +59,13 @@ class BaseAddedRowsScanTask
     }
 
     @Override
-    public List<DeleteFile> deletes() {
-      return parentTask().deletes();
+    protected SplitAddedRowsScanTask copyWithNewLength(long newLength) {
+      return new SplitAddedRowsScanTask(parentTask(), start(), newLength);
     }
 
     @Override
-    public SplitAddedRowsScanTask merge(ScanTask other) {
-      SplitAddedRowsScanTask that = (SplitAddedRowsScanTask) other;
-      return new SplitAddedRowsScanTask(parentTask(), start(), length() + that.length());
+    public List<DeleteFile> deletes() {
+      return parentTask().deletes();
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
@@ -41,25 +41,20 @@ class BaseAddedRowsScanTask
   }
 
   @Override
+  protected AddedRowsScanTask newSplitTask(AddedRowsScanTask parentTask, long offset, long length) {
+    return new SplitAddedRowsScanTask(parentTask, offset, length);
+  }
+
+  @Override
   public List<DeleteFile> deletes() {
     return ImmutableList.copyOf(deletes);
   }
 
-  @Override
-  protected Iterable<AddedRowsScanTask> splitUsingOffsets(List<Long> offsets) {
-    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
-  }
-
-  @Override
-  protected Iterable<AddedRowsScanTask> splitUsingFixedSize(long targetSplitSize) {
-    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
-  }
-
-  private static class SplitScanTaskImpl
-      extends SplitScanTask<SplitScanTaskImpl, AddedRowsScanTask, DataFile>
+  private static class SplitAddedRowsScanTask
+      extends SplitScanTask<SplitAddedRowsScanTask, AddedRowsScanTask, DataFile>
       implements AddedRowsScanTask {
 
-    SplitScanTaskImpl(AddedRowsScanTask parentTask, long offset, long length) {
+    SplitAddedRowsScanTask(AddedRowsScanTask parentTask, long offset, long length) {
       super(parentTask, offset, length);
     }
 
@@ -69,35 +64,9 @@ class BaseAddedRowsScanTask
     }
 
     @Override
-    public SplitScanTaskImpl merge(ScanTask other) {
-      SplitScanTaskImpl that = (SplitScanTaskImpl) other;
-      return new SplitScanTaskImpl(parentTask(), start(), length() + that.length());
-    }
-  }
-
-  private static class OffsetsAwareSplitScanTaskIteratorImpl
-      extends OffsetsAwareSplitScanTaskIterator<AddedRowsScanTask> {
-
-    OffsetsAwareSplitScanTaskIteratorImpl(AddedRowsScanTask parentTask, List<Long> offsets) {
-      super(parentTask, parentTask.length(), offsets);
-    }
-
-    @Override
-    protected AddedRowsScanTask newSplitTask(AddedRowsScanTask parentTask, long offset, long length) {
-      return new SplitScanTaskImpl(parentTask, offset, length);
-    }
-  }
-
-  private static class FixedSizeSplitScanTaskIteratorImpl
-      extends FixedSizeSplitScanTaskIterator<AddedRowsScanTask> {
-
-    FixedSizeSplitScanTaskIteratorImpl(AddedRowsScanTask parentTask, long splitSize) {
-      super(parentTask, parentTask.length(), splitSize);
-    }
-
-    @Override
-    protected AddedRowsScanTask newSplitTask(AddedRowsScanTask parentTask, long offset, long length) {
-      return new SplitScanTaskImpl(parentTask, offset, length);
+    public SplitAddedRowsScanTask merge(ScanTask other) {
+      SplitAddedRowsScanTask that = (SplitAddedRowsScanTask) other;
+      return new SplitAddedRowsScanTask(parentTask(), start(), length() + that.length());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAddedRowsScanTask.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+class BaseAddedRowsScanTask
+    extends BaseChangelogContentScanTask<AddedRowsScanTask, DataFile>
+    implements AddedRowsScanTask {
+
+  private final DeleteFile[] deletes;
+
+  BaseAddedRowsScanTask(int changeOrdinal, long commitSnapshotId, DataFile file, DeleteFile[] deletes,
+                        String schemaString, String specString, ResidualEvaluator residuals) {
+    super(changeOrdinal, commitSnapshotId, file, schemaString, specString, residuals);
+    this.deletes = deletes != null ? deletes : new DeleteFile[0];
+  }
+
+  @Override
+  protected AddedRowsScanTask self() {
+    return this;
+  }
+
+  @Override
+  public List<DeleteFile> deletes() {
+    return ImmutableList.copyOf(deletes);
+  }
+
+  @Override
+  protected Iterable<AddedRowsScanTask> splitUsingOffsets(List<Long> offsets) {
+    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
+  }
+
+  @Override
+  protected Iterable<AddedRowsScanTask> splitUsingFixedSize(long targetSplitSize) {
+    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
+  }
+
+  private static class SplitScanTaskImpl
+      extends SplitScanTask<SplitScanTaskImpl, AddedRowsScanTask, DataFile>
+      implements AddedRowsScanTask {
+
+    SplitScanTaskImpl(AddedRowsScanTask parentTask, long offset, long length) {
+      super(parentTask, offset, length);
+    }
+
+    @Override
+    public List<DeleteFile> deletes() {
+      return parentTask().deletes();
+    }
+
+    @Override
+    public SplitScanTaskImpl merge(ScanTask other) {
+      SplitScanTaskImpl that = (SplitScanTaskImpl) other;
+      return new SplitScanTaskImpl(parentTask(), start(), length() + that.length());
+    }
+  }
+
+  private static class OffsetsAwareSplitScanTaskIteratorImpl
+      extends OffsetsAwareSplitScanTaskIterator<AddedRowsScanTask> {
+
+    OffsetsAwareSplitScanTaskIteratorImpl(AddedRowsScanTask parentTask, List<Long> offsets) {
+      super(parentTask, parentTask.length(), offsets);
+    }
+
+    @Override
+    protected AddedRowsScanTask newSplitTask(AddedRowsScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+
+  private static class FixedSizeSplitScanTaskIteratorImpl
+      extends FixedSizeSplitScanTaskIterator<AddedRowsScanTask> {
+
+    FixedSizeSplitScanTaskIteratorImpl(AddedRowsScanTask parentTask, long splitSize) {
+      super(parentTask, parentTask.length(), splitSize);
+    }
+
+    @Override
+    protected AddedRowsScanTask newSplitTask(AddedRowsScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
@@ -23,7 +23,8 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
-abstract class BaseChangelogContentScanTask<ThisT, F extends ContentFile<F>>
+abstract class BaseChangelogContentScanTask
+    <ThisT extends ContentScanTask<F> & ChangelogScanTask, F extends ContentFile<F>>
     extends BaseContentScanTask<ThisT, F>
     implements ChangelogScanTask {
 
@@ -58,20 +59,21 @@ abstract class BaseChangelogContentScanTask<ThisT, F extends ContentFile<F>>
         .toString();
   }
 
-  abstract static class SplitScanTask<ThisT, T extends ContentScanTask<F> & ChangelogScanTask, F extends ContentFile<F>>
+  abstract static class SplitScanTask
+      <ThisT, ParentT extends ContentScanTask<F> & ChangelogScanTask, F extends ContentFile<F>>
       implements ContentScanTask<F>, ChangelogScanTask, MergeableScanTask<ThisT> {
 
-    private final T parentTask;
+    private final ParentT parentTask;
     private final long offset;
     private final long length;
 
-    protected SplitScanTask(T parentTask, long offset, long length) {
+    protected SplitScanTask(ParentT parentTask, long offset, long length) {
       this.parentTask = parentTask;
       this.offset = offset;
       this.length = length;
     }
 
-    protected T parentTask() {
+    protected ParentT parentTask() {
       return parentTask;
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
@@ -73,6 +73,8 @@ abstract class BaseChangelogContentScanTask
       this.length = length;
     }
 
+    protected abstract ThisT copyWithNewLength(long newLength);
+
     protected ParentT parentTask() {
       return parentTask;
     }
@@ -124,6 +126,12 @@ abstract class BaseChangelogContentScanTask
       } else {
         return false;
       }
+    }
+
+    @Override
+    public ThisT merge(ScanTask other) {
+      SplitScanTask<?, ?, ?> that = (SplitScanTask<?, ?, ?>) other;
+      return copyWithNewLength(length() + that.length());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseChangelogContentScanTask.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+abstract class BaseChangelogContentScanTask<ThisT, F extends ContentFile<F>>
+    extends BaseContentScanTask<ThisT, F>
+    implements ChangelogScanTask {
+
+  private final int changeOrdinal;
+  private final long commitSnapshotId;
+
+  BaseChangelogContentScanTask(int changeOrdinal, long commitSnapshotId, F file,
+                               String schemaString, String specString, ResidualEvaluator residuals) {
+    super(file, schemaString, specString, residuals);
+    this.changeOrdinal = changeOrdinal;
+    this.commitSnapshotId = commitSnapshotId;
+  }
+
+  @Override
+  public int changeOrdinal() {
+    return changeOrdinal;
+  }
+
+  @Override
+  public long commitSnapshotId() {
+    return commitSnapshotId;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("change_ordinal", changeOrdinal)
+        .add("commit_snapshot_id", commitSnapshotId)
+        .add("file", file().path())
+        .add("partition_data", file().partition())
+        .add("residual", residual())
+        .toString();
+  }
+
+  abstract static class SplitScanTask<ThisT, T extends ContentScanTask<F> & ChangelogScanTask, F extends ContentFile<F>>
+      implements ContentScanTask<F>, ChangelogScanTask, MergeableScanTask<ThisT> {
+
+    private final T parentTask;
+    private final long offset;
+    private final long length;
+
+    protected SplitScanTask(T parentTask, long offset, long length) {
+      this.parentTask = parentTask;
+      this.offset = offset;
+      this.length = length;
+    }
+
+    protected T parentTask() {
+      return parentTask;
+    }
+
+    @Override
+    public int changeOrdinal() {
+      return parentTask.changeOrdinal();
+    }
+
+    @Override
+    public long commitSnapshotId() {
+      return parentTask.commitSnapshotId();
+    }
+
+    @Override
+    public F file() {
+      return parentTask.file();
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return parentTask.spec();
+    }
+
+    @Override
+    public long start() {
+      return offset;
+    }
+
+    @Override
+    public long length() {
+      return length;
+    }
+
+    @Override
+    public Expression residual() {
+      return parentTask.residual();
+    }
+
+    @Override
+    public boolean canMerge(ScanTask other) {
+      if (getClass().equals(other.getClass())) {
+        SplitScanTask<?, ?, ?> that = (SplitScanTask<?, ?, ?>) other;
+        return changeOrdinal() == that.changeOrdinal() &&
+            commitSnapshotId() == that.commitSnapshotId() &&
+            file().equals(that.file()) &&
+            start() + length() == that.start();
+
+      } else {
+        return false;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("change_ordinal", changeOrdinal())
+          .add("commit_snapshot_id", commitSnapshotId())
+          .add("file", file().path())
+          .add("partition_data", file().partition())
+          .add("offset", offset)
+          .add("length", length)
+          .add("residual", residual())
+          .toString();
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+abstract class BaseContentScanTask<ThisT, F extends ContentFile<F>>
+    implements ContentScanTask<F>, SplittableScanTask<ThisT> {
+
+  private final F file;
+  private final String schemaString;
+  private final String specString;
+  private final ResidualEvaluator residuals;
+
+  private transient volatile PartitionSpec spec = null;
+
+  BaseContentScanTask(F file, String schemaString, String specString, ResidualEvaluator residuals) {
+    this.file = file;
+    this.schemaString = schemaString;
+    this.specString = specString;
+    this.residuals = residuals;
+  }
+
+  protected abstract ThisT self();
+
+  protected abstract Iterable<ThisT> splitUsingOffsets(List<Long> offsets);
+
+  protected abstract Iterable<ThisT> splitUsingFixedSize(long targetSplitSize);
+
+  @Override
+  public F file() {
+    return file;
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    if (spec == null) {
+      synchronized (this) {
+        if (spec == null) {
+          this.spec = PartitionSpecParser.fromJson(SchemaParser.fromJson(schemaString), specString);
+        }
+      }
+    }
+    return spec;
+  }
+
+  @Override
+  public long start() {
+    return 0;
+  }
+
+  @Override
+  public long length() {
+    return file.fileSizeInBytes();
+  }
+
+  @Override
+  public Expression residual() {
+    return residuals.residualFor(file.partition());
+  }
+
+  @Override
+  public Iterable<ThisT> split(long targetSplitSize) {
+    if (file.format().isSplittable()) {
+      if (file.splitOffsets() != null) {
+        return splitUsingOffsets(file.splitOffsets());
+      } else {
+        return splitUsingFixedSize(targetSplitSize);
+      }
+    }
+
+    return ImmutableList.of(self());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("file", file().path())
+        .add("partition_data", file().partition())
+        .add("residual", residual())
+        .toString();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
@@ -59,14 +59,13 @@ class BaseDeletedDataFileScanTask
     }
 
     @Override
-    public List<DeleteFile> existingDeletes() {
-      return parentTask().existingDeletes();
+    protected SplitDeletedDataFileScanTask copyWithNewLength(long newLength) {
+      return new SplitDeletedDataFileScanTask(parentTask(), start(), newLength);
     }
 
     @Override
-    public SplitDeletedDataFileScanTask merge(ScanTask other) {
-      SplitDeletedDataFileScanTask that = (SplitDeletedDataFileScanTask) other;
-      return new SplitDeletedDataFileScanTask(parentTask(), start(), length() + that.length());
+    public List<DeleteFile> existingDeletes() {
+      return parentTask().existingDeletes();
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
@@ -41,25 +41,20 @@ class BaseDeletedDataFileScanTask
   }
 
   @Override
+  protected DeletedDataFileScanTask newSplitTask(DeletedDataFileScanTask parentTask, long offset, long length) {
+    return new SplitDeletedDataFileScanTask(parentTask, offset, length);
+  }
+
+  @Override
   public List<DeleteFile> existingDeletes() {
     return ImmutableList.copyOf(deletes);
   }
 
-  @Override
-  protected Iterable<DeletedDataFileScanTask> splitUsingOffsets(List<Long> offsets) {
-    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
-  }
-
-  @Override
-  protected Iterable<DeletedDataFileScanTask> splitUsingFixedSize(long targetSplitSize) {
-    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
-  }
-
-  private static class SplitScanTaskImpl
-      extends SplitScanTask<SplitScanTaskImpl, DeletedDataFileScanTask, DataFile>
+  private static class SplitDeletedDataFileScanTask
+      extends SplitScanTask<SplitDeletedDataFileScanTask, DeletedDataFileScanTask, DataFile>
       implements DeletedDataFileScanTask {
 
-    SplitScanTaskImpl(DeletedDataFileScanTask parentTask, long offset, long length) {
+    SplitDeletedDataFileScanTask(DeletedDataFileScanTask parentTask, long offset, long length) {
       super(parentTask, offset, length);
     }
 
@@ -69,35 +64,9 @@ class BaseDeletedDataFileScanTask
     }
 
     @Override
-    public SplitScanTaskImpl merge(ScanTask other) {
-      SplitScanTaskImpl that = (SplitScanTaskImpl) other;
-      return new SplitScanTaskImpl(parentTask(), start(), length() + that.length());
-    }
-  }
-
-  private static class OffsetsAwareSplitScanTaskIteratorImpl
-      extends OffsetsAwareSplitScanTaskIterator<DeletedDataFileScanTask> {
-
-    OffsetsAwareSplitScanTaskIteratorImpl(DeletedDataFileScanTask parentTask, List<Long> offsets) {
-      super(parentTask, parentTask.length(), offsets);
-    }
-
-    @Override
-    protected DeletedDataFileScanTask newSplitTask(DeletedDataFileScanTask parentTask, long offset, long length) {
-      return new SplitScanTaskImpl(parentTask, offset, length);
-    }
-  }
-
-  private static class FixedSizeSplitScanTaskIteratorImpl
-      extends FixedSizeSplitScanTaskIterator<DeletedDataFileScanTask> {
-
-    FixedSizeSplitScanTaskIteratorImpl(DeletedDataFileScanTask parentTask, long splitSize) {
-      super(parentTask, parentTask.length(), splitSize);
-    }
-
-    @Override
-    protected DeletedDataFileScanTask newSplitTask(DeletedDataFileScanTask parentTask, long offset, long length) {
-      return new SplitScanTaskImpl(parentTask, offset, length);
+    public SplitDeletedDataFileScanTask merge(ScanTask other) {
+      SplitDeletedDataFileScanTask that = (SplitDeletedDataFileScanTask) other;
+      return new SplitDeletedDataFileScanTask(parentTask(), start(), length() + that.length());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDeletedDataFileScanTask.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+class BaseDeletedDataFileScanTask
+    extends BaseChangelogContentScanTask<DeletedDataFileScanTask, DataFile>
+    implements DeletedDataFileScanTask {
+
+  private final DeleteFile[] deletes;
+
+  BaseDeletedDataFileScanTask(int changeOrdinal, long commitSnapshotId, DataFile file, DeleteFile[] deletes,
+                              String schemaString, String specString, ResidualEvaluator residuals) {
+    super(changeOrdinal, commitSnapshotId, file, schemaString, specString, residuals);
+    this.deletes = deletes != null ? deletes : new DeleteFile[0];
+  }
+
+  @Override
+  protected DeletedDataFileScanTask self() {
+    return this;
+  }
+
+  @Override
+  public List<DeleteFile> existingDeletes() {
+    return ImmutableList.copyOf(deletes);
+  }
+
+  @Override
+  protected Iterable<DeletedDataFileScanTask> splitUsingOffsets(List<Long> offsets) {
+    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
+  }
+
+  @Override
+  protected Iterable<DeletedDataFileScanTask> splitUsingFixedSize(long targetSplitSize) {
+    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
+  }
+
+  private static class SplitScanTaskImpl
+      extends SplitScanTask<SplitScanTaskImpl, DeletedDataFileScanTask, DataFile>
+      implements DeletedDataFileScanTask {
+
+    SplitScanTaskImpl(DeletedDataFileScanTask parentTask, long offset, long length) {
+      super(parentTask, offset, length);
+    }
+
+    @Override
+    public List<DeleteFile> existingDeletes() {
+      return parentTask().existingDeletes();
+    }
+
+    @Override
+    public SplitScanTaskImpl merge(ScanTask other) {
+      SplitScanTaskImpl that = (SplitScanTaskImpl) other;
+      return new SplitScanTaskImpl(parentTask(), start(), length() + that.length());
+    }
+  }
+
+  private static class OffsetsAwareSplitScanTaskIteratorImpl
+      extends OffsetsAwareSplitScanTaskIterator<DeletedDataFileScanTask> {
+
+    OffsetsAwareSplitScanTaskIteratorImpl(DeletedDataFileScanTask parentTask, List<Long> offsets) {
+      super(parentTask, parentTask.length(), offsets);
+    }
+
+    @Override
+    protected DeletedDataFileScanTask newSplitTask(DeletedDataFileScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+
+  private static class FixedSizeSplitScanTaskIteratorImpl
+      extends FixedSizeSplitScanTaskIterator<DeletedDataFileScanTask> {
+
+    FixedSizeSplitScanTaskIteratorImpl(DeletedDataFileScanTask parentTask, long splitSize) {
+      super(parentTask, parentTask.length(), splitSize);
+    }
+
+    @Override
+    protected DeletedDataFileScanTask newSplitTask(DeletedDataFileScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseDeletedRowsScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDeletedRowsScanTask.java
@@ -67,6 +67,11 @@ class BaseDeletedRowsScanTask
     }
 
     @Override
+    protected SplitDeletedRowsScanTask copyWithNewLength(long newLength) {
+      return new SplitDeletedRowsScanTask(parentTask(), start(), newLength);
+    }
+
+    @Override
     public List<DeleteFile> addedDeletes() {
       return parentTask().addedDeletes();
     }
@@ -74,12 +79,6 @@ class BaseDeletedRowsScanTask
     @Override
     public List<DeleteFile> existingDeletes() {
       return parentTask().existingDeletes();
-    }
-
-    @Override
-    public SplitDeletedRowsScanTask merge(ScanTask other) {
-      SplitDeletedRowsScanTask that = (SplitDeletedRowsScanTask) other;
-      return new SplitDeletedRowsScanTask(parentTask(), start(), length() + that.length());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseDeletedRowsScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDeletedRowsScanTask.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+class BaseDeletedRowsScanTask
+    extends BaseChangelogContentScanTask<DeletedRowsScanTask, DataFile>
+    implements DeletedRowsScanTask {
+
+  private final DeleteFile[] addedDeletes;
+  private final DeleteFile[] existingDeletes;
+
+  BaseDeletedRowsScanTask(int changeOrdinal, long commitSnapshotId, DataFile file,
+                          DeleteFile[] addedDeletes, DeleteFile[] existingDeletes,
+                          String schemaString, String specString, ResidualEvaluator residuals) {
+    super(changeOrdinal, commitSnapshotId, file, schemaString, specString, residuals);
+    this.addedDeletes = addedDeletes != null ? addedDeletes : new DeleteFile[0];
+    this.existingDeletes = existingDeletes != null ? existingDeletes : new DeleteFile[0];
+  }
+
+  @Override
+  protected DeletedRowsScanTask self() {
+    return this;
+  }
+
+  @Override
+  public List<DeleteFile> addedDeletes() {
+    return ImmutableList.copyOf(addedDeletes);
+  }
+
+  @Override
+  public List<DeleteFile> existingDeletes() {
+    return ImmutableList.copyOf(existingDeletes);
+  }
+
+  @Override
+  protected Iterable<DeletedRowsScanTask> splitUsingOffsets(List<Long> offsets) {
+    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
+  }
+
+  @Override
+  protected Iterable<DeletedRowsScanTask> splitUsingFixedSize(long targetSplitSize) {
+    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
+  }
+
+  private static class SplitScanTaskImpl
+      extends SplitScanTask<SplitScanTaskImpl, DeletedRowsScanTask, DataFile>
+      implements DeletedRowsScanTask {
+
+    SplitScanTaskImpl(DeletedRowsScanTask parentTask, long offset, long length) {
+      super(parentTask, offset, length);
+    }
+
+    @Override
+    public List<DeleteFile> addedDeletes() {
+      return parentTask().addedDeletes();
+    }
+
+    @Override
+    public List<DeleteFile> existingDeletes() {
+      return parentTask().existingDeletes();
+    }
+
+    @Override
+    public SplitScanTaskImpl merge(ScanTask other) {
+      SplitScanTaskImpl that = (SplitScanTaskImpl) other;
+      return new SplitScanTaskImpl(parentTask(), start(), length() + that.length());
+    }
+  }
+
+  private static class OffsetsAwareSplitScanTaskIteratorImpl
+      extends OffsetsAwareSplitScanTaskIterator<DeletedRowsScanTask> {
+
+    OffsetsAwareSplitScanTaskIteratorImpl(DeletedRowsScanTask parentTask, List<Long> offsets) {
+      super(parentTask, parentTask.length(), offsets);
+    }
+
+    @Override
+    protected DeletedRowsScanTask newSplitTask(DeletedRowsScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+
+  private static class FixedSizeSplitScanTaskIteratorImpl
+      extends FixedSizeSplitScanTaskIterator<DeletedRowsScanTask> {
+
+    FixedSizeSplitScanTaskIteratorImpl(DeletedRowsScanTask parentTask, long splitSize) {
+      super(parentTask, parentTask.length(), splitSize);
+    }
+
+    @Override
+    protected DeletedRowsScanTask newSplitTask(DeletedRowsScanTask parentTask, long offset, long length) {
+      return new SplitScanTaskImpl(parentTask, offset, length);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile> implements FileScanTask {
@@ -48,7 +49,8 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
     return ImmutableList.copyOf(deletes);
   }
 
-  private static final class SplitScanTask implements FileScanTask, MergeableScanTask<SplitScanTask> {
+  @VisibleForTesting
+  static final class SplitScanTask implements FileScanTask, MergeableScanTask<SplitScanTask> {
     private final long len;
     private final long offset;
     private final FileScanTask fileScanTask;

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile> implements FileScanTask {
@@ -40,42 +39,13 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
   }
 
   @Override
+  protected FileScanTask newSplitTask(FileScanTask parentTask, long offset, long length) {
+    return new SplitScanTask(offset, length, parentTask);
+  }
+
+  @Override
   public List<DeleteFile> deletes() {
     return ImmutableList.copyOf(deletes);
-  }
-
-  @Override
-  protected Iterable<FileScanTask> splitUsingOffsets(List<Long> offsets) {
-    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
-  }
-
-  @Override
-  protected Iterable<FileScanTask> splitUsingFixedSize(long targetSplitSize) {
-    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
-  }
-
-  @VisibleForTesting
-  static class OffsetsAwareSplitScanTaskIteratorImpl extends OffsetsAwareSplitScanTaskIterator<FileScanTask> {
-    OffsetsAwareSplitScanTaskIteratorImpl(FileScanTask parentTask, List<Long> offsets) {
-      super(parentTask, parentTask.length(), offsets);
-    }
-
-    @Override
-    protected FileScanTask newSplitTask(FileScanTask parentTask, long offset, long length) {
-      return new SplitScanTask(offset, length, parentTask);
-    }
-  }
-
-  @VisibleForTesting
-  static class FixedSizeSplitScanTaskIteratorImpl extends FixedSizeSplitScanTaskIterator<FileScanTask> {
-    FixedSizeSplitScanTaskIteratorImpl(FileScanTask parentTask, long splitSize) {
-      super(parentTask, parentTask.length(), splitSize);
-    }
-
-    @Override
-    protected FileScanTask newSplitTask(FileScanTask parentTask, long offset, long length) {
-      return new SplitScanTask(offset, length, parentTask);
-    }
   }
 
   private static final class SplitScanTask implements FileScanTask, MergeableScanTask<SplitScanTask> {

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -19,37 +19,24 @@
 
 package org.apache.iceberg;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
-import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
-public class BaseFileScanTask implements FileScanTask {
-  private final DataFile file;
+public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile> implements FileScanTask {
   private final DeleteFile[] deletes;
-  private final String schemaString;
-  private final String specString;
-  private final ResidualEvaluator residuals;
-
-  private transient PartitionSpec spec = null;
 
   public BaseFileScanTask(DataFile file, DeleteFile[] deletes, String schemaString, String specString,
-                   ResidualEvaluator residuals) {
-    this.file = file;
+                          ResidualEvaluator residuals) {
+    super(file, schemaString, specString, residuals);
     this.deletes = deletes != null ? deletes : new DeleteFile[0];
-    this.schemaString = schemaString;
-    this.specString = specString;
-    this.residuals = residuals;
   }
 
   @Override
-  public DataFile file() {
-    return file;
+  protected FileScanTask self() {
+    return this;
   }
 
   @Override
@@ -58,116 +45,36 @@ public class BaseFileScanTask implements FileScanTask {
   }
 
   @Override
-  public PartitionSpec spec() {
-    if (spec == null) {
-      this.spec = PartitionSpecParser.fromJson(SchemaParser.fromJson(schemaString), specString);
-    }
-    return spec;
+  protected Iterable<FileScanTask> splitUsingOffsets(List<Long> offsets) {
+    return () -> new OffsetsAwareSplitScanTaskIteratorImpl(this, offsets);
   }
 
   @Override
-  public long start() {
-    return 0;
-  }
-
-  @Override
-  public long length() {
-    return file.fileSizeInBytes();
-  }
-
-  @Override
-  public Expression residual() {
-    return residuals.residualFor(file.partition());
-  }
-
-  @Override
-  public Iterable<FileScanTask> split(long targetSplitSize) {
-    if (file.format().isSplittable()) {
-      if (file.splitOffsets() != null) {
-        return () -> new OffsetsAwareTargetSplitSizeScanTaskIterator(file.splitOffsets(), this);
-      } else {
-        return () -> new FixedSizeSplitScanTaskIterator(targetSplitSize, this);
-      }
-    }
-    return ImmutableList.of(this);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("file", file.path())
-        .add("partition_data", file.partition())
-        .add("residual", residual())
-        .toString();
-  }
-
-  /**
-   * This iterator returns {@link FileScanTask} using guidance provided by split offsets.
-   */
-  @VisibleForTesting
-  static final class OffsetsAwareTargetSplitSizeScanTaskIterator implements Iterator<FileScanTask> {
-    private final List<Long> offsets;
-    private final List<Long> splitSizes;
-    private final FileScanTask parentScanTask;
-    private int sizeIdx = 0;
-
-    OffsetsAwareTargetSplitSizeScanTaskIterator(List<Long> offsetList, FileScanTask parentScanTask) {
-      this.offsets = ImmutableList.copyOf(offsetList);
-      this.parentScanTask = parentScanTask;
-      this.splitSizes = Lists.newArrayListWithCapacity(offsets.size());
-      if (offsets.size() > 0) {
-        int lastIndex = offsets.size() - 1;
-        for (int index = 0; index < lastIndex; index++) {
-          splitSizes.add(offsets.get(index + 1) - offsets.get(index));
-        }
-        splitSizes.add(parentScanTask.length() - offsets.get(lastIndex));
-      }
-    }
-
-    @Override
-    public boolean hasNext() {
-      return sizeIdx < splitSizes.size();
-    }
-
-    @Override
-    public FileScanTask next() {
-      if (!hasNext()) {
-        throw new NoSuchElementException();
-      }
-      int offsetIdx = sizeIdx;
-      long currentSize = splitSizes.get(sizeIdx);
-      sizeIdx += 1; // Create 1 split per offset
-      return new SplitScanTask(offsets.get(offsetIdx), currentSize, parentScanTask);
-    }
-
+  protected Iterable<FileScanTask> splitUsingFixedSize(long targetSplitSize) {
+    return () -> new FixedSizeSplitScanTaskIteratorImpl(this, targetSplitSize);
   }
 
   @VisibleForTesting
-  static final class FixedSizeSplitScanTaskIterator implements Iterator<FileScanTask> {
-    private long offset;
-    private long remainingLen;
-    private long splitSize;
-    private final FileScanTask fileScanTask;
-
-    FixedSizeSplitScanTaskIterator(long splitSize, FileScanTask fileScanTask) {
-      this.offset = 0;
-      this.remainingLen = fileScanTask.length();
-      this.splitSize = splitSize;
-      this.fileScanTask = fileScanTask;
+  static class OffsetsAwareSplitScanTaskIteratorImpl extends OffsetsAwareSplitScanTaskIterator<FileScanTask> {
+    OffsetsAwareSplitScanTaskIteratorImpl(FileScanTask parentTask, List<Long> offsets) {
+      super(parentTask, parentTask.length(), offsets);
     }
 
     @Override
-    public boolean hasNext() {
-      return remainingLen > 0;
+    protected FileScanTask newSplitTask(FileScanTask parentTask, long offset, long length) {
+      return new SplitScanTask(offset, length, parentTask);
+    }
+  }
+
+  @VisibleForTesting
+  static class FixedSizeSplitScanTaskIteratorImpl extends FixedSizeSplitScanTaskIterator<FileScanTask> {
+    FixedSizeSplitScanTaskIteratorImpl(FileScanTask parentTask, long splitSize) {
+      super(parentTask, parentTask.length(), splitSize);
     }
 
     @Override
-    public FileScanTask next() {
-      long len = Math.min(splitSize, remainingLen);
-      final FileScanTask splitTask = new SplitScanTask(offset, len, fileScanTask);
-      offset += len;
-      remainingLen -= len;
-      return splitTask;
+    protected FileScanTask newSplitTask(FileScanTask parentTask, long offset, long length) {
+      return new SplitScanTask(offset, length, parentTask);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/FixedSizeSplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/FixedSizeSplitScanTaskIterator.java
@@ -27,15 +27,15 @@ package org.apache.iceberg;
 class FixedSizeSplitScanTaskIterator<T extends ScanTask> implements SplitScanTaskIterator<T> {
   private final T parentTask;
   private final long splitSize;
-  private final CreateSplitTaskFunction<T> createSplitTaskFunc;
+  private final SplitScanTaskCreator<T> splitTaskCreator;
   private long offset;
   private long remainingLength;
 
   FixedSizeSplitScanTaskIterator(T parentTask, long parentTaskLength, long splitSize,
-                                 CreateSplitTaskFunction<T> createSplitTaskFunc) {
+                                 SplitScanTaskCreator<T> splitTaskCreator) {
     this.parentTask = parentTask;
     this.splitSize = splitSize;
-    this.createSplitTaskFunc = createSplitTaskFunc;
+    this.splitTaskCreator = splitTaskCreator;
     this.offset = 0;
     this.remainingLength = parentTaskLength;
   }
@@ -48,7 +48,7 @@ class FixedSizeSplitScanTaskIterator<T extends ScanTask> implements SplitScanTas
   @Override
   public T next() {
     long length = Math.min(splitSize, remainingLength);
-    T splitTask = createSplitTaskFunc.apply(parentTask, offset, length);
+    T splitTask = splitTaskCreator.create(parentTask, offset, length);
     offset += length;
     remainingLength -= length;
     return splitTask;

--- a/core/src/main/java/org/apache/iceberg/FixedSizeSplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/FixedSizeSplitScanTaskIterator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Iterator;
+
+/**
+ * An iterator that splits tasks using a fixed target split size.
+ *
+ * @param <T> the Java type of tasks produced by this iterator
+ */
+abstract class FixedSizeSplitScanTaskIterator<T extends ScanTask> implements Iterator<T> {
+  private final T parentTask;
+  private final long splitSize;
+  private long offset;
+  private long remainingLength;
+
+  FixedSizeSplitScanTaskIterator(T parentTask, long parentTaskLength, long splitSize) {
+    this.parentTask = parentTask;
+    this.splitSize = splitSize;
+    this.offset = 0;
+    this.remainingLength = parentTaskLength;
+  }
+
+  protected abstract T newSplitTask(T parent, long splitTaskOffset, long splitTaskLength);
+
+  @Override
+  public boolean hasNext() {
+    return remainingLength > 0;
+  }
+
+  @Override
+  public T next() {
+    long length = Math.min(splitSize, remainingLength);
+    T splitTask = newSplitTask(parentTask, offset, length);
+    offset += length;
+    remainingLength -= length;
+    return splitTask;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * An iterator that splits tasks using split offsets such as row group offsets in Parquet.
+ *
+ * @param <T> the Java type of tasks produced by this iterator
+ */
+abstract class OffsetsAwareSplitScanTaskIterator<T extends ScanTask> implements Iterator<T> {
+  private final T parentTask;
+  private final List<Long> offsets;
+  private final List<Long> splitSizes;
+  private int sizeIdx = 0;
+
+  OffsetsAwareSplitScanTaskIterator(T parentTask, long parentTaskLength, List<Long> offsetList) {
+    this.parentTask = parentTask;
+    this.offsets = ImmutableList.copyOf(offsetList);
+    this.splitSizes = Lists.newArrayListWithCapacity(offsets.size());
+    if (offsets.size() > 0) {
+      int lastIndex = offsets.size() - 1;
+      for (int index = 0; index < lastIndex; index++) {
+        splitSizes.add(offsets.get(index + 1) - offsets.get(index));
+      }
+      splitSizes.add(parentTaskLength - offsets.get(lastIndex));
+    }
+  }
+
+  protected abstract T newSplitTask(T parent, long splitTaskOffset, long splitTaskLength);
+
+  @Override
+  public boolean hasNext() {
+    return sizeIdx < splitSizes.size();
+  }
+
+  @Override
+  public T next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    int offsetIdx = sizeIdx;
+    long currentSize = splitSizes.get(sizeIdx);
+    sizeIdx += 1; // create 1 split per offset
+    return newSplitTask(parentTask, offsets.get(offsetIdx), currentSize);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/SplitScanTaskIterator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Iterator;
+
+/**
+ * An iterator that splits tasks.
+ *
+ * @param <T> the Java type of tasks produced by this iterator
+ */
+interface SplitScanTaskIterator<T extends ScanTask> extends Iterator<T> {
+
+  @FunctionalInterface
+  interface CreateSplitTaskFunction<T extends ScanTask> {
+    T apply(T parentTask, long offset, long length);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/SplitScanTaskIterator.java
@@ -29,7 +29,7 @@ import java.util.Iterator;
 interface SplitScanTaskIterator<T extends ScanTask> extends Iterator<T> {
 
   @FunctionalInterface
-  interface CreateSplitTaskFunction<T extends ScanTask> {
-    T apply(T parentTask, long offset, long length);
+  interface SplitScanTaskCreator<T extends ScanTask> {
+    T create(T parentTask, long offset, long length);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFixedSizeSplitScanTaskIterator.java
+++ b/core/src/test/java/org/apache/iceberg/TestFixedSizeSplitScanTaskIterator.java
@@ -20,11 +20,10 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import org.apache.iceberg.BaseFileScanTask.FixedSizeSplitScanTaskIteratorImpl;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.apache.iceberg.BaseFileScanTask.FixedSizeSplitScanTaskIterator;
 
 public class TestFixedSizeSplitScanTaskIterator {
   @Test
@@ -38,7 +37,7 @@ public class TestFixedSizeSplitScanTaskIterator {
 
   private static void verify(long splitSize, long fileLen, List<List<Long>> offsetLenPairs) {
     List<FileScanTask> tasks = Lists.newArrayList(
-        new FixedSizeSplitScanTaskIterator(splitSize, new MockFileScanTask(fileLen)));
+        new FixedSizeSplitScanTaskIteratorImpl(new MockFileScanTask(fileLen), splitSize));
     for (int i = 0; i < tasks.size(); i++) {
       FileScanTask task = tasks.get(i);
       List<Long> split = offsetLenPairs.get(i);

--- a/core/src/test/java/org/apache/iceberg/TestOffsetsBasedSplitScanTaskIterator.java
+++ b/core/src/test/java/org/apache/iceberg/TestOffsetsBasedSplitScanTaskIterator.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg;
 
 import java.util.List;
-import org.apache.iceberg.BaseFileScanTask.OffsetsAwareSplitScanTaskIteratorImpl;
+import org.apache.iceberg.BaseFileScanTask.SplitScanTask;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,9 +40,13 @@ public class TestOffsetsBasedSplitScanTaskIterator {
   }
 
   private static void verify(List<Long> offsetRanges, long fileLen, List<List<Long>> offsetLenPairs) {
-    List<FileScanTask> tasks = Lists.newArrayList(
-        new OffsetsAwareSplitScanTaskIteratorImpl(new MockFileScanTask(fileLen), offsetRanges));
+    FileScanTask mockFileScanTask = new MockFileScanTask(fileLen);
+    SplitScanTaskIterator<FileScanTask> splitTaskIterator = new OffsetsAwareSplitScanTaskIterator<>(
+        mockFileScanTask, mockFileScanTask.length(),
+        offsetRanges, TestOffsetsBasedSplitScanTaskIterator::createSplitTask);
+    List<FileScanTask> tasks = Lists.newArrayList(splitTaskIterator);
     Assert.assertEquals("Number of tasks don't match", offsetLenPairs.size(), tasks.size());
+
     for (int i = 0; i < tasks.size(); i++) {
       FileScanTask task = tasks.get(i);
       List<Long> split = offsetLenPairs.get(i);
@@ -55,5 +59,9 @@ public class TestOffsetsBasedSplitScanTaskIterator {
 
   private static <T> List<T> asList(T... items) {
     return Lists.newArrayList(items);
+  }
+
+  private static FileScanTask createSplitTask(FileScanTask parentTask, long offset, long length) {
+    return new SplitScanTask(offset, length, parentTask);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestOffsetsBasedSplitScanTaskIterator.java
+++ b/core/src/test/java/org/apache/iceberg/TestOffsetsBasedSplitScanTaskIterator.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import org.apache.iceberg.BaseFileScanTask.OffsetsAwareSplitScanTaskIteratorImpl;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,8 +41,7 @@ public class TestOffsetsBasedSplitScanTaskIterator {
 
   private static void verify(List<Long> offsetRanges, long fileLen, List<List<Long>> offsetLenPairs) {
     List<FileScanTask> tasks = Lists.newArrayList(
-        new BaseFileScanTask.OffsetsAwareTargetSplitSizeScanTaskIterator(
-            offsetRanges, new MockFileScanTask(fileLen)));
+        new OffsetsAwareSplitScanTaskIteratorImpl(new MockFileScanTask(fileLen), offsetRanges));
     Assert.assertEquals("Number of tasks don't match", offsetLenPairs.size(), tasks.size());
     for (int i = 0; i < tasks.size(); i++) {
       FileScanTask task = tasks.get(i);


### PR DESCRIPTION
This PR adds implementations for changelog tasks to be used in the changelog scan.
This PR currently relies on existing tests. More tests will come with the scan implementation.