### PR TITLE
Spark: Support Bulk deletion in expire-snapshots if fileIO allows

### DIFF
--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -1183,6 +1183,21 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
+  public void testExpireBulkDeleteWithThrowOnUnsupportedFileIO() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Set<String> bulkDeletedFiles = Sets.newHashSet();
+
+    AssertHelpers.assertThrows(
+        "Should complain about unsupported fileIO",
+        IllegalArgumentException.class,
+        "does not support bulk deletion",
+        () ->
+            SparkActions.get()
+                .expireSnapshots(table)
+                .bulkDeleteWith(files -> files.forEach(bulkDeletedFiles::add)));
+  }
+
+  @Test
   public void testUseLocalIterator() {
     table.newFastAppend().appendFile(FILE_A).commit();
 


### PR DESCRIPTION
In #4052, S3 fileIO now implement a new interfaces to support S3 batch deletion, this PR introduce it for Spark expire-snapshots procedure to conditionally support delete files in batch if underlying fileIO supports it (if implements `SupportsBulkOperations` interface and currently only S3FileIO support such)

It default to use S3 batch deletion if fileIO is supported in catalog, allow for customization with `bulkDeleteWith` method
- cannot reuse the existing  `bulkDelete` consumer function because it only take single file name at a time instead of a iterable
- did not add interface override, want to keep this change as small as possible, once approved then we can retroactively apply to interface and previous spark version (2.4/3.0/3.1/3.2)
- Considering the existing test fixture all use HadoopTables and it's very hard to test the integration of S3FileIO and Spark action together in unit tests, so I am looking for a way to do some integration tests and will share the results later 

Similar to #5373 but for expire-snapshots procedure, relate to #4012

CC @rdblue , @danielcweeks, @amogh-jahagirdar, @szehon-ho 