### PR TITLE
Core: Remove TestEnvironmentUtil#testEnvironmentSubstitution() as it is bui…

### DIFF
--- a/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
@@ -26,10 +26,21 @@ import org.junit.jupiter.api.Test;
 class TestEnvironmentUtil {
   @Test
   public void testEnvironmentSubstitution() {
-    Assertions.assertEquals(
-        ImmutableMap.of("user-test", System.getenv().get("USER")),
-        EnvironmentUtil.resolveAll(ImmutableMap.of("user-test", "env:USER")),
-        "Should get the user from the environment");
+    String userFromEnv = System.getenv().get("USER");
+    Map<String, String> resolvedProps =
+        EnvironmentUtil.resolveAll(ImmutableMap.of("user-test", "env:USER"));
+    if (userFromEnv == null) {
+      // some build env may not have the USER env variable set
+      Assertions.assertEquals(
+          ImmutableMap.of(),
+          resolvedProps,
+          "Resolved properties should be empty if not exist from environment variables");
+    } else {
+      Assertions.assertEquals(
+          ImmutableMap.of("user-test", userFromEnv),
+          resolvedProps,
+          "Should get the user from the environment");
+    }
   }
 
   @Test


### PR DESCRIPTION
…ld env dependent. It will fail with `ImmutableMap.of("user-test", System.getenv().get("USER"))`, if the build env doesn't contain USER env variable, which is the case for our internal build env.

```
 java.lang.NullPointerException: null value in entry: user-test=null
         at org.apache.iceberg.relocated.com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:33)
         at org.apache.iceberg.relocated.com.google.common.collect.SingletonImmutableBiMap.<init>(SingletonImmutableBiMap.java:43)
         at org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap.of(ImmutableBiMap.java:81)
         at org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap.of(ImmutableMap.java:126)
         at org.apache.iceberg.util.TestEnvironmentUtil.testEnvironmentSubstitution(TestEnvironmentUtil.java:31)
```

Although I can supply the env variables for our internal build env, I found that this test only covers a trivial method. Hence I think it is probably better just remove the unit test for this trivial method.
```
  public static Map<String, String> resolveAll(Map<String, String> properties) {
    return resolveAll(System.getenv(), properties);
  }
```

the other non-public `resolveAll(env, properties)` is already covered by `TestEnvironmentUtil#testMultipleEnvironmentSubstitutions()`.