### PR TITLE
Core: Print DateTime strings always with +00:00 Zone offset

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -19,22 +19,17 @@
 
 package org.apache.iceberg;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.DateTimeUtil;
 
 public class FindFiles {
   private FindFiles() {
   }
-
-  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
   public static Builder in(Table table) {
     return new Builder(table);
@@ -109,7 +104,7 @@ public class FindFiles {
       // case, there is no valid snapshot to read.
       Preconditions.checkArgument(lastSnapshotId != null,
           "Cannot find a snapshot older than %s",
-          DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(timestampMillis), ZoneOffset.UTC)));
+          DateTimeUtil.formatTimestampMillis(timestampMillis));
       return inSnapshot(lastSnapshotId);
     }
 

--- a/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -25,14 +25,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
 public class DateTimeUtil {
   private DateTimeUtil() {
   }
-
-  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
 
   public static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
   public static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
@@ -86,6 +83,6 @@ public class DateTimeUtil {
   }
 
   public static String formatTimestampMillis(long millis) {
-    return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC));
+    return Instant.ofEpochMilli(millis).toString().replace("Z", "+00:00");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.time.ZonedDateTime;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestDateTimeUtil {
+
+  @Test
+  public void formatTimestampMillis() {
+    String timestamp = "1970-01-01T00:00:00.001+00:00";
+    Assertions.assertThat(DateTimeUtil.formatTimestampMillis(1L)).isEqualTo(timestamp);
+    Assertions.assertThat(ZonedDateTime.parse(timestamp).toInstant().toEpochMilli()).isEqualTo(1L);
+
+    timestamp = "1970-01-01T00:16:40+00:00";
+    Assertions.assertThat(DateTimeUtil.formatTimestampMillis(1000000L)).isEqualTo(timestamp);
+    Assertions.assertThat(ZonedDateTime.parse(timestamp).toInstant().toEpochMilli()).isEqualTo(1000000L);
+  }
+}

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.joda.time.format.DateTimeFormat;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -396,7 +396,7 @@ public class TestContinuousSplitPlannerImpl {
 
     AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
         IllegalArgumentException.class,
-        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        "Cannot find a snapshot older than 1970-01-01T00:00:00.001+00:00",
         () -> splitPlanner.planSplits(null));
   }
 
@@ -405,9 +405,7 @@ public class TestContinuousSplitPlannerImpl {
     appendTwoSnapshots();
 
     long invalidSnapshotTimestampMs = snapshot1.timestampMillis() - 1000L;
-    String invalidSnapshotTimestampMsStr = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
-        .withZoneUTC()
-        .print(invalidSnapshotTimestampMs);
+    String invalidSnapshotTimestampMsStr = DateTimeUtil.formatTimestampMillis(invalidSnapshotTimestampMs);
 
     ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
         .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -156,7 +156,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
     // emtpy table
     AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
         IllegalArgumentException.class,
-        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        "Cannot find a snapshot older than 1970-01-01T00:00:00.001+00:00",
         () -> ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContextInvalidSnapshotTimestamp));
 
     appendThreeSnapshots();

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.joda.time.format.DateTimeFormat;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -396,7 +396,7 @@ public class TestContinuousSplitPlannerImpl {
 
     AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
         IllegalArgumentException.class,
-        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        "Cannot find a snapshot older than 1970-01-01T00:00:00.001+00:00",
         () -> splitPlanner.planSplits(null));
   }
 
@@ -405,9 +405,7 @@ public class TestContinuousSplitPlannerImpl {
     appendTwoSnapshots();
 
     long invalidSnapshotTimestampMs = snapshot1.timestampMillis() - 1000L;
-    String invalidSnapshotTimestampMsStr = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
-        .withZoneUTC()
-        .print(invalidSnapshotTimestampMs);
+    String invalidSnapshotTimestampMsStr = DateTimeUtil.formatTimestampMillis(invalidSnapshotTimestampMs);
 
     ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
         .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -156,7 +156,7 @@ public class TestContinuousSplitPlannerImplStartStrategy {
     // emtpy table
     AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
         IllegalArgumentException.class,
-        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        "Cannot find a snapshot older than 1970-01-01T00:00:00.001+00:00",
         () -> ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContextInvalidSnapshotTimestamp));
 
     appendThreeSnapshots();


### PR DESCRIPTION
This should make it fairly clear that all timestamps are in UTC.
Additionally, this makes also sure that a timestamp string can be parsed
by `ZonedDateTime.parse(timestamp)`.

fixes #5321