### PR TITLE
CI: Enable dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,9 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+


### PR DESCRIPTION
This will check the version of the Github Actions versions each week, so we don't have to do it by hand :)