### PR TITLE
Spark 3.2: Support different task types in readers

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseBatchReader.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.arrow.vector.NullCheckingForGet;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+abstract class BaseBatchReader<T extends ScanTask> extends BaseReader<ColumnarBatch, T> {
+  private final int batchSize;
+
+  BaseBatchReader(Table table, ScanTaskGroup<T> taskGroup, Schema expectedSchema, boolean caseSensitive,
+                  int batchSize) {
+    super(table, taskGroup, expectedSchema, caseSensitive);
+    this.batchSize = batchSize;
+  }
+
+  protected CloseableIterable<ColumnarBatch> newBatchIterable(InputFile inputFile, FileFormat format,
+                                                              long start, long length, Expression residual,
+                                                              Map<Integer, ?> idToConstant,
+                                                              SparkDeleteFilter deleteFilter) {
+    switch (format) {
+      case PARQUET:
+        return newParquetIterable(inputFile, start, length, residual, idToConstant, deleteFilter);
+
+      case ORC:
+        return newOrcIterable(inputFile, start, length, residual, idToConstant);
+
+      default:
+        throw new UnsupportedOperationException("Format: " + format + " not supported for batched reads");
+    }
+  }
+
+  private CloseableIterable<ColumnarBatch> newParquetIterable(InputFile inputFile, long start, long length,
+                                                              Expression residual, Map<Integer, ?> idToConstant,
+                                                              SparkDeleteFilter deleteFilter) {
+    // get required schema for filtering out equality-delete rows in case equality-delete uses columns are
+    // not selected.
+    Schema requiredSchema = deleteFilter != null && deleteFilter.hasEqDeletes() ?
+        deleteFilter.requiredSchema() : expectedSchema();
+
+    return Parquet.read(inputFile)
+        .project(requiredSchema)
+        .split(start, length)
+        .createBatchedReaderFunc(fileSchema -> VectorizedSparkParquetReaders.buildReader(requiredSchema,
+            fileSchema, /* setArrowValidityVector */ NullCheckingForGet.NULL_CHECKING_ENABLED, idToConstant,
+            deleteFilter))
+        .recordsPerBatch(batchSize)
+        .filter(residual)
+        .caseSensitive(caseSensitive())
+        // Spark eagerly consumes the batches. So the underlying memory allocated could be reused
+        // without worrying about subsequent reads clobbering over each other. This improves
+        // read performance as every batch read doesn't have to pay the cost of allocating memory.
+        .reuseContainers()
+        .withNameMapping(nameMapping())
+        .build();
+  }
+
+  private CloseableIterable<ColumnarBatch> newOrcIterable(InputFile inputFile, long start, long length,
+                                                          Expression residual, Map<Integer, ?> idToConstant) {
+    Set<Integer> constantFieldIds = idToConstant.keySet();
+    Set<Integer> metadataFieldIds = MetadataColumns.metadataFieldIds();
+    Sets.SetView<Integer> constantAndMetadataFieldIds = Sets.union(constantFieldIds, metadataFieldIds);
+    Schema schemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(expectedSchema(), constantAndMetadataFieldIds);
+
+    return ORC.read(inputFile)
+        .project(schemaWithoutConstantAndMetadataFields)
+        .split(start, length)
+        .createBatchedReaderFunc(fileSchema -> VectorizedSparkOrcReaders.buildReader(expectedSchema(), fileSchema,
+            idToConstant))
+        .recordsPerBatch(batchSize)
+        .filter(residual)
+        .caseSensitive(caseSensitive())
+        .withNameMapping(nameMapping())
+        .build();
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.data.SparkAvroReader;
+import org.apache.iceberg.spark.data.SparkOrcReader;
+import org.apache.iceberg.spark.data.SparkParquetReaders;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+abstract class BaseRowReader<T extends ScanTask> extends BaseReader<InternalRow, T> {
+  BaseRowReader(Table table, ScanTaskGroup<T> taskGroup, Schema expectedSchema, boolean caseSensitive) {
+    super(table, taskGroup, expectedSchema, caseSensitive);
+  }
+
+  protected CloseableIterable<InternalRow> newIterable(InputFile file, FileFormat format, long start, long length,
+                                                       Expression residual, Schema projection,
+                                                       Map<Integer, ?> idToConstant) {
+    switch (format) {
+      case PARQUET:
+        return newParquetIterable(file, start, length, residual, projection, idToConstant);
+
+      case AVRO:
+        return newAvroIterable(file, start, length, projection, idToConstant);
+
+      case ORC:
+        return newOrcIterable(file, start, length, residual, projection, idToConstant);
+
+      default:
+        throw new UnsupportedOperationException("Cannot read unknown format: " + format);
+    }
+  }
+
+  private CloseableIterable<InternalRow> newAvroIterable(InputFile file, long start, long length, Schema projection,
+                                                         Map<Integer, ?> idToConstant) {
+    return Avro.read(file)
+        .reuseContainers()
+        .project(projection)
+        .split(start, length)
+        .createReaderFunc(readSchema -> new SparkAvroReader(projection, readSchema, idToConstant))
+        .withNameMapping(nameMapping())
+        .build();
+  }
+
+  private CloseableIterable<InternalRow> newParquetIterable(InputFile file, long start, long length,
+                                                            Expression residual, Schema readSchema,
+                                                            Map<Integer, ?> idToConstant) {
+    return Parquet.read(file)
+        .reuseContainers()
+        .split(start, length)
+        .project(readSchema)
+        .createReaderFunc(fileSchema -> SparkParquetReaders.buildReader(readSchema, fileSchema, idToConstant))
+        .filter(residual)
+        .caseSensitive(caseSensitive())
+        .withNameMapping(nameMapping())
+        .build();
+  }
+
+  private CloseableIterable<InternalRow> newOrcIterable(InputFile file, long start, long length, Expression residual,
+                                                        Schema readSchema, Map<Integer, ?> idToConstant) {
+    Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(readSchema,
+        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
+
+    return ORC.read(file)
+        .project(readSchemaWithoutConstantAndMetadataFields)
+        .split(start, length)
+        .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema, idToConstant))
+        .filter(residual)
+        .caseSensitive(caseSensitive())
+        .withNameMapping(nameMapping())
+        .build();
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -20,139 +20,44 @@
 package org.apache.iceberg.spark.source;
 
 import java.util.Map;
-import java.util.Set;
-import org.apache.arrow.vector.NullCheckingForGet;
-import org.apache.iceberg.CombinedScanTask;
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.FileFormat;
+import java.util.stream.Stream;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.data.DeleteFilter;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.mapping.NameMappingParser;
-import org.apache.iceberg.orc.ORC;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
-import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
-import org.apache.iceberg.types.TypeUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
-import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
-class BatchDataReader extends BaseDataReader<ColumnarBatch> {
-  private final Schema expectedSchema;
-  private final String nameMapping;
-  private final boolean caseSensitive;
-  private final int batchSize;
-
-  BatchDataReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive, int size) {
-    super(table, task);
-    this.expectedSchema = expectedSchema;
-    this.nameMapping = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
-    this.caseSensitive = caseSensitive;
-    this.batchSize = size;
+class BatchDataReader extends BaseBatchReader<FileScanTask> {
+  BatchDataReader(ScanTaskGroup<FileScanTask> task, Table table, Schema expectedSchema, boolean caseSensitive,
+                  int size) {
+    super(table, task, expectedSchema, caseSensitive, size);
   }
 
   @Override
-  CloseableIterator<ColumnarBatch> open(FileScanTask task) {
-    DataFile file = task.file();
+  protected Stream<ContentFile<?>> referencedFiles(FileScanTask task) {
+    return Stream.concat(Stream.of(task.file()), task.deletes().stream());
+  }
+
+  @Override
+  protected CloseableIterator<ColumnarBatch> open(FileScanTask task) {
+    String filePath = task.file().path().toString();
 
     // update the current file for Spark's filename() function
-    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
+    InputFileBlockHolder.set(filePath, task.start(), task.length());
 
-    Map<Integer, ?> idToConstant = constantsMap(task, expectedSchema);
+    Map<Integer, ?> idToConstant = constantsMap(task, expectedSchema());
 
-    CloseableIterable<ColumnarBatch> iter;
-    InputFile location = getInputFile(task);
-    Preconditions.checkNotNull(location, "Could not find InputFile associated with FileScanTask");
-    if (task.file().format() == FileFormat.PARQUET) {
-      SparkDeleteFilter deleteFilter = deleteFilter(task);
-      // get required schema for filtering out equality-delete rows in case equality-delete uses columns are
-      // not selected.
-      Schema requiredSchema = requiredSchema(deleteFilter);
+    InputFile inputFile = getInputFile(filePath);
+    Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with FileScanTask");
 
-      Parquet.ReadBuilder builder = Parquet.read(location)
-          .project(requiredSchema)
-          .split(task.start(), task.length())
-          .createBatchedReaderFunc(fileSchema -> VectorizedSparkParquetReaders.buildReader(requiredSchema,
-              fileSchema, /* setArrowValidityVector */ NullCheckingForGet.NULL_CHECKING_ENABLED, idToConstant,
-              deleteFilter))
-          .recordsPerBatch(batchSize)
-          .filter(task.residual())
-          .caseSensitive(caseSensitive)
-          // Spark eagerly consumes the batches. So the underlying memory allocated could be reused
-          // without worrying about subsequent reads clobbering over each other. This improves
-          // read performance as every batch read doesn't have to pay the cost of allocating memory.
-          .reuseContainers();
+    SparkDeleteFilter deleteFilter = task.deletes().isEmpty() ? null : new SparkDeleteFilter(filePath, task.deletes());
 
-      if (nameMapping != null) {
-        builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-      }
-
-      iter = builder.build();
-    } else if (task.file().format() == FileFormat.ORC) {
-      Set<Integer> constantFieldIds = idToConstant.keySet();
-      Set<Integer> metadataFieldIds = MetadataColumns.metadataFieldIds();
-      Sets.SetView<Integer> constantAndMetadataFieldIds = Sets.union(constantFieldIds, metadataFieldIds);
-      Schema schemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(expectedSchema, constantAndMetadataFieldIds);
-      ORC.ReadBuilder builder = ORC.read(location)
-          .project(schemaWithoutConstantAndMetadataFields)
-          .split(task.start(), task.length())
-          .createBatchedReaderFunc(fileSchema -> VectorizedSparkOrcReaders.buildReader(expectedSchema, fileSchema,
-              idToConstant))
-          .recordsPerBatch(batchSize)
-          .filter(task.residual())
-          .caseSensitive(caseSensitive);
-
-      if (nameMapping != null) {
-        builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-      }
-
-      iter = builder.build();
-    } else {
-      throw new UnsupportedOperationException(
-          "Format: " + task.file().format() + " not supported for batched reads");
-    }
-    return iter.iterator();
-  }
-
-  private SparkDeleteFilter deleteFilter(FileScanTask task) {
-    return task.deletes().isEmpty() ? null : new SparkDeleteFilter(task, table().schema(), expectedSchema);
-  }
-
-  private Schema requiredSchema(DeleteFilter deleteFilter) {
-    if (deleteFilter != null && deleteFilter.hasEqDeletes()) {
-      return deleteFilter.requiredSchema();
-    } else {
-      return expectedSchema;
-    }
-  }
-
-  private class SparkDeleteFilter extends DeleteFilter<InternalRow> {
-    private final InternalRowWrapper asStructLike;
-
-    SparkDeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
-      super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
-      this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
-    }
-
-    @Override
-    protected StructLike asStructLike(InternalRow row) {
-      return asStructLike.wrap(row);
-    }
-
-    @Override
-    protected InputFile getInputFile(String location) {
-      return BatchDataReader.this.getInputFile(location);
-    }
+    return newBatchIterable(inputFile, task.file().format(), task.start(), task.length(), task.residual(),
+        idToConstant, deleteFilter).iterator();
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRowReader.java
@@ -30,20 +30,17 @@ import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 public class EqualityDeleteRowReader extends RowDataReader {
-  private final Schema expectedSchema;
-
   public EqualityDeleteRowReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive) {
-    super(task, table, table.schema(), caseSensitive);
-    this.expectedSchema = expectedSchema;
+    super(task, table, expectedSchema, caseSensitive);
   }
 
   @Override
-  CloseableIterator<InternalRow> open(FileScanTask task) {
-    SparkDeleteFilter matches = new SparkDeleteFilter(task, tableSchema(), expectedSchema);
+  protected CloseableIterator<InternalRow> open(FileScanTask task) {
+    SparkDeleteFilter matches = new SparkDeleteFilter(task.file().path().toString(), task.deletes());
 
     // schema or rows returned by readers
     Schema requiredSchema = matches.requiredSchema();
-    Map<Integer, ?> idToConstant = constantsMap(task, expectedSchema);
+    Map<Integer, ?> idToConstant = constantsMap(task, expectedSchema());
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -20,185 +20,58 @@
 package org.apache.iceberg.spark.source;
 
 import java.util.Map;
-import org.apache.iceberg.CombinedScanTask;
-import org.apache.iceberg.DataFile;
+import java.util.stream.Stream;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataTask;
 import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.avro.Avro;
-import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.mapping.NameMappingParser;
-import org.apache.iceberg.orc.ORC;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.SparkAvroReader;
-import org.apache.iceberg.spark.data.SparkOrcReader;
-import org.apache.iceberg.spark.data.SparkParquetReaders;
-import org.apache.iceberg.types.TypeUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
-class RowDataReader extends BaseDataReader<InternalRow> {
-
-  private final Schema tableSchema;
-  private final Schema expectedSchema;
-  private final String nameMapping;
-  private final boolean caseSensitive;
-
-  RowDataReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive) {
-    super(table, task);
-    this.tableSchema = table.schema();
-    this.expectedSchema = expectedSchema;
-    this.nameMapping = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
-    this.caseSensitive = caseSensitive;
+class RowDataReader extends BaseRowReader<FileScanTask> {
+  RowDataReader(ScanTaskGroup<FileScanTask> task, Table table, Schema expectedSchema, boolean caseSensitive) {
+    super(table, task, expectedSchema, caseSensitive);
   }
 
   @Override
-  CloseableIterator<InternalRow> open(FileScanTask task) {
-    SparkDeleteFilter deletes = new SparkDeleteFilter(task, tableSchema, expectedSchema);
-
-    // schema or rows returned by readers
-    Schema requiredSchema = deletes.requiredSchema();
-    Map<Integer, ?> idToConstant = constantsMap(task, expectedSchema);
-    DataFile file = task.file();
-
-    // update the current file for Spark's filename() function
-    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
-
-    return deletes.filter(open(task, requiredSchema, idToConstant)).iterator();
+  protected Stream<ContentFile<?>> referencedFiles(FileScanTask task) {
+    return Stream.concat(Stream.of(task.file()), task.deletes().stream());
   }
 
-  protected Schema tableSchema() {
-    return tableSchema;
+  @Override
+  protected CloseableIterator<InternalRow> open(FileScanTask task) {
+    String filePath = task.file().path().toString();
+    SparkDeleteFilter deleteFilter = new SparkDeleteFilter(filePath, task.deletes());
+
+    // schema or rows returned by readers
+    Schema requiredSchema = deleteFilter.requiredSchema();
+    Map<Integer, ?> idToConstant = constantsMap(task, requiredSchema);
+
+    // update the current file for Spark's filename() function
+    InputFileBlockHolder.set(filePath, task.start(), task.length());
+
+    return deleteFilter.filter(open(task, requiredSchema, idToConstant)).iterator();
   }
 
   protected CloseableIterable<InternalRow> open(FileScanTask task, Schema readSchema, Map<Integer, ?> idToConstant) {
-    CloseableIterable<InternalRow> iter;
     if (task.isDataTask()) {
-      iter = newDataIterable(task.asDataTask(), readSchema);
+      return newDataIterable(task.asDataTask(), readSchema);
     } else {
-      InputFile location = getInputFile(task);
-      Preconditions.checkNotNull(location, "Could not find InputFile associated with FileScanTask");
-
-      switch (task.file().format()) {
-        case PARQUET:
-          iter = newParquetIterable(location, task, readSchema, idToConstant);
-          break;
-
-        case AVRO:
-          iter = newAvroIterable(location, task, readSchema, idToConstant);
-          break;
-
-        case ORC:
-          iter = newOrcIterable(location, task, readSchema, idToConstant);
-          break;
-
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot read unknown format: " + task.file().format());
-      }
+      InputFile inputFile = getInputFile(task.file().path().toString());
+      Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with FileScanTask");
+      return newIterable(inputFile, task.file().format(), task.start(), task.length(), task.residual(), readSchema,
+          idToConstant);
     }
-
-    return iter;
-  }
-
-  private CloseableIterable<InternalRow> newAvroIterable(
-      InputFile location,
-      FileScanTask task,
-      Schema projection,
-      Map<Integer, ?> idToConstant) {
-    Avro.ReadBuilder builder = Avro.read(location)
-        .reuseContainers()
-        .project(projection)
-        .split(task.start(), task.length())
-        .createReaderFunc(readSchema -> new SparkAvroReader(projection, readSchema, idToConstant));
-
-    if (nameMapping != null) {
-      builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-    }
-
-    return builder.build();
-  }
-
-  private CloseableIterable<InternalRow> newParquetIterable(
-      InputFile location,
-      FileScanTask task,
-      Schema readSchema,
-      Map<Integer, ?> idToConstant) {
-    Parquet.ReadBuilder builder = Parquet.read(location)
-        .reuseContainers()
-        .split(task.start(), task.length())
-        .project(readSchema)
-        .createReaderFunc(fileSchema -> SparkParquetReaders.buildReader(readSchema, fileSchema, idToConstant))
-        .filter(task.residual())
-        .caseSensitive(caseSensitive);
-
-    if (nameMapping != null) {
-      builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-    }
-
-    return builder.build();
-  }
-
-  private CloseableIterable<InternalRow> newOrcIterable(
-      InputFile location,
-      FileScanTask task,
-      Schema readSchema,
-      Map<Integer, ?> idToConstant) {
-    Schema readSchemaWithoutConstantAndMetadataFields = TypeUtil.selectNot(readSchema,
-        Sets.union(idToConstant.keySet(), MetadataColumns.metadataFieldIds()));
-
-    ORC.ReadBuilder builder = ORC.read(location)
-        .project(readSchemaWithoutConstantAndMetadataFields)
-        .split(task.start(), task.length())
-        .createReaderFunc(readOrcSchema -> new SparkOrcReader(readSchema, readOrcSchema, idToConstant))
-        .filter(task.residual())
-        .caseSensitive(caseSensitive);
-
-    if (nameMapping != null) {
-      builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-    }
-
-    return builder.build();
   }
 
   private CloseableIterable<InternalRow> newDataIterable(DataTask task, Schema readSchema) {
     StructInternalRow row = new StructInternalRow(readSchema.asStruct());
-    CloseableIterable<InternalRow> asSparkRows = CloseableIterable.transform(
-        task.asDataTask().rows(), row::setStruct);
-    return asSparkRows;
-  }
-
-  protected class SparkDeleteFilter extends DeleteFilter<InternalRow> {
-    private final InternalRowWrapper asStructLike;
-
-    SparkDeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
-      super(task.file().path().toString(), task.deletes(), tableSchema, requestedSchema);
-      this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
-    }
-
-    @Override
-    protected StructLike asStructLike(InternalRow row) {
-      return asStructLike.wrap(row);
-    }
-
-    @Override
-    protected InputFile getInputFile(String location) {
-      return RowDataReader.this.getInputFile(location);
-    }
-
-    @Override
-    protected void markRowDeleted(InternalRow row) {
-      row.setBoolean(columnIsDeletedPosition(), true);
-    }
+    return CloseableIterable.transform(task.asDataTask().rows(), row::setStruct);
   }
 }


### PR DESCRIPTION
Cherry-picked from d7b1a874677b3dc58c20656d9b06c571fe0a475a. This is the same change as #5248 applying to the module Spark 3.2.
@aokolnychyi @szehon-ho  @RussellSpitzer 