### PR TITLE
AWS: Fix S3FileIO#prefixList integration test

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -341,7 +341,7 @@ public class TestS3FileIOIntegration {
     String listPrefix = String.format("s3://%s/%s", bucketName, "prefix-list-test");
 
     scaleSizes.parallelStream().forEach(scale -> {
-      String scalePrefix = String.format("%s/%s/", prefix, scale);
+      String scalePrefix = String.format("%s/%s/", listPrefix, scale);
       createRandomObjects(scalePrefix, scale);
       assertEquals((long) scale, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
     });


### PR DESCRIPTION
Fix scale prefix in listPrefix test. In https://github.com/apache/iceberg/pull/5289 I made a change to fix some flaky tests and added some integration tests, but in the listPrefix integ test, the incorrect prefix is being used. For the prefix list integ test, all the objects are created under s3:://<test_bucket>/prefix-list-test/scale/. The test fails during S3 URI creation.  After fixing this, the test is passing.