### PR TITLE
AWS: Remove sorting of parts in multi-part upload

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -329,7 +329,6 @@ class S3OutputStream extends PositionOutputStream {
         multiPartMap.values()
             .stream()
             .map(CompletableFuture::join)
-            .sorted(Comparator.comparing(CompletedPart::partNumber))
             .collect(Collectors.toList());
 
     CompleteMultipartUploadRequest request = CompleteMultipartUploadRequest.builder()


### PR DESCRIPTION
Currently in the MPU logic, the parts are sorted when completing the upload, which is not necessary. Sorting can be removed; this is more to simplify the code a bit, from a performance perspective sorting is likely negligible in most practical cases. Assume a 1 GB object and 32 mb part sizes, it's sorting only 32 elements, which is negligible