### PR TITLE
Spark: Fix a separate table cache being created for each rewriteFiles

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -186,6 +186,14 @@ public class RewriteDataFilesSparkAction
     }
   }
 
+  @Override
+  protected SparkSession spark() {
+    // Disable Adaptive Query Execution as this may change the output partitioning of our write
+    SparkSession spark = super.spark().cloneSession();
+    spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    return spark;
+  }
+
   Map<StructLike, List<List<FileScanTask>>> planFileGroups(long startingSnapshotId) {
     CloseableIterable<FileScanTask> fileScanTasks =
         table
@@ -490,10 +498,7 @@ public class RewriteDataFilesSparkAction
   }
 
   private BinPackStrategy binPackStrategy() {
-    // Disable Adaptive Query Execution as this may change the output partitioning of our write
-    SparkSession spark = spark().cloneSession();
-    spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
-    return new SparkBinPackStrategy(table, spark);
+    return new SparkBinPackStrategy(table, spark());
   }
 
   private SortStrategy sortStrategy() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -95,14 +95,12 @@ public class RewriteDataFilesSparkAction
   private boolean useStartingSequenceNumber;
   private RewriteJobOrder rewriteJobOrder;
   private RewriteStrategy strategy = null;
-  private final SparkSession cloneSession;
 
   RewriteDataFilesSparkAction(SparkSession spark, Table table) {
-    super(spark);
-    this.table = table;
+    super(spark.cloneSession());
     // Disable Adaptive Query Execution as this may change the output partitioning of our write
-    this.cloneSession = spark.cloneSession();
-    this.cloneSession.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    spark().conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    this.table = table;
   }
 
   @Override
@@ -494,15 +492,15 @@ public class RewriteDataFilesSparkAction
   }
 
   private BinPackStrategy binPackStrategy() {
-    return new SparkBinPackStrategy(table, cloneSession);
+    return new SparkBinPackStrategy(table, spark());
   }
 
   private SortStrategy sortStrategy() {
-    return new SparkSortStrategy(table, cloneSession);
+    return new SparkSortStrategy(table, spark());
   }
 
   private SortStrategy zOrderStrategy(String... columnNames) {
-    return new SparkZOrderStrategy(table, cloneSession, Lists.newArrayList(columnNames));
+    return new SparkZOrderStrategy(table, spark(), Lists.newArrayList(columnNames));
   }
 
   @VisibleForTesting

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -68,6 +68,7 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.StructLikeMap;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -489,7 +490,10 @@ public class RewriteDataFilesSparkAction
   }
 
   private BinPackStrategy binPackStrategy() {
-    return new SparkBinPackStrategy(table, spark());
+    // Disable Adaptive Query Execution as this may change the output partitioning of our write
+    SparkSession spark = spark().cloneSession();
+    spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    return new SparkBinPackStrategy(table, spark);
   }
 
   private SortStrategy sortStrategy() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackStrategy.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackStrategy.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.internal.SQLConf;
 
 public class SparkBinPackStrategy extends BinPackStrategy {
   private final Table table;
@@ -45,9 +44,7 @@ public class SparkBinPackStrategy extends BinPackStrategy {
 
   public SparkBinPackStrategy(Table table, SparkSession spark) {
     this.table = table;
-    // Disable Adaptive Query Execution as this may change the output partitioning of our write
-    this.spark = spark.cloneSession();
-    this.spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
+    this.spark = spark;
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
@@ -202,6 +202,7 @@ public class SparkZOrderStrategy extends SparkSortStrategy {
       tableCache().add(groupID, table());
       manager().stageTasks(table(), groupID, filesToRewrite);
 
+      // spark session from parent
       SparkSession spark = spark();
       // Reset Shuffle Partitions for our sort
       long numOutputFiles =

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
@@ -232,7 +232,7 @@ public class SparkZOrderStrategy extends SparkSortStrategy {
 
       Dataset<Row> zvalueDF = scanDF.withColumn(Z_COLUMN, zOrderUDF.interleaveBytes(zvalueArray));
 
-      SQLConf sqlConf = spark().sessionState().conf();
+      SQLConf sqlConf = spark.sessionState().conf();
       LogicalPlan sortPlan = sortPlan(distribution, ordering, zvalueDF.logicalPlan(), sqlConf);
       Dataset<Row> sortedDf = new Dataset<>(spark, sortPlan, zvalueDF.encoder());
       sortedDf

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderStrategy.java
@@ -202,17 +202,14 @@ public class SparkZOrderStrategy extends SparkSortStrategy {
       tableCache().add(groupID, table());
       manager().stageTasks(table(), groupID, filesToRewrite);
 
-      // Disable Adaptive Query Execution as this may change the output partitioning of our write
-      SparkSession cloneSession = spark().cloneSession();
-      cloneSession.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), false);
-
+      SparkSession spark = spark();
       // Reset Shuffle Partitions for our sort
       long numOutputFiles =
           numOutputFiles((long) (inputFileSize(filesToRewrite) * sizeEstimateMultiple()));
-      cloneSession.conf().set(SQLConf.SHUFFLE_PARTITIONS().key(), Math.max(1, numOutputFiles));
+      spark.conf().set(SQLConf.SHUFFLE_PARTITIONS().key(), Math.max(1, numOutputFiles));
 
       Dataset<Row> scanDF =
-          cloneSession
+          spark
               .read()
               .format("iceberg")
               .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID, groupID)
@@ -235,9 +232,9 @@ public class SparkZOrderStrategy extends SparkSortStrategy {
 
       Dataset<Row> zvalueDF = scanDF.withColumn(Z_COLUMN, zOrderUDF.interleaveBytes(zvalueArray));
 
-      SQLConf sqlConf = cloneSession.sessionState().conf();
+      SQLConf sqlConf = spark().sessionState().conf();
       LogicalPlan sortPlan = sortPlan(distribution, ordering, zvalueDF.logicalPlan(), sqlConf);
-      Dataset<Row> sortedDf = new Dataset<>(cloneSession, sortPlan, zvalueDF.encoder());
+      Dataset<Row> sortedDf = new Dataset<>(spark, sortPlan, zvalueDF.encoder());
       sortedDf
           .select(originalColumns)
           .write()


### PR DESCRIPTION
Currently, during Spark's rewrite data files procedure with bin pack strategy, `SparkSession` is cloned to disable AQE in each `rewriteFiles`. Since a cloned `SparkSession` has its own state, V2SessionCatalog is reloaded every time and a separate table cache is created. That means each file group has its own table cache and effectively disables the table cache.

This PR fixes it by cloning `SparkSession` when creating `SparkBinPackStrategy`.