### PR TITLE
API: add Histogram metric type

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 
 /** A default {@link MetricsContext} implementation that uses native Java counters/timers. */
 public class DefaultMetricsContext implements MetricsContext {
+  private static final int DEFAULT_HISTOGRAM_RESERVOIR_SIZE = 10_000;
 
   @Override
   @Deprecated
@@ -46,5 +47,10 @@ public class DefaultMetricsContext implements MetricsContext {
   @Override
   public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
     return new DefaultCounter(name, unit);
+  }
+
+  @Override
+  public Histogram histogram(String name) {
+    return new FixedReservoirHistogram(DEFAULT_HISTOGRAM_RESERVOIR_SIZE);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
@@ -54,16 +54,12 @@ public class FixedReservoirHistogram implements Histogram {
    */
   @Override
   public Statistics statistics() {
-    int size = measurements.length;
-    if (count < (long) measurements.length) {
-      size = count;
+    int size = (int) Math.min(count, (long) measurements.length);
+    if (size == 0) {
+      return UniformWeightStatistics.EMPTY;
     }
 
     long[] values = new long[size];
-    if (size == 0) {
-      return new UniformWeightStatistics(values, 0.0, 0.0);
-    }
-
     double sum = 0.0d;
     double sumSquares = 0.0d;
     for (int i = 0; i < values.length; ++i) {
@@ -86,6 +82,9 @@ public class FixedReservoirHistogram implements Histogram {
   }
 
   private static class UniformWeightStatistics implements Statistics {
+    private static final UniformWeightStatistics EMPTY =
+        new UniformWeightStatistics(new long[0], 0.0, 0.0);
+
     private final long[] values;
     private final double mean;
     private final double stdDev;

--- a/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Arrays;
+import java.util.Random;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/** A {@link Histogram} implementation with reservoir sampling. */
+public class FixedReservoirHistogram implements Histogram {
+  private final Random rand;
+  private final long[] measurements;
+  private int count;
+
+  public FixedReservoirHistogram(int reservoirSize) {
+    this.rand = new Random();
+    this.measurements = new long[reservoirSize];
+    this.count = 0;
+  }
+
+  @Override
+  public synchronized int count() {
+    return count;
+  }
+
+  @Override
+  public synchronized void update(long value) {
+    count += 1;
+    int index = count <= measurements.length ? count - 1 : rand.nextInt(count);
+    if (index < measurements.length) {
+      measurements[index] = value;
+    }
+  }
+
+  /**
+   * Naive algorithm for calculating variance:
+   * https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
+   */
+  @Override
+  public Statistics statistics() {
+    int size = measurements.length;
+    if (count < (long) measurements.length) {
+      size = count;
+    }
+
+    long[] values = new long[size];
+    if (size == 0) {
+      return new UniformWeightStatistics(values, 0.0, 0.0);
+    }
+
+    double sum = 0.0d;
+    double sumSquares = 0.0d;
+    for (int i = 0; i < values.length; ++i) {
+      synchronized (this) {
+        values[i] = measurements[i];
+      }
+
+      sum += values[i];
+      // Convert to double value to avoid potential overflow of square
+      double value = (double) values[i];
+      sumSquares += value * value;
+    }
+
+    double mean = sum / size;
+    // Use the uncorrected estimator. Bessel's correction is not a good fit in this context.
+    // https://en.wikipedia.org/wiki/Bessel%27s_correction#Caveats
+    double variance = (sumSquares - (sum * sum) / size) / size;
+    double stdDev = Math.sqrt(variance);
+    return new UniformWeightStatistics(values, mean, stdDev);
+  }
+
+  private static class UniformWeightStatistics implements Statistics {
+    private final long[] values;
+    private final double mean;
+    private final double stdDev;
+
+    private UniformWeightStatistics(long[] values, double mean, double stdDev) {
+      this.values = values;
+      this.mean = mean;
+      this.stdDev = stdDev;
+
+      // since the input values is already a copied array,
+      // there is no need to copy again.
+      Arrays.sort(this.values);
+    }
+
+    @Override
+    public int size() {
+      return values.length;
+    }
+
+    @Override
+    public double mean() {
+      return mean;
+    }
+
+    @Override
+    public double stdDev() {
+      return stdDev;
+    }
+
+    @Override
+    public long max() {
+      return values.length == 0 ? 0L : values[values.length - 1];
+    }
+
+    @Override
+    public long min() {
+      return values.length == 0 ? 0L : values[0];
+    }
+
+    @Override
+    public long percentile(double percentile) {
+      Preconditions.checkArgument(
+          !Double.isNaN(percentile) && percentile >= 0.0 && percentile <= 1.0,
+          "Percentile point cannot be outside the range of [0.0 - 1.0]: %s",
+          percentile);
+      if (values.length == 0) {
+        return 0L;
+      } else {
+        double position = percentile * values.length;
+        int index = (int) position;
+        if (index < 1) {
+          return values[0];
+        } else if (index >= values.length) {
+          return values[values.length - 1];
+        } else {
+          double lower = (double) values[index - 1];
+          double upper = (double) values[index];
+          double interpolated = lower + (position - Math.floor(position)) * (upper - lower);
+          return (long) interpolated;
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/FixedReservoirHistogram.java
@@ -60,13 +60,13 @@ public class FixedReservoirHistogram implements Histogram {
     }
 
     long[] values = new long[size];
+    synchronized (this) {
+      System.arraycopy(measurements, 0, values, 0, size);
+    }
+
     double sum = 0.0d;
     double sumSquares = 0.0d;
     for (int i = 0; i < values.length; ++i) {
-      synchronized (this) {
-        values[i] = measurements[i];
-      }
-
       sum += values[i];
       // Convert to double value to avoid potential overflow of square
       double value = (double) values[i];

--- a/api/src/main/java/org/apache/iceberg/metrics/Histogram.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/Histogram.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+public interface Histogram {
+  /** Update the histogram with a new value observed. */
+  void update(long value);
+
+  /** Return the number of observations. */
+  int count();
+
+  /** Calculate the statistics of the observed values. */
+  Statistics statistics();
+
+  interface Statistics {
+    /**
+     * Return the number of values that the statistics computation is based on.
+     *
+     * <p>If the number of sampling is less than the reservoir size, the sampling count should be
+     * returned. Otherwise, the reservoir size is returned.
+     */
+    int size();
+
+    /** Returns the mean value of the histogram observations. */
+    double mean();
+
+    /** Returns the standard deviation of the histogram distribution. */
+    double stdDev();
+
+    /** Returns the maximum value of the histogram observations. */
+    long max();
+
+    /** Returns the minimum value of the histogram observations. */
+    long min();
+
+    /**
+     * Returns the percentile value based on the histogram statistics.
+     *
+     * @param percentile percentile point in double. E.g., 0.75 means 75 percentile. It is up to the
+     *     implementation to decide what valid percentile points are supported.
+     * @return Value for the given percentile
+     */
+    long percentile(double percentile);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -140,6 +140,10 @@ public interface MetricsContext extends Serializable {
     throw new UnsupportedOperationException("Timer is not supported.");
   }
 
+  default Histogram histogram(String name) {
+    throw new UnsupportedOperationException("Histogram is not supported.");
+  }
+
   /**
    * Utility method for producing no metrics.
    *

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.metrics;
 
+import static org.assertj.core.api.Assertions.withinPercentage;
+
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
@@ -111,5 +113,29 @@ public class TestDefaultMetricsContext {
     Timer timer = metricsContext.timer("test", TimeUnit.MICROSECONDS);
     timer.record(10, TimeUnit.MINUTES);
     Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ofMinutes(10L));
+  }
+
+  @Test
+  public void histogram() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    int reservoirSize = 1000;
+    Histogram histogram = metricsContext.histogram("test");
+    for (int i = 1; i <= reservoirSize; ++i) {
+      histogram.update(i);
+    }
+
+    Assertions.assertThat(histogram.count()).isEqualTo(reservoirSize);
+    Histogram.Statistics statistics = histogram.statistics();
+    Assertions.assertThat(statistics.size()).isEqualTo(reservoirSize);
+    Assertions.assertThat(statistics.mean()).isEqualTo(500.5);
+    Assertions.assertThat(statistics.stdDev()).isCloseTo(288.67499, withinPercentage(0.001));
+    Assertions.assertThat(statistics.max()).isEqualTo(1000L);
+    Assertions.assertThat(statistics.min()).isEqualTo(1L);
+    Assertions.assertThat(statistics.percentile(0.50)).isEqualTo(500);
+    Assertions.assertThat(statistics.percentile(0.75)).isEqualTo(750);
+    Assertions.assertThat(statistics.percentile(0.90)).isEqualTo(900);
+    Assertions.assertThat(statistics.percentile(0.95)).isEqualTo(950);
+    Assertions.assertThat(statistics.percentile(0.99)).isEqualTo(990);
+    Assertions.assertThat(statistics.percentile(0.999)).isEqualTo(999);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/metrics/TestFixedReservoirHistogram.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestFixedReservoirHistogram.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestFixedReservoirHistogram {
+  @Test
+  public void emptyHistogram() {
+    FixedReservoirHistogram histogram = new FixedReservoirHistogram(100);
+    Assertions.assertThat(histogram.count()).isEqualTo(0);
+    Histogram.Statistics statistics = histogram.statistics();
+    Assertions.assertThat(statistics.size()).isEqualTo(0);
+    Assertions.assertThat(statistics.mean()).isEqualTo(0.0);
+    Assertions.assertThat(statistics.stdDev()).isEqualTo(0.0);
+    Assertions.assertThat(statistics.max()).isEqualTo(0L);
+    Assertions.assertThat(statistics.min()).isEqualTo(0L);
+    Assertions.assertThat(statistics.percentile(0.50)).isEqualTo(0L);
+    Assertions.assertThat(statistics.percentile(0.99)).isEqualTo(0L);
+  }
+
+  @Test
+  public void singleObservation() {
+    FixedReservoirHistogram histogram = new FixedReservoirHistogram(100);
+    histogram.update(123L);
+    Assertions.assertThat(histogram.count()).isEqualTo(1);
+    Histogram.Statistics statistics = histogram.statistics();
+    Assertions.assertThat(statistics.size()).isEqualTo(1);
+    Assertions.assertThat(statistics.mean()).isEqualTo(123.0);
+    Assertions.assertThat(statistics.stdDev()).isEqualTo(0.0);
+    Assertions.assertThat(statistics.max()).isEqualTo(123L);
+    Assertions.assertThat(statistics.min()).isEqualTo(123L);
+    Assertions.assertThat(statistics.percentile(0.50)).isEqualTo(123L);
+    Assertions.assertThat(statistics.percentile(0.99)).isEqualTo(123L);
+  }
+
+  @Test
+  public void minMaxPercentilePoints() {
+    int reservoirSize = 100;
+    FixedReservoirHistogram histogram = new FixedReservoirHistogram(reservoirSize);
+    for (int i = 0; i < reservoirSize; ++i) {
+      histogram.update(i);
+    }
+
+    Histogram.Statistics statistics = histogram.statistics();
+    Assertions.assertThat(statistics.percentile(0.0)).isEqualTo(0L);
+    Assertions.assertThat(statistics.percentile(1.0)).isEqualTo(99L);
+  }
+
+  @Test
+  public void invalidPercentilePoints() {
+    int reservoirSize = 100;
+    FixedReservoirHistogram histogram = new FixedReservoirHistogram(reservoirSize);
+    for (int i = 0; i < reservoirSize; ++i) {
+      histogram.update(i);
+    }
+
+    Histogram.Statistics statistics = histogram.statistics();
+
+    Assertions.assertThatThrownBy(() -> statistics.percentile(-0.1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Percentile point cannot be outside the range of [0.0 - 1.0]: " + -0.1);
+
+    Assertions.assertThatThrownBy(() -> statistics.percentile(1.1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Percentile point cannot be outside the range of [0.0 - 1.0]: " + 1.1);
+  }
+
+  @Test
+  public void testMultipleThreadWriters() throws InterruptedException {
+    int threads = 10;
+    int samplesPerThread = 100;
+    int totalSamples = threads * samplesPerThread;
+
+    FixedReservoirHistogram histogram = new FixedReservoirHistogram(totalSamples);
+    CyclicBarrier barrier = new CyclicBarrier(threads);
+    ExecutorService executor = newFixedThreadPool(threads);
+
+    List<Future<Integer>> futures =
+        IntStream.range(0, threads)
+            .mapToObj(
+                threadIndex ->
+                    executor.submit(
+                        () -> {
+                          try {
+                            barrier.await(30, SECONDS);
+                            for (int i = 1; i <= 100; ++i) {
+                              histogram.update(threadIndex * samplesPerThread + i);
+                            }
+                            return threadIndex;
+                          } catch (Exception e) {
+                            throw new RuntimeException(e);
+                          }
+                        }))
+            .collect(Collectors.toList());
+
+    futures.stream()
+        .map(
+            f -> {
+              try {
+                return f.get(30, SECONDS);
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .collect(Collectors.toList());
+
+    executor.shutdownNow();
+    executor.awaitTermination(5, SECONDS);
+    Histogram.Statistics statistics = histogram.statistics();
+
+    Assertions.assertThat(histogram.count()).isEqualTo(totalSamples);
+    Assertions.assertThat(statistics.size()).isEqualTo(totalSamples);
+    Assertions.assertThat(statistics.mean()).isEqualTo(500.5);
+    Assertions.assertThat(statistics.stdDev()).isCloseTo(288.67499, withinPercentage(0.001));
+    Assertions.assertThat(statistics.max()).isEqualTo(1000L);
+    Assertions.assertThat(statistics.min()).isEqualTo(1L);
+    Assertions.assertThat(statistics.percentile(0.50)).isEqualTo(500);
+    Assertions.assertThat(statistics.percentile(0.75)).isEqualTo(750);
+    Assertions.assertThat(statistics.percentile(0.90)).isEqualTo(900);
+    Assertions.assertThat(statistics.percentile(0.95)).isEqualTo(950);
+    Assertions.assertThat(statistics.percentile(0.99)).isEqualTo(990);
+    Assertions.assertThat(statistics.percentile(0.999)).isEqualTo(999);
+  }
+}


### PR DESCRIPTION
@rdblue here is the metrics PR. As we discussed, Flink Iceberg sink would need Gauge (e.g. last commit duration) and Histogram (e.g. file size distribution) metrics.

cc @danielcweeks @nastra for additional reviews