### PR TITLE
Python: Refactor unary and set expressions

### DIFF
--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -383,7 +383,7 @@ class NotNull(UnaryPredicate[T]):
 class BoundIsNaN(BoundUnaryPredicate[T]):
     def __new__(cls, term: BoundTerm[T]):
         bound_type = term.ref().field.field_type
-        if bound_type == FloatType() or bound_type == DoubleType():
+        if type(bound_type) in {FloatType, DoubleType}:
             return super().__new__(cls)
         return AlwaysFalse()
 
@@ -394,7 +394,7 @@ class BoundIsNaN(BoundUnaryPredicate[T]):
 class BoundNotNaN(BoundUnaryPredicate[T]):
     def __new__(cls, term: BoundTerm[T]):
         bound_type = term.ref().field.field_type
-        if bound_type == FloatType() or bound_type == DoubleType():
+        if type(bound_type) in {FloatType, DoubleType}:
             return super().__new__(cls)
         return AlwaysTrue()
 

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -296,7 +296,7 @@ class BoundUnaryPredicate(BoundPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundIsNull(BoundUnaryPredicate[T]):
-    def __new__(cls, term: BoundTerm[T]):
+    def __new__(cls, term: BoundTerm[T]):  # pylint: disable=W0221
         if term.ref().field.required:
             return AlwaysFalse()
         return super().__new__(cls)
@@ -307,7 +307,7 @@ class BoundIsNull(BoundUnaryPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundNotNull(BoundUnaryPredicate[T]):
-    def __new__(cls, term: BoundTerm[T]):
+    def __new__(cls, term: BoundTerm[T]):  # pylint: disable=W0221
         if term.ref().field.required:
             return AlwaysTrue()
         return super().__new__(cls)
@@ -334,7 +334,7 @@ class NotNull(UnaryPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundIsNaN(BoundUnaryPredicate[T]):
-    def __new__(cls, term: BoundTerm[T]):
+    def __new__(cls, term: BoundTerm[T]):  # pylint: disable=W0221
         bound_type = term.ref().field.field_type
         if type(bound_type) in {FloatType, DoubleType}:
             return super().__new__(cls)
@@ -346,7 +346,7 @@ class BoundIsNaN(BoundUnaryPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundNotNaN(BoundUnaryPredicate[T]):
-    def __new__(cls, term: BoundTerm[T]):
+    def __new__(cls, term: BoundTerm[T]):  # pylint: disable=W0221
         bound_type = term.ref().field.field_type
         if type(bound_type) in {FloatType, DoubleType}:
             return super().__new__(cls)
@@ -394,7 +394,7 @@ class BoundSetPredicate(BoundPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundIn(BoundSetPredicate[T]):
-    def __new__(cls, term: BoundTerm[T], literals: set[Literal[T]]):
+    def __new__(cls, term: BoundTerm[T], literals: set[Literal[T]]):  # pylint: disable=W0221
         count = len(literals)
         if count == 0:
             return AlwaysFalse()
@@ -409,7 +409,7 @@ class BoundIn(BoundSetPredicate[T]):
 
 @dataclass(frozen=True)
 class BoundNotIn(BoundSetPredicate[T]):
-    def __new__(cls, term: BoundTerm[T], literals: set[Literal[T]]):
+    def __new__(cls, term: BoundTerm[T], literals: set[Literal[T]]):  # pylint: disable=W0221
         count = len(literals)
         if count == 0:
             return AlwaysTrue()
@@ -426,7 +426,7 @@ class BoundNotIn(BoundSetPredicate[T]):
 class In(SetPredicate[T]):
     as_bound = BoundIn
 
-    def __new__(cls, term: UnboundTerm[T], literals: tuple[Literal[T], ...]):
+    def __new__(cls, term: UnboundTerm[T], literals: tuple[Literal[T], ...]):  # pylint: disable=W0221
         count = len(literals)
         if count == 0:
             return AlwaysFalse()
@@ -443,7 +443,7 @@ class In(SetPredicate[T]):
 class NotIn(SetPredicate[T]):
     as_bound = BoundNotIn
 
-    def __new__(cls, term: UnboundTerm[T], literals: tuple[Literal[T], ...]):
+    def __new__(cls, term: UnboundTerm[T], literals: tuple[Literal[T], ...]):  # pylint: disable=W0221
         count = len(literals)
         if count == 0:
             return AlwaysTrue()

--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -399,7 +399,7 @@ class BoundIn(BoundSetPredicate[T]):
         if count == 0:
             return AlwaysFalse()
         elif count == 1:
-            return BoundEq(term, next(iter(literals)))
+            return BoundEqualTo(term, next(iter(literals)))
         else:
             return super().__new__(cls)
 
@@ -414,7 +414,7 @@ class BoundNotIn(BoundSetPredicate[T]):
         if count == 0:
             return AlwaysTrue()
         elif count == 1:
-            return BoundNotEq(term, next(iter(literals)))
+            return BoundNotEqualTo(term, next(iter(literals)))
         else:
             return super().__new__(cls)
 
@@ -431,7 +431,7 @@ class In(SetPredicate[T]):
         if count == 0:
             return AlwaysFalse()
         elif count == 1:
-            return Eq(term, literals[0])
+            return EqualTo(term, literals[0])
         else:
             return super().__new__(cls)
 
@@ -448,7 +448,7 @@ class NotIn(SetPredicate[T]):
         if count == 0:
             return AlwaysTrue()
         elif count == 1:
-            return NotEq(term, literals[0])
+            return NotEqualTo(term, literals[0])
         else:
             return super().__new__(cls)
 
@@ -477,87 +477,87 @@ class BoundLiteralPredicate(BoundPredicate[T]):
 
 
 @dataclass(frozen=True)
-class BoundEq(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundNotEq[T]:
-        return BoundNotEq(self.term, self.literal)
+class BoundEqualTo(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundNotEqualTo[T]:
+        return BoundNotEqualTo(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class BoundNotEq(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundEq[T]:
-        return BoundEq(self.term, self.literal)
+class BoundNotEqualTo(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundEqualTo[T]:
+        return BoundEqualTo(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class BoundGtEq(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundLt[T]:
-        return BoundLt(self.term, self.literal)
+class BoundGreaterThanOrEqual(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundLessThan[T]:
+        return BoundLessThan(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class BoundGt(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundLtEq[T]:
-        return BoundLtEq(self.term, self.literal)
+class BoundGreaterThan(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundLessThanOrEqual[T]:
+        return BoundLessThanOrEqual(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class BoundLt(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundGtEq[T]:
-        return BoundGtEq(self.term, self.literal)
+class BoundLessThan(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundGreaterThanOrEqual[T]:
+        return BoundGreaterThanOrEqual(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class BoundLtEq(BoundLiteralPredicate[T]):
-    def __invert__(self) -> BoundGt[T]:
-        return BoundGt(self.term, self.literal)
+class BoundLessThanOrEqual(BoundLiteralPredicate[T]):
+    def __invert__(self) -> BoundGreaterThan[T]:
+        return BoundGreaterThan(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class Eq(LiteralPredicate[T]):
-    as_bound = BoundEq
+class EqualTo(LiteralPredicate[T]):
+    as_bound = BoundEqualTo
 
-    def __invert__(self) -> NotEq[T]:
-        return NotEq(self.term, self.literal)
-
-
-@dataclass(frozen=True)
-class NotEq(LiteralPredicate[T]):
-    as_bound = BoundNotEq
-
-    def __invert__(self) -> Eq[T]:
-        return Eq(self.term, self.literal)
+    def __invert__(self) -> NotEqualTo[T]:
+        return NotEqualTo(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class Lt(LiteralPredicate[T]):
-    as_bound = BoundLt
+class NotEqualTo(LiteralPredicate[T]):
+    as_bound = BoundNotEqualTo
 
-    def __invert__(self) -> GtEq[T]:
-        return GtEq(self.term, self.literal)
-
-
-@dataclass(frozen=True)
-class GtEq(LiteralPredicate[T]):
-    as_bound = BoundGtEq
-
-    def __invert__(self) -> Lt[T]:
-        return Lt(self.term, self.literal)
+    def __invert__(self) -> EqualTo[T]:
+        return EqualTo(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class Gt(LiteralPredicate[T]):
-    as_bound = BoundGt
+class LessThan(LiteralPredicate[T]):
+    as_bound = BoundLessThan
 
-    def __invert__(self) -> LtEq[T]:
-        return LtEq(self.term, self.literal)
+    def __invert__(self) -> GreaterThanOrEqual[T]:
+        return GreaterThanOrEqual(self.term, self.literal)
 
 
 @dataclass(frozen=True)
-class LtEq(LiteralPredicate[T]):
-    as_bound = BoundLtEq
+class GreaterThanOrEqual(LiteralPredicate[T]):
+    as_bound = BoundGreaterThanOrEqual
 
-    def __invert__(self) -> Gt[T]:
-        return Gt(self.term, self.literal)
+    def __invert__(self) -> LessThan[T]:
+        return LessThan(self.term, self.literal)
+
+
+@dataclass(frozen=True)
+class GreaterThan(LiteralPredicate[T]):
+    as_bound = BoundGreaterThan
+
+    def __invert__(self) -> LessThanOrEqual[T]:
+        return LessThanOrEqual(self.term, self.literal)
+
+
+@dataclass(frozen=True)
+class LessThanOrEqual(LiteralPredicate[T]):
+    as_bound = BoundLessThanOrEqual
+
+    def __invert__(self) -> GreaterThan[T]:
+        return GreaterThan(self.term, self.literal)
 
 
 class BooleanExpressionVisitor(Generic[T], ABC):

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -25,7 +25,7 @@ import struct
 from abc import ABC, abstractmethod
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatch, singledispatchmethod
-from typing import Optional, Union, Generic, TypeVar
+from typing import Generic, TypeVar
 from uuid import UUID
 
 from pyiceberg.types import (
@@ -98,8 +98,6 @@ class Literal(Generic[T], ABC):
 
     def __ge__(self, other):
         return self.value >= other.value
-
-
 
 
 @singledispatch
@@ -219,7 +217,7 @@ class LongLiteral(Literal[int]):
         return self
 
     @to.register(IntegerType)
-    def _(self, type_var: IntegerType) -> Union[AboveMax, BelowMin, Literal[int]]:
+    def _(self, type_var: IntegerType) -> AboveMax | BelowMin | Literal[int]:
         if IntegerType.max < self.value:
             return AboveMax()
         elif IntegerType.min > self.value:
@@ -307,7 +305,7 @@ class DoubleLiteral(Literal[float]):
         return self
 
     @to.register(FloatType)
-    def _(self, type_var: FloatType) -> Union[AboveMax, BelowMin, Literal[float]]:
+    def _(self, type_var: FloatType) -> AboveMax | BelowMin | Literal[float]:
         if FloatType.max < self.value:
             return AboveMax()
         elif FloatType.min > self.value:
@@ -371,7 +369,7 @@ class DecimalLiteral(Literal[Decimal]):
         return None
 
     @to.register(DecimalType)
-    def _(self, type_var: DecimalType) -> Optional[Literal[Decimal]]:
+    def _(self, type_var: DecimalType) -> Literal[Decimal] | None:
         if type_var.scale == abs(self.value.as_tuple().exponent):
             return self
         return None
@@ -390,28 +388,28 @@ class StringLiteral(Literal[str]):
         return self
 
     @to.register(DateType)
-    def _(self, type_var: DateType) -> Optional[Literal[int]]:
+    def _(self, type_var: DateType) -> Literal[int] | None:
         try:
             return DateLiteral(date_to_days(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimeType)
-    def _(self, type_var: TimeType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimeType) -> Literal[int] | None:
         try:
             return TimeLiteral(time_to_micros(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimestampType)
-    def _(self, type_var: TimestampType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimestampType) -> Literal[int] | None:
         try:
             return TimestampLiteral(timestamp_to_micros(self.value))
         except (TypeError, ValueError):
             return None
 
     @to.register(TimestamptzType)
-    def _(self, type_var: TimestamptzType) -> Optional[Literal[int]]:
+    def _(self, type_var: TimestamptzType) -> Literal[int] | None:
         try:
             return TimestampLiteral(timestamptz_to_micros(self.value))
         except (TypeError, ValueError):
@@ -422,7 +420,7 @@ class StringLiteral(Literal[str]):
         return UUIDLiteral(UUID(self.value))
 
     @to.register(DecimalType)
-    def _(self, type_var: DecimalType) -> Optional[Literal[Decimal]]:
+    def _(self, type_var: DecimalType) -> Literal[Decimal] | None:
         dec = Decimal(self.value)
         if type_var.scale == abs(dec.as_tuple().exponent):
             return DecimalLiteral(dec)
@@ -452,7 +450,7 @@ class FixedLiteral(Literal[bytes]):
         return None
 
     @to.register(FixedType)
-    def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
+    def _(self, type_var: FixedType) -> Literal[bytes] | None:
         if len(self.value) == type_var.length:
             return self
         else:
@@ -476,7 +474,7 @@ class BinaryLiteral(Literal[bytes]):
         return self
 
     @to.register(FixedType)
-    def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
+    def _(self, type_var: FixedType) -> Literal[bytes] | None:
         if type_var.length == len(self.value):
             return FixedLiteral(self.value)
         else:

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -246,7 +246,7 @@ def test_ref_binding_case_insensitive_failure(request):
 
 
 def test_in_to_eq():
-    assert base.In(base.Reference("x"), (literal(34.56),)) == base.Eq(base.Reference("x"), literal(34.56))
+    assert base.In(base.Reference("x"), (literal(34.56),)) == base.EqualTo(base.Reference("x"), literal(34.56))
 
 
 def test_bind_in(request):
@@ -267,7 +267,7 @@ def test_bind_dedup(request):
 
 def test_bind_dedup_to_eq(request):
     schema = request.getfixturevalue("table_schema_simple")
-    bound = base.BoundEq(base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)), literal("hello"))
+    bound = base.BoundEqualTo(base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)), literal("hello"))
     assert base.In(base.Reference("foo"), (literal("hello"), literal("hello"))).bind(schema) == bound
 
 
@@ -279,27 +279,27 @@ def test_bind_dedup_to_eq(request):
             "table_schema_simple",
         ),
         (
-            base.NotEq(base.Reference("foo"), literal("hello")),
+            base.NotEqualTo(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
         (
-            base.Eq(base.Reference("foo"), literal("hello")),
+            base.EqualTo(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
         (
-            base.Gt(base.Reference("foo"), literal("hello")),
+            base.GreaterThan(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
         (
-            base.Lt(base.Reference("foo"), literal("hello")),
+            base.LessThan(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
         (
-            base.GtEq(base.Reference("foo"), literal("hello")),
+            base.GreaterThanOrEqual(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
         (
-            base.LtEq(base.Reference("foo"), literal("hello")),
+            base.LessThanOrEqual(base.Reference("foo"), literal("hello")),
             "table_schema_simple",
         ),
     ],
@@ -321,27 +321,27 @@ def test_bind(a, schema, request):
             "table_schema_simple",
         ),
         (
-            base.NotEq(base.Reference("Bar"), literal(5)),
+            base.NotEqualTo(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
         (
-            base.Eq(base.Reference("Bar"), literal(5)),
+            base.EqualTo(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
         (
-            base.Gt(base.Reference("Bar"), literal(5)),
+            base.GreaterThan(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
         (
-            base.Lt(base.Reference("Bar"), literal(5)),
+            base.LessThan(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
         (
-            base.GtEq(base.Reference("Bar"), literal(5)),
+            base.GreaterThanOrEqual(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
         (
-            base.LtEq(base.Reference("Bar"), literal(5)),
+            base.LessThanOrEqual(base.Reference("Bar"), literal(5)),
             "table_schema_simple",
         ),
     ],
@@ -406,9 +406,9 @@ def test_eq(exp, testexpra, testexprb):
             base.NotIn(base.Reference("foo"), (literal("hello"), literal("world"))),
             base.In(base.Reference("foo"), (literal("hello"), literal("world"))),
         ),
-        (base.Gt(base.Reference("foo"), literal(5)), base.LtEq(base.Reference("foo"), literal(5))),
-        (base.Lt(base.Reference("foo"), literal(5)), base.GtEq(base.Reference("foo"), literal(5))),
-        (base.Eq(base.Reference("foo"), literal(5)), base.NotEq(base.Reference("foo"), literal(5))),
+        (base.GreaterThan(base.Reference("foo"), literal(5)), base.LessThanOrEqual(base.Reference("foo"), literal(5))),
+        (base.LessThan(base.Reference("foo"), literal(5)), base.GreaterThanOrEqual(base.Reference("foo"), literal(5))),
+        (base.EqualTo(base.Reference("foo"), literal(5)), base.NotEqualTo(base.Reference("foo"), literal(5))),
         (
             ExpressionA(),
             ExpressionB(),
@@ -633,7 +633,7 @@ def test_always_false_or_always_true_expression_binding(table_schema_simple):
                         ),
                         {StringLiteral("bar"), StringLiteral("baz")},
                     ),
-                    base.BoundEq[int](
+                    base.BoundEqualTo[int](
                         base.BoundReference(
                             field=NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
                             accessor=Accessor(position=1, inner=None),
@@ -641,7 +641,7 @@ def test_always_false_or_always_true_expression_binding(table_schema_simple):
                         LongLiteral(1),
                     ),
                 ),
-                base.BoundEq[str](
+                base.BoundEqualTo[str](
                     base.BoundReference(
                         field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
                         accessor=Accessor(position=0, inner=None),
@@ -778,7 +778,7 @@ def test_or_expression_binding(unbound_or_expression, expected_bound_expression,
                 base.Reference("foo"),
                 (literal("bar"),),
             ),
-            base.BoundEq(
+            base.BoundEqualTo(
                 base.BoundReference[str](
                     field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
                     accessor=Accessor(position=0, inner=None),

--- a/python/tests/expressions/test_expressions_base.py
+++ b/python/tests/expressions/test_expressions_base.py
@@ -22,10 +22,15 @@ from typing import List
 import pytest
 
 from pyiceberg.expressions import base
-from pyiceberg.expressions.base import BoundReference
 from pyiceberg.expressions.literals import LongLiteral, StringLiteral, literal
 from pyiceberg.schema import Accessor, Schema
-from pyiceberg.types import IntegerType, NestedField, StringType, FloatType, DoubleType
+from pyiceberg.types import (
+    DoubleType,
+    FloatType,
+    IntegerType,
+    NestedField,
+    StringType,
+)
 from pyiceberg.utils.singleton import Singleton
 
 
@@ -247,24 +252,22 @@ def test_in_to_eq():
 def test_bind_in(request):
     schema = request.getfixturevalue("table_schema_simple")
     bound = base.BoundIn(
-        base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)),
-        {literal("hello"), literal("world")})
+        base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)), {literal("hello"), literal("world")}
+    )
     assert base.In(base.Reference("foo"), (literal("hello"), literal("world"))).bind(schema) == bound
 
 
 def test_bind_dedup(request):
     schema = request.getfixturevalue("table_schema_simple")
     bound = base.BoundIn(
-        base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)),
-        {literal("hello"), literal("world")})
+        base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)), {literal("hello"), literal("world")}
+    )
     assert base.In(base.Reference("foo"), (literal("hello"), literal("world"), literal("world"))).bind(schema) == bound
 
 
 def test_bind_dedup_to_eq(request):
     schema = request.getfixturevalue("table_schema_simple")
-    bound = base.BoundEq(
-        base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)),
-        literal("hello"))
+    bound = base.BoundEq(base.BoundReference(schema.find_field(1), schema.accessor_for_field(1)), literal("hello"))
     assert base.In(base.Reference("foo"), (literal("hello"), literal("hello"))).bind(schema) == bound
 
 
@@ -272,32 +275,32 @@ def test_bind_dedup_to_eq(request):
     "a,  schema",
     [
         (
-                base.NotIn(base.Reference("foo"), (literal("hello"), literal("world"))),
-                "table_schema_simple",
+            base.NotIn(base.Reference("foo"), (literal("hello"), literal("world"))),
+            "table_schema_simple",
         ),
         (
-                base.NotEq(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.NotEq(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
         (
-                base.Eq(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.Eq(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
         (
-                base.Gt(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.Gt(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
         (
-                base.Lt(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.Lt(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
         (
-                base.GtEq(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.GtEq(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
         (
-                base.LtEq(base.Reference("foo"), literal("hello")),
-                "table_schema_simple",
+            base.LtEq(base.Reference("foo"), literal("hello")),
+            "table_schema_simple",
         ),
     ],
 )
@@ -310,36 +313,36 @@ def test_bind(a, schema, request):
     "a,  schema",
     [
         (
-                base.In(base.Reference("Bar"), (literal(5), literal(2))),
-                "table_schema_simple",
+            base.In(base.Reference("Bar"), (literal(5), literal(2))),
+            "table_schema_simple",
         ),
         (
-                base.NotIn(base.Reference("Bar"), (literal(5), literal(2))),
-                "table_schema_simple",
+            base.NotIn(base.Reference("Bar"), (literal(5), literal(2))),
+            "table_schema_simple",
         ),
         (
-                base.NotEq(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.NotEq(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
         (
-                base.Eq(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.Eq(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
         (
-                base.Gt(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.Gt(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
         (
-                base.Lt(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.Lt(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
         (
-                base.GtEq(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.GtEq(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
         (
-                base.LtEq(base.Reference("Bar"), literal(5)),
-                "table_schema_simple",
+            base.LtEq(base.Reference("Bar"), literal(5)),
+            "table_schema_simple",
         ),
     ],
 )
@@ -780,7 +783,7 @@ def test_or_expression_binding(unbound_or_expression, expected_bound_expression,
                     field=NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
                     accessor=Accessor(position=0, inner=None),
                 ),
-                StringLiteral("bar")
+                StringLiteral("bar"),
             ),
         ),
     ],


### PR DESCRIPTION
This refactors unary and set expressions to use base classes. In addition, this updates binding to produce `AlwaysTrue()` or `AlwaysFalse()` values based on the bound type. For example, `IsNull(a)` when bound to a required field a will produce `AlwaysFalse()` because the value is required.

This also adds missing tests.