### PR TITLE
Substitute the method of PropertyUtil#propertyAsLong for IcebergSource#propertyAsLong

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -122,8 +122,8 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
     setupDefaultSparkCatalogs(spark);
     String path = options.get(SparkReadOptions.PATH);
 
-    Long snapshotId = propertyAsLong(options, SparkReadOptions.SNAPSHOT_ID);
-    Long asOfTimestamp = propertyAsLong(options, SparkReadOptions.AS_OF_TIMESTAMP);
+    Long snapshotId = PropertyUtil.propertyAsLong(options, SparkReadOptions.SNAPSHOT_ID, -1);
+    Long asOfTimestamp = PropertyUtil.propertyAsLong(options, SparkReadOptions.AS_OF_TIMESTAMP, -1);
     Preconditions.checkArgument(
         asOfTimestamp == null || snapshotId == null,
         "Cannot specify both snapshot-id (%s) and as-of-timestamp (%s)",
@@ -202,15 +202,6 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
   public Optional<String> extractTimeTravelTimestamp(CaseInsensitiveStringMap options) {
     return Optional.ofNullable(
         PropertyUtil.propertyAsString(options, SparkReadOptions.TIMESTAMP_AS_OF, null));
-  }
-
-  private static Long propertyAsLong(CaseInsensitiveStringMap options, String property) {
-    String value = options.get(property);
-    if (value != null) {
-      return Long.parseLong(value);
-    }
-
-    return null;
   }
 
   private static void setupDefaultSparkCatalogs(SparkSession spark) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -125,18 +125,18 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
     Long snapshotId = PropertyUtil.propertyAsLong(options, SparkReadOptions.SNAPSHOT_ID, -1);
     Long asOfTimestamp = PropertyUtil.propertyAsLong(options, SparkReadOptions.AS_OF_TIMESTAMP, -1);
     Preconditions.checkArgument(
-        asOfTimestamp == null || snapshotId == null,
+        asOfTimestamp == -1 || snapshotId == -1,
         "Cannot specify both snapshot-id (%s) and as-of-timestamp (%s)",
         snapshotId,
         asOfTimestamp);
 
     String selector = null;
 
-    if (snapshotId != null) {
+    if (snapshotId != -1) {
       selector = SNAPSHOT_ID + snapshotId;
     }
 
-    if (asOfTimestamp != null) {
+    if (asOfTimestamp != -1) {
       selector = AT_TIMESTAMP + asOfTimestamp;
     }
 


### PR DESCRIPTION
The IcebergSource#propertyAsLong is redundant, it can be replaced by PropertyUtil#propertyAsLong.