### PR TITLE
feat: FlinkSink support dynamically changed schema

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
@@ -303,6 +303,9 @@ class FlinkOrcWriters {
 
     @Override
     protected Object get(RowData struct, int index) {
+      if (index >= struct.getArity()) {
+        return null;
+      }
       return fieldGetters.get(index).getFieldOrNull(struct);
     }
   }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -498,6 +498,9 @@ public class FlinkParquetWriters {
 
     @Override
     protected Object get(RowData struct, int index) {
+      if (index >= struct.getArity()) {
+        return null;
+      }
       return fieldGetter[index].getFieldOrNull(struct);
     }
   }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
@@ -236,7 +236,7 @@ public class FlinkValueWriters {
     @Override
     public void write(RowData row, Encoder encoder) throws IOException {
       for (int i = 0; i < writers.length; i += 1) {
-        if (row.isNullAt(i)) {
+        if (i >= row.getArity() || row.isNullAt(i)) {
           writers[i].write(null, encoder);
         } else {
           write(row, i, writers[i], encoder);
@@ -247,7 +247,11 @@ public class FlinkValueWriters {
     @SuppressWarnings("unchecked")
     private <T> void write(RowData row, int pos, ValueWriter<T> writer, Encoder encoder)
         throws IOException {
-      writer.write((T) getters[pos].getFieldOrNull(row), encoder);
+      T value = null;
+      if (pos < row.getArity()) {
+        value = (T) getters[pos].getFieldOrNull(row);
+      }
+      writer.write(value, encoder);
     }
   }
 }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -434,7 +434,7 @@ public class FlinkSink {
       }
 
       IcebergStreamWriter<RowData> streamWriter =
-          createStreamWriter(table, flinkWriteConf, flinkRowType, equalityFieldIds);
+          createStreamWriter(table, flinkWriteConf, flinkRowType, equalityFieldIds, tableLoader);
 
       int parallelism = writeParallelism == null ? input.getParallelism() : writeParallelism;
       SingleOutputStreamOperator<WriteResult> writerStream =
@@ -546,6 +546,15 @@ public class FlinkSink {
       FlinkWriteConf flinkWriteConf,
       RowType flinkRowType,
       List<Integer> equalityFieldIds) {
+    return createStreamWriter(table, flinkWriteConf, flinkRowType, equalityFieldIds, null);
+  }
+
+  static IcebergStreamWriter<RowData> createStreamWriter(
+      Table table,
+      FlinkWriteConf flinkWriteConf,
+      RowType flinkRowType,
+      List<Integer> equalityFieldIds,
+      TableLoader tableLoader) {
     Preconditions.checkArgument(table != null, "Iceberg table shouldn't be null");
 
     Table serializableTable = SerializableTable.copyOf(table);
@@ -556,7 +565,8 @@ public class FlinkSink {
             flinkWriteConf.targetDataFileSize(),
             flinkWriteConf.dataFileFormat(),
             equalityFieldIds,
-            flinkWriteConf.upsertMode());
+            flinkWriteConf.upsertMode(),
+            tableLoader);
     return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
   }
 }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
@@ -78,6 +78,7 @@ class IcebergStreamWriter<T> extends AbstractStreamOperator<WriteResult>
       writer.close();
       writer = null;
     }
+    taskWriterFactory.close();
   }
 
   @Override

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/TaskWriterFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/TaskWriterFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.io.IOException;
 import java.io.Serializable;
 import org.apache.iceberg.io.TaskWriter;
 
@@ -42,4 +43,11 @@ public interface TaskWriterFactory<T> extends Serializable {
    * @return a newly created task writer.
    */
   TaskWriter<T> create();
+
+  /**
+   * close the factory
+   *
+   * @throws IOException close may be throw IOException
+   */
+  void close() throws IOException;
 }


### PR DESCRIPTION
FlinkSink support dynamically changed schema. This commit only implements the dynamic update schema on the FlinkSink side, and users need to implement the update of RowData in their own code. The code below is my example code for dynamically building RowData.

```
public class RowDataFlatMap extends RichFlatMapFunction<Map<String, String>, RowData>
        implements CheckpointListener {
    private static final Logger LOG = LoggerFactory.getLogger(RowDataFlatMap.class);
    private final TableLoader tableLoader;
    private DataTypeConverter dataTypeConverter;
    private Table table;

    public RowDataFlatMap(TableLoader tableLoader) {
        this.tableLoader = tableLoader;
    }

    @Override
    public void open(Configuration parameters) {
        tableLoader.open();
        table = tableLoader.loadTable();
        dataTypeConverter = new DataTypeConverter(table.schema());
    }

    @Override
    public void close() throws Exception {
        tableLoader.close();
    }

    @Override
    public void flatMap(Map<String, String> value, Collector<RowData> out) {
        try {
            out.collect(dataTypeConverter.map2RowData(value));
        } catch (LogProcessException e) {
            LOG.debug("exception type: {}, value: {}", e.getClass(), value);
        }
    }

    @Override
    public void notifyCheckpointComplete(long checkpointId) {
        table.refresh();
        if (!dataTypeConverter.isSameSchema(table.schema())) {
            dataTypeConverter.updateSchema(table.schema());
        }
    }
}
```