### PR TITLE
API, Spark: Update remove orphan files procedure to use bulk deletion if applicable

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
@@ -23,7 +23,7 @@ public interface SupportsBulkOperations {
    * Delete the files at the given paths.
    *
    * @param pathsToDelete The paths to delete
-   * @throws BulkDeletionFailureException in
+   * @throws BulkDeletionFailureException in case of failure to delete at least 1 file
    */
   void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException;
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -338,7 +338,7 @@ public class TestS3FileIOIntegration {
   public void testPrefixList() {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
     List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
-    String listPrefix = String.format("s3://%s/%s", bucketName, "prefix-list-test");
+    String listPrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-list-test");
 
     scaleSizes.parallelStream().forEach(scale -> {
       String scalePrefix = String.format("%s/%s/", listPrefix, scale);
@@ -355,7 +355,7 @@ public class TestS3FileIOIntegration {
     AwsProperties properties = new AwsProperties();
     properties.setS3FileIoDeleteBatchSize(100);
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
-    String deletePrefix = String.format("s3://%s/%s", bucketName, "prefix-delete-test");
+    String deletePrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-delete-test");
 
     List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1000, 2500);
     scaleSizes.parallelStream().forEach(scale -> {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -81,7 +81,9 @@ public class TestS3FileIO {
           "s3.write.tags.tagKey1",
           "TagValue1",
           "s3.delete.batch-size",
-          Integer.toString(batchDeletionSize));
+          Integer.toString(batchDeletionSize),
+          "s3.delete.num-threads",
+          "1");
 
   @Before
   public void before() {


### PR DESCRIPTION
In this change, the DeleteOrphanFiles procedure has been updated to perform bulk deletion in case a deletion batch size is set and is supported. If a batch size greater than 1 is set and the underlying FileIO does not support batch deletion, the procedure will fail.

There maybe are more sophisticated heuristics for determining if if bulk deletion should be used but for now it seems reasonable that it gets used when the FIleIO supports it and there is a batch size greater than 1.