### PR TITLE
Spark: Support truncate in FunctionCatalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -254,7 +254,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return UnicodeUtil.truncateStringUnsafe(length, value);
+      return UnicodeUtil.truncateString(value, length);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -393,7 +393,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return BinaryUtil.truncateBinaryUnsafe(length, value);
+      return BinaryUtil.truncateBinaryUnsafe(value, length);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -31,6 +31,8 @@ import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.TruncateUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 
 abstract class Truncate<T> implements Transform<T, T> {
@@ -87,7 +89,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return value - (((value % width) + width) % width);
+      return TruncateUtil.truncateInt(width, value);
     }
 
     @Override
@@ -171,7 +173,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return value - (((value % width) + width) % width);
+      return TruncateUtil.truncateLong(width, value);
     }
 
     @Override
@@ -252,7 +254,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return UnicodeUtil.truncateString(value, length);
+      return UnicodeUtil.truncateStringUnsafe(length, value);
     }
 
     @Override
@@ -391,9 +393,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      ByteBuffer ret = value.duplicate();
-      ret.limit(Math.min(value.limit(), value.position() + length));
-      return ret;
+      return BinaryUtil.truncateBinaryUnsafe(length, value);
     }
 
     @Override
@@ -480,16 +480,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      BigDecimal remainder =
-          new BigDecimal(
-              value
-                  .unscaledValue()
-                  .remainder(unscaledWidth)
-                  .add(unscaledWidth)
-                  .remainder(unscaledWidth),
-              value.scale());
-
-      return value.subtract(remainder);
+      return TruncateUtil.truncateDecimal(unscaledWidth, value);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -53,14 +53,12 @@ public class BinaryUtil {
   /**
    * Truncates the input byte buffer to the given length.
    *
-   * <p>This skips input validation, and avoids copying the backing bytes if possible for efficiency
-   * reasons. This function should only be used if the input doesn't need validation. Likely {@link
-   * #truncateBinary(ByteBuffer, int)} is preferred.
+   * <p>Unlike {@linkplain #truncateBinary(ByteBuffer, int)}, this skips copying the input data.
    *
-   * @param width The non-negative length to truncate input to
    * @param value The ByteBuffer to be truncated
+   * @param width The non-negative length to truncate input to
    */
-  public static ByteBuffer truncateBinaryUnsafe(int width, ByteBuffer value) {
+  public static ByteBuffer truncateBinaryUnsafe(ByteBuffer value, int width) {
     ByteBuffer ret = value.duplicate();
     ret.limit(Math.min(value.limit(), value.position() + width));
     return ret;

--- a/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BinaryUtil.java
@@ -51,6 +51,22 @@ public class BinaryUtil {
   }
 
   /**
+   * Truncates the input byte buffer to the given length.
+   *
+   * <p>This skips input validation, and avoids copying the backing bytes if possible for efficiency
+   * reasons. This function should only be used if the input doesn't need validation. Likely {@link
+   * #truncateBinary(ByteBuffer, int)} is preferred.
+   *
+   * @param width The non-negative length to truncate input to
+   * @param value The ByteBuffer to be truncated
+   */
+  public static ByteBuffer truncateBinaryUnsafe(int width, ByteBuffer value) {
+    ByteBuffer ret = value.duplicate();
+    ret.limit(Math.min(value.limit(), value.position() + width));
+    return ret;
+  }
+
+  /**
    * Returns a byte buffer whose length is lesser than or equal to truncateLength and is lower than
    * the given input
    */

--- a/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+/**
+ * Contains the logic for various {@code truncate} transformations for various types.
+ *
+ * <p>This utility class allows for the logic to be reused in different scenarios where input
+ * validation is done at different times either in org.apache.iceberg.transforms.Truncate and within
+ * defined SQL functions for different compute engines for usage in SQL.
+ *
+ * <p>In general, the inputs to the functions should have already been validated by the calling
+ * code, as different classes use truncate with different preprocessing. This generally means that
+ * the truncation width is positive and the value to truncate is non-null.
+ *
+ * <p>Thus, <b>none</b> of these utility functions validate their input. <i>It is the responsibility
+ * of the calling code to validate input.</i>
+ *
+ * <p>See also {@linkplain UnicodeUtil#truncateStringUnsafe(int, CharSequence)} and {@link
+ * BinaryUtil#truncateBinaryUnsafe(int, ByteBuffer)} for similar methods for Strings and
+ * ByteBuffers.
+ */
+public class TruncateUtil {
+
+  private TruncateUtil() {}
+
+  public static byte truncateByte(int width, byte value) {
+    return (byte) (value - (((value % width) + width) % width));
+  }
+
+  public static short truncateShort(int width, short value) {
+    return (short) (value - (((value % width) + width) % width));
+  }
+
+  public static int truncateInt(int width, int value) {
+    return value - (((value % width) + width) % width);
+  }
+
+  public static long truncateLong(int width, long value) {
+    return value - (((value % width) + width) % width);
+  }
+
+  public static BigDecimal truncateDecimal(BigInteger unscaledWidth, BigDecimal value) {
+    BigDecimal remainder =
+        new BigDecimal(
+            value
+                .unscaledValue()
+                .remainder(unscaledWidth)
+                .add(unscaledWidth)
+                .remainder(unscaledWidth),
+            value.scale());
+
+    return value.subtract(remainder);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
@@ -36,7 +36,7 @@ import java.nio.ByteBuffer;
  * <p>Thus, <b>none</b> of these utility functions validate their input. <i>It is the responsibility
  * of the calling code to validate input.</i>
  *
- * <p>See also {@linkplain UnicodeUtil#truncateStringUnsafe(int, CharSequence)} and {@link
+ * <p>See also {@linkplain UnicodeUtil#truncateString(CharSequence, int)} and {@link
  * BinaryUtil#truncateBinaryUnsafe(ByteBuffer, int)} for similar methods for Strings and
  * ByteBuffers.
  */

--- a/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/TruncateUtil.java
@@ -37,7 +37,7 @@ import java.nio.ByteBuffer;
  * of the calling code to validate input.</i>
  *
  * <p>See also {@linkplain UnicodeUtil#truncateStringUnsafe(int, CharSequence)} and {@link
- * BinaryUtil#truncateBinaryUnsafe(int, ByteBuffer)} for similar methods for Strings and
+ * BinaryUtil#truncateBinaryUnsafe(ByteBuffer, int)} for similar methods for Strings and
  * ByteBuffers.
  */
 public class TruncateUtil {

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -40,17 +40,6 @@ public class UnicodeUtil {
    */
   public static CharSequence truncateString(CharSequence input, int length) {
     Preconditions.checkArgument(length > 0, "Truncate length should be positive");
-    return truncateStringUnsafe(length, input);
-  }
-
-  /**
-   * Truncate the input charSequence such that the returned charSequence is a valid unicode string
-   * and the number of unicode characters in the truncated charSequence is lesser than or equal to
-   * length.
-   *
-   * <p>Note that this function does not validate the input
-   */
-  public static CharSequence truncateStringUnsafe(int length, CharSequence input) {
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -40,6 +40,17 @@ public class UnicodeUtil {
    */
   public static CharSequence truncateString(CharSequence input, int length) {
     Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+    return truncateStringUnsafe(length, input);
+  }
+
+  /**
+   * Truncate the input charSequence such that the returned charSequence is a valid unicode string
+   * and the number of unicode characters in the truncated charSequence is lesser than or equal to
+   * length.
+   *
+   * <p>Note that this function does not validate the input
+   */
+  public static CharSequence truncateStringUnsafe(int length, CharSequence input) {
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());

--- a/core/src/test/java/org/apache/iceberg/util/TestTruncateUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTruncateUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TestTruncateUtil {
+  @Test
+  public void testInvalidInputWidthBehavior() {
+    Assertions.assertThatNoException()
+        .as("Invalid width input shouldn't necessarily throw an exception as it's not validated")
+        .isThrownBy(() -> TruncateUtil.truncateInt(-1, 100));
+
+    Assertions.assertThatException()
+        .as("Invalid width input can possibly throw an exception")
+        .isThrownBy(() -> TruncateUtil.truncateInt(0, 100));
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -30,7 +30,9 @@ public class SparkFunctions {
   private SparkFunctions() {}
 
   private static final Map<String, UnboundFunction> FUNCTIONS =
-      ImmutableMap.of("iceberg_version", new IcebergVersionFunction());
+      ImmutableMap.of(
+          "iceberg_version", new IcebergVersionFunction(),
+          "truncate", new TruncateFunction());
 
   private static final List<String> FUNCTION_NAMES = ImmutableList.copyOf(FUNCTIONS.keySet());
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -256,9 +256,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
-          ? null
-          : invoke(input.getInt(0), input.getUTF8String(1));
+      return input.isNullAt(0) ? null : invoke(input.getInt(0), input.getUTF8String(1));
     }
   }
 
@@ -290,9 +288,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
-          ? null
-          : invoke(input.getInt(0), input.getBinary(1));
+      return input.isNullAt(0) ? null : invoke(input.getInt(0), input.getBinary(1));
     }
   }
 
@@ -332,7 +328,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(0)
           ? null
           : invoke(input.getInt(0), input.getDecimal(1, precision, scale));
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -54,7 +54,7 @@ public class TruncateFunction implements UnboundFunction {
   private static final int WIDTH_ORDINAL = 0;
   private static final int VALUE_ORDINAL = 1;
 
-  private static void validateTruncationWidthType(DataType widthType) {
+  private static void validateWidthType(DataType widthType) {
     if (!DataTypes.IntegerType.sameType(widthType)
         && !DataTypes.ShortType.sameType(widthType)
         && !DataTypes.ByteType.sameType(widthType)) {
@@ -72,7 +72,8 @@ public class TruncateFunction implements UnboundFunction {
 
     StructField widthField = inputType.fields()[WIDTH_ORDINAL];
     StructField toTruncateField = inputType.fields()[VALUE_ORDINAL];
-    validateTruncationWidthType(widthField.dataType());
+
+    validateWidthType(widthField.dataType());
 
     DataType toTruncateDataType = toTruncateField.dataType();
     if (toTruncateDataType instanceof ByteType) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -73,10 +73,6 @@ public class TruncateFunction implements UnboundFunction {
           "Expected truncation width to be tinyint, shortint or int");
     }
 
-    if (widthField.nullable()) {
-      throw new UnsupportedOperationException("Truncation width field cannot be nullable");
-    }
-
     DataType valueType = valueField.dataType();
     if (valueType instanceof ByteType) {
       return new TruncateTinyInt();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -269,7 +269,7 @@ public class TruncateFunction implements UnboundFunction {
       }
 
       return ByteBuffers.toByteArray(
-          BinaryUtil.truncateBinaryUnsafe(width, ByteBuffer.wrap(value)));
+          BinaryUtil.truncateBinaryUnsafe(ByteBuffer.wrap(value), width));
     }
 
     @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -20,12 +20,9 @@ package org.apache.iceberg.spark.functions;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.util.BinaryUtil;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.TruncateUtil;
-import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
@@ -238,17 +235,12 @@ public class TruncateFunction implements UnboundFunction {
 
   public static class TruncateString extends TruncateBase<UTF8String> {
     // magic function for usage with codegen
-    // TODO - This can likely be made more efficient, but using existing definition for now.
     public static UTF8String invoke(int width, UTF8String value) {
       if (value == null) {
         return null;
       }
 
-      ByteBuffer bb = value.getByteBuffer();
-      CharSequence charSequence = StandardCharsets.UTF_8.decode(bb);
-      CharSequence truncated = UnicodeUtil.truncateStringUnsafe(width, charSequence);
-      ByteBuffer truncatedBytes = StandardCharsets.UTF_8.encode(CharBuffer.wrap(truncated));
-      return UTF8String.fromBytes(ByteBuffers.toByteArray(truncatedBytes));
+      return value.substring(0, width);
     }
 
     @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -256,7 +256,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      return input.isNullAt(0) ? null : invoke(input.getInt(0), input.getUTF8String(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getUTF8String(1));
     }
   }
 
@@ -288,7 +290,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      return input.isNullAt(0) ? null : invoke(input.getInt(0), input.getBinary(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getBinary(1));
     }
   }
 
@@ -328,7 +332,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      return input.isNullAt(0)
+      return input.isNullAt(0) || input.isNullAt(1)
           ? null
           : invoke(input.getInt(0), input.getDecimal(1, precision, scale));
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -139,9 +139,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Byte produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getByte(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getByte(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -168,9 +170,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Short produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getShort(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getShort(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -197,9 +201,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getInt(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getInt(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -226,9 +232,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Long produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -259,9 +267,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getUTF8String(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getUTF8String(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -293,9 +303,11 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getBinary(VALUE_ORDINAL));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(input.getInt(WIDTH_ORDINAL), input.getBinary(VALUE_ORDINAL));
+      }
     }
   }
 
@@ -335,9 +347,12 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(WIDTH_ORDINAL), input.getDecimal(VALUE_ORDINAL, precision, scale));
+      if (input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)) {
+        return null;
+      } else {
+        return invoke(
+            input.getInt(WIDTH_ORDINAL), input.getDecimal(VALUE_ORDINAL, precision, scale));
+      }
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -73,6 +73,10 @@ public class TruncateFunction implements UnboundFunction {
           "Expected truncation width to be tinyint, shortint or int");
     }
 
+    if (widthField.nullable()) {
+      throw new UnsupportedOperationException("Truncation width field cannot be nullable");
+    }
+
     DataType valueType = valueField.dataType();
     if (valueType instanceof ByteType) {
       return new TruncateTinyInt();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -51,6 +51,9 @@ import org.apache.spark.unsafe.types.UTF8String;
  */
 public class TruncateFunction implements UnboundFunction {
 
+  private static final int WIDTH_ORDINAL = 0;
+  private static final int VALUE_ORDINAL = 1;
+
   private static void validateTruncationWidthType(DataType widthType) {
     if (!DataTypes.IntegerType.sameType(widthType)
         && !DataTypes.ShortType.sameType(widthType)
@@ -67,8 +70,8 @@ public class TruncateFunction implements UnboundFunction {
           "Cannot bind truncate: wrong number of inputs (expected width and value)");
     }
 
-    StructField widthField = inputType.fields()[0];
-    StructField toTruncateField = inputType.fields()[1];
+    StructField widthField = inputType.fields()[WIDTH_ORDINAL];
+    StructField toTruncateField = inputType.fields()[VALUE_ORDINAL];
     validateTruncationWidthType(widthField.dataType());
 
     DataType toTruncateDataType = toTruncateField.dataType();
@@ -136,9 +139,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Byte produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getByte(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getByte(VALUE_ORDINAL));
     }
   }
 
@@ -165,9 +168,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Short produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getShort(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getShort(VALUE_ORDINAL));
     }
   }
 
@@ -194,9 +197,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getInt(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getInt(VALUE_ORDINAL));
     }
   }
 
@@ -223,9 +226,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Long produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getLong(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getLong(VALUE_ORDINAL));
     }
   }
 
@@ -256,9 +259,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getUTF8String(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getUTF8String(VALUE_ORDINAL));
     }
   }
 
@@ -290,9 +293,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getBinary(1));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getBinary(VALUE_ORDINAL));
     }
   }
 
@@ -332,9 +335,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      return input.isNullAt(0) || input.isNullAt(1)
+      return input.isNullAt(WIDTH_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
-          : invoke(input.getInt(0), input.getDecimal(1, precision, scale));
+          : invoke(input.getInt(WIDTH_ORDINAL), input.getDecimal(VALUE_ORDINAL, precision, scale));
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.functions;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.TruncateUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
+import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.CharType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.ShortType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.VarcharType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * A Spark function implementation for the Iceberg truncate transform.
+ *
+ * <p>Example usage: {@code SELECT system.truncate(1, 'abc')}, which returns the String 'a'.
+ *
+ * <p>Note that for performance reasons, the given input width is not validated in the
+ * implementations used in code-gen. The width must remain non-negative to give meaningful results.
+ */
+public class TruncateFunction implements UnboundFunction {
+
+  private static void validateTruncationWidthType(DataType widthType) {
+    if (!DataTypes.IntegerType.sameType(widthType)
+        && !DataTypes.ShortType.sameType(widthType)
+        && !DataTypes.ByteType.sameType(widthType)) {
+      throw new UnsupportedOperationException(
+          "Expected truncation width to be one of [ByteType, ShortType, IntegerType], but found "
+              + widthType);
+    }
+  }
+
+  @Override
+  public BoundFunction bind(StructType inputType) {
+    if (inputType.fields().length != 2) {
+      throw new UnsupportedOperationException(
+          "Cannot bind truncate: wrong number of inputs (expected width and value)");
+    }
+
+    StructField widthField = inputType.fields()[0];
+    StructField toTruncateField = inputType.fields()[1];
+    validateTruncationWidthType(widthField.dataType());
+
+    DataType toTruncateDataType = toTruncateField.dataType();
+    if (toTruncateDataType instanceof ByteType) {
+      return new TruncateTinyInt();
+    } else if (toTruncateDataType instanceof ShortType) {
+      return new TruncateSmallInt();
+    } else if (toTruncateDataType instanceof IntegerType) {
+      return new TruncateInt();
+    } else if (toTruncateDataType instanceof LongType) {
+      return new TruncateBigInt();
+    } else if (toTruncateDataType instanceof DecimalType) {
+      return new TruncateDecimal(
+          ((DecimalType) toTruncateDataType).precision(),
+          ((DecimalType) toTruncateDataType).scale());
+    } else if (toTruncateDataType instanceof StringType
+        || toTruncateDataType instanceof VarcharType
+        || toTruncateDataType instanceof CharType) {
+      return new TruncateString();
+    } else if (toTruncateDataType instanceof BinaryType) {
+      return new TruncateBinary();
+    } else {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Invalid input type to truncate. Expected one of [ByteType, ShortType, IntegerType, LongType, "
+                  + "DecimalType, StringType, VarcharType, CharType, BinaryType], but found %s",
+              toTruncateDataType));
+    }
+  }
+
+  @Override
+  public String description() {
+    return name()
+        + "(width, col) - Call Iceberg's truncate transform\n"
+        + "  width :: width for truncation, e.g. truncate(10, 255) -> 250 (must be an integer)\n"
+        + "  col :: column to truncate (must be an integer, decimal, string, or binary)";
+  }
+
+  @Override
+  public String name() {
+    return "truncate";
+  }
+
+  public abstract static class TruncateBase<T> implements ScalarFunction<T> {
+    @Override
+    public String name() {
+      return "truncate";
+    }
+  }
+
+  public static class TruncateTinyInt extends TruncateBase<Byte> {
+    public static byte invoke(int width, byte value) {
+      return TruncateUtil.truncateByte(width, value);
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.ByteType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.ByteType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](tinyint)";
+    }
+
+    @Override
+    public Byte produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getByte(1));
+    }
+  }
+
+  public static class TruncateSmallInt extends TruncateBase<Short> {
+    // magic method used in codegen
+    public static short invoke(int width, short value) {
+      return TruncateUtil.truncateShort(width, value);
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.ShortType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.ShortType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](smallint)";
+    }
+
+    @Override
+    public Short produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getShort(1));
+    }
+  }
+
+  public static class TruncateInt extends TruncateBase<Integer> {
+    // magic method used in codegen
+    public static int invoke(int width, int value) {
+      return TruncateUtil.truncateInt(width, value);
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.IntegerType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.IntegerType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](int)";
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getInt(1));
+    }
+  }
+
+  public static class TruncateBigInt extends TruncateBase<Long> {
+    // magic function for usage with codegen
+    public static long invoke(int width, long value) {
+      return TruncateUtil.truncateLong(width, value);
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.LongType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.LongType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](bigint)";
+    }
+
+    @Override
+    public Long produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getLong(1));
+    }
+  }
+
+  public static class TruncateString extends TruncateBase<UTF8String> {
+    // magic function for usage with codegen
+    // TODO - This can likely be made more efficient, but using existing definition for now.
+    public static UTF8String invoke(int width, UTF8String value) {
+      if (value == null) {
+        return null;
+      }
+
+      ByteBuffer bb = value.getByteBuffer();
+      CharSequence charSequence = StandardCharsets.UTF_8.decode(bb);
+      CharSequence truncated = UnicodeUtil.truncateStringUnsafe(width, charSequence);
+      ByteBuffer truncatedBytes = StandardCharsets.UTF_8.encode(CharBuffer.wrap(truncated));
+      return UTF8String.fromBytes(ByteBuffers.toByteArray(truncatedBytes));
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.StringType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.StringType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](string)";
+    }
+
+    @Override
+    public UTF8String produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getUTF8String(1));
+    }
+  }
+
+  public static class TruncateBinary extends TruncateBase<byte[]> {
+    // magic method used in codegen
+    public static byte[] invoke(int width, byte[] value) {
+      if (value == null) {
+        return null;
+      }
+
+      return ByteBuffers.toByteArray(
+          BinaryUtil.truncateBinaryUnsafe(width, ByteBuffer.wrap(value)));
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.BinaryType};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.BinaryType;
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.truncate[width](binary)";
+    }
+
+    @Override
+    public byte[] produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getBinary(1));
+    }
+  }
+
+  public static class TruncateDecimal extends TruncateBase<Decimal> {
+    private final int precision;
+    private final int scale;
+
+    public TruncateDecimal(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    // magic method used in codegen
+    public static Decimal invoke(int width, Decimal value) {
+      if (value == null) {
+        return null;
+      }
+
+      return Decimal.apply(
+          TruncateUtil.truncateDecimal(BigInteger.valueOf(width), value.toJavaBigDecimal()));
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.createDecimalType(precision, scale);
+    }
+
+    @Override
+    public String canonicalName() {
+      return String.format("iceberg.truncate[width](decimal(%d,%d))", precision, scale);
+    }
+
+    @Override
+    public Decimal produceResult(InternalRow input) {
+      int width = readWidth(input);
+      return input.isNullAt(1) ? null : invoke(width, input.getDecimal(1, precision, scale));
+    }
+  }
+
+  // Does not validate that the width is positive, but throws on a `null` width.
+  // This matches the behavior of the magic method `invoke`, except the magic method will return
+  // `null` if a `null` width is used.
+  private static int readWidth(InternalRow input) {
+    if (input.isNullAt(0)) {
+      throw new IllegalArgumentException("Invalid truncation width: null");
+    }
+
+    return input.getInt(0);
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -87,9 +87,7 @@ public class TruncateFunction implements UnboundFunction {
       return new TruncateDecimal(
           ((DecimalType) toTruncateDataType).precision(),
           ((DecimalType) toTruncateDataType).scale());
-    } else if (toTruncateDataType instanceof StringType
-        || toTruncateDataType instanceof VarcharType
-        || toTruncateDataType instanceof CharType) {
+    } else if (toTruncateDataType instanceof StringType) {
       return new TruncateString();
     } else if (toTruncateDataType instanceof BinaryType) {
       return new TruncateBinary();
@@ -97,7 +95,7 @@ public class TruncateFunction implements UnboundFunction {
       throw new UnsupportedOperationException(
           String.format(
               "Invalid input type to truncate. Expected one of [ByteType, ShortType, IntegerType, LongType, "
-                  + "DecimalType, StringType, VarcharType, CharType, BinaryType], but found %s",
+                  + "DecimalType, StringType, BinaryType], but found %s",
               toTruncateDataType));
     }
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -91,10 +91,7 @@ public class TruncateFunction implements UnboundFunction {
       return new TruncateBinary();
     } else {
       throw new UnsupportedOperationException(
-          String.format(
-              "Invalid input type to truncate. Expected one of [ByteType, ShortType, IntegerType, LongType, "
-                  + "DecimalType, StringType, BinaryType], but found %s",
-              toTruncateDataType));
+          "Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary");
     }
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -56,8 +56,7 @@ public class TruncateFunction implements UnboundFunction {
         && !DataTypes.ShortType.sameType(widthType)
         && !DataTypes.ByteType.sameType(widthType)) {
       throw new UnsupportedOperationException(
-          "Expected truncation width to be one of [ByteType, ShortType, IntegerType], but found "
-              + widthType);
+          "Expected truncation width to be tinyint, shortint or int");
     }
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -140,7 +140,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Byte produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getByte(1));
     }
   }
@@ -168,7 +168,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Short produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getShort(1));
     }
   }
@@ -196,7 +196,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getInt(1));
     }
   }
@@ -224,7 +224,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Long produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getLong(1));
     }
   }
@@ -256,7 +256,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getUTF8String(1));
     }
   }
@@ -289,7 +289,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getBinary(1));
     }
   }
@@ -330,15 +330,15 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      int width = readWidth(input);
+      int width = width(input);
       return input.isNullAt(1) ? null : invoke(width, input.getDecimal(1, precision, scale));
     }
   }
 
-  // Does not validate that the width is positive, but throws on a `null` width.
-  // This matches the behavior of the magic method `invoke`, except the magic method will return
-  // `null` if a `null` width is used.
-  private static int readWidth(InternalRow input) {
+  // Not identical behavior to magic methods used in codegen,
+  // This function throws on a `null` width, to avoid boxing.
+  // The magic method in Spark's codegen will return `null` for a `null` width.
+  private static int width(InternalRow input) {
     if (input.isNullAt(0)) {
       throw new IllegalArgumentException("Invalid truncation width: null");
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -61,7 +61,7 @@ public class TruncateFunction implements UnboundFunction {
 
   @Override
   public BoundFunction bind(StructType inputType) {
-    if (inputType.fields().length != 2) {
+    if (inputType.size() != 2) {
       throw new UnsupportedOperationException(
           "Cannot bind truncate: wrong number of inputs (expected width and value)");
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -136,8 +136,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Byte produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getByte(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getByte(1));
     }
   }
 
@@ -164,8 +165,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Short produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getShort(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getShort(1));
     }
   }
 
@@ -192,8 +194,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getInt(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getInt(1));
     }
   }
 
@@ -220,8 +223,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Long produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getLong(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getLong(1));
     }
   }
 
@@ -252,8 +256,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public UTF8String produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getUTF8String(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getUTF8String(1));
     }
   }
 
@@ -285,8 +290,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public byte[] produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getBinary(1));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getBinary(1));
     }
   }
 
@@ -326,19 +332,9 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public Decimal produceResult(InternalRow input) {
-      int width = width(input);
-      return input.isNullAt(1) ? null : invoke(width, input.getDecimal(1, precision, scale));
+      return input.isNullAt(0) || input.isNullAt(1)
+          ? null
+          : invoke(input.getInt(0), input.getDecimal(1, precision, scale));
     }
-  }
-
-  // Not identical behavior to magic methods used in codegen,
-  // This function throws on a `null` width, to avoid boxing.
-  // The magic method in Spark's codegen will return `null` for a `null` width.
-  private static int width(InternalRow input) {
-    if (input.isNullAt(0)) {
-      throw new IllegalArgumentException("Invalid truncation width: null");
-    }
-
-    return input.getInt(0);
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -66,29 +66,28 @@ public class TruncateFunction implements UnboundFunction {
     }
 
     StructField widthField = inputType.fields()[WIDTH_ORDINAL];
-    StructField toTruncateField = inputType.fields()[VALUE_ORDINAL];
+    StructField valueField = inputType.fields()[VALUE_ORDINAL];
 
     if (!SUPPORTED_WIDTH_TYPES.contains(widthField.dataType())) {
       throw new UnsupportedOperationException(
           "Expected truncation width to be tinyint, shortint or int");
     }
 
-    DataType toTruncateDataType = toTruncateField.dataType();
-    if (toTruncateDataType instanceof ByteType) {
+    DataType valueType = valueField.dataType();
+    if (valueType instanceof ByteType) {
       return new TruncateTinyInt();
-    } else if (toTruncateDataType instanceof ShortType) {
+    } else if (valueType instanceof ShortType) {
       return new TruncateSmallInt();
-    } else if (toTruncateDataType instanceof IntegerType) {
+    } else if (valueType instanceof IntegerType) {
       return new TruncateInt();
-    } else if (toTruncateDataType instanceof LongType) {
+    } else if (valueType instanceof LongType) {
       return new TruncateBigInt();
-    } else if (toTruncateDataType instanceof DecimalType) {
+    } else if (valueType instanceof DecimalType) {
       return new TruncateDecimal(
-          ((DecimalType) toTruncateDataType).precision(),
-          ((DecimalType) toTruncateDataType).scale());
-    } else if (toTruncateDataType instanceof StringType) {
+          ((DecimalType) valueType).precision(), ((DecimalType) valueType).scale());
+    } else if (valueType instanceof StringType) {
       return new TruncateString();
-    } else if (toTruncateDataType instanceof BinaryType) {
+    } else if (valueType instanceof BinaryType) {
       return new TruncateBinary();
     } else {
       throw new UnsupportedOperationException(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -62,8 +62,7 @@ public class TruncateFunction implements UnboundFunction {
   @Override
   public BoundFunction bind(StructType inputType) {
     if (inputType.size() != 2) {
-      throw new UnsupportedOperationException(
-          "Cannot bind truncate: wrong number of inputs (expected width and value)");
+      throw new UnsupportedOperationException("Wrong number of inputs (expected width and value)");
     }
 
     StructField widthField = inputType.fields()[WIDTH_ORDINAL];

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/TruncateFunction.java
@@ -29,7 +29,6 @@ import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.ByteType;
-import org.apache.spark.sql.types.CharType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
@@ -40,7 +39,6 @@ import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StringType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.types.VarcharType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -137,7 +135,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](tinyint)";
+      return "iceberg.truncate(tinyint)";
     }
 
     @Override
@@ -165,7 +163,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](smallint)";
+      return "iceberg.truncate(smallint)";
     }
 
     @Override
@@ -193,7 +191,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](int)";
+      return "iceberg.truncate(int)";
     }
 
     @Override
@@ -221,7 +219,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](bigint)";
+      return "iceberg.truncate(bigint)";
     }
 
     @Override
@@ -253,7 +251,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](string)";
+      return "iceberg.truncate(string)";
     }
 
     @Override
@@ -286,7 +284,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return "iceberg.truncate[width](binary)";
+      return "iceberg.truncate(binary)";
     }
 
     @Override
@@ -327,7 +325,7 @@ public class TruncateFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return String.format("iceberg.truncate[width](decimal(%d,%d))", precision, scale);
+      return String.format("iceberg.truncate(decimal(%d,%d))", precision, scale);
     }
 
     @Override

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -297,7 +297,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         () -> scalarSql("SELECT system.truncate('5', 10)"));
 
     AssertHelpers.assertThrows(
-        "Interval year to month  type should not be coercible to the width field",
+        "Interval year to month type should not be coercible to the width field",
         AnalysisException.class,
         "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
         () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"));
@@ -307,6 +307,15 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         AnalysisException.class,
         "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
         () -> scalarSql("SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"));
+  }
+
+  @Test
+  public void testInvalidTypesForTruncationColumn() {
+    AssertHelpers.assertThrows(
+        "Interval day-time type should not be usable for truncation column",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, interval day to second): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, CAST('11 23:4:0' AS INTERVAL DAY TO SECOND))"));
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -53,9 +53,8 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     // Check that different widths can be used
     Assert.assertEquals((byte) -2, scalarSql("SELECT system.truncate(2, -1Y)"));
 
-    Assert.assertEquals(
+    Assert.assertNull(
         "Null input should return null",
-        null,
         scalarSql("SELECT system.truncate(2, CAST(null AS tinyint))"));
   }
 
@@ -75,10 +74,13 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     // Check that different widths can be used
     Assert.assertEquals((short) -2, scalarSql("SELECT system.truncate(2, -1S)"));
 
-    Assert.assertEquals(
+    Assert.assertNull(
         "Null input should return null",
-        null,
         scalarSql("SELECT system.truncate(2, CAST(null AS smallint))"));
+
+    Assert.assertNull(
+        "A null width should return null, as that's the behavior of Spark's code generation",
+        scalarSql("SELECT system.truncate(cast(null as int), 1S)"));
   }
 
   @Test
@@ -98,9 +100,8 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     Assert.assertEquals(-2, scalarSql("SELECT system.truncate(2, -1)"));
     Assert.assertEquals(0, scalarSql("SELECT system.truncate(300, 1)"));
 
-    Assert.assertEquals(
+    Assert.assertNull(
         "Null input should return null",
-        null,
         scalarSql("SELECT system.truncate(2, CAST(null AS int))"));
   }
 
@@ -120,9 +121,8 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     // Check that different widths can be used
     Assert.assertEquals(-2L, scalarSql("SELECT system.truncate(2, -1L)"));
 
-    Assert.assertEquals(
+    Assert.assertNull(
         "Null input should return null",
-        null,
         scalarSql("SELECT system.truncate(2, CAST(null AS bigint))"));
   }
 
@@ -170,9 +170,8 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         BigDecimal.valueOf(-500, 4),
         truncatedDecimal);
 
-    Assert.assertEquals(
+    Assert.assertNull(
         "Null input should return null",
-        null,
         scalarSql("SELECT system.truncate(2, CAST(null AS decimal))"));
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -101,8 +101,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     Assert.assertEquals(0, scalarSql("SELECT system.truncate(300, 1)"));
 
     Assert.assertNull(
-        "Null input should return null",
-        scalarSql("SELECT system.truncate(2, CAST(null AS int))"));
+        "Null input should return null", scalarSql("SELECT system.truncate(2, CAST(null AS int))"));
   }
 
   @Test
@@ -300,6 +299,27 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         "Byte types should be allowed for the width field",
         0,
         scalarSql("SELECT system.truncate(5Y, 1)"));
+  }
+
+  @Test
+  public void testWrongNumberOfArguments() {
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with zero arguments",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (): Wrong number of inputs (expected width and value)",
+        () -> scalarSql("SELECT system.truncate()"));
+
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with only one argument",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int): Wrong number of inputs (expected width and value)",
+        () -> scalarSql("SELECT system.truncate(1)"));
+
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with more than two arguments",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, bigint, int): Wrong number of inputs (expected width and value)",
+        () -> scalarSql("SELECT system.truncate(1, 1L, 1)"));
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -182,22 +182,29 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         "Should system.truncate strings longer than length",
         "abcde",
         scalarSql("SELECT system.truncate(5, 'abcdefg')"));
+
     Assert.assertEquals(
         "Should not pad strings shorter than length",
         "abc",
         scalarSql("SELECT system.truncate(5, 'abc')"));
+
     Assert.assertEquals(
         "Should not alter strings equal to length",
         "abcde",
         scalarSql("SELECT system.truncate(5, 'abcde')"));
+
     Assert.assertEquals(
         "Should handle three-byte UTF-8 characters appropriately",
         "测",
         scalarSql("SELECT system.truncate(1, '测试')"));
+
     Assert.assertEquals(
         "Should handle three-byte UTF-8 characters mixed with two byte utf-8 characters",
         "测试ra",
         scalarSql("SELECT system.truncate(4, '测试raul试测')"));
+
+    Assert.assertEquals(
+        "Should not fail on the empty string", "", scalarSql("SELECT system.truncate(10, '')"));
 
     Assert.assertEquals(
         "Null input should return null as output",

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.AnalysisException;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
+  public TestSparkTruncateFunction() {}
+
+  @Before
+  public void useCatalog() {
+    sql("USE %s", catalogName);
+  }
+
+  @Test
+  public void testTruncateTinyInt() {
+    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 0Y)"));
+    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 1Y)"));
+    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 5Y)"));
+    Assert.assertEquals((byte) 0, scalarSql("SELECT system.truncate(10, 9Y)"));
+    Assert.assertEquals((byte) 10, scalarSql("SELECT system.truncate(10, 10Y)"));
+    Assert.assertEquals((byte) 10, scalarSql("SELECT system.truncate(10, 11Y)"));
+    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -1Y)"));
+    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -5Y)"));
+    Assert.assertEquals((byte) -10, scalarSql("SELECT system.truncate(10, -10Y)"));
+    Assert.assertEquals((byte) -20, scalarSql("SELECT system.truncate(10, -11Y)"));
+
+    // Check that different widths can be used
+    Assert.assertEquals((byte) -2, scalarSql("SELECT system.truncate(2, -1Y)"));
+
+    Assert.assertEquals(
+        "Null input should return null",
+        null,
+        scalarSql("SELECT system.truncate(2, CAST(null AS tinyint))"));
+  }
+
+  @Test
+  public void testTruncateSmallInt() {
+    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 0S)"));
+    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 1S)"));
+    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 5S)"));
+    Assert.assertEquals((short) 0, scalarSql("SELECT system.truncate(10, 9S)"));
+    Assert.assertEquals((short) 10, scalarSql("SELECT system.truncate(10, 10S)"));
+    Assert.assertEquals((short) 10, scalarSql("SELECT system.truncate(10, 11S)"));
+    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -1S)"));
+    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -5S)"));
+    Assert.assertEquals((short) -10, scalarSql("SELECT system.truncate(10, -10S)"));
+    Assert.assertEquals((short) -20, scalarSql("SELECT system.truncate(10, -11S)"));
+
+    // Check that different widths can be used
+    Assert.assertEquals((short) -2, scalarSql("SELECT system.truncate(2, -1S)"));
+
+    Assert.assertEquals(
+        "Null input should return null",
+        null,
+        scalarSql("SELECT system.truncate(2, CAST(null AS smallint))"));
+  }
+
+  @Test
+  public void testTruncateInt() {
+    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 0)"));
+    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 1)"));
+    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 5)"));
+    Assert.assertEquals(0, scalarSql("SELECT system.truncate(10, 9)"));
+    Assert.assertEquals(10, scalarSql("SELECT system.truncate(10, 10)"));
+    Assert.assertEquals(10, scalarSql("SELECT system.truncate(10, 11)"));
+    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -1)"));
+    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -5)"));
+    Assert.assertEquals(-10, scalarSql("SELECT system.truncate(10, -10)"));
+    Assert.assertEquals(-20, scalarSql("SELECT system.truncate(10, -11)"));
+
+    // Check that different widths can be used
+    Assert.assertEquals(-2, scalarSql("SELECT system.truncate(2, -1)"));
+    Assert.assertEquals(0, scalarSql("SELECT system.truncate(300, 1)"));
+
+    Assert.assertEquals(
+        "Null input should return null",
+        null,
+        scalarSql("SELECT system.truncate(2, CAST(null AS int))"));
+  }
+
+  @Test
+  public void testTruncateBigInt() {
+    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 0L)"));
+    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 1L)"));
+    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 5L)"));
+    Assert.assertEquals(0L, scalarSql("SELECT system.truncate(10, 9L)"));
+    Assert.assertEquals(10L, scalarSql("SELECT system.truncate(10, 10L)"));
+    Assert.assertEquals(10L, scalarSql("SELECT system.truncate(10, 11L)"));
+    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -1L)"));
+    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -5L)"));
+    Assert.assertEquals(-10L, scalarSql("SELECT system.truncate(10, -10L)"));
+    Assert.assertEquals(-20L, scalarSql("SELECT system.truncate(10, -11L)"));
+
+    // Check that different widths can be used
+    Assert.assertEquals(-2L, scalarSql("SELECT system.truncate(2, -1L)"));
+
+    Assert.assertEquals(
+        "Null input should return null",
+        null,
+        scalarSql("SELECT system.truncate(2, CAST(null AS bigint))"));
+  }
+
+  @Test
+  public void testTruncateDecimal() {
+    // decimal truncation works by applying the decimal scale to the width: ie 10 scale 2 = 0.10
+    Assert.assertEquals(
+        new BigDecimal("12.30"),
+        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.34"));
+
+    Assert.assertEquals(
+        new BigDecimal("12.30"),
+        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "12.30"));
+
+    Assert.assertEquals(
+        new BigDecimal("12.290"),
+        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 3)))", "12.299"));
+
+    Assert.assertEquals(
+        new BigDecimal("0.03"),
+        scalarSql("SELECT system.truncate(3, CAST(%s as DECIMAL(5, 2)))", "0.05"));
+
+    Assert.assertEquals(
+        new BigDecimal("0.00"),
+        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "0.05"));
+
+    Assert.assertEquals(
+        new BigDecimal("-0.10"),
+        scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(9, 2)))", "-0.05"));
+
+    Assert.assertEquals(
+        "Implicit decimal scale and precision should be allowed",
+        new BigDecimal("12345.3480"),
+        scalarSql("SELECT system.truncate(10, 12345.3482)"));
+
+    BigDecimal truncatedDecimal =
+        (BigDecimal) scalarSql("SELECT system.truncate(10, CAST(%s as DECIMAL(6, 4)))", "-0.05");
+    Assert.assertEquals(
+        "Truncating a decimal should return a decimal with the same scale",
+        4,
+        truncatedDecimal.scale());
+
+    Assert.assertEquals(
+        "Truncating a decimal should return a decimal with the correct scale",
+        BigDecimal.valueOf(-500, 4),
+        truncatedDecimal);
+
+    Assert.assertEquals(
+        "Null input should return null",
+        null,
+        scalarSql("SELECT system.truncate(2, CAST(null AS decimal))"));
+  }
+
+  @Test
+  public void testTruncateString() {
+    Assert.assertEquals(
+        "Should system.truncate strings longer than length",
+        "abcde",
+        scalarSql("SELECT system.truncate(5, 'abcdefg')"));
+    Assert.assertEquals(
+        "Should not pad strings shorter than length",
+        "abc",
+        scalarSql("SELECT system.truncate(5, 'abc')"));
+    Assert.assertEquals(
+        "Should not alter strings equal to length",
+        "abcde",
+        scalarSql("SELECT system.truncate(5, 'abcde')"));
+    Assert.assertEquals(
+        "Should handle three-byte UTF-8 characters appropriately",
+        "测",
+        scalarSql("SELECT system.truncate(1, '测试')"));
+    Assert.assertEquals(
+        "Should handle three-byte UTF-8 characters mixed with two byte utf-8 characters",
+        "测试ra",
+        scalarSql("SELECT system.truncate(4, '测试raul试测')"));
+
+    Assert.assertEquals(
+        "Null input should return null as output",
+        null,
+        scalarSql("SELECT system.truncate(3, CAST(null AS string))"));
+
+    Assert.assertEquals(
+        "Varchar should work like string",
+        "测试ra",
+        scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS varchar(8)))"));
+
+    Assert.assertEquals(
+        "Char should work like string",
+        "测试ra",
+        scalarSql("SELECT system.truncate(4, CAST('测试raul试测' AS char(8)))"));
+  }
+
+  @Test
+  public void testTruncateBinary() {
+    Assert.assertArrayEquals(
+        new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+        (byte[]) scalarSql("SELECT system.truncate(10, X'0102030405060708090a0b0c0d0e0f')"));
+    Assert.assertArrayEquals(
+        "Should return the same input when value is equal to truncation width",
+        "abc".getBytes(StandardCharsets.UTF_8),
+        (byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abcdefg")));
+    Assert.assertArrayEquals(
+        "Should not truncate, pad, or trim the input when its length is less than the width",
+        "abc\0\0".getBytes(StandardCharsets.UTF_8),
+        (byte[]) scalarSql("SELECT system.truncate(10, %s)", asBytesLiteral("abc\0\0")));
+    Assert.assertArrayEquals(
+        "Should not pad the input when its length is equal to the width",
+        "abc".getBytes(StandardCharsets.UTF_8),
+        (byte[]) scalarSql("SELECT system.truncate(3, %s)", asBytesLiteral("abc")));
+    Assert.assertArrayEquals(
+        "Should handle three-byte UTF-8 characters appropriately",
+        "测试".getBytes(StandardCharsets.UTF_8),
+        (byte[]) scalarSql("SELECT system.truncate(6, %s)", asBytesLiteral("测试_")));
+
+    Assert.assertEquals(
+        "Null input should return null as output",
+        null,
+        scalarSql("SELECT system.truncate(3, CAST(null AS binary))"));
+  }
+
+  @Test
+  public void testTruncateUsingDataframeForWidthWithVaryingWidth() {
+    // This situation is atypical but allowed. Typically, width is static as data is partitioned on
+    // one width.
+    long rumRows = 10L;
+    long numNonZero =
+        spark
+            .range(rumRows)
+            .toDF("value")
+            .selectExpr("CAST(value +1 AS INT) AS width", "value")
+            .selectExpr("system.truncate(width, value) as truncated_value")
+            .filter("truncated_value == 0")
+            .count();
+    Assert.assertEquals(
+        "A truncate function with variable widths should be usable on dataframe columns",
+        rumRows,
+        numNonZero);
+  }
+
+  @Test
+  public void testWidthAcceptsShortAndByte() {
+    Assert.assertEquals(
+        "Short types should be usable for the width field",
+        0L,
+        scalarSql("SELECT system.truncate(5S, 1L)"));
+
+    Assert.assertEquals(
+        "Byte types should be allowed for the width field",
+        0,
+        scalarSql("SELECT system.truncate(5Y, 1)"));
+  }
+
+  @Test
+  public void testInvalidTypesCannotBeUsedForWidth() {
+    AssertHelpers.assertThrows(
+        "Decimal type should not be coercible to the width field",
+        AnalysisException.class,
+        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        () -> scalarSql("SELECT system.truncate(CAST(12.34 as DECIMAL(9, 2)), 10)", 12.34));
+
+    AssertHelpers.assertThrows(
+        "String type should not be coercible to the width field",
+        AnalysisException.class,
+        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        () -> scalarSql("SELECT system.truncate('5', 10)"));
+
+    AssertHelpers.assertThrows(
+        "Interval year to month  type should not be coercible to the width field",
+        AnalysisException.class,
+        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"));
+
+    AssertHelpers.assertThrows(
+        "Interval day-time type should not be coercible to the width field",
+        AnalysisException.class,
+        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        () -> scalarSql("SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"));
+  }
+
+  @Test
+  public void testMagicFunctionsResolveForTinyIntAndSmallIntWidths() {
+    // Magic functions have staticinvoke in the explain output. Nonmagic calls use
+    // applyfunctionexpression instead.
+    String tinyIntWidthExplain =
+        (String) scalarSql("EXPLAIN EXTENDED SELECT system.truncate(1Y, 6)");
+    Assertions.assertThat(tinyIntWidthExplain)
+        .contains("cast(1 as int)")
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateInt");
+
+    String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5S, 6L)");
+    Assertions.assertThat(smallIntWidth)
+        .contains("cast(5 as int)")
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
+  }
+
+  @Test
+  public void testThatMagicFunctionsAreInvoked() {
+    // Magic functions have `staticinvoke` in the explain output.
+    // Non-magic calls have `applyfunctionexpression` instead.
+
+    // TinyInt
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED select system.truncate(5, 6Y)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateTinyInt");
+
+    // SmallInt
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED select system.truncate(5, 6S)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateSmallInt");
+
+    // Int
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED select system.truncate(5, 6)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateInt");
+
+    // Long
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5, 6L)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBigInt");
+
+    // String
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5, 'abcdefg')"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateString");
+
+    // Decimal
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.truncate(5, 12.34)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateDecimal");
+
+    // Binary
+    Assertions.assertThat(
+            scalarSql("EXPLAIN EXTENDED SELECT system.truncate(4, X'0102030405060708')"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.TruncateFunction$TruncateBinary");
+  }
+
+  private String asBytesLiteral(String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    return "X'" + BaseEncoding.base16().encode(bytes) + "'";
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -288,7 +288,7 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
         "Decimal type should not be coercible to the width field",
         AnalysisException.class,
         "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
-        () -> scalarSql("SELECT system.truncate(CAST(12.34 as DECIMAL(9, 2)), 10)", 12.34));
+        () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"));
 
     AssertHelpers.assertThrows(
         "String type should not be coercible to the width field",

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -20,10 +20,19 @@ package org.apache.iceberg.spark.sql;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -286,10 +295,35 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
 
   @Test
   public void testWidthFieldFailsWithNullableType() {
-    AssertHelpers.assertThrows("The width field should reject using a nullable int type",
+    AssertHelpers.assertThrows(
+        "The width field should reject using a nullable int type",
         AnalysisException.class,
         "Function 'truncate' cannot process input: (int, int): Truncation width field cannot be nullable",
         () -> scalarSql("SELECT system.truncate(cast(null as int), 1)"));
+  }
+
+  @Test
+  public void testWidthFieldFailsWithNullableDataframeType() {
+    List<Integer> data = ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+    Dataset<Row> df =
+        spark
+            .createDataset(data, Encoders.INT())
+            .toDF("value")
+            .selectExpr("cast(value as int) as width", "value");
+
+    StructType schemaWithNullableWidth =
+        new StructType()
+            .add(new StructField("width", DataTypes.IntegerType, true, Metadata.empty()))
+            .add(new StructField("value", DataTypes.IntegerType, true, Metadata.empty()));
+
+    Dataset<Row> dfWithNullableWidth = spark.createDataFrame(df.javaRDD(), schemaWithNullableWidth);
+
+    AssertHelpers.assertThrows(
+        "Using a nullable integer type for the width field should throw",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, int): Truncation width field cannot be nullable;",
+        () -> dfWithNullableWidth.selectExpr("system.truncate(width, value) as truncated").count());
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -312,13 +312,43 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
   @Test
   public void testInvalidTypesForTruncationColumn() {
     AssertHelpers.assertThrows(
-        "Interval year to month type should not be usable for truncation column",
+        "FLoat type should not be truncatable",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, float): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, cast(12.3456 as float))"));
+
+    AssertHelpers.assertThrows(
+        "Double type should not be truncatable",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, double): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, cast(12.3456 as double))"));
+
+    AssertHelpers.assertThrows(
+        "Boolean type should not be truncatable",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, boolean): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, true)"));
+
+    AssertHelpers.assertThrows(
+        "Map types should not be truncatable",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, map<int,int>): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, map(1, 1))"));
+
+    AssertHelpers.assertThrows(
+        "Array types should not be truncatable",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, array<bigint>): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, array(1L))"));
+
+    AssertHelpers.assertThrows(
+        "Interval year-to-month type should not be truncatable",
         AnalysisException.class,
         "Function 'truncate' cannot process input: (int, interval year to month): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
         () -> scalarSql("SELECT system.truncate(10, INTERVAL '100-00' YEAR TO MONTH)"));
 
     AssertHelpers.assertThrows(
-        "Interval day-time type should not be usable for truncation column",
+        "Interval day-time type should not be truncatable",
         AnalysisException.class,
         "Function 'truncate' cannot process input: (int, interval day to second): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
         () -> scalarSql("SELECT system.truncate(10, CAST('11 23:4:0' AS INTERVAL DAY TO SECOND))"));

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkTruncateFunction.java
@@ -287,30 +287,36 @@ public class TestSparkTruncateFunction extends SparkTestBaseWithCatalog {
     AssertHelpers.assertThrows(
         "Decimal type should not be coercible to the width field",
         AnalysisException.class,
-        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        "Function 'truncate' cannot process input: (decimal(9,2), int): Expected truncation width to be tinyint, shortint or int",
         () -> scalarSql("SELECT system.truncate(CAST('12.34' as DECIMAL(9, 2)), 10)"));
 
     AssertHelpers.assertThrows(
         "String type should not be coercible to the width field",
         AnalysisException.class,
-        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        "Function 'truncate' cannot process input: (string, int): Expected truncation width to be tinyint, shortint or int",
         () -> scalarSql("SELECT system.truncate('5', 10)"));
 
     AssertHelpers.assertThrows(
         "Interval year to month type should not be coercible to the width field",
         AnalysisException.class,
-        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        "Function 'truncate' cannot process input: (interval year to month, int): Expected truncation width to be tinyint, shortint or int",
         () -> scalarSql("SELECT system.truncate(INTERVAL '100-00' YEAR TO MONTH, 10)"));
 
     AssertHelpers.assertThrows(
         "Interval day-time type should not be coercible to the width field",
         AnalysisException.class,
-        "Expected truncation width to be one of [ByteType, ShortType, IntegerType]",
+        "Function 'truncate' cannot process input: (interval day to second, int): Expected truncation width to be tinyint, shortint or int",
         () -> scalarSql("SELECT system.truncate(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"));
   }
 
   @Test
   public void testInvalidTypesForTruncationColumn() {
+    AssertHelpers.assertThrows(
+        "Interval year to month type should not be usable for truncation column",
+        AnalysisException.class,
+        "Function 'truncate' cannot process input: (int, interval year to month): Expected truncation col to be tinyint, shortint, int, bigint, decimal, string, or binary",
+        () -> scalarSql("SELECT system.truncate(10, INTERVAL '100-00' YEAR TO MONTH)"));
+
     AssertHelpers.assertThrows(
         "Interval day-time type should not be usable for truncation column",
         AnalysisException.class,


### PR DESCRIPTION
This is an offshoot of https://github.com/apache/iceberg/pull/5305 and partially closes https://github.com/apache/iceberg/issues/5349.

Adds a `system.truncate` function that can be used in Spark SQL, as well as can be used as a `FunctionCatalog` function that can be turned into a transform for storage partitioned joins.

This also breaks the definition of `Truncate` out into utility functions inside of `TruncateUtil`. Because different usages validate input at different times, all of the functions in `TruncateUtil` do not validate their input and instead assume that the input is validated by the calling code. This allows for the `Truncate` transforms to validate their width one time (on instantiation), and for the Spark `truncate` function to skip input validation for faster generated code.