### PR TITLE
Support force option on RegisterTable procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -336,14 +336,17 @@ public interface Catalog {
   default void invalidateTable(TableIdentifier identifier) {}
 
   /**
-   * Register a table with the catalog if it does not exist.
+   * Register a table with the catalog.
    *
    * @param identifier a table identifier
    * @param metadataFileLocation the location of a metadata file
+   * @param force If true will register the table even if the table already existed, otherwise
+   *     it will throw table already existing error. Default is false.
    * @return a Table instance
    * @throws AlreadyExistsException if the table already exists in the catalog.
    */
-  default Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
+  default Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean force) {
     throw new UnsupportedOperationException("Registering tables is not supported");
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
@@ -308,7 +308,7 @@ public class TestDynamoDbCatalog {
     Assertions.assertThat(catalog.dropTable(identifier, false)).isTrue();
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((DynamoDbTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThat(catalog.registerTable(identifier, metadataLocation)).isNotNull();
+    Assertions.assertThat(catalog.registerTable(identifier, metadataLocation, false)).isNotNull();
     Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
     Assertions.assertThat(catalog.dropTable(identifier, true)).isTrue();
     Assertions.assertThat(catalog.dropNamespace(namespace)).isTrue();
@@ -323,7 +323,9 @@ public class TestDynamoDbCatalog {
     Table registeringTable = catalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((DynamoDbTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
+    catalog.registerTable(identifier, metadataLocation, true);
+    Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
         .isInstanceOf(AlreadyExistsException.class);
     Assertions.assertThat(catalog.dropTable(identifier, true)).isTrue();
     Assertions.assertThat(catalog.dropNamespace(namespace)).isTrue();

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -445,7 +445,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
     Assertions.assertThat(glueCatalog.dropTable(identifier, false)).isTrue();
-    Assertions.assertThat(glueCatalog.registerTable(identifier, metadataLocation)).isNotNull();
+    Assertions.assertThat(glueCatalog.registerTable(identifier, metadataLocation, false)).isNotNull();
     Assertions.assertThat(glueCatalog.loadTable(identifier)).isNotNull();
     Assertions.assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     Assertions.assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();
@@ -459,7 +459,9 @@ public class TestGlueCatalogTable extends GlueTestBase {
     TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
     Table table = glueCatalog.loadTable(identifier);
     String metadataLocation = ((BaseTable) table).operations().current().metadataFileLocation();
-    Assertions.assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation))
+    glueCatalog.registerTable(identifier, metadataLocation, true);
+    Assertions.assertThat(glueCatalog.loadTable(identifier)).isNotNull();
+    Assertions.assertThatThrownBy(() -> glueCatalog.registerTable(identifier, metadataLocation, false))
         .isInstanceOf(AlreadyExistsException.class);
     Assertions.assertThat(glueCatalog.dropTable(identifier, true)).isTrue();
     Assertions.assertThat(glueCatalog.dropNamespace(Namespace.of(namespace))).isTrue();

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -82,7 +82,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       }
       TableMetadata current = ops.current();
       if (metadataFileLocation.equals(current.metadataFileLocation())) {
-        LOG.info("The metadata file location is the same as the existing table, ignore it.");
+        LOG.warn("The metadata file location is the same as the existing table, ignore this operation.");
         return new BaseTable(ops, identifier.toString());
       }
       dropTable(identifier, false);

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -188,8 +188,9 @@ public class CachingCatalog implements Catalog {
   }
 
   @Override
-  public Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
-    Table table = catalog.registerTable(identifier, metadataFileLocation);
+  public Table registerTable(
+      TableIdentifier identifier, String metadataFileLocation, boolean force) {
+    Table table = catalog.registerTable(identifier, metadataFileLocation, force);
     invalidateTable(identifier);
     return table;
   }

--- a/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/BaseSessionCatalog.java
@@ -85,7 +85,7 @@ public abstract class BaseSessionCatalog implements SessionCatalog {
     }
 
     @Override
-    public Table registerTable(TableIdentifier ident, String metadataFileLocation) {
+    public Table registerTable(TableIdentifier ident, String metadataFileLocation, boolean force) {
       return BaseSessionCatalog.this.registerTable(context, ident, metadataFileLocation);
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -203,8 +203,8 @@ public class RESTCatalog
   }
 
   @Override
-  public Table registerTable(TableIdentifier ident, String metadataFileLocation) {
-    return delegate.registerTable(ident, metadataFileLocation);
+  public Table registerTable(TableIdentifier ident, String metadataFileLocation, boolean force) {
+    return delegate.registerTable(ident, metadataFileLocation, force);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -643,7 +643,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Table registeringTable = catalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((HadoopTableOperations) ops).current().metadataFileLocation();
-    Assertions.assertThat(catalog.registerTable(identifier2, metadataLocation)).isNotNull();
+    Assertions.assertThat(catalog.registerTable(identifier2, metadataLocation, false)).isNotNull();
     Assertions.assertThat(catalog.loadTable(identifier2)).isNotNull();
     Assertions.assertThat(catalog.dropTable(identifier)).isTrue();
     Assertions.assertThat(catalog.dropTable(identifier2)).isTrue();
@@ -657,7 +657,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Table registeringTable = catalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((HadoopTableOperations) ops).current().metadataFileLocation();
-    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
+    catalog.registerTable(identifier, metadataLocation, true);
+    Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
     Assertions.assertThat(catalog.dropTable(identifier)).isTrue();

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -694,7 +694,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     catalog.dropTable(identifier, false);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((JdbcTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThat(catalog.registerTable(identifier, metadataLocation)).isNotNull();
+    Assertions.assertThat(catalog.registerTable(identifier, metadataLocation, false)).isNotNull();
     Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
     Assertions.assertThat(catalog.dropTable(identifier)).isTrue();
   }
@@ -706,7 +706,9 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     Table registeringTable = catalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((JdbcTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation))
+    catalog.registerTable(identifier, metadataLocation, true);
+    Assertions.assertThat(catalog.loadTable(identifier)).isNotNull();
+    Assertions.assertThatThrownBy(() -> catalog.registerTable(identifier, metadataLocation, false))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
     Assertions.assertThat(catalog.dropTable(identifier)).isTrue();

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
@@ -190,7 +190,8 @@ public class TestEcsCatalog {
     ecsCatalog.dropTable(identifier, false);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((EcsTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThat(ecsCatalog.registerTable(identifier, metadataLocation)).isNotNull();
+    Assertions.assertThat(ecsCatalog.registerTable(identifier, metadataLocation, false))
+        .isNotNull();
     Assertions.assertThat(ecsCatalog.loadTable(identifier)).isNotNull();
     Assertions.assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();
   }
@@ -202,7 +203,10 @@ public class TestEcsCatalog {
     Table registeringTable = ecsCatalog.loadTable(identifier);
     TableOperations ops = ((HasTableOperations) registeringTable).operations();
     String metadataLocation = ((EcsTableOperations) ops).currentMetadataLocation();
-    Assertions.assertThatThrownBy(() -> ecsCatalog.registerTable(identifier, metadataLocation))
+    ecsCatalog.registerTable(identifier, metadataLocation, true);
+    Assertions.assertThat(ecsCatalog.loadTable(identifier)).isNotNull();
+    Assertions.assertThatThrownBy(
+            () -> ecsCatalog.registerTable(identifier, metadataLocation, false))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: a.t1");
     Assertions.assertThat(ecsCatalog.dropTable(identifier, true)).isTrue();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -431,7 +431,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     List<String> metadataVersionFiles = metadataVersionFiles(TABLE_NAME);
     Assert.assertEquals(1, metadataVersionFiles.size());
 
-    catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0));
+    catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0), false);
 
     org.apache.hadoop.hive.metastore.api.Table newTable =
         metastoreClient.getTable(DB_NAME, TABLE_NAME);
@@ -482,7 +482,7 @@ public class HiveTableTest extends HiveTableBaseTest {
 
     // register the table to hive catalog using the latest metadata file
     String latestMetadataFile = ((BaseTable) table).operations().current().metadataFileLocation();
-    catalog.registerTable(identifier, "file:" + latestMetadataFile);
+    catalog.registerTable(identifier, "file:" + latestMetadataFile, false);
     Assert.assertNotNull(metastoreClient.getTable(DB_NAME, "table1"));
 
     // load the table in hive catalog
@@ -546,7 +546,8 @@ public class HiveTableTest extends HiveTableBaseTest {
         "Should complain that the table already exists",
         AlreadyExistsException.class,
         "Table already exists",
-        () -> catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0)));
+        () ->
+            catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0), false));
   }
 
   @Test

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -414,7 +414,7 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   private void validateRegister(TableIdentifier identifier, String metadataVersionFiles) {
-    Assertions.assertThat(catalog.registerTable(identifier, "file:" + metadataVersionFiles))
+    Assertions.assertThat(catalog.registerTable(identifier, "file:" + metadataVersionFiles, false))
         .isNotNull();
     Table newTable = catalog.loadTable(identifier);
     Assertions.assertThat(newTable).isNotNull();
@@ -445,12 +445,16 @@ public class TestNessieTable extends BaseTestIceberg {
     TableIdentifier defaultIdentifier =
         TableIdentifier.of(DB_NAME, defaultTableReference.toString());
     Assertions.assertThatThrownBy(
-            () -> catalog.registerTable(defaultIdentifier, "file:" + metadataVersionFiles.get(0)))
+            () ->
+                catalog.registerTable(
+                    defaultIdentifier, "file:" + metadataVersionFiles.get(0), false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Nessie ref 'default' does not exist");
     // Case 2: Table Already Exists
     Assertions.assertThatThrownBy(
-            () -> catalog.registerTable(TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0)))
+            () ->
+                catalog.registerTable(
+                    TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0), false))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: db.tbl");
     // Case 3: Registering using a tag
@@ -464,19 +468,21 @@ public class TestNessieTable extends BaseTestIceberg {
         ImmutableTableReference.builder().reference("tag_1").name(TABLE_NAME).build();
     TableIdentifier tagIdentifier = TableIdentifier.of(DB_NAME, tagTableReference.toString());
     Assertions.assertThatThrownBy(
-            () -> catalog.registerTable(tagIdentifier, "file:" + metadataVersionFiles.get(0)))
+            () ->
+                catalog.registerTable(tagIdentifier, "file:" + metadataVersionFiles.get(0), false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("You can only mutate tables when using a branch without a hash or timestamp.");
     // Case 4: non-null metadata path with null metadata location
     Assertions.assertThatThrownBy(
             () ->
                 catalog.registerTable(
-                    TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0) + "invalidName"))
+                    TABLE_IDENTIFIER, "file:" + metadataVersionFiles.get(0) + "invalidName", false))
         .isInstanceOf(NotFoundException.class);
     // Case 5: null identifier
     Assertions.assertThatThrownBy(
             () ->
-                catalog.registerTable(null, "file:" + metadataVersionFiles.get(0) + "invalidName"))
+                catalog.registerTable(
+                    null, "file:" + metadataVersionFiles.get(0) + "invalidName", false))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid identifier: null");
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RegisterTableProcedure.java
@@ -39,7 +39,8 @@ class RegisterTableProcedure extends BaseProcedure {
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
-        ProcedureParameter.required("metadata_file", DataTypes.StringType)
+        ProcedureParameter.required("metadata_file", DataTypes.StringType),
+        ProcedureParameter.optional("force", DataTypes.StringType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -78,6 +79,7 @@ class RegisterTableProcedure extends BaseProcedure {
     TableIdentifier tableName =
         Spark3Util.identifierToTableIdentifier(toIdentifier(args.getString(0), "table"));
     String metadataFile = args.getString(1);
+    boolean force = !args.isNullAt(2) && args.getString(2).equalsIgnoreCase("force");
     Preconditions.checkArgument(
         tableCatalog() instanceof HasIcebergCatalog,
         "Cannot use Register Table in a non-Iceberg catalog");
@@ -86,7 +88,8 @@ class RegisterTableProcedure extends BaseProcedure {
         "Cannot handle an empty argument metadata_file");
 
     Catalog icebergCatalog = ((HasIcebergCatalog) tableCatalog()).icebergCatalog();
-    Table table = icebergCatalog.registerTable(tableName, metadataFile);
+    Table table = icebergCatalog.registerTable(tableName, metadataFile, force);
+
     Long currentSnapshotId = null;
     Long totalDataFiles = null;
     Long totalRecords = null;


### PR DESCRIPTION
fix https://github.com/apache/iceberg/issues/5163
Add 'force' option to register existing table, this is optional
usage: `CALL mycatalogname.system.register_table('mycatalogname.mydb.mytablename','xx://xxxxx/metadata/xx.metadata.json','force')`