### PR TITLE
Infra - Upgrade Stale GH Action to Latest 5.1.1

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,7 +30,7 @@ jobs:
   stale:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v5.1.1
         with:
           stale-issue-label: 'stale'
           exempt-issue-labels: 'not-stale'


### PR DESCRIPTION
Now that the GH Action for marking issues as stale has been merged in https://github.com/apache/iceberg/pull/4949 and we've seen it work, we should upgrade it to the latest version to pick up some bug fixes.

Upgrades from v4 to v5.1.1 (the latest version found under releases https://github.com/actions/stale).

This will make it more efficient as it will not double check `stale` issues accidentally, and our limit of number of issues to consider in a run will be the value set (and not some fraction of it).