### PR TITLE
Python: Add __version__ to the package

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [tool.poetry]
 name = "pyiceberg"
-version = "0.0.1rc1"
+version = "0.14.0.dev0"
 readme = "README.md"
 homepage = "https://iceberg.apache.org/"
 repository = "https://github.com/apache/iceberg/"

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -14,6 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from importlib import metadata
+import re
 
-__version__ = metadata.version(__package__)
+from pyiceberg import __version__
+
+
+def test_version_format():
+    # should be in the format of 0.14.0 or 0.14.0.dev0
+    assert re.search(r"\d+.\d+.\d+(.dev\d+)?", __version__)


### PR DESCRIPTION
I've updated the version to `0.14.0.dev0`. I'm not sure when we want to release the first version, and still tbd if we do it together with the Java stuff, or if we are going to run a separate release process.

I wanted to add the version to the python side as well, so we can inject it into the HTTP headers of the rest catalog introduced in https://github.com/apache/iceberg/pull/5287.

We store the version in `__version__`, which is the defacto standard way of doing this in Python: https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package

For Java we use `0.14.0-SNAPSHOT` and we fetch it from the `version.txt` or from the git tag itself. I've dug into replicating this logic in Python, but there it is a bit more cumbersome because we have to make sure that the logic both works when developing, and after doing a release (since we're setting the version dynamically). Just setting it through poetry (`poetry version 0.14.0` gives me much more peace of mind since this is the official way of poetry. Instead of having a `-SNAPSHOT` version, indicating the development version, I've conformed to [PEP440](https://peps.python.org/pep-0440/) and went for the `.dev0` postfix. We could also introduce the `.rcN` postfixes in the [release process](https://github.com/apache/iceberg/blob/master/python/dev/RELEASE.md). You can upload these artifacts to pypi, and everyone can give them a try, but you can only use them by explicitly stating the `rc`, which makes the barrier for people to give the RC a try much lower.