### PR TITLE
Add SparkV2Filters

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -169,14 +169,13 @@ public class SparkV2Filters {
             Preconditions.checkNotNull(
                 value, "Expression is always false (eq is not null-safe): %s", predicate);
             return handleEqual(unquote(attributeName), value);
-          } else if (predicate.name().equals("<=>")) {
+          } else { // "<=>"
             if (value == null) {
               return isNull(unquote(attributeName));
             } else {
               return handleEqual(unquote(attributeName), value);
             }
           }
-          break;
 
         case IN:
           return in(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -103,7 +103,6 @@ public class SparkV2Filters {
   @SuppressWarnings("unchecked")
   private static <T> T leftChild(Predicate predicate) {
     org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
-    Preconditions.checkArgument(children.length == 2, "%s should have two children", predicate);
     return (T) children[0];
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -96,7 +96,8 @@ public class SparkV2Filters {
   @SuppressWarnings("unchecked")
   private static <T> T child(Predicate predicate) {
     org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
-    Preconditions.checkArgument(children.length == 1, "Predicate should have one child: %s", predicate);
+    Preconditions.checkArgument(
+        children.length == 1, "Predicate should have one child: %s", predicate);
     return (T) children[0];
   }
 
@@ -109,7 +110,8 @@ public class SparkV2Filters {
   @SuppressWarnings("unchecked")
   private static <T> T rightChild(Predicate predicate) {
     org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
-    Preconditions.checkArgument(children.length == 2, "Predicate should have two children: %s", predicate);
+    Preconditions.checkArgument(
+        children.length == 2, "Predicate should have two children: %s", predicate);
     return (T) children[1];
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -96,7 +96,7 @@ public class SparkV2Filters {
   @SuppressWarnings("unchecked")
   private static <T> T child(Predicate predicate) {
     org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
-    Preconditions.checkArgument(children.length == 1, "%s should have one child", predicate);
+    Preconditions.checkArgument(children.length == 1, "Predicate should have one child: %s", predicate);
     return (T) children[0];
   }
 
@@ -109,7 +109,7 @@ public class SparkV2Filters {
   @SuppressWarnings("unchecked")
   private static <T> T rightChild(Predicate predicate) {
     org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
-    Preconditions.checkArgument(children.length == 2, "%s should have two children", predicate);
+    Preconditions.checkArgument(children.length == 2, "Predicate should have two children: %s", predicate);
     return (T) children[1];
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -219,11 +219,8 @@ public class SparkV2Filters {
           Expression right = convert(orPredicate.right());
           if (left != null && right != null) {
             return or(left, right);
-          } else if (left != null) {
-            return left;
-          } else {
-            return right;
           }
+          return null;
         }
 
         case STARTS_WITH: {
@@ -332,7 +329,7 @@ public class SparkV2Filters {
 
         case OR:
           Or orFilter = (Or) predicate;
-          if (checkIfPredicateValid(orFilter.left()) == null && checkIfPredicateValid(orFilter.right()) == null) {
+          if (checkIfPredicateValid(orFilter.left()) == null || checkIfPredicateValid(orFilter.right()) == null) {
             return null;
           } else {
             return predicate;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -32,9 +32,7 @@ import org.apache.spark.sql.connector.expressions.filter.And;
 import org.apache.spark.sql.connector.expressions.filter.Not;
 import org.apache.spark.sql.connector.expressions.filter.Or;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
-import org.apache.spark.sql.types.DateType$;
-import org.apache.spark.sql.types.IntegerType$;
-import org.apache.spark.sql.types.TimestampType$;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,7 +53,7 @@ public class TestSparkV2Filters {
           org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
               new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
 
-          LiteralValue value = new LiteralValue(1, IntegerType$.MODULE$);
+          LiteralValue value = new LiteralValue(1, DataTypes.IntegerType);
           org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
               new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
           org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
@@ -182,7 +180,7 @@ public class TestSparkV2Filters {
     long epochMicros = ChronoUnit.MICROS.between(Instant.EPOCH, instant);
 
     NamedReference namedReference = FieldReference.apply("x");
-    LiteralValue ts = new LiteralValue(epochMicros, TimestampType$.MODULE$);
+    LiteralValue ts = new LiteralValue(epochMicros, DataTypes.TimestampType);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
         new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, ts};
 
@@ -202,7 +200,7 @@ public class TestSparkV2Filters {
     long epochDay = localDate.toEpochDay();
 
     NamedReference namedReference = FieldReference.apply("x");
-    LiteralValue ts = new LiteralValue(epochDay, DateType$.MODULE$);
+    LiteralValue ts = new LiteralValue(epochDay, DataTypes.DateType);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
         new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, ts};
 
@@ -219,8 +217,8 @@ public class TestSparkV2Filters {
   @Test
   public void testNestedInInsideNot() {
     NamedReference namedReference1 = FieldReference.apply("col1");
-    LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
-    LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
+    LiteralValue v1 = new LiteralValue(1, DataTypes.IntegerType);
+    LiteralValue v2 = new LiteralValue(2, DataTypes.IntegerType);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue1 =
         new org.apache.spark.sql.connector.expressions.Expression[] {namedReference1, v1};
     Predicate equal = new Predicate("=", attrAndValue1);
@@ -238,8 +236,8 @@ public class TestSparkV2Filters {
   @Test
   public void testNotIn() {
     NamedReference namedReference = FieldReference.apply("col");
-    LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
-    LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
+    LiteralValue v1 = new LiteralValue(1, DataTypes.IntegerType);
+    LiteralValue v2 = new LiteralValue(2, DataTypes.IntegerType);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
         new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, v1, v2};
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -58,6 +58,8 @@ public class TestSparkV2Filters {
           LiteralValue value = new LiteralValue(1, IntegerType$.MODULE$);
           org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
               new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+          org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+              new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
           Predicate isNull = new Predicate("IS_NULL", attrOnly);
           Expression expectedIsNull = Expressions.isNull(unquoted);
@@ -71,67 +73,104 @@ public class TestSparkV2Filters {
           Assert.assertEquals(
               "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
 
-          Predicate lt = new Predicate("<", attrAndValue);
-          Expression expectedLt = Expressions.lessThan(unquoted, 1);
-          Expression actualLt = SparkV2Filters.convert(lt);
-          Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
+          Predicate lt1 = new Predicate("<", attrAndValue);
+          Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
+          Expression actualLt1 = SparkV2Filters.convert(lt1);
+          Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
 
-          Predicate ltEq = new Predicate("<=", attrAndValue);
-          Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
-          Expression actualLtEq = SparkV2Filters.convert(ltEq);
+          Predicate lt2 = new Predicate("<", valueAndAttr);
+          Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
+          Expression actualLt2 = SparkV2Filters.convert(lt2);
+          Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
+
+          Predicate ltEq1 = new Predicate("<=", attrAndValue);
+          Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
+          Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
           Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
+              "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
 
-          Predicate gt = new Predicate(">", attrAndValue);
-          Expression expectedGt = Expressions.greaterThan(unquoted, 1);
-          Expression actualGt = SparkV2Filters.convert(gt);
-          Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
-
-          Predicate gtEq = new Predicate(">=", attrAndValue);
-          Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
-          Expression actualGtEq = SparkV2Filters.convert(gtEq);
+          Predicate ltEq2 = new Predicate("<=", valueAndAttr);
+          Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
+          Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
           Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
+              "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
 
-          Predicate eq = new Predicate("=", attrAndValue);
-          Expression expectedEq = Expressions.equal(unquoted, 1);
-          Expression actualEq = SparkV2Filters.convert(eq);
-          Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
+          Predicate gt1 = new Predicate(">", attrAndValue);
+          Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
+          Expression actualGt1 = SparkV2Filters.convert(gt1);
+          Assert.assertEquals(
+              "GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
 
-          Predicate eqNullSafe = new Predicate("<=>", attrAndValue);
-          Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
-          Expression actualEqNullSafe = SparkV2Filters.convert(eqNullSafe);
+          Predicate gt2 = new Predicate(">", valueAndAttr);
+          Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
+          Expression actualGt2 = SparkV2Filters.convert(gt2);
+          Assert.assertEquals(
+              "GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
+
+          Predicate gtEq1 = new Predicate(">=", attrAndValue);
+          Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
+          Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
+          Assert.assertEquals(
+              "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
+
+          Predicate gtEq2 = new Predicate(">=", valueAndAttr);
+          Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
+          Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
+          Assert.assertEquals(
+              "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
+
+          Predicate eq1 = new Predicate("=", attrAndValue);
+          Expression expectedEq1 = Expressions.equal(unquoted, 1);
+          Expression actualEq1 = SparkV2Filters.convert(eq1);
+          Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+
+          Predicate eq2 = new Predicate("=", valueAndAttr);
+          Expression expectedEq2 = Expressions.equal(unquoted, 1);
+          Expression actualEq2 = SparkV2Filters.convert(eq2);
+          Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+
+          Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
+          Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
+          Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
           Assert.assertEquals(
               "EqualNullSafe must match",
-              expectedEqNullSafe.toString(),
-              actualEqNullSafe.toString());
+              expectedEqNullSafe1.toString(),
+              actualEqNullSafe1.toString());
+
+          Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
+          Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
+          Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
+          Assert.assertEquals(
+              "EqualNullSafe must match",
+              expectedEqNullSafe2.toString(),
+              actualEqNullSafe2.toString());
 
           Predicate in = new Predicate("IN", attrAndValue);
           Expression expectedIn = Expressions.in(unquoted, 1);
           Expression actualIn = SparkV2Filters.convert(in);
           Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
 
-          Predicate and = new And(lt, eq);
-          Expression expectedAnd = Expressions.and(expectedLt, expectedEq);
+          Predicate and = new And(lt1, eq1);
+          Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
           Expression actualAnd = SparkV2Filters.convert(and);
           Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
 
           Predicate invalid = new Predicate("<", attrOnly);
-          Predicate andWithInvalidLeft = new And(invalid, eq);
+          Predicate andWithInvalidLeft = new And(invalid, eq1);
           Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
           Assert.assertEquals("And must match", convertedAnd, null);
 
-          Predicate or = new Or(lt, eq);
-          Expression expectedOr = Expressions.or(expectedLt, expectedEq);
+          Predicate or = new Or(lt1, eq1);
+          Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
           Expression actualOr = SparkV2Filters.convert(or);
           Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
 
-          Predicate orWithInvalidLeft = new Or(invalid, eq);
+          Predicate orWithInvalidLeft = new Or(invalid, eq1);
           Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
           Assert.assertEquals("Or must match", convertedOr, null);
 
-          Predicate not = new Not(lt);
-          Expression expectedNot = Expressions.not(expectedLt);
+          Predicate not = new Not(lt1);
+          Expression expectedNot = Expressions.not(expectedLt1);
           Expression actualNot = SparkV2Filters.convert(not);
           Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
         });

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.filter.And;
+import org.apache.spark.sql.connector.expressions.filter.Not;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DateType$;
+import org.apache.spark.sql.types.IntegerType$;
+import org.apache.spark.sql.types.TimestampType$;
+import org.junit.Assert;
+import org.junit.Test;
+import scala.collection.JavaConverters;
+
+public class TestSparkV2Filters {
+
+  @Test
+  public void testQuotedAttributes() {
+    Map<String, String> attrMap = Maps.newHashMap();
+    attrMap.put("id", "id");
+    attrMap.put("`i.d`", "i.d");
+    attrMap.put("`i``d`", "i`d");
+    attrMap.put("`d`.b.`dd```", "d.b.dd`");
+    attrMap.put("a.`aa```.c", "a.aa`.c");
+
+    attrMap.forEach((quoted, unquoted) -> {
+      List<String> ref = new ArrayList();
+      ref.add(quoted);
+      FieldReference quotedAttr = new FieldReference(JavaConverters.asScalaBuffer(ref).toSeq());
+
+      org.apache.spark.sql.connector.expressions.Expression[] attr =
+          new org.apache.spark.sql.connector.expressions.Expression[]{quotedAttr};
+
+      LiteralValue value = new LiteralValue(1, IntegerType$.MODULE$);
+      org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+          new org.apache.spark.sql.connector.expressions.Expression[]{quotedAttr, value};
+
+      Predicate isNull = new Predicate("IS_NULL", attr);
+      Expression expectedIsNull = Expressions.isNull(unquoted);
+      Expression actualIsNull = SparkV2Filters.convert(isNull);
+      Assert.assertEquals("IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+
+      Predicate isNotNull = new Predicate("IS_NOT_NULL", attr);
+      Expression expectedIsNotNull = Expressions.notNull(unquoted);
+      Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
+      Assert.assertEquals("IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+
+      Predicate lt = new Predicate("<", attrAndValue);
+      Expression expectedLt = Expressions.lessThan(unquoted, 1);
+      Expression actualLt = SparkV2Filters.convert(lt);
+      Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
+
+      Predicate ltEq = new Predicate("<=", attrAndValue);
+      Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
+      Expression actualLtEq = SparkV2Filters.convert(ltEq);
+      Assert.assertEquals("LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
+
+      Predicate gt = new Predicate(">", attrAndValue);
+      Expression expectedGt = Expressions.greaterThan(unquoted, 1);
+      Expression actualGt = SparkV2Filters.convert(gt);
+      Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
+
+      Predicate gtEq = new Predicate(">=", attrAndValue);
+      Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
+      Expression actualGtEq = SparkV2Filters.convert(gtEq);
+      Assert.assertEquals("GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
+
+      Predicate eq = new Predicate("=", attrAndValue);
+      Expression expectedEq = Expressions.equal(unquoted, 1);
+      Expression actualEq = SparkV2Filters.convert(eq);
+      Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
+
+      Predicate eqNullSafe = new Predicate("<=>", attrAndValue);
+      Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
+      Expression actualEqNullSafe = SparkV2Filters.convert(eqNullSafe);
+      Assert.assertEquals("EqualNullSafe must match", expectedEqNullSafe.toString(), actualEqNullSafe.toString());
+
+      Predicate in = new Predicate("IN", attrAndValue);
+      Expression expectedIn = Expressions.in(unquoted, 1);
+      Expression actualIn = SparkV2Filters.convert(in);
+      Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+    });
+  }
+
+  @Test
+  public void testTimestampFilterConversion() {
+    Instant instant = Instant.parse("2018-10-18T00:00:57.907Z");
+    long epochMicros = ChronoUnit.MICROS.between(Instant.EPOCH, instant);
+
+    List<String> ref = new ArrayList();
+    ref.add("x");
+    FieldReference attr = new FieldReference(JavaConverters.asScalaBuffer(ref).toSeq());
+    LiteralValue ts = new LiteralValue(epochMicros, TimestampType$.MODULE$);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[]{attr, ts};
+
+    Predicate predicate = new Predicate(">", attrAndValue);
+    Expression tsExpression = SparkV2Filters.convert(predicate);
+    Expression rawExpression = Expressions.greaterThan("x", epochMicros);
+
+    Assert.assertEquals("Generated Timestamp expression should be correct",
+        rawExpression.toString(), tsExpression.toString());
+  }
+
+  @Test
+  public void testDateFilterConversion() {
+    LocalDate localDate = LocalDate.parse("2018-10-18");
+    long epochDay = localDate.toEpochDay();
+
+    List<String> ref = new ArrayList();
+    ref.add("x");
+    FieldReference attr = new FieldReference(JavaConverters.asScalaBuffer(ref).toSeq());
+    LiteralValue ts = new LiteralValue(epochDay, DateType$.MODULE$);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[]{attr, ts};
+
+    Predicate predicate = new Predicate(">", attrAndValue);
+    Expression dateExpression = SparkV2Filters.convert(predicate);
+    Expression rawExpression = Expressions.greaterThan("x", epochDay);
+
+    Assert.assertEquals("Generated date expression should be correct",
+        rawExpression.toString(), dateExpression.toString());
+  }
+
+  @Test
+  public void testNestedInInsideNot() {
+    List<String> ref1 = new ArrayList();
+    ref1.add("col1");
+    FieldReference attr1 = new FieldReference(JavaConverters.asScalaBuffer(ref1).toSeq());
+    LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
+    LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue1 =
+        new org.apache.spark.sql.connector.expressions.Expression[]{attr1, v1};
+    Predicate equal = new Predicate("=", attrAndValue1);
+
+    List<String> ref2 = new ArrayList();
+    ref2.add("col2");
+    FieldReference attr2 = new FieldReference(JavaConverters.asScalaBuffer(ref2).toSeq());
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue2 =
+        new org.apache.spark.sql.connector.expressions.Expression[]{attr2, v1, v2};
+    Predicate in = new Predicate("IN", attrAndValue2);
+
+    Not filter = new Not(new And(equal, in));
+    Expression converted = SparkV2Filters.convert(filter);
+    Assert.assertNull("Expression should not be converted", converted);
+  }
+
+  @Test
+  public void testNotIn() {
+    List<String> ref = new ArrayList();
+    ref.add("col");
+    FieldReference attr = new FieldReference(JavaConverters.asScalaBuffer(ref).toSeq());
+    LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
+    LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[]{attr, v1, v2};
+
+    Predicate in = new Predicate("IN", attrAndValue);
+    Not not = new Not(in);
+
+    Expression actual = SparkV2Filters.convert(not);
+    Expression expected = Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
+    Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -121,10 +121,7 @@ public class TestSparkV2Filters {
 
       Predicate orWithInvalidLeft = new Or(invalid, eq);
       Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-      Assert.assertEquals("Or must match", convertedOr.toString(), SparkV2Filters.convert(eq).toString());
-
-      Predicate orWithBothInvalid = new Or(invalid, invalid);
-      Assert.assertEquals("Or must match", SparkV2Filters.convert(orWithBothInvalid), null);
+      Assert.assertEquals("Or must match", convertedOr, null);
 
       Predicate not = new Not(lt);
       Expression expectedNot = Expressions.not(expectedLt);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark;
 
 import java.time.Instant;
@@ -50,84 +49,92 @@ public class TestSparkV2Filters {
     attrMap.put("`d`.b.`dd```", "d.b.dd`");
     attrMap.put("a.`aa```.c", "a.aa`.c");
 
-    attrMap.forEach((quoted, unquoted) -> {
-      NamedReference namedReference = FieldReference.apply(quoted);
-      org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
-          new org.apache.spark.sql.connector.expressions.Expression[]{namedReference};
+    attrMap.forEach(
+        (quoted, unquoted) -> {
+          NamedReference namedReference = FieldReference.apply(quoted);
+          org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
+              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
 
-      LiteralValue value = new LiteralValue(1, IntegerType$.MODULE$);
-      org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
-          new org.apache.spark.sql.connector.expressions.Expression[]{namedReference, value};
+          LiteralValue value = new LiteralValue(1, IntegerType$.MODULE$);
+          org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
 
-      Predicate isNull = new Predicate("IS_NULL", attrOnly);
-      Expression expectedIsNull = Expressions.isNull(unquoted);
-      Expression actualIsNull = SparkV2Filters.convert(isNull);
-      Assert.assertEquals("IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+          Predicate isNull = new Predicate("IS_NULL", attrOnly);
+          Expression expectedIsNull = Expressions.isNull(unquoted);
+          Expression actualIsNull = SparkV2Filters.convert(isNull);
+          Assert.assertEquals(
+              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
 
-      Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
-      Expression expectedIsNotNull = Expressions.notNull(unquoted);
-      Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-      Assert.assertEquals("IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+          Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
+          Expression expectedIsNotNull = Expressions.notNull(unquoted);
+          Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
+          Assert.assertEquals(
+              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
 
-      Predicate lt = new Predicate("<", attrAndValue);
-      Expression expectedLt = Expressions.lessThan(unquoted, 1);
-      Expression actualLt = SparkV2Filters.convert(lt);
-      Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
+          Predicate lt = new Predicate("<", attrAndValue);
+          Expression expectedLt = Expressions.lessThan(unquoted, 1);
+          Expression actualLt = SparkV2Filters.convert(lt);
+          Assert.assertEquals("LessThan must match", expectedLt.toString(), actualLt.toString());
 
-      Predicate ltEq = new Predicate("<=", attrAndValue);
-      Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
-      Expression actualLtEq = SparkV2Filters.convert(ltEq);
-      Assert.assertEquals("LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
+          Predicate ltEq = new Predicate("<=", attrAndValue);
+          Expression expectedLtEq = Expressions.lessThanOrEqual(unquoted, 1);
+          Expression actualLtEq = SparkV2Filters.convert(ltEq);
+          Assert.assertEquals(
+              "LessThanOrEqual must match", expectedLtEq.toString(), actualLtEq.toString());
 
-      Predicate gt = new Predicate(">", attrAndValue);
-      Expression expectedGt = Expressions.greaterThan(unquoted, 1);
-      Expression actualGt = SparkV2Filters.convert(gt);
-      Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
+          Predicate gt = new Predicate(">", attrAndValue);
+          Expression expectedGt = Expressions.greaterThan(unquoted, 1);
+          Expression actualGt = SparkV2Filters.convert(gt);
+          Assert.assertEquals("GreaterThan must match", expectedGt.toString(), actualGt.toString());
 
-      Predicate gtEq = new Predicate(">=", attrAndValue);
-      Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
-      Expression actualGtEq = SparkV2Filters.convert(gtEq);
-      Assert.assertEquals("GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
+          Predicate gtEq = new Predicate(">=", attrAndValue);
+          Expression expectedGtEq = Expressions.greaterThanOrEqual(unquoted, 1);
+          Expression actualGtEq = SparkV2Filters.convert(gtEq);
+          Assert.assertEquals(
+              "GreaterThanOrEqual must match", expectedGtEq.toString(), actualGtEq.toString());
 
-      Predicate eq = new Predicate("=", attrAndValue);
-      Expression expectedEq = Expressions.equal(unquoted, 1);
-      Expression actualEq = SparkV2Filters.convert(eq);
-      Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
+          Predicate eq = new Predicate("=", attrAndValue);
+          Expression expectedEq = Expressions.equal(unquoted, 1);
+          Expression actualEq = SparkV2Filters.convert(eq);
+          Assert.assertEquals("EqualTo must match", expectedEq.toString(), actualEq.toString());
 
-      Predicate eqNullSafe = new Predicate("<=>", attrAndValue);
-      Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
-      Expression actualEqNullSafe = SparkV2Filters.convert(eqNullSafe);
-      Assert.assertEquals("EqualNullSafe must match", expectedEqNullSafe.toString(), actualEqNullSafe.toString());
+          Predicate eqNullSafe = new Predicate("<=>", attrAndValue);
+          Expression expectedEqNullSafe = Expressions.equal(unquoted, 1);
+          Expression actualEqNullSafe = SparkV2Filters.convert(eqNullSafe);
+          Assert.assertEquals(
+              "EqualNullSafe must match",
+              expectedEqNullSafe.toString(),
+              actualEqNullSafe.toString());
 
-      Predicate in = new Predicate("IN", attrAndValue);
-      Expression expectedIn = Expressions.in(unquoted, 1);
-      Expression actualIn = SparkV2Filters.convert(in);
-      Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+          Predicate in = new Predicate("IN", attrAndValue);
+          Expression expectedIn = Expressions.in(unquoted, 1);
+          Expression actualIn = SparkV2Filters.convert(in);
+          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
 
-      Predicate and = new And(lt, eq);
-      Expression expectedAnd = Expressions.and(expectedLt, expectedEq);
-      Expression actualAnd = SparkV2Filters.convert(and);
-      Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+          Predicate and = new And(lt, eq);
+          Expression expectedAnd = Expressions.and(expectedLt, expectedEq);
+          Expression actualAnd = SparkV2Filters.convert(and);
+          Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
 
-      Predicate invalid = new Predicate("<", attrOnly);
-      Predicate andWithInvalidLeft = new And(invalid, eq);
-      Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-      Assert.assertEquals("And must match", convertedAnd, null);
+          Predicate invalid = new Predicate("<", attrOnly);
+          Predicate andWithInvalidLeft = new And(invalid, eq);
+          Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
+          Assert.assertEquals("And must match", convertedAnd, null);
 
-      Predicate or = new Or(lt, eq);
-      Expression expectedOr = Expressions.or(expectedLt, expectedEq);
-      Expression actualOr = SparkV2Filters.convert(or);
-      Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+          Predicate or = new Or(lt, eq);
+          Expression expectedOr = Expressions.or(expectedLt, expectedEq);
+          Expression actualOr = SparkV2Filters.convert(or);
+          Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
 
-      Predicate orWithInvalidLeft = new Or(invalid, eq);
-      Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-      Assert.assertEquals("Or must match", convertedOr, null);
+          Predicate orWithInvalidLeft = new Or(invalid, eq);
+          Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
+          Assert.assertEquals("Or must match", convertedOr, null);
 
-      Predicate not = new Not(lt);
-      Expression expectedNot = Expressions.not(expectedLt);
-      Expression actualNot = SparkV2Filters.convert(not);
-      Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
-    });
+          Predicate not = new Not(lt);
+          Expression expectedNot = Expressions.not(expectedLt);
+          Expression actualNot = SparkV2Filters.convert(not);
+          Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
+        });
   }
 
   @Test
@@ -138,14 +145,16 @@ public class TestSparkV2Filters {
     NamedReference namedReference = FieldReference.apply("x");
     LiteralValue ts = new LiteralValue(epochMicros, TimestampType$.MODULE$);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
-        new org.apache.spark.sql.connector.expressions.Expression[]{namedReference, ts};
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, ts};
 
     Predicate predicate = new Predicate(">", attrAndValue);
     Expression tsExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochMicros);
 
-    Assert.assertEquals("Generated Timestamp expression should be correct",
-        rawExpression.toString(), tsExpression.toString());
+    Assert.assertEquals(
+        "Generated Timestamp expression should be correct",
+        rawExpression.toString(),
+        tsExpression.toString());
   }
 
   @Test
@@ -156,14 +165,16 @@ public class TestSparkV2Filters {
     NamedReference namedReference = FieldReference.apply("x");
     LiteralValue ts = new LiteralValue(epochDay, DateType$.MODULE$);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
-        new org.apache.spark.sql.connector.expressions.Expression[]{namedReference, ts};
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, ts};
 
     Predicate predicate = new Predicate(">", attrAndValue);
     Expression dateExpression = SparkV2Filters.convert(predicate);
     Expression rawExpression = Expressions.greaterThan("x", epochDay);
 
-    Assert.assertEquals("Generated date expression should be correct",
-        rawExpression.toString(), dateExpression.toString());
+    Assert.assertEquals(
+        "Generated date expression should be correct",
+        rawExpression.toString(),
+        dateExpression.toString());
   }
 
   @Test
@@ -172,12 +183,12 @@ public class TestSparkV2Filters {
     LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
     LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue1 =
-        new org.apache.spark.sql.connector.expressions.Expression[]{namedReference1, v1};
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference1, v1};
     Predicate equal = new Predicate("=", attrAndValue1);
 
     NamedReference namedReference2 = FieldReference.apply("col2");
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue2 =
-        new org.apache.spark.sql.connector.expressions.Expression[]{namedReference2, v1, v2};
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference2, v1, v2};
     Predicate in = new Predicate("IN", attrAndValue2);
 
     Not filter = new Not(new And(equal, in));
@@ -191,13 +202,14 @@ public class TestSparkV2Filters {
     LiteralValue v1 = new LiteralValue(1, IntegerType$.MODULE$);
     LiteralValue v2 = new LiteralValue(2, IntegerType$.MODULE$);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
-        new org.apache.spark.sql.connector.expressions.Expression[]{namedReference, v1, v2};
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, v1, v2};
 
     Predicate in = new Predicate("IN", attrAndValue);
     Not not = new Not(in);
 
     Expression actual = SparkV2Filters.convert(not);
-    Expression expected = Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
+    Expression expected =
+        Expressions.and(Expressions.notNull("col"), Expressions.notIn("col", 1, 2));
     Assert.assertEquals("Expressions should match", expected.toString(), actual.toString());
   }
 }


### PR DESCRIPTION
This PR adds `SparkV2Filters` and `TestSparkV2Filters`. In next PR, I will make `SparkScanBuilder` implement `SupportsPushDownV2Filters` and add a test `TestV2FilteredScan`. 

Currently, Spark still uses V2 Filter in `SupportsRuntimeFiltering` and `SupportsDelete`. I have a PR to add `SupportsRuntimeV2Filtering` and will have a PR to add V2 Filter in `SupportsDelete`  in Spark. Before these support are released on Spark side, we can use `Filter.toV2` to convert V1 filter to V2 filter for now.

Spark V2 Filter format:
```
Predicate(String name, Expression[] children)
```

The Predicate could be

```
name: IS_NULL
children[0] is NamedReference

name: IS_NOT_NULL
children[0] is NamedReference

name: STARTS_WITH
children[0] is NamedReference
children[1] is LiteralValue

name: IN
children[0] is NamedReference
children[1...n] is LiteralValue

name: =
children[0] is NamedReference
children[1] is LiteralValue

name: <>
children[0] is NamedReference
children[1] is LiteralValue

name: <=>
children[0] is NamedReference
children[1] is LiteralValue

name: <
children[0] is NamedReference
children[1] is LiteralValue

name: <=
children[0] is NamedReference
children[1] is LiteralValue

name: >
children[0] is NamedReference
children[1] is LiteralValue

name: >=
children[0] is NamedReference
children[1] is LiteralValue

name: AND
  public And(Predicate left, Predicate right) {
    super("AND", new Predicate[]{left, right});
  }

name: OR
  public Or(Predicate left, Predicate right) {
    super("OR", new Predicate[]{left, right});
  }

name: NOT
  public Not(Predicate child) {
    super("NOT", new Predicate[]{child});
  }

name: ALWAYS_TRUE
  public AlwaysTrue() {
    super("ALWAYS_TRUE", new Predicate[]{});
  }

name: ALWAYS_FALSE
  public AlwaysFalse() {
    super("ALWAYS_FALSE", new Predicate[]{});
  }
```



