### PR TITLE
API, Spark: Generate symlink manifest action

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -64,4 +64,10 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /** Instantiates an action to generate a symlink manifest of a table */
+  default GenerateSymlinkManifest generateSymlinkManifest(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement deleteReachableFiles");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/GenerateSymlinkManifest.java
+++ b/api/src/main/java/org/apache/iceberg/actions/GenerateSymlinkManifest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+public interface GenerateSymlinkManifest
+    extends Action<GenerateSymlinkManifest, GenerateSymlinkManifest.Result> {
+
+  GenerateSymlinkManifest ignoreDeleteFiles();
+
+  GenerateSymlinkManifest symlinkManifestRootLocation(String rootLocation);
+
+  /** The action result that contains a summary of the execution. */
+  interface Result {
+
+    /** Returns the number of data files in the generated symlink file */
+    long dataFilesCount();
+
+    /** Returns the snapshot id used when generating the symlink file */
+    long snapshotId();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/GenerateSymlinkManifestActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/GenerateSymlinkManifestActionResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+public class GenerateSymlinkManifestActionResult implements GenerateSymlinkManifest.Result {
+
+  private final long dataFilesCount;
+  private final long snapshotId;
+
+  public GenerateSymlinkManifestActionResult(long snapshotId, long dataFilesCount) {
+    this.snapshotId = snapshotId;
+    this.dataFilesCount = dataFilesCount;
+  }
+
+  @Override
+  public long dataFilesCount() {
+    return dataFilesCount;
+  }
+
+  @Override
+  public long snapshotId() {
+    return snapshotId;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/GenerateSymlinkManifestAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/GenerateSymlinkManifestAction.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.GenerateSymlinkManifest;
+import org.apache.iceberg.actions.GenerateSymlinkManifestActionResult;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+public class GenerateSymlinkManifestAction extends BaseSparkAction<GenerateSymlinkManifestAction>
+    implements GenerateSymlinkManifest {
+
+  private final Table table;
+  private boolean ignoreDeleteFiles = false;
+  private String rootLocation;
+
+  private static final String SYMLINK_MANIFEST_DEFAULT_DIRECTORY = "_symlink_format_manifest";
+
+  protected GenerateSymlinkManifestAction(SparkSession spark, Table table) {
+    super(spark);
+    ValidationException.check(
+        table.currentSnapshot() != null, "Cannot generate symlink manifest for empty table");
+    this.table = table;
+  }
+
+  @Override
+  public GenerateSymlinkManifestAction.Result execute() {
+    JobGroupInfo info = newJobGroupInfo("GENERATE-SYMLINK-MANIFEST", jobDesc());
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  @Override
+  protected GenerateSymlinkManifestAction self() {
+    return this;
+  }
+
+  @Override
+  public GenerateSymlinkManifest ignoreDeleteFiles() {
+    this.ignoreDeleteFiles = true;
+    return this;
+  }
+
+  @Override
+  public GenerateSymlinkManifest symlinkManifestRootLocation(String rootLocation) {
+    this.rootLocation = rootLocation;
+    return this;
+  }
+
+  private GenerateSymlinkManifest.Result doExecute() {
+    long snapshot = table.currentSnapshot().snapshotId();
+    Dataset<Row> entries =
+        SparkTableUtil.loadMetadataTable(spark(), table, MetadataTableType.ENTRIES);
+    // If we're not ignoring delete files, check if there are any delete manifests for the snapshot.
+    if (!ignoreDeleteFiles) {
+      boolean deletesExist = entries.filter("status < 2 and data_file.content > 0").isEmpty();
+      if (deletesExist) {
+        throw new UnsupportedOperationException(
+            "Cannot generate symlink manifest when there are delete files. Set ignore delete files for generating a "
+                + "symlink manifest of only data files");
+      }
+    }
+    Dataset<Row> activeDataFiles = entries.filter("status < 2 AND data_file.content = 0");
+
+    activeDataFiles.cache();
+    long datafileCount = activeDataFiles.count();
+    Types.StructType partitionType = Partitioning.partitionType(table);
+    String[] partitionColumns =
+        partitionType.fields().stream().map(Types.NestedField::name).toArray(String[]::new);
+
+    String[] partitionColumnNames =
+        Arrays.stream(partitionColumns)
+            .map(name -> "data_file.partition." + name)
+            .toArray(String[]::new);
+
+    Dataset<Row> symlinkDataset =
+        partitionColumns.length == 0
+            ? activeDataFiles.select("data_file.file_path")
+            : activeDataFiles.select("data_file.file_path", partitionColumnNames);
+    DataFrameWriter<Row> writer = symlinkDataset.write().format("text");
+    if (partitionColumns.length == 0) {
+      writer.save(symlinkManifestRootLocation());
+    } else {
+      writer.partitionBy(partitionColumns).save(symlinkManifestRootLocation());
+    }
+    return new GenerateSymlinkManifestActionResult(snapshot, datafileCount);
+  }
+
+  private String symlinkManifestRootLocation() {
+    if (rootLocation != null) {
+      return rootLocation;
+    }
+    String tableLocation = table.location();
+    long snapshot = table.currentSnapshot().snapshotId();
+    StringBuilder sb = new StringBuilder();
+    sb.append(tableLocation);
+    if (!tableLocation.endsWith("/")) {
+      sb.append("/");
+    }
+    sb.append(SYMLINK_MANIFEST_DEFAULT_DIRECTORY);
+    sb.append("/");
+    sb.append(snapshot);
+    return sb.toString();
+  }
+
+  private String jobDesc() {
+    List<String> options = Lists.newArrayList();
+
+    options.add("ignoreDeleteFiles" + ignoreDeleteFiles);
+    StringBuilder sb = new StringBuilder();
+    sb.append("Generating symlink for table ").append(table.name()).append(" at snapshot ");
+    sb.append(table.currentSnapshot().snapshotId()).append(".");
+    if (ignoreDeleteFiles) {
+      sb.append(" Ignoring delete files.");
+    }
+    return sb.toString();
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -53,7 +53,7 @@ public class SparkActions implements ActionsProvider {
     CatalogPlugin defaultCatalog = spark.sessionState().catalogManager().currentCatalog();
     CatalogAndIdentifier catalogAndIdent =
         Spark3Util.catalogAndIdentifier(ctx, spark, tableIdent, defaultCatalog);
-    return new SnapshotTableSparkAction(
+      return new SnapshotTableSparkAction(
         spark, catalogAndIdent.catalog(), catalogAndIdent.identifier());
   }
 
@@ -90,5 +90,10 @@ public class SparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFilesSparkAction deleteReachableFiles(String metadataLocation) {
     return new DeleteReachableFilesSparkAction(spark, metadataLocation);
+  }
+
+  @Override
+  public GenerateSymlinkManifestAction generateSymlinkManifest(Table table) {
+    return new GenerateSymlinkManifestAction(spark, table);
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestGenerateSymlinkManifestAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestGenerateSymlinkManifestAction.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.hadoop.HiddenPathFilter;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestGenerateSymlinkManifestAction extends SparkTestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  protected static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.IntegerType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+  protected String tableLocation = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    this.tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @Test
+  public void testGenerateSymlinkManifestEmptyTableFails() {
+    Table table =
+        TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
+    AssertHelpers.assertThrows(
+        "Should not support generating symlink manifest for empty table",
+        ValidationException.class,
+        "Cannot generate symlink manifest for empty table",
+        () -> SparkActions.get().generateSymlinkManifest(table).execute());
+  }
+
+  @Test
+  public void testGenerateSymlinkManifestWithDeleteFilesFailsWithoutIgnore() {
+    Table table =
+        TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+    table.newDelete().deleteFromRowFilter(Expressions.equal("c1", 1)).commit();
+    AssertHelpers.assertThrows(
+        "Should not support generate symlink manifest when there are delete files",
+        UnsupportedOperationException.class,
+        "Cannot generate symlink manifest when there are delete files",
+        () -> SparkActions.get().generateSymlinkManifest(table).execute());
+  }
+
+  @Test
+  public void testGenerateSymlinkManifestUnpartitioned() throws IOException {
+    Table table =
+        TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    SparkActions.get().generateSymlinkManifest(table).ignoreDeleteFiles().execute();
+
+    long snapshot = table.currentSnapshot().snapshotId();
+    Path dataPath = new Path(tableLocation + "_symlink_format_manifest/" + snapshot + "/");
+    FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
+    List<String> allFiles =
+        Arrays.stream(fs.listStatus(dataPath, HiddenPathFilter.get()))
+            .filter(FileStatus::isFile)
+            .map(file -> file.getPath().toString())
+            .collect(Collectors.toList());
+    Assert.assertEquals("Should be 1 file", 1, allFiles.size());
+  }
+
+  @Test
+  public void testGenerateSymlinkManifestPartitioned() {}
+
+  @Test
+  public void testGenerateSymlinkManifestPartitionedCustomLocation() {}
+}


### PR DESCRIPTION
This is an action implementation for generating symlink manifests for the data files in a table based off of https://github.com/apache/iceberg/pull/4401, with some changes to fail if there are active delete files (as well as addressing some comments). After this action change, we can add the procedure which leverages the action.

This action implementation uses the table snapshot at the time of executing the action, but in a follow on PR the snapshot can be passed in to generate symlinks manifests for historical snapshots of the table.


