### PR TITLE
AWS: Call abortUpload only once when any of the completable future fails

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -337,8 +338,10 @@ class S3OutputStream extends PositionOutputStream {
                             }
 
                             if (thrown != null) {
+                              // Exception observed here will be thrown as part of
+                              // CompletionException
+                              // when we will join completable futures.
                               LOG.error("Failed to upload part: {}", uploadRequest, thrown);
-                              abortUpload();
                             }
                           });
 
@@ -349,11 +352,19 @@ class S3OutputStream extends PositionOutputStream {
   private void completeMultiPartUpload() {
     Preconditions.checkState(closed, "Complete upload called on open stream: " + location);
 
-    List<CompletedPart> completedParts =
-        multiPartMap.values().stream()
-            .map(CompletableFuture::join)
-            .sorted(Comparator.comparing(CompletedPart::partNumber))
-            .collect(Collectors.toList());
+    List<CompletedPart> completedParts;
+    try {
+      completedParts =
+          multiPartMap.values().stream()
+              .map(CompletableFuture::join)
+              .sorted(Comparator.comparing(CompletedPart::partNumber))
+              .collect(Collectors.toList());
+    } catch (CompletionException ce) {
+      // cancel the remaining futures.
+      multiPartMap.values().forEach(c -> c.cancel(true));
+      abortUpload();
+      throw ce;
+    }
 
     CompleteMultipartUploadRequest request =
         CompleteMultipartUploadRequest.builder()

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -136,7 +135,7 @@ public class TestS3OutputStream {
         .isInstanceOf(mockException.getClass())
         .hasMessageContaining(mockException.getMessage());
 
-    verify(s3mock, atLeastOnce()).abortMultipartUpload((AbortMultipartUploadRequest) any());
+    verify(s3mock, times(1)).abortMultipartUpload((AbortMultipartUploadRequest) any());
   }
 
   @Test
@@ -156,7 +155,7 @@ public class TestS3OutputStream {
         .isInstanceOf(mockException.getClass())
         .hasMessageContaining(mockException.getMessage());
 
-    verify(s3mock).abortMultipartUpload((AbortMultipartUploadRequest) any());
+    verify(s3mock, times(1)).abortMultipartUpload((AbortMultipartUploadRequest) any());
   }
 
   @Test


### PR DESCRIPTION
### About the Change :
Presently whenever a failure is observed in any of the completableFutures in `uploadParts()`, it causes further completable futures fail with `FileNotFoundException`, when it tries to create a request for it using `RequestBody.fromFile(file)`, as all the stagings files deleted as part of `abortUpload` which is called on failure of first completableFuture.

https://github.com/apache/iceberg/blob/7a92bf5e31a995c61dc598d2a36f598d5c120756/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java#L306

I think this is what was also highlighted in @stevenzwu 's observation here (https://github.com/apache/iceberg/issues/4168#issuecomment-1123025380)

This change attempts : 
* To avoid unnecessary deletes being called for all staging files on every `completableFutures` which fail due to fileNotFoundException.
* Cancels the remaining futures in which would not be required as the abort is called, reduces number of calls to abort multi-part upload as well.

### Testing Done

Existing UT's +  a UT to see abort is called only once rather than atleast once.

cc @rdblue @jackye1995 @RussellSpitzer @stevenzwu @amogh-jahagirdar @rajarshisarkar