### PR TITLE
AWS - Fix ErrorProne warning of malformed Javadoc

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -122,7 +122,7 @@ public class AwsProperties implements Serializable {
   public static final String GLUE_LAKEFORMATION_ENABLED = "glue.lakeformation-enabled";
   public static final boolean GLUE_LAKEFORMATION_ENABLED_DEFAULT = false;
 
-  /*
+  /**
    * Configure an alternative endpoint of the Glue service for GlueCatalog to access.
    * <p>
    * This could be used to use GlueCatalog with any glue-compatible metastore service that has a different endpoint


### PR DESCRIPTION
Noticed this error prone warning when checking my work for warnings.

This fixes  the malformed JavaDoc on the `GLUE_CATALOG_ENDPOINT` configuration constant.

```
> Task :iceberg-aws:compileJava
/Users/kylebendickson/repos/iceberg/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java:130: warning: [AlmostJavadoc] This comment contains Javadoc or HTML tags, but isn't started with a double asterisk (/**); is it meant to be Javadoc?
  public static final String GLUE_CATALOG_ENDPOINT = "glue.endpoint";
                             ^
    (see https://errorprone.info/bugpattern/AlmostJavadoc)
  Did you mean '/**'?
```
