### PR TITLE
Python: Handle OAuthErrorResponse properly

### DIFF
--- a/python/pyiceberg/exceptions.py
+++ b/python/pyiceberg/exceptions.py
@@ -70,3 +70,7 @@ class ForbiddenError(RESTError):
 
 class AuthorizationExpiredError(RESTError):
     """When the credentials are expired when performing an action on the REST catalog"""
+
+
+class OAuthError(RESTError):
+    """Raises when there is an error with the OAuth call"""

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -27,6 +27,7 @@ from pyiceberg.exceptions import (
     BadCredentialsError,
     NoSuchNamespaceError,
     NoSuchTableError,
+    OAuthError,
     TableAlreadyExistsError,
 )
 from pyiceberg.schema import Schema
@@ -74,6 +75,18 @@ def test_token_200(rest_mock: Mocker):
         status_code=200,
     )
     assert RestCatalog("rest", {}, TEST_URI, TEST_CREDENTIALS).token == TEST_TOKEN
+
+
+def test_token_400(rest_mock: Mocker):
+    rest_mock.post(
+        f"{TEST_URI}v1/oauth/tokens",
+        json={"error": "invalid_client", "error_description": "Credentials for key invalid_key do not match"},
+        status_code=400,
+    )
+
+    with pytest.raises(OAuthError) as e:
+        RestCatalog("rest", {}, TEST_URI, credentials=TEST_CREDENTIALS)
+    assert str(e.value) == "invalid_client: Credentials for key invalid_key do not match"
 
 
 def test_token_401(rest_mock: Mocker):


### PR DESCRIPTION
The `/token` endpoint can return an OAuthErrorResponse as part of a HTTP400.

https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L1675-L1695

This has a different structure as the other error responses:

```json
{"error": "invalid_client", "error_description": "Credentials for key invalid_key do not match"}
```

Instead of:

```json
{
    "error": {
        "message": "Invalid client ID: abc",
        "type": "BadCredentialsException",
        "code": 401,
    }
}
```

Therefore we check this and format the exception before throwing it