### PR TITLE
Spec: Inconsistency around files_count

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -52,11 +52,11 @@ public interface ManifestFile {
       optional(
           503, "added_snapshot_id", Types.LongType.get(), "Snapshot ID that added the manifest");
   Types.NestedField ADDED_FILES_COUNT =
-      optional(504, "added_data_files_count", Types.IntegerType.get(), "Added entry count");
+      optional(504, "added_files_count", Types.IntegerType.get(), "Added entry count");
   Types.NestedField EXISTING_FILES_COUNT =
-      optional(505, "existing_data_files_count", Types.IntegerType.get(), "Existing entry count");
+      optional(505, "existing_files_count", Types.IntegerType.get(), "Existing entry count");
   Types.NestedField DELETED_FILES_COUNT =
-      optional(506, "deleted_data_files_count", Types.IntegerType.get(), "Deleted entry count");
+      optional(506, "deleted_files_count", Types.IntegerType.get(), "Deleted entry count");
   Types.NestedField ADDED_ROWS_COUNT =
       optional(512, "added_rows_count", Types.LongType.get(), "Added rows count");
   Types.NestedField EXISTING_ROWS_COUNT =

--- a/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
@@ -162,12 +162,11 @@ public class TestManifestListVersions {
     Assert.assertEquals("Length", LENGTH, generic.get("manifest_length"));
     Assert.assertEquals("Spec id", SPEC_ID, generic.get("partition_spec_id"));
     Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) generic.get("added_snapshot_id"));
+    Assert.assertEquals("Added files count", ADDED_FILES, (int) generic.get("added_files_count"));
     Assert.assertEquals(
-        "Added files count", ADDED_FILES, (int) generic.get("added_data_files_count"));
+        "Existing files count", EXISTING_FILES, (int) generic.get("existing_files_count"));
     Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) generic.get("existing_data_files_count"));
-    Assert.assertEquals(
-        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_data_files_count"));
+        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_files_count"));
     Assert.assertEquals("Added rows count", ADDED_ROWS, (long) generic.get("added_rows_count"));
     Assert.assertEquals(
         "Existing rows count", EXISTING_ROWS, (long) generic.get("existing_rows_count"));
@@ -190,12 +189,11 @@ public class TestManifestListVersions {
     Assert.assertEquals("Length", LENGTH, generic.get("manifest_length"));
     Assert.assertEquals("Spec id", SPEC_ID, generic.get("partition_spec_id"));
     Assert.assertEquals("Snapshot id", SNAPSHOT_ID, (long) generic.get("added_snapshot_id"));
+    Assert.assertEquals("Added files count", ADDED_FILES, (int) generic.get("added_files_count"));
     Assert.assertEquals(
-        "Added files count", ADDED_FILES, (int) generic.get("added_data_files_count"));
+        "Existing files count", EXISTING_FILES, (int) generic.get("existing_files_count"));
     Assert.assertEquals(
-        "Existing files count", EXISTING_FILES, (int) generic.get("existing_data_files_count"));
-    Assert.assertEquals(
-        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_data_files_count"));
+        "Deleted files count", DELETED_FILES, (int) generic.get("deleted_files_count"));
     Assert.assertEquals("Added rows count", ADDED_ROWS, (long) generic.get("added_rows_count"));
     Assert.assertEquals(
         "Existing rows count", EXISTING_ROWS, (long) generic.get("existing_rows_count"));
@@ -217,9 +215,9 @@ public class TestManifestListVersions {
             "manifest_length",
             "partition_spec_id",
             "added_snapshot_id",
-            "added_data_files_count",
-            "existing_data_files_count",
-            "deleted_data_files_count",
+            "added_files_count",
+            "existing_files_count",
+            "deleted_files_count",
             "partitions");
     Schema schemaWithoutRowStats =
         V1Metadata.MANIFEST_LIST_SCHEMA.select(columnNamesWithoutRowStats);
@@ -240,9 +238,9 @@ public class TestManifestListVersions {
               .set("manifest_length", 1024L)
               .set("partition_spec_id", 1)
               .set("added_snapshot_id", 100L)
-              .set("added_data_files_count", 2)
-              .set("existing_data_files_count", 3)
-              .set("deleted_data_files_count", 4)
+              .set("added_files_count", 2)
+              .set("existing_files_count", 3)
+              .set("deleted_files_count", 4)
               .set("partitions", null)
               .build();
       appender.add(withoutRowStats);


### PR DESCRIPTION
When building the Manifest mappers for Python, @rdblue  noticed that the `added_data_files_count` should be `added_files_count` according to the spec. 

However, this field is written in Java as `added_data_files_count` to Avro by the Java implementation:  
https://github.com/apache/iceberg/blob/8104769f81ba79338fd3c94d5bd9267f22d31ed7/api/src/main/java/org/apache/iceberg/ManifestFile.java#L44-L49

Luckily this doesn't affect the reading/writing because it is position based.

However, it is confusing. I think we should resolve this. We could either do this by changing the Java impl, which probably works, but we could also change the spec. I know that this isn't something lightweight, but we could take it into consideration.

I think we should also update the references in the code to `{added,existing,deleted}_data_files_count` to make everything consistent and avoid confusion in the future.

Closes #8684