### PR TITLE
Hive: More distinctive cached client pool key to avoid conflict

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -32,7 +32,8 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 
 public class CachedClientPool implements ClientPool<IMetaStoreClient, TException> {
-  private static final String CATALOG_DEFAULT = "metastore.catalog.default";
+
+  @VisibleForTesting static final String CATALOG_DEFAULT = "metastore.catalog.default";
   private static Cache<String, HiveClientPool> clientPoolCache;
 
   private final Configuration conf;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -32,17 +32,18 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 
 public class CachedClientPool implements ClientPool<IMetaStoreClient, TException> {
-
+  private static final String CATALOG_DEFAULT = "metastore.catalog.default";
   private static Cache<String, HiveClientPool> clientPoolCache;
 
   private final Configuration conf;
-  private final String metastoreUri;
+  private final String key;
   private final int clientPoolSize;
   private final long evictionInterval;
 
   CachedClientPool(Configuration conf, Map<String, String> properties) {
     this.conf = conf;
-    this.metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
+    this.key =
+        conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "") + conf.get(CATALOG_DEFAULT, "");
     this.clientPoolSize =
         PropertyUtil.propertyAsInt(
             properties,
@@ -58,7 +59,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
   @VisibleForTesting
   HiveClientPool clientPool() {
-    return clientPoolCache.get(metastoreUri, k -> new HiveClientPool(clientPoolSize, conf));
+    return clientPoolCache.get(key, k -> new HiveClientPool(clientPoolSize, conf));
   }
 
   private synchronized void init() {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -37,13 +37,13 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
   private static Cache<String, HiveClientPool> clientPoolCache;
 
   private final Configuration conf;
-  private final String key;
+  private final String clientPoolKey;
   private final int clientPoolSize;
   private final long evictionInterval;
 
   CachedClientPool(Configuration conf, Map<String, String> properties) {
     this.conf = conf;
-    this.key =
+    this.clientPoolKey =
         conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "") + conf.get(CATALOG_DEFAULT, "");
     this.clientPoolSize =
         PropertyUtil.propertyAsInt(
@@ -60,7 +60,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
   @VisibleForTesting
   HiveClientPool clientPool() {
-    return clientPoolCache.get(key, k -> new HiveClientPool(clientPoolSize, conf));
+    return clientPoolCache.get(clientPoolKey, k -> new HiveClientPool(clientPoolSize, conf));
   }
 
   private synchronized void init() {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -43,8 +43,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
 
   CachedClientPool(Configuration conf, Map<String, String> properties) {
     this.conf = conf;
-    this.clientPoolKey =
-        conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "") + conf.get(CATALOG_DEFAULT, "");
+    this.clientPoolKey = cacheKey(conf);
     this.clientPoolSize =
         PropertyUtil.propertyAsInt(
             properties,
@@ -56,6 +55,13 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
             CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS,
             CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS_DEFAULT);
     init();
+  }
+
+  @VisibleForTesting
+  static String cacheKey(Configuration conf) {
+    return String.format(
+        "%s:%s",
+        conf.get(HiveConf.ConfVars.METASTOREURIS.varname, ""), conf.get(CATALOG_DEFAULT, ""));
   }
 
   @VisibleForTesting

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
@@ -56,5 +56,7 @@ public class TestCachedClientPool extends HiveMetastoreTest {
     Assert.assertTrue(CachedClientPool.clientPoolCache().getIfPresent(key1) == clientPool1);
     Assert.assertTrue(CachedClientPool.clientPoolCache().getIfPresent(key2) == clientPool2);
     Assert.assertTrue(clientPool1 != clientPool2);
+
+    hiveConf.unset(CATALOG_DEFAULT);
   }
 }


### PR DESCRIPTION
Hive 3+ allows users to set the default catalog name within the same HMS. A job can have two Spark catalogs configured with the same uri and a **different catalog name** as the following example shows.
```
"spark.sql.catalog.catalog1": "org.apache.iceberg.spark.SparkCatalog",
"spark.sql.catalog.catalog1.hadoop.metastore.catalog.default": "catalog1",
"spark.sql.catalog.catalog1.type": "hive",
"spark.sql.catalog.catalog1.uri": "thrift://hms.com:8092",

"spark.sql.catalog.catalog2": "org.apache.iceberg.spark.SparkCatalog",
"spark.sql.catalog.catalog2.hadoop.metastore.catalog.default": "catalog2",
"spark.sql.catalog.catalog2.type": "hive",
"spark.sql.catalog.catalog2.uri": "thrift://hms.com:8092",
```
We need to distinguish them in the cached hive client pool.
@szehon-ho @RussellSpitzer 