### PR TITLE
Flink: change precondition check to allow table pass in

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -294,7 +294,8 @@ public class FlinkSink {
     private <T> DataStreamSink<T> chainIcebergOperators() {
       Preconditions.checkArgument(inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
-      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
+      Preconditions.checkArgument(tableLoader != null || table != null,
+          "Table loader or table should be exist");
 
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -308,7 +308,8 @@ public class FlinkSink {
     private <T> DataStreamSink<T> chainIcebergOperators() {
       Preconditions.checkArgument(inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
-      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
+      Preconditions.checkArgument(tableLoader != null || table != null,
+          "Table loader or table should be exist");
 
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -305,7 +305,8 @@ public class FlinkSink {
     private <T> DataStreamSink<T> chainIcebergOperators() {
       Preconditions.checkArgument(inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
-      Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
+      Preconditions.checkArgument(tableLoader != null || table != null,
+          "Table loader or table should be exist");
 
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 


### PR DESCRIPTION
This change precondition to allow passing in the table instance. 

Sometimes the table is already loaded and accessed before building the sink, this change can avoid load the table again.