### PR TITLE
AWS: S3FileIo Integration test include UUID prefix in Prefix integration tests

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -338,7 +338,7 @@ public class TestS3FileIOIntegration {
   public void testPrefixList() {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
     List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
-    String listPrefix = String.format("s3://%s/%s", bucketName, "prefix-list-test");
+    String listPrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-list-test");
 
     scaleSizes.parallelStream().forEach(scale -> {
       String scalePrefix = String.format("%s/%s/", listPrefix, scale);
@@ -355,7 +355,7 @@ public class TestS3FileIOIntegration {
     AwsProperties properties = new AwsProperties();
     properties.setS3FileIoDeleteBatchSize(100);
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
-    String deletePrefix = String.format("s3://%s/%s", bucketName, "prefix-delete-test");
+    String deletePrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-delete-test");
 
     List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1000, 2500);
     scaleSizes.parallelStream().forEach(scale -> {


### PR DESCRIPTION
Right now, running s3 file io integration test multiple times will lead to failures in expectations of the testPrefixList. This is because the cleanup which happens in AfterClass only cleans up under s3://bucket/uuid-prefix where uuid prefix is the random uuid created on each run of the test class. The testPrefixList is creating objects in s3://bucket/prefix-list-test. We should actually put this in s3://bucket/uuid-prefix/prefix-list-test so that After class will properly clean this up, and we can run multiple runs of the integ test successfully.

Going forward, we will also want https://github.com/apache/iceberg/pull/4855 so that issues like this can be caught earlier on. I tested this by running the AWS integ tests multiple times on a pre-existing bucket I used for iceberg-aws integration tests.