### PR TITLE
Build: Do not specify scala-library version explicitly in Spark 3.2 and 3.3 build scripts

### DIFF
--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -136,7 +136,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   dependencies {
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
-    compileOnly "org.scala-lang:scala-library:${scalaVersion}"
+    compileOnly "org.scala-lang:scala-library"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly project(':iceberg-api')
     compileOnly project(':iceberg-core')

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -125,7 +125,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   dependencies {
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
-    compileOnly "org.scala-lang:scala-library:${scalaVersion}"
+    compileOnly "org.scala-lang:scala-library"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly project(':iceberg-api')
     compileOnly project(':iceberg-core')


### PR DESCRIPTION
The version is incorrectly set to "$scalaVersion" which is 2.12. It should use semver, e.g. 2.12.15.
By removing the explicit version, the version specified by Spark modules will be used.

For reference, build scripts for Spark 3.0 and 3.1 do not specify an explicit version for scala-library.