### PR TITLE
Spec: Always send the properties

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -858,6 +858,7 @@ components:
       type: object
       required:
         - namespace
+        - properties
       properties:
         namespace:
           $ref: '#/components/schemas/Namespace'


### PR DESCRIPTION
The spec allows us to set the properties to `null`, but instead, we can just send the default empty dict `{}` if we don't want to set any properties at all.