### PR TITLE
API: Assign the right field ids when merging schema, #5394

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -289,7 +289,7 @@ public class TypeUtil {
   }
 
   public static Schema reassignOrRefreshIds(Schema schema, Schema idSourceSchema) {
-    AtomicInteger highest = new AtomicInteger(schema.highestFieldId());
+    AtomicInteger highest = new AtomicInteger(idSourceSchema.highestFieldId());
     Types.StructType struct =
         visit(schema, new ReassignIds(idSourceSchema, highest::incrementAndGet)).asStructType();
     return new Schema(struct.fields(), refreshIdentifierFields(struct, schema));

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -600,4 +600,28 @@ public class TestTypeUtil {
     Schema actualNoStruct = TypeUtil.selectNot(schema, Sets.newHashSet(2));
     Assert.assertEquals(schema.asStruct(), actualNoStruct.asStruct());
   }
+
+  @Test
+  public void testReassignOrRefreshIds() {
+    Schema schema =
+        new Schema(
+            Lists.newArrayList(
+                required(10, "a", Types.IntegerType.get()),
+                required(11, "c", Types.IntegerType.get()),
+                required(12, "B", Types.IntegerType.get())),
+            Sets.newHashSet(10));
+    Schema sourceSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(1, "a", Types.IntegerType.get()),
+                required(15, "B", Types.IntegerType.get())));
+    final Schema actualSchema = TypeUtil.reassignOrRefreshIds(schema, sourceSchema);
+    final Schema expectedSchema =
+        new Schema(
+            Lists.newArrayList(
+                required(1, "a", Types.IntegerType.get()),
+                required(16, "c", Types.IntegerType.get()),
+                required(15, "B", Types.IntegerType.get())));
+    Assert.assertEquals(expectedSchema.asStruct(), actualSchema.asStruct());
+  }
 }


### PR DESCRIPTION
Starting with schema:
```
{A: 1, B: 2, C:3}
```

And then a user drops C, resulting in:
```
{A: 1, B: 2} Highest Field ID = 3
```

Then do a mergeSchema with
```
{A, B, D}
```

This will end up assigning (highestId({A:1, B:2}) + 1) to D (3)
The table would then have schemas :

```
Schemas {
{A: 1, B: 2, C: 3}
{A: 1, B: 2}
{A: 1, B :2, D: 3}
}
```