### PR TITLE
API: CloseableIterable.concat evaluates first item twice

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -118,12 +118,7 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
   }
 
   static <E> CloseableIterable<E> concat(Iterable<CloseableIterable<E>> iterable) {
-    Iterator<CloseableIterable<E>> iterables = iterable.iterator();
-    if (!iterables.hasNext()) {
-      return empty();
-    } else {
-      return new ConcatCloseableIterable<>(iterable);
-    }
+    return new ConcatCloseableIterable<>(iterable);
   }
 
   class ConcatCloseableIterable<E> extends CloseableGroup implements CloseableIterable<E> {
@@ -148,8 +143,6 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
 
       private ConcatCloseableIterator(Iterable<CloseableIterable<E>> inputs) {
         this.iterables = inputs.iterator();
-        this.currentIterable = iterables.next();
-        this.currentIterator = currentIterable.iterator();
       }
 
       @Override
@@ -158,13 +151,15 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
           return false;
         }
 
-        if (currentIterator.hasNext()) {
+        if (null != currentIterator && currentIterator.hasNext()) {
           return true;
         }
 
         while (iterables.hasNext()) {
           try {
-            currentIterable.close();
+            if (null != currentIterable) {
+              currentIterable.close();
+            }
           } catch (IOException e) {
             throw new RuntimeIOException(e, "Failed to close iterable");
           }
@@ -178,7 +173,9 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
         }
 
         try {
-          currentIterable.close();
+          if (null != currentIterable) {
+            currentIterable.close();
+          }
         } catch (IOException e) {
           throw new RuntimeIOException(e, "Failed to close iterable");
         }

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -20,11 +20,15 @@
 package org.apache.iceberg.io;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.io.TestableCloseableIterable.TestableCloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,7 +64,7 @@ public class TestCloseableIterable {
   }
 
   @Test
-  public void testConcateWithEmptyIterables() {
+  public void testConcatWithEmptyIterables() {
     CloseableIterable<Integer> iter = CloseableIterable.combine(Lists.newArrayList(1, 2, 3), () -> { });
     CloseableIterable<Integer> empty = CloseableIterable.empty();
 
@@ -81,5 +85,39 @@ public class TestCloseableIterable {
     AssertHelpers.assertThrows("should throw NoSuchElementException",
         NoSuchElementException.class,
         () -> Iterables.getLast(concat5));
+  }
+
+  @Test
+  public void testConcatWithEmpty() {
+    AtomicInteger counter = new AtomicInteger(0);
+    CloseableIterable.concat(Collections.emptyList()).forEach(c -> counter.incrementAndGet());
+    Assertions.assertThat(counter.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void concatShouldOnlyEvaluateItemsOnce() throws IOException {
+    AtomicInteger counter = new AtomicInteger(0);
+    List<Integer> items = Lists.newArrayList(1, 2, 3, 4, 5);
+    Iterable<Integer> iterable = Iterables.filter(items, item -> {
+      counter.incrementAndGet();
+      return true;
+    });
+
+    Iterable<CloseableIterable<Integer>> transform =
+        Iterables.transform(iterable, item -> new CloseableIterable<Integer>() {
+          @Override
+          public void close() {
+          }
+
+          @Override
+          public CloseableIterator<Integer> iterator() {
+            return CloseableIterator.withClose(Collections.singletonList(item).iterator());
+          }
+        });
+
+    try (CloseableIterable<Integer> concat = CloseableIterable.concat(transform)) {
+      concat.forEach(c -> c++);
+    }
+    Assertions.assertThat(counter.get()).isEqualTo(items.size());
   }
 }


### PR DESCRIPTION
While working on Scan reporting (#5268) I noticed that this entire chain https://github.com/apache/iceberg/blob/eff879daa492641ac8bc829e7c4625dcdfac05fa/core/src/main/java/org/apache/iceberg/ManifestGroup.java#L218-L237 would be evaluated twice.
It turns out we eventually use `CloseableIterable.concat` with those
`CloseableIterables` in
https://github.com/apache/iceberg/blob/eff879daa492641ac8bc829e7c4625dcdfac05fa/core/src/main/java/org/apache/iceberg/ManifestGroup.java#L198.

When `CloseableIterable.concat` would check for emptyness via
```
if (!iterables.hasNext()) {
  return empty();
}
```
it would actually evaluate the first chain of Iterables twice.