### PR TITLE
Ignore case for partition transform

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -351,7 +352,7 @@ public class Spark3Util {
     Preconditions.checkArgument(transform.references().length == 1,
         "Cannot convert transform with more than one column reference: %s", transform);
     String colName = DOT.join(transform.references()[0].fieldNames());
-    switch (transform.name()) {
+    switch (transform.name().toLowerCase(Locale.ROOT)) {
       case "identity":
         return org.apache.iceberg.expressions.Expressions.ref(colName);
       case "bucket":
@@ -390,7 +391,7 @@ public class Spark3Util {
       Preconditions.checkArgument(transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           builder.identity(colName);
           break;

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -50,6 +50,17 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformIgnoreCase() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (HOURS(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (hours(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -351,7 +352,7 @@ public class Spark3Util {
     Preconditions.checkArgument(transform.references().length == 1,
         "Cannot convert transform with more than one column reference: %s", transform);
     String colName = DOT.join(transform.references()[0].fieldNames());
-    switch (transform.name()) {
+    switch (transform.name().toLowerCase(Locale.ROOT)) {
       case "identity":
         return org.apache.iceberg.expressions.Expressions.ref(colName);
       case "bucket":
@@ -390,7 +391,7 @@ public class Spark3Util {
       Preconditions.checkArgument(transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           builder.identity(colName);
           break;

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -50,6 +50,17 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformIgnoreCase() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (HOURS(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (hours(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -317,7 +318,7 @@ public class Spark3Util {
       Preconditions.checkArgument("zorder".equals(transform.name()) || transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
@@ -369,7 +370,7 @@ public class Spark3Util {
       Preconditions.checkArgument(transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           builder.identity(colName);
           break;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -50,6 +50,17 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformIgnoreCase() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (HOURS(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (hours(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -317,7 +318,7 @@ public class Spark3Util {
       Preconditions.checkArgument("zorder".equals(transform.name()) || transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
@@ -369,7 +370,7 @@ public class Spark3Util {
       Preconditions.checkArgument(transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s", transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
-      switch (transform.name()) {
+      switch (transform.name().toLowerCase(Locale.ROOT)) {
         case "identity":
           builder.identity(colName);
           break;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -50,6 +50,17 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformIgnoreCase() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (HOURS(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) " +
+        "USING iceberg partitioned by (hours(ts))", tableName);
+    Assert.assertTrue("Table should already exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 


### PR DESCRIPTION
Transform is not supported for upper case, otherwise throw SQLException as follow:
```
java.sql.SQLException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: java.lang.UnsupportedOperationException: Transform is not supported: HOURS(timestamp_)
at org.apache.iceberg.spark.Spark3Util.toPartitionSpec(Spark3Util.java:423)
at org.apache.iceberg.spark.SparkCatalog.createTable(SparkCatalog.java:156)
at org.apache.iceberg.spark.SparkCatalog.createTable(SparkCatalog.java:98)
at org.apache.iceberg.spark.SparkSessionCatalog.createTable(SparkSessionCatalog.java:139)
at org.apache.spark.sql.execution.datasources.v2.CreateTableExec.run(CreateTableExec.scala:41)
```

Since Spark side never check upper or lower case and SQL parse is ok,  we could ignore case for iceberg side.