### PR TITLE
Chores: using bulk delete if it's possible

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -35,11 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.util.CharSequenceSet;
-import org.apache.iceberg.util.StructLikeMap;
-import org.apache.iceberg.util.StructProjection;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
+import org.apache.iceberg.util.*;
 
 public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private final List<DataFile> completedDataFiles = Lists.newArrayList();
@@ -77,11 +73,9 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     close();
 
     // clean up files created by this writer
-    Tasks.foreach(Iterables.concat(completedDataFiles, completedDeleteFiles))
+    FileIOUtil.bulkDeleteFiles(io, Iterables.concat(completedDataFiles, completedDeleteFiles))
         .executeWith(ThreadPools.getWorkerPool())
-        .throwFailureWhenFinished()
-        .noRetry()
-        .run(file -> io.deleteFile(file.path().toString()));
+        .execute();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/FileIOUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/FileIOUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.concurrent.ExecutorService;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsBulkOperations;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileIOUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(FileIOUtil.class);
+
+  public static BulkDeleter bulkDeleteManifests(FileIO io, Iterable<ManifestFile> files) {
+    return bulkDelete(io, Iterables.transform(files, ManifestFile::path));
+  }
+
+  public static <C extends ContentFile<?>> BulkDeleter bulkDeleteFiles(
+      FileIO io, Iterable<C> files) {
+    return bulkDelete(io, Iterables.transform(files, file -> file.path().toString()));
+  }
+
+  public static BulkDeleter bulkDelete(FileIO io, Iterable<String> files) {
+    return new BulkDeleter(io, files);
+  }
+
+  public static BulkDeleter bulkDelete(FileIO io, String file) {
+    return new BulkDeleter(io, Sets.newHashSet(file));
+  }
+
+  public static class BulkDeleter {
+    private final FileIO io;
+    private final Iterable<String> files;
+    private String name = "files";
+    private ExecutorService service = null;
+
+    private BulkDeleter(FileIO io, Iterable<String> files) {
+      this.io = io;
+      this.files = files;
+    }
+
+    public BulkDeleter name(String newName) {
+      this.name = newName;
+      return this;
+    }
+
+    public BulkDeleter executeWith(ExecutorService svc) {
+      this.service = svc;
+      return this;
+    }
+
+    public void execute() {
+      if (io instanceof SupportsBulkOperations) {
+        try {
+          SupportsBulkOperations bulkIO = (SupportsBulkOperations) io;
+          bulkIO.deleteFiles(files);
+        } catch (BulkDeletionFailureException e) {
+          LOG.warn("Failed to delete {} {}", e.numberFailedObjects(), name);
+        } catch (Exception e) {
+          // ignore
+        }
+      } else {
+        Tasks.foreach(files)
+            .noRetry()
+            .executeWith(service)
+            .suppressFailureWhenFinished()
+            .onFailure((file, exc) -> LOG.warn("Delete failed for {}: {}", name, file, exc))
+            .run(io::deleteFile);
+      }
+    }
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -59,8 +59,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.iceberg.util.FileIOUtil;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
@@ -678,11 +678,9 @@ public class SparkTableUtil {
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {
-    Tasks.foreach(manifests)
+    FileIOUtil.bulkDeleteManifests(io, manifests)
         .executeWith(ThreadPools.getWorkerPool())
-        .noRetry()
-        .suppressFailureWhenFinished()
-        .run(item -> io.deleteFile(item.path()));
+        .execute();
   }
 
   /**

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -53,8 +53,8 @@ import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkDataFile;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.FileIOUtil;
 import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
@@ -322,12 +322,7 @@ public class RewriteManifestsSparkAction
   }
 
   private void deleteFiles(Iterable<String> locations) {
-    Tasks.foreach(locations)
-        .executeWith(ThreadPools.getWorkerPool())
-        .noRetry()
-        .suppressFailureWhenFinished()
-        .onFailure((location, exc) -> LOG.warn("Failed to delete: {}", location, exc))
-        .run(fileIO::deleteFile);
+    FileIOUtil.bulkDelete(fileIO, locations).executeWith(ThreadPools.getWorkerPool()).execute();
   }
 
   private static ManifestFile writeManifest(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -61,10 +61,7 @@ import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.CharSequenceSet;
-import org.apache.iceberg.util.StructProjection;
-import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.ThreadPools;
+import org.apache.iceberg.util.*;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.SparkSession;
@@ -144,11 +141,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
   }
 
   private static <T extends ContentFile<T>> void cleanFiles(FileIO io, Iterable<T> files) {
-    Tasks.foreach(files)
-        .executeWith(ThreadPools.getWorkerPool())
-        .throwFailureWhenFinished()
-        .noRetry()
-        .run(file -> io.deleteFile(file.path().toString()));
+    FileIOUtil.bulkDeleteFiles(io, files).executeWith(ThreadPools.getWorkerPool()).execute();
   }
 
   private class PositionDeltaBatchWrite implements DeltaBatchWrite {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -68,6 +68,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.SparkWriteConf;
+import org.apache.iceberg.util.FileIOUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
@@ -674,11 +675,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   }
 
   private static <T extends ContentFile<T>> void deleteFiles(FileIO io, List<T> files) {
-    Tasks.foreach(files)
-        .executeWith(ThreadPools.getWorkerPool())
-        .throwFailureWhenFinished()
-        .noRetry()
-        .run(file -> io.deleteFile(file.path().toString()));
+    FileIOUtil.bulkDeleteFiles(io, files).executeWith(ThreadPools.getWorkerPool()).execute();
   }
 
   private static class UnpartitionedDataWriter implements DataWriter<InternalRow> {


### PR DESCRIPTION
Using batch delete (a.k.a bulk delete) to perform delete multiple files if `FileIO` implement `SupportsBulkOperations`
#4012