### PR TITLE
Core: Add readable metrics columns to files metadata tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -102,7 +102,8 @@ public interface DataFile extends ContentFile<DataFile> {
   int PARTITION_ID = 102;
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
-  // NEXT ID TO ASSIGN: 142
+
+  int NEXT_ID_TO_ASSIGN = 142;
 
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -234,6 +234,16 @@ public class Schema implements Serializable {
   }
 
   /**
+   * Returns a map for this schema between field id and qualified field names. Initializes the map,
+   * if it has not been initialized by calls to {@link #findColumnName(int)}.
+   *
+   * @return a map of field id to qualified field names
+   */
+  public Map<Integer, String> idToName() {
+    return lazyIdToName();
+  }
+
+  /**
    * Returns the underlying {@link StructType struct type} for this schema.
    *
    * @return the StructType version of this schema.

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -234,8 +234,7 @@ public class Schema implements Serializable {
   }
 
   /**
-   * Returns a map for this schema between field id and qualified field names. Initializes the map,
-   * if it has not been initialized by calls to {@link #findColumnName(int)}.
+   * Returns a map for this schema between field id and qualified field names.
    *
    * @return a map of field id to qualified field names
    */

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -142,9 +142,21 @@ public class TypeUtil {
   }
 
   public static Schema join(Schema left, Schema right) {
-    List<Types.NestedField> joinedColumns = Lists.newArrayList();
-    joinedColumns.addAll(left.columns());
-    joinedColumns.addAll(right.columns());
+    List<Types.NestedField> joinedColumns = Lists.newArrayList(left.columns());
+    for (Types.NestedField rightColumn : right.columns()) {
+      Types.NestedField leftColumn = left.findField(rightColumn.fieldId());
+
+      if (leftColumn == null) {
+        joinedColumns.add(rightColumn);
+      } else {
+        Preconditions.checkArgument(
+            leftColumn.equals(rightColumn),
+            "Schemas have different columns with same id: %s, %s",
+            leftColumn,
+            rightColumn);
+      }
+    }
+
     return new Schema(joinedColumns);
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
@@ -32,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 
 /** Base class logic for files metadata tables */
@@ -48,10 +50,12 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     if (partitionType.fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition
       // field
-      return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
-    } else {
-      return schema;
+      schema = TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     }
+
+    return TypeUtil.join(
+        schema,
+        MetricsUtil.readableMetricsSchema(table().schema(), schema, DataFile.NEXT_ID_TO_ASSIGN));
   }
 
   private static CloseableIterable<FileScanTask> planFiles(
@@ -140,15 +144,26 @@ abstract class BaseFilesTable extends BaseMetadataTable {
   }
 
   static class ManifestReadTask extends BaseFileScanTask implements DataTask {
+
+    private static final Schema PROJECTION_FOR_READABLE_METRICS =
+        new Schema(
+            DataFile.COLUMN_SIZES,
+            DataFile.VALUE_COUNTS,
+            DataFile.NULL_VALUE_COUNTS,
+            DataFile.NAN_VALUE_COUNTS,
+            DataFile.LOWER_BOUNDS,
+            DataFile.UPPER_BOUNDS);
+
     private final FileIO io;
     private final Map<Integer, PartitionSpec> specsById;
     private final ManifestFile manifest;
-    private final Schema schema;
+    private final Schema dataTableSchema;
+    private final Schema projection;
 
     ManifestReadTask(
         Table table,
         ManifestFile manifest,
-        Schema schema,
+        Schema projection,
         String schemaString,
         String specString,
         ResidualEvaluator residuals) {
@@ -156,24 +171,47 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       this.io = table.io();
       this.specsById = Maps.newHashMap(table.specs());
       this.manifest = manifest;
-      this.schema = schema;
+      this.dataTableSchema = table.schema();
+      this.projection = projection;
     }
 
     @Override
     public CloseableIterable<StructLike> rows() {
-      return CloseableIterable.transform(manifestEntries(), file -> (StructLike) file);
+      Types.NestedField readableMetricsField = projection.findField(MetricsUtil.READABLE_METRICS);
+
+      if (readableMetricsField == null) {
+        return CloseableIterable.transform(files(projection), file -> (StructLike) file);
+      } else {
+        Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
+        Schema fileProjection = TypeUtil.selectNot(projection, readableMetricsIds);
+
+        // If readable_metrics is selected,
+        // original metrics columns need to be selected for readable_metrics derivation
+        Schema projectionForMetrics =
+            TypeUtil.join(fileProjection, PROJECTION_FOR_READABLE_METRICS);
+        return CloseableIterable.transform(files(projectionForMetrics), this::withReadableMetrics);
+      }
     }
 
-    private CloseableIterable<? extends ContentFile<?>> manifestEntries() {
+    private CloseableIterable<? extends ContentFile<?>> files(Schema fileProjection) {
       switch (manifest.content()) {
         case DATA:
-          return ManifestFiles.read(manifest, io, specsById).project(schema);
+          return ManifestFiles.read(manifest, io, specsById).project(fileProjection);
         case DELETES:
-          return ManifestFiles.readDeleteManifest(manifest, io, specsById).project(schema);
+          return ManifestFiles.readDeleteManifest(manifest, io, specsById).project(fileProjection);
         default:
           throw new IllegalArgumentException(
               "Unsupported manifest content type:" + manifest.content());
       }
+    }
+
+    private StructLike withReadableMetrics(ContentFile<?> file) {
+      int structSize = projection.columns().size();
+      StructType projectedMetricType =
+          projection.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+      MetricsUtil.ReadableMetricsStruct readableMetrics =
+          MetricsUtil.readableMetricsStruct(dataTableSchema, file, projectedMetricType);
+      return new ContentFileStructWithMetrics(structSize, (StructLike) file, readableMetrics);
     }
 
     @Override
@@ -184,6 +222,45 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     @VisibleForTesting
     ManifestFile manifest() {
       return manifest;
+    }
+  }
+
+  static class ContentFileStructWithMetrics implements StructLike {
+    private final int structSize;
+    private final StructLike fileAsStruct;
+    private final MetricsUtil.ReadableMetricsStruct readableMetrics;
+
+    ContentFileStructWithMetrics(
+        int structSize,
+        StructLike fileAsStruct,
+        MetricsUtil.ReadableMetricsStruct readableMetrics) {
+      this.structSize = structSize;
+      this.fileAsStruct = fileAsStruct;
+      this.readableMetrics = readableMetrics;
+    }
+
+    @Override
+    public int size() {
+      return structSize;
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      if (pos < (structSize - 1)) {
+        return fileAsStruct.get(pos, javaClass);
+      } else if (pos == (structSize - 1)) {
+        return javaClass.cast(readableMetrics);
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Illegal position access for ContentFileStructWithMetrics: %d, max allowed is %d",
+                pos, (structSize - 1)));
+      }
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("ContentFileStructWithMetrics is read only");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -18,13 +18,29 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MetricsUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsUtil.class);
 
   private MetricsUtil() {}
 
@@ -55,5 +71,271 @@ public class MetricsUtil {
 
     String columnName = inputSchema.findColumnName(fieldId);
     return metricsConfig.columnMode(columnName);
+  }
+
+  public static final List<ReadableMetricCol> READABLE_COL_METRICS =
+      ImmutableList.of(
+          new ReadableMetricCol("column_size", f -> Types.LongType.get(), "Total size on disk"),
+          new ReadableMetricCol(
+              "value_count", f -> Types.LongType.get(), "Total count, including null and NaN"),
+          new ReadableMetricCol("null_value_count", f -> Types.LongType.get(), "Null value count"),
+          new ReadableMetricCol("nan_value_count", f -> Types.LongType.get(), "NaN value count"),
+          new ReadableMetricCol("lower_bound", Types.NestedField::type, "Lower bound"),
+          new ReadableMetricCol("upper_bound", Types.NestedField::type, "Upper bound"));
+
+  public static final String READABLE_METRICS = "readable_metrics";
+
+  public static class ReadableMetricCol {
+    private final String name;
+    private final Function<Types.NestedField, Type> typeFunction;
+    private final String doc;
+
+    ReadableMetricCol(String name, Function<Types.NestedField, Type> typeFunction, String doc) {
+      this.name = name;
+      this.typeFunction = typeFunction;
+      this.doc = doc;
+    }
+
+    String name() {
+      return name;
+    }
+
+    Type type(Types.NestedField field) {
+      return typeFunction.apply(field);
+    }
+
+    String doc() {
+      return doc;
+    }
+  }
+
+  /**
+   * Represents a struct of metrics for a primitive column
+   *
+   * @param <T> primitive column type
+   */
+  public static class ReadableColMetricsStruct<T> implements StructLike {
+
+    private final String columnName;
+    private final Long columnSize;
+    private final Long valueCount;
+    private final Long nullValueCount;
+    private final Long nanValueCount;
+    private final T lowerBound;
+    private final T upperBound;
+    private final Map<Integer, Integer> projectionMap;
+
+    public ReadableColMetricsStruct(
+        String columnName,
+        Long columnSize,
+        Long valueCount,
+        Long nullValueCount,
+        Long nanValueCount,
+        T lowerBound,
+        T upperBound,
+        Types.NestedField projection) {
+      this.columnName = columnName;
+      this.columnSize = columnSize;
+      this.valueCount = valueCount;
+      this.nullValueCount = nullValueCount;
+      this.nanValueCount = nanValueCount;
+      this.lowerBound = lowerBound;
+      this.upperBound = upperBound;
+      this.projectionMap = readableMetricsProjection(projection);
+    }
+
+    @Override
+    public int size() {
+      return projectionMap.size();
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      Object value = get(pos);
+      return value == null ? null : javaClass.cast(value);
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("ReadableMetricsStruct is read only");
+    }
+
+    private Object get(int pos) {
+      int projectedPos = projectionMap.get(pos);
+      switch (projectedPos) {
+        case 0:
+          return columnSize;
+        case 1:
+          return valueCount;
+        case 2:
+          return nullValueCount;
+        case 3:
+          return nanValueCount;
+        case 4:
+          return lowerBound;
+        case 5:
+          return upperBound;
+        default:
+          throw new IllegalArgumentException(
+              String.format("Invalid projected pos %d", projectedPos));
+      }
+    }
+
+    /** @return map of projected position to actual position of this struct's fields */
+    private Map<Integer, Integer> readableMetricsProjection(Types.NestedField projection) {
+      Map<Integer, Integer> result = Maps.newHashMap();
+
+      Set<String> projectedFields =
+          Sets.newHashSet(
+              projection.type().asStructType().fields().stream()
+                  .map(Types.NestedField::name)
+                  .collect(Collectors.toSet()));
+
+      int projectedIndex = 0;
+      for (int fieldIndex = 0; fieldIndex < READABLE_COL_METRICS.size(); fieldIndex++) {
+        ReadableMetricCol readableMetric = READABLE_COL_METRICS.get(fieldIndex);
+
+        if (projectedFields.contains(readableMetric.name())) {
+          result.put(projectedIndex, fieldIndex);
+          projectedIndex++;
+        }
+      }
+      return result;
+    }
+
+    String columnName() {
+      return columnName;
+    }
+  }
+
+  /**
+   * Represents a struct, consisting of all {@link ReadableColMetricsStruct} for all primitive
+   * columns of the table
+   */
+  public static class ReadableMetricsStruct implements StructLike {
+
+    private final List<StructLike> columnMetrics;
+
+    public ReadableMetricsStruct(List<StructLike> columnMetrics) {
+      this.columnMetrics = columnMetrics;
+    }
+
+    @Override
+    public int size() {
+      return columnMetrics.size();
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      return javaClass.cast(columnMetrics.get(pos));
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("ReadableMetricsStruct is read only");
+    }
+  }
+
+  /**
+   * Calculates a dynamic schema for readable_metrics to add to metadata tables. The type will be
+   * the struct {@link ReadableColMetricsStruct}, composed of {@link ReadableMetricsStruct} for all
+   * primitive columns in the data table
+   *
+   * @param dataTableSchema schema of data table
+   * @param metadataTableSchema schema of existing metadata table (to ensure id uniqueness)
+   * @param baseId first id to assign. This algorithm assigns field ids by incrementing this value
+   *     and avoiding conflict with existing metadata table schema
+   * @return schema of readable_metrics struct
+   */
+  public static Schema readableMetricsSchema(
+      Schema dataTableSchema, Schema metadataTableSchema, int baseId) {
+    List<Types.NestedField> fields = Lists.newArrayList();
+    Set<Integer> usedIds = metadataTableSchema.idToName().keySet();
+
+    class NextFieldId {
+      private int next;
+
+      NextFieldId() {
+        this.next = baseId;
+      }
+
+      int next() {
+        do {
+          next++;
+        } while (usedIds.contains(next));
+        return next;
+      }
+    }
+    NextFieldId next = new NextFieldId();
+
+    Map<Integer, String> idToName = dataTableSchema.idToName();
+    for (int id : idToName.keySet()) {
+      Types.NestedField field = dataTableSchema.findField(id);
+
+      if (field.type().isPrimitiveType()) {
+        String colName = idToName.get(id);
+
+        fields.add(
+            Types.NestedField.of(
+                next.next(),
+                true,
+                colName,
+                Types.StructType.of(
+                    READABLE_COL_METRICS.stream()
+                        .map(m -> optional(next.next(), m.name(), m.type(field), m.doc()))
+                        .collect(Collectors.toList())),
+                String.format("Metrics for column %s", colName)));
+      }
+    }
+
+    fields.sort(Comparator.comparing(Types.NestedField::name));
+    return new Schema(
+        optional(
+            next.next(),
+            "readable_metrics",
+            Types.StructType.of(fields),
+            "Column metrics in readable form"));
+  }
+
+  /**
+   * Return a readable metrics struct row from file metadata
+   *
+   * @param schema schema of original data table
+   * @param file content file with metrics
+   * @param projectedSchema user requested projection
+   * @return {@link ReadableMetricsStruct}
+   */
+  public static ReadableMetricsStruct readableMetricsStruct(
+      Schema schema, ContentFile<?> file, Types.StructType projectedSchema) {
+    Map<Integer, String> idToName = schema.idToName();
+    List<ReadableColMetricsStruct<?>> colMetrics = Lists.newArrayList();
+
+    for (int id : idToName.keySet()) {
+      String qualifiedName = idToName.get(id);
+      Types.NestedField field = schema.findField(id);
+
+      if (field.type().isPrimitiveType()
+          && // Iceberg stores metrics only for primitive types
+          projectedSchema.field(qualifiedName) != null) { // User has requested this column metric
+        colMetrics.add(
+            new ReadableColMetricsStruct(
+                qualifiedName,
+                file.columnSizes() == null ? null : file.columnSizes().get(id),
+                file.valueCounts() == null ? null : file.valueCounts().get(id),
+                file.nullValueCounts() == null ? null : file.nullValueCounts().get(id),
+                file.nanValueCounts() == null ? null : file.nanValueCounts().get(id),
+                file.lowerBounds() == null
+                    ? null
+                    : Conversions.fromByteBuffer(field.type(), file.lowerBounds().get(id)),
+                file.upperBounds() == null
+                    ? null
+                    : Conversions.fromByteBuffer(field.type(), file.upperBounds().get(id)),
+                projectedSchema.field(qualifiedName)));
+      }
+    }
+
+    colMetrics.sort(Comparator.comparing(ReadableColMetricsStruct::columnName));
+    return new ReadableMetricsStruct(
+        colMetrics.stream().map(m -> (StructLike) m).collect(Collectors.toList()));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -528,6 +528,93 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @Test
+  public void testFilesTableReadableMetricsSchema() {
+
+    Table filesTable = new FilesTable(table.ops(), table);
+    Types.StructType actual = filesTable.newScan().schema().select("readable_metrics").asStruct();
+
+    Types.StructType expected =
+        Types.StructType.of(
+            optional(
+                DataFile.NEXT_ID_TO_ASSIGN + 15,
+                "readable_metrics",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        DataFile.NEXT_ID_TO_ASSIGN + 1,
+                        "data",
+                        Types.StructType.of(
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 2,
+                                "column_size",
+                                Types.LongType.get(),
+                                "Total size on disk"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 3,
+                                "value_count",
+                                Types.LongType.get(),
+                                "Total count, including null and NaN"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 4,
+                                "null_value_count",
+                                Types.LongType.get(),
+                                "Null value count"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 5,
+                                "nan_value_count",
+                                Types.LongType.get(),
+                                "NaN value count"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 6,
+                                "lower_bound",
+                                Types.StringType.get(),
+                                "Lower bound"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 7,
+                                "upper_bound",
+                                Types.StringType.get(),
+                                "Upper bound")),
+                        "Metrics for column data"),
+                    Types.NestedField.optional(
+                        DataFile.NEXT_ID_TO_ASSIGN + 8,
+                        "id",
+                        Types.StructType.of(
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 9,
+                                "column_size",
+                                Types.LongType.get(),
+                                "Total size on disk"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 10,
+                                "value_count",
+                                Types.LongType.get(),
+                                "Total count, including null and NaN"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 11,
+                                "null_value_count",
+                                Types.LongType.get(),
+                                "Null value count"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 12,
+                                "nan_value_count",
+                                Types.LongType.get(),
+                                "NaN value count"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 13,
+                                "lower_bound",
+                                Types.IntegerType.get(),
+                                "Lower bound"),
+                            Types.NestedField.optional(
+                                DataFile.NEXT_ID_TO_ASSIGN + 14,
+                                "upper_bound",
+                                Types.IntegerType.get(),
+                                "Upper bound")),
+                        "Metrics for column id")),
+                "Column metrics in readable form"));
+
+    Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+  }
+
+  @Test
   public void testPartitionSpecEvolutionAdditive() {
     preparePartitionedTable();
 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -25,8 +25,10 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,7 +40,11 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
@@ -55,6 +61,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -65,6 +74,7 @@ import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.data.TestHelpers;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.SparkException;
@@ -454,8 +464,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord = asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -488,6 +498,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
     inputDF.select("data", "id").write().mode("overwrite").insertInto("parquet_table");
 
+    NameMapping mapping = MappingUtil.create(table.schema());
+    String mappingJson = NameMappingParser.toJson(mapping);
+
+    table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson).commit();
+
     try {
       String stagingLocation = table.location() + "/metadata";
       SparkTableUtil.importSparkTable(
@@ -510,8 +525,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             Avro.read(in).project(entriesTable.schema()).build()) {
           for (GenericData.Record record : rows) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord = asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -620,8 +635,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord = asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -738,8 +753,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord = asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -1751,7 +1766,91 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .build();
   }
 
-  private void asMetadataRecord(GenericData.Record file) {
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file) {
+    return asMetadataRecordWithMetrics(dataTable, file, FileContent.DATA);
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file, FileContent content) {
+
+    Table filesTable =
+        MetadataTableUtils.createMetadataTableInstance(dataTable, MetadataTableType.FILES);
+
+    GenericData.Record record =
+        new GenericData.Record(AvroSchemaUtil.convert(filesTable.schema(), "dummy"));
+    boolean isPartitioned = Partitioning.partitionType(dataTable).fields().size() != 0;
+    int filesFields = isPartitioned ? 17 : 16;
+    for (int i = 0; i < filesFields; i++) {
+      if (i == 0) {
+        record.put(0, content.id());
+      } else if (i == 3) {
+        record.put(3, 0); // spec id
+      } else {
+        record.put(i, file.get(i));
+      }
+    }
+    record.put(
+        isPartitioned ? 17 : 16,
+        expectedReadableMetrics(
+            dataTable.schema(),
+            filesTable.schema(),
+            (Map<Integer, Long>) file.get("column_sizes"),
+            (Map<Integer, Long>) file.get("value_counts"),
+            (Map<Integer, Long>) file.get("null_value_counts"),
+            (Map<Integer, Long>) file.get("nan_value_counts"),
+            (Map<Integer, ByteBuffer>) file.get("lower_bounds"),
+            (Map<Integer, ByteBuffer>) file.get("upper_bounds")));
+    return record;
+  }
+
+  public static GenericData.Record expectedReadableMetrics(
+      Schema dataTableSchema,
+      Schema filesTableSchema,
+      Map<Integer, Long> columnSizes,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts,
+      Map<Integer, Long> nanValueCounts,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    Types.StructType readableMetricsType =
+        filesTableSchema.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+    GenericData.Record result = new GenericData.Record(AvroSchemaUtil.convert(readableMetricsType));
+    Map<Integer, String> nameById = dataTableSchema.idToName();
+    for (int columnId : nameById.keySet()) {
+      String colName = nameById.get(columnId);
+      Types.StructType readableMetricColSchema =
+          filesTableSchema
+              .findField(MetricsUtil.READABLE_METRICS)
+              .type()
+              .asStructType()
+              .field(colName)
+              .type()
+              .asStructType();
+      GenericData.Record record =
+          new GenericData.Record(AvroSchemaUtil.convert(readableMetricColSchema));
+      record.put(0, columnSizes == null ? null : columnSizes.get(columnId));
+      record.put(1, valueCounts == null ? null : valueCounts.get(columnId));
+      record.put(2, nullValueCounts == null ? null : nullValueCounts.get(columnId));
+      record.put(3, nanValueCounts == null ? null : nanValueCounts.get(columnId));
+      record.put(
+          4,
+          lowerBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), lowerBounds.get(columnId)));
+      record.put(
+          5,
+          upperBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), upperBounds.get(columnId)));
+      result.put(nameById.get(columnId), record);
+    }
+    return result;
+  }
+
+  public static void asMetadataRecord(GenericData.Record file) {
     file.put(0, FileContent.DATA.id());
     file.put(3, 0); // specId
   }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -39,9 +39,17 @@ import java.util.UUID;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -766,5 +774,94 @@ public class TestHelpers {
           expectedValues.isNullAt(i) ? null : expectedValues.get(i, valueType),
           actualValues.isNullAt(i) ? null : actualValues.get(i, valueType));
     }
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file) {
+    return asMetadataRecordWithMetrics(dataTable, file, FileContent.DATA);
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file, FileContent content) {
+
+    Table filesTable =
+        MetadataTableUtils.createMetadataTableInstance(dataTable, MetadataTableType.FILES);
+
+    GenericData.Record record =
+        new GenericData.Record(AvroSchemaUtil.convert(filesTable.schema(), "dummy"));
+    boolean isPartitioned = Partitioning.partitionType(dataTable).fields().size() != 0;
+    int filesFields = isPartitioned ? 17 : 16;
+    for (int i = 0; i < filesFields; i++) {
+      if (i == 0) {
+        record.put(0, content.id());
+      } else if (i == 3) {
+        record.put(3, 0); // spec id
+      } else {
+        record.put(i, file.get(i));
+      }
+    }
+    record.put(
+        isPartitioned ? 17 : 16,
+        expectedReadableMetrics(
+            dataTable.schema(),
+            filesTable.schema(),
+            (Map<Integer, Long>) file.get("column_sizes"),
+            (Map<Integer, Long>) file.get("value_counts"),
+            (Map<Integer, Long>) file.get("null_value_counts"),
+            (Map<Integer, Long>) file.get("nan_value_counts"),
+            (Map<Integer, ByteBuffer>) file.get("lower_bounds"),
+            (Map<Integer, ByteBuffer>) file.get("upper_bounds")));
+    return record;
+  }
+
+  public static GenericData.Record expectedReadableMetrics(
+      Schema dataTableSchema,
+      Schema filesTableSchema,
+      Map<Integer, Long> columnSizes,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts,
+      Map<Integer, Long> nanValueCounts,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    Types.StructType readableMetricsType =
+        filesTableSchema.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+    GenericData.Record result = new GenericData.Record(AvroSchemaUtil.convert(readableMetricsType));
+    Map<Integer, String> nameById = dataTableSchema.idToName();
+    for (int columnId : nameById.keySet()) {
+      String colName = nameById.get(columnId);
+      Types.StructType readableMetricColSchema =
+          filesTableSchema
+              .findField(MetricsUtil.READABLE_METRICS)
+              .type()
+              .asStructType()
+              .field(colName)
+              .type()
+              .asStructType();
+      GenericData.Record record =
+          new GenericData.Record(AvroSchemaUtil.convert(readableMetricColSchema));
+      record.put(0, columnSizes == null ? null : columnSizes.get(columnId));
+      record.put(1, valueCounts == null ? null : valueCounts.get(columnId));
+      record.put(2, nullValueCounts == null ? null : nullValueCounts.get(columnId));
+      record.put(3, nanValueCounts == null ? null : nanValueCounts.get(columnId));
+      record.put(
+          4,
+          lowerBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), lowerBounds.get(columnId)));
+      record.put(
+          5,
+          upperBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), upperBounds.get(columnId)));
+      result.put(nameById.get(columnId), record);
+    }
+    return result;
+  }
+
+  public static void asMetadataRecord(GenericData.Record file) {
+    file.put(0, FileContent.DATA.id());
+    file.put(3, 0); // specId
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -36,7 +36,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -55,6 +54,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -173,7 +175,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             row.put(2, 0L); // data sequence number
             row.put(3, 0L); // file sequence number
             GenericData.Record file = (GenericData.Record) row.get("data_file");
-            asMetadataRecord(file);
+            TestHelpers.asMetadataRecord(file);
             expected.add(row);
           });
     }
@@ -367,7 +369,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
               row.put(2, 0L); // data sequence number
               row.put(3, 0L); // file sequence number
               GenericData.Record file = (GenericData.Record) row.get("data_file");
-              asMetadataRecord(file);
+              TestHelpers.asMetadataRecord(file);
               expected.add(row);
             });
       }
@@ -452,8 +454,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -486,6 +489,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
     inputDF.select("data", "id").write().mode("overwrite").insertInto("parquet_table");
 
+    NameMapping mapping = MappingUtil.create(table.schema());
+    String mappingJson = NameMappingParser.toJson(mapping);
+
+    table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson).commit();
+
     try {
       String stagingLocation = table.location() + "/metadata";
       SparkTableUtil.importSparkTable(
@@ -508,8 +516,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             Avro.read(in).project(entriesTable.schema()).build()) {
           for (GenericData.Record record : rows) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -618,8 +627,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -736,8 +746,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -1787,11 +1798,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                         .build()))
         .set("reference_snapshot_id", referenceSnapshotId)
         .build();
-  }
-
-  private void asMetadataRecord(GenericData.Record file) {
-    file.put(0, FileContent.DATA.id());
-    file.put(3, 0); // specId
   }
 
   private PositionDeleteWriter<InternalRow> newPositionDeleteWriter(

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -615,20 +615,15 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             Record file = (Record) record.get("data_file");
             if (partitionMatch(file, partValue)) {
-              asMetadataRecord(file, expectedContent);
-              expected.add(file);
+              Record expectedRecord =
+                  TestHelpers.asMetadataRecordWithMetrics(table, file, expectedContent);
+              expected.add(expectedRecord);
             }
           }
         }
       }
     }
     return expected;
-  }
-
-  // Populate certain fields derived in the metadata tables
-  private void asMetadataRecord(Record file, FileContent content) {
-    file.put(0, content.id());
-    file.put(3, 0); // specId
   }
 
   private boolean partitionMatch(Record file, String partValue) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -44,14 +44,21 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -816,5 +823,94 @@ public class TestHelpers {
         .flatMap(s -> s.allManifests(table.io()).stream())
         .map(ManifestFile::path)
         .collect(Collectors.toSet());
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file) {
+    return asMetadataRecordWithMetrics(dataTable, file, FileContent.DATA);
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file, FileContent content) {
+
+    Table filesTable =
+        MetadataTableUtils.createMetadataTableInstance(dataTable, MetadataTableType.FILES);
+
+    GenericData.Record record =
+        new GenericData.Record(AvroSchemaUtil.convert(filesTable.schema(), "dummy"));
+    boolean isPartitioned = Partitioning.partitionType(dataTable).fields().size() != 0;
+    int filesFields = isPartitioned ? 17 : 16;
+    for (int i = 0; i < filesFields; i++) {
+      if (i == 0) {
+        record.put(0, content.id());
+      } else if (i == 3) {
+        record.put(3, 0); // spec id
+      } else {
+        record.put(i, file.get(i));
+      }
+    }
+    record.put(
+        isPartitioned ? 17 : 16,
+        expectedReadableMetrics(
+            dataTable.schema(),
+            filesTable.schema(),
+            (Map<Integer, Long>) file.get("column_sizes"),
+            (Map<Integer, Long>) file.get("value_counts"),
+            (Map<Integer, Long>) file.get("null_value_counts"),
+            (Map<Integer, Long>) file.get("nan_value_counts"),
+            (Map<Integer, ByteBuffer>) file.get("lower_bounds"),
+            (Map<Integer, ByteBuffer>) file.get("upper_bounds")));
+    return record;
+  }
+
+  public static GenericData.Record expectedReadableMetrics(
+      Schema dataTableSchema,
+      Schema filesTableSchema,
+      Map<Integer, Long> columnSizes,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts,
+      Map<Integer, Long> nanValueCounts,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    Types.StructType readableMetricsType =
+        filesTableSchema.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+    GenericData.Record result = new GenericData.Record(AvroSchemaUtil.convert(readableMetricsType));
+    Map<Integer, String> nameById = dataTableSchema.idToName();
+    for (int columnId : nameById.keySet()) {
+      String colName = nameById.get(columnId);
+      Types.StructType readableMetricColSchema =
+          filesTableSchema
+              .findField(MetricsUtil.READABLE_METRICS)
+              .type()
+              .asStructType()
+              .field(colName)
+              .type()
+              .asStructType();
+      GenericData.Record record =
+          new GenericData.Record(AvroSchemaUtil.convert(readableMetricColSchema));
+      record.put(0, columnSizes == null ? null : columnSizes.get(columnId));
+      record.put(1, valueCounts == null ? null : valueCounts.get(columnId));
+      record.put(2, nullValueCounts == null ? null : nullValueCounts.get(columnId));
+      record.put(3, nanValueCounts == null ? null : nanValueCounts.get(columnId));
+      record.put(
+          4,
+          lowerBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), lowerBounds.get(columnId)));
+      record.put(
+          5,
+          upperBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), upperBounds.get(columnId)));
+      result.put(nameById.get(columnId), record);
+    }
+    return result;
+  }
+
+  public static void asMetadataRecord(GenericData.Record file) {
+    file.put(0, FileContent.DATA.id());
+    file.put(3, 0); // specId
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -36,7 +36,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -55,6 +54,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -173,7 +175,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             row.put(2, 0L); // data sequence number
             row.put(3, 0L); // file sequence number
             GenericData.Record file = (GenericData.Record) row.get("data_file");
-            asMetadataRecord(file);
+            TestHelpers.asMetadataRecord(file);
             expected.add(row);
           });
     }
@@ -367,7 +369,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
               row.put(2, 0L); // data sequence number
               row.put(3, 0L); // file sequence number
               GenericData.Record file = (GenericData.Record) row.get("data_file");
-              asMetadataRecord(file);
+              TestHelpers.asMetadataRecord(file);
               expected.add(row);
             });
       }
@@ -452,8 +454,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -486,6 +489,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
     inputDF.select("data", "id").write().mode("overwrite").insertInto("parquet_table");
 
+    NameMapping mapping = MappingUtil.create(table.schema());
+    String mappingJson = NameMappingParser.toJson(mapping);
+
+    table.updateProperties().set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson).commit();
+
     try {
       String stagingLocation = table.location() + "/metadata";
       SparkTableUtil.importSparkTable(
@@ -508,8 +516,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             Avro.read(in).project(entriesTable.schema()).build()) {
           for (GenericData.Record record : rows) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -618,8 +627,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -736,8 +746,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             GenericData.Record file = (GenericData.Record) record.get("data_file");
-            asMetadataRecord(file);
-            expected.add(file);
+            GenericData.Record expectedRecord =
+                TestHelpers.asMetadataRecordWithMetrics(table, file);
+            expected.add(expectedRecord);
           }
         }
       }
@@ -1804,11 +1815,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                         .build()))
         .set("reference_snapshot_id", referenceSnapshotId)
         .build();
-  }
-
-  private void asMetadataRecord(GenericData.Record file) {
-    file.put(0, FileContent.DATA.id());
-    file.put(3, 0); // specId
   }
 
   private PositionDeleteWriter<InternalRow> newPositionDeleteWriter(

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -615,20 +615,15 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             Record file = (Record) record.get("data_file");
             if (partitionMatch(file, partValue)) {
-              asMetadataRecord(file, expectedContent);
-              expected.add(file);
+              Record expectedRecord =
+                  TestHelpers.asMetadataRecordWithMetrics(table, file, expectedContent);
+              expected.add(expectedRecord);
             }
           }
         }
       }
     }
     return expected;
-  }
-
-  // Populate certain fields derived in the metadata tables
-  private void asMetadataRecord(Record file, FileContent content) {
-    file.put(0, content.id());
-    file.put(3, 0); // specId
   }
 
   private boolean partitionMatch(Record file, String partValue) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -44,14 +44,21 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -816,5 +823,95 @@ public class TestHelpers {
         .flatMap(s -> s.allManifests(table.io()).stream())
         .map(ManifestFile::path)
         .collect(Collectors.toSet());
+  }
+
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file) {
+    return asMetadataRecordWithMetrics(dataTable, file, FileContent.DATA);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static GenericData.Record asMetadataRecordWithMetrics(
+      Table dataTable, GenericData.Record file, FileContent content) {
+
+    Table filesTable =
+        MetadataTableUtils.createMetadataTableInstance(dataTable, MetadataTableType.FILES);
+
+    GenericData.Record record =
+        new GenericData.Record(AvroSchemaUtil.convert(filesTable.schema(), "dummy"));
+    boolean isPartitioned = Partitioning.partitionType(dataTable).fields().size() != 0;
+    int filesFields = isPartitioned ? 17 : 16;
+    for (int i = 0; i < filesFields; i++) {
+      if (i == 0) {
+        record.put(0, content.id());
+      } else if (i == 3) {
+        record.put(3, 0); // spec id
+      } else {
+        record.put(i, file.get(i));
+      }
+    }
+    record.put(
+        isPartitioned ? 17 : 16,
+        expectedReadableMetrics(
+            dataTable.schema(),
+            filesTable.schema(),
+            (Map<Integer, Long>) file.get("column_sizes"),
+            (Map<Integer, Long>) file.get("value_counts"),
+            (Map<Integer, Long>) file.get("null_value_counts"),
+            (Map<Integer, Long>) file.get("nan_value_counts"),
+            (Map<Integer, ByteBuffer>) file.get("lower_bounds"),
+            (Map<Integer, ByteBuffer>) file.get("upper_bounds")));
+    return record;
+  }
+
+  public static GenericData.Record expectedReadableMetrics(
+      Schema dataTableSchema,
+      Schema filesTableSchema,
+      Map<Integer, Long> columnSizes,
+      Map<Integer, Long> valueCounts,
+      Map<Integer, Long> nullValueCounts,
+      Map<Integer, Long> nanValueCounts,
+      Map<Integer, ByteBuffer> lowerBounds,
+      Map<Integer, ByteBuffer> upperBounds) {
+    Types.StructType readableMetricsType =
+        filesTableSchema.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+    GenericData.Record result = new GenericData.Record(AvroSchemaUtil.convert(readableMetricsType));
+    Map<Integer, String> nameById = dataTableSchema.idToName();
+    for (int columnId : nameById.keySet()) {
+      String colName = nameById.get(columnId);
+      Types.StructType readableMetricColSchema =
+          filesTableSchema
+              .findField(MetricsUtil.READABLE_METRICS)
+              .type()
+              .asStructType()
+              .field(colName)
+              .type()
+              .asStructType();
+      GenericData.Record record =
+          new GenericData.Record(AvroSchemaUtil.convert(readableMetricColSchema));
+      record.put(0, columnSizes == null ? null : columnSizes.get(columnId));
+      record.put(1, valueCounts == null ? null : valueCounts.get(columnId));
+      record.put(2, nullValueCounts == null ? null : nullValueCounts.get(columnId));
+      record.put(3, nanValueCounts == null ? null : nanValueCounts.get(columnId));
+      record.put(
+          4,
+          lowerBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), lowerBounds.get(columnId)));
+      record.put(
+          5,
+          upperBounds == null
+              ? null
+              : Conversions.fromByteBuffer(
+                  dataTableSchema.findType(columnId), upperBounds.get(columnId)));
+      result.put(nameById.get(columnId), record);
+    }
+    return result;
+  }
+
+  public static void asMetadataRecord(GenericData.Record file) {
+    file.put(0, FileContent.DATA.id());
+    file.put(3, 0); // specId
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private static final Types.StructType LEAF_STRUCT_TYPE =
+      Types.StructType.of(
+          optional(1, "leafLongCol", Types.LongType.get()),
+          optional(2, "leafDoubleCol", Types.DoubleType.get()));
+
+  private static final Types.StructType NESTED_STRUCT_TYPE =
+      Types.StructType.of(required(3, "leafStructCol", LEAF_STRUCT_TYPE));
+
+  private static final Schema NESTED_SCHEMA =
+      new Schema(required(4, "nestedStructCol", NESTED_STRUCT_TYPE));
+
+  private static final Schema PRIMITIVE_SCHEMA =
+      new Schema(
+          required(1, "booleanCol", Types.BooleanType.get()),
+          required(2, "intCol", Types.IntegerType.get()),
+          required(3, "longCol", Types.LongType.get()),
+          required(4, "floatCol", Types.FloatType.get()),
+          required(5, "doubleCol", Types.DoubleType.get()),
+          optional(6, "decimalCol", Types.DecimalType.of(10, 2)),
+          optional(7, "stringCol", Types.StringType.get()),
+          optional(8, "fixedCol", Types.FixedType.ofLength(3)),
+          optional(9, "binaryCol", Types.BinaryType.get()));
+
+  public TestMetadataTableReadableMetrics() {
+    // only SparkCatalog supports metadata table sql queries
+    super(SparkCatalogConfig.HIVE);
+  }
+
+  protected String tableName() {
+    return tableName.split("\\.")[2];
+  }
+
+  protected String database() {
+    return tableName.split("\\.")[1];
+  }
+
+  private Table createPrimitiveTable() throws IOException {
+    Table table =
+        catalog.createTable(
+            TableIdentifier.of(Namespace.of(database()), tableName()),
+            PRIMITIVE_SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of());
+    List<Record> records =
+        Lists.newArrayList(
+            createPrimitiveRecord(
+                false,
+                1,
+                1L,
+                0,
+                1.0D,
+                new BigDecimal("1.00"),
+                "1",
+                Base64.getDecoder().decode("1111"),
+                ByteBuffer.wrap(Base64.getDecoder().decode("1111"))),
+            createPrimitiveRecord(
+                true,
+                2,
+                2L,
+                0,
+                2.0D,
+                new BigDecimal("2.00"),
+                "2",
+                Base64.getDecoder().decode("2222"),
+                ByteBuffer.wrap(Base64.getDecoder().decode("2222"))),
+            createPrimitiveRecord(false, 1, 1, Float.NaN, Double.NaN, null, "1", null, null),
+            createPrimitiveRecord(
+                false, 2, 2L, Float.NaN, 2.0D, new BigDecimal("2.00"), "2", null, null));
+
+    DataFile dataFile =
+        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    table.newAppend().appendFile(dataFile).commit();
+    return table;
+  }
+
+  private void createNestedTable() throws IOException {
+    Table table =
+        catalog.createTable(
+            TableIdentifier.of(Namespace.of(database()), tableName()),
+            NESTED_SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of());
+
+    List<Record> records =
+        Lists.newArrayList(
+            createNestedRecord(0L, 0.0),
+            createNestedRecord(1L, Double.NaN),
+            createNestedRecord(null, null));
+    DataFile dataFile =
+        FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), records);
+    table.newAppend().appendFile(dataFile).commit();
+  }
+
+  @After
+  public void dropTable() {
+    sql("DROP TABLE %s", tableName);
+  }
+
+  private Dataset<Row> filesDf() {
+    return spark.read().format("iceberg").load(database() + "." + tableName() + ".files");
+  }
+
+  protected GenericRecord createPrimitiveRecord(
+      boolean booleanCol,
+      int intCol,
+      long longCol,
+      float floatCol,
+      double doubleCol,
+      BigDecimal decimalCol,
+      String stringCol,
+      byte[] fixedCol,
+      ByteBuffer binaryCol) {
+    GenericRecord record = GenericRecord.create(PRIMITIVE_SCHEMA);
+    record.set(0, booleanCol);
+    record.set(1, intCol);
+    record.set(2, longCol);
+    record.set(3, floatCol);
+    record.set(4, doubleCol);
+    record.set(5, decimalCol);
+    record.set(6, stringCol);
+    record.set(7, fixedCol);
+    record.set(8, binaryCol);
+    return record;
+  }
+
+  private GenericRecord createNestedRecord(Long longCol, Double doubleCol) {
+    GenericRecord record = GenericRecord.create(NESTED_SCHEMA);
+    GenericRecord nested = GenericRecord.create(NESTED_STRUCT_TYPE);
+    GenericRecord leaf = GenericRecord.create(LEAF_STRUCT_TYPE);
+    leaf.set(0, longCol);
+    leaf.set(1, doubleCol);
+    nested.set(0, leaf);
+    record.set(0, nested);
+    return record;
+  }
+
+  @Test
+  public void testPrimitiveColumns() throws Exception {
+    createPrimitiveTable();
+
+    Object[] binaryCol =
+        row(
+            59L,
+            4L,
+            2L,
+            null,
+            Base64.getDecoder().decode("1111"),
+            Base64.getDecoder().decode("2222"));
+    Object[] booleanCol = row(44L, 4L, 0L, null, false, true);
+    Object[] decimalCol = row(97L, 4L, 1L, null, new BigDecimal("1.00"), new BigDecimal("2.00"));
+    Object[] doubleCol = row(99L, 4L, 0L, 1L, 1.0D, 2.0D);
+    Object[] fixedCol =
+        row(
+            55L,
+            4L,
+            2L,
+            null,
+            Base64.getDecoder().decode("1111"),
+            Base64.getDecoder().decode("2222"));
+    Object[] floatCol = row(90L, 4L, 0L, 2L, 0f, 0f);
+    Object[] intCol = row(91L, 4L, 0L, null, 1, 2);
+    Object[] longCol = row(91L, 4L, 0L, null, 1L, 2L);
+    Object[] stringCol = row(99L, 4L, 0L, null, "1", "2");
+
+    Object[] metrics =
+        row(
+            binaryCol,
+            booleanCol,
+            decimalCol,
+            doubleCol,
+            fixedCol,
+            floatCol,
+            intCol,
+            longCol,
+            stringCol);
+
+    assertEquals(
+        "Row should match",
+        ImmutableList.of(new Object[] {metrics}),
+        sql("SELECT readable_metrics FROM %s.files", tableName));
+  }
+
+  @Test
+  public void testSelect() throws Exception {
+    createPrimitiveTable();
+
+    assertEquals(
+        "select of nested readable_metrics fields should work",
+        ImmutableList.of(row(1, true)),
+        sql(
+            "SELECT readable_metrics.intCol.lower_bound, readable_metrics.booleanCol.upper_bound FROM %s.files",
+            tableName));
+
+    assertEquals(
+        "mixed select of readable_metrics and other field should work",
+        ImmutableList.of(row(0, 4L)),
+        sql("SELECT content, readable_metrics.longCol.value_count FROM %s.files", tableName));
+
+    assertEquals(
+        "mixed select of readable_metrics and other field should work, in the other order",
+        ImmutableList.of(row(4L, 0)),
+        sql("SELECT readable_metrics.longCol.value_count, content FROM %s.files", tableName));
+  }
+
+  @Test
+  public void testNestedValues() throws Exception {
+    createNestedTable();
+
+    Object[] leafDoubleCol = row(53L, 3L, 1L, 1L, 0.0D, 0.0D);
+    Object[] leafLongCol = row(54L, 3L, 1L, null, 0L, 1L);
+    Object[] metrics = row(leafDoubleCol, leafLongCol);
+
+    assertEquals(
+        "Row should match",
+        ImmutableList.of(new Object[] {metrics}),
+        sql("SELECT readable_metrics FROM %s.files", tableName));
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -236,11 +236,11 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSelect() throws Exception {
+  public void testSelectPrimitiveValues() throws Exception {
     createPrimitiveTable();
 
     assertEquals(
-        "select of nested readable_metrics fields should work",
+        "select of primitive readable_metrics fields should work",
         ImmutableList.of(row(1, true)),
         sql(
             "SELECT readable_metrics.intCol.lower_bound, readable_metrics.booleanCol.upper_bound FROM %s.files",
@@ -255,6 +255,19 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
         "mixed select of readable_metrics and other field should work, in the other order",
         ImmutableList.of(row(4L, 0)),
         sql("SELECT readable_metrics.longCol.value_count, content FROM %s.files", tableName));
+  }
+
+  @Test
+  public void testSelectNestedValues() throws Exception {
+    createNestedTable();
+
+    assertEquals(
+        "select of nested readable_metrics fields should work",
+        ImmutableList.of(row(0L, 3L)),
+        sql(
+            "SELECT readable_metrics.`nestedStructCol.leafStructCol.leafLongCol`.lower_bound, "
+                + "readable_metrics.`nestedStructCol.leafStructCol.leafDoubleCol`.value_count FROM %s.files",
+            tableName));
   }
 
   @Test


### PR DESCRIPTION
Closes #4362

This adds following columns to all files tables:

- readable_metrics, which is struct of:
- column_sizes
- value_counts
- null_value_counts
- nan_value_counts
- lower_bounds
- upper_bounds

These are then a map of column_name to value.
