### PR TITLE
API: Deprecate Counter#count() / Add Counter#value() 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/IntCounter.java
@@ -50,6 +50,11 @@ class IntCounter implements MetricsContext.Counter<Integer> {
   }
 
   @Override
+  public Integer value() {
+    return counter.get();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("counter", counter)

--- a/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LongCounter.java
@@ -50,6 +50,11 @@ class LongCounter implements MetricsContext.Counter<Long> {
   }
 
   @Override
+  public Long value() {
+    return counter.get();
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("counter", counter)

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -66,9 +66,20 @@ public interface MetricsContext extends Serializable {
      * Reporting count is optional if the counter is reporting externally.
      *
      * @return current count if available
+     * @deprecated Use {@link Counter#value()}
      */
+    @Deprecated
     default Optional<T> count() {
       return Optional.empty();
+    }
+
+    /**
+     * Reports the current count.
+     *
+     * @return The current count
+     */
+    default T value() {
+      throw new UnsupportedOperationException("Count is not supported.");
     }
 
     default Unit unit() {

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
@@ -39,7 +39,7 @@ public class TestDefaultMetricsContext {
     MetricsContext metricsContext = new DefaultMetricsContext();
     MetricsContext.Counter<Integer> counter = metricsContext.counter("test", Integer.class, MetricsContext.Unit.COUNT);
     counter.increment(5);
-    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(5);
+    Assertions.assertThat(counter.value()).isEqualTo(5);
   }
 
   @Test
@@ -50,7 +50,7 @@ public class TestDefaultMetricsContext {
     Assertions.assertThatThrownBy(counter::increment)
         .isInstanceOf(ArithmeticException.class)
         .hasMessage("integer overflow");
-    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(Integer.MAX_VALUE);
+    Assertions.assertThat(counter.value()).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class TestDefaultMetricsContext {
     MetricsContext metricsContext = new DefaultMetricsContext();
     MetricsContext.Counter<Long> counter = metricsContext.counter("test", Long.class, MetricsContext.Unit.COUNT);
     counter.increment(5L);
-    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(5L);
+    Assertions.assertThat(counter.value()).isEqualTo(5L);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class TestDefaultMetricsContext {
     Assertions.assertThatThrownBy(counter::increment)
         .isInstanceOf(ArithmeticException.class)
         .hasMessage("long overflow");
-    Assertions.assertThat(counter.count()).isPresent().get().isEqualTo(Long.MAX_VALUE);
+    Assertions.assertThat(counter.value()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderMetricsContext.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderMetricsContext.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.reader;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -59,25 +60,25 @@ public class ReaderMetricsContext implements MetricsContext {
     switch (name) {
       case ASSIGNED_SPLITS:
         ValidationException.check(type == Long.class, "'%s' requires Long type", ASSIGNED_SPLITS);
-        return (Counter<T>) longCounter(assignedSplits::addAndGet);
+        return (Counter<T>) longCounter(assignedSplits::addAndGet, assignedSplits::get);
       case ASSIGNED_BYTES:
         ValidationException.check(type == Long.class, "'%s' requires Integer type", ASSIGNED_BYTES);
-        return (Counter<T>) longCounter(assignedBytes::addAndGet);
+        return (Counter<T>) longCounter(assignedBytes::addAndGet, assignedBytes::get);
       case FINISHED_SPLITS:
         ValidationException.check(type == Long.class, "'%s' requires Long type", FINISHED_SPLITS);
-        return (Counter<T>) longCounter(finishedSplits::addAndGet);
+        return (Counter<T>) longCounter(finishedSplits::addAndGet, finishedSplits::get);
       case FINISHED_BYTES:
         ValidationException.check(type == Long.class, "'%s' requires Integer type", FINISHED_BYTES);
-        return (Counter<T>) longCounter(finishedBytes::addAndGet);
+        return (Counter<T>) longCounter(finishedBytes::addAndGet, finishedBytes::get);
       case SPLIT_READER_FETCH_CALLS:
         ValidationException.check(type == Long.class, "'%s' requires Integer type", SPLIT_READER_FETCH_CALLS);
-        return (Counter<T>) longCounter(splitReaderFetchCalls::addAndGet);
+        return (Counter<T>) longCounter(splitReaderFetchCalls::addAndGet, splitReaderFetchCalls::get);
       default:
         throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
     }
   }
 
-  private Counter<Long> longCounter(Consumer<Long> consumer) {
+  private Counter<Long> longCounter(Consumer<Long> consumer, Supplier<Long> supplier) {
     return  new Counter<Long>() {
       @Override
       public void increment() {
@@ -87,6 +88,11 @@ public class ReaderMetricsContext implements MetricsContext {
       @Override
       public void increment(Long amount) {
         consumer.accept(amount);
+      }
+
+      @Override
+      public Long value() {
+        return supplier.get();
       }
     };
   }


### PR DESCRIPTION
The rationale behind this change is that usually a Counter should always
be able to report the actual count it is counting. The reason
`count()` was made `Optional` initially is because in the case of Hadoop
we are reporting the count to Hadoop's file system statistics and don't
necessarily want to report the count in that case.