### PR TITLE
Core: Put property names at the end in JsonUtil error messages 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -105,11 +105,11 @@ public class JsonUtil {
   }
 
   public static int getInt(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing int %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing int: %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isNumber(),
-        "Cannot parse %s to an integer value: %s",
+        "Cannot parse to an integer value: %s: %s",
         property,
         pNode);
     return pNode.asInt();
@@ -122,7 +122,7 @@ public class JsonUtil {
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isIntegralNumber() && pNode.canConvertToInt(),
-        "Cannot parse %s to an integer value: %s",
+        "Cannot parse to an integer value: %s: %s",
         property,
         pNode);
     return pNode.asInt();
@@ -135,40 +135,40 @@ public class JsonUtil {
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isIntegralNumber() && pNode.canConvertToLong(),
-        "Cannot parse %s to a long value: %s",
+        "Cannot parse to a long value: %s: %s",
         property,
         pNode);
     return pNode.asLong();
   }
 
   public static long getLong(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing long %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing long: %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isNumber(),
-        "Cannot parse %s to a long value: %s",
+        "Cannot parse to a long value: %s: %s",
         property,
         pNode);
     return pNode.asLong();
   }
 
   public static boolean getBool(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing boolean %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing boolean: %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isBoolean(),
-        "Cannot parse %s to a boolean value: %s",
+        "Cannot parse to a boolean value: %s: %s",
         property,
         pNode);
     return pNode.asBoolean();
   }
 
   public static String getString(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing string %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing string: %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isTextual(),
-        "Cannot parse %s to a string value: %s",
+        "Cannot parse to a string value: %s: %s",
         property,
         pNode);
     return pNode.asText();
@@ -184,18 +184,18 @@ public class JsonUtil {
     }
     Preconditions.checkArgument(
         pNode != null && pNode.isTextual(),
-        "Cannot parse %s from non-string value: %s",
+        "Cannot parse from non-string value: %s: %s",
         property,
         pNode);
     return pNode.asText();
   }
 
   public static Map<String, String> getStringMap(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing map %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing map: %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(
         pNode != null && !pNode.isNull() && pNode.isObject(),
-        "Cannot parse %s from non-object value: %s",
+        "Cannot parse from non-object value: %s: %s",
         property,
         pNode);
 
@@ -222,14 +222,15 @@ public class JsonUtil {
   }
 
   public static List<String> getStringList(String property, JsonNode node) {
-    Preconditions.checkArgument(node.has(property), "Cannot parse missing list %s", property);
+    Preconditions.checkArgument(node.has(property), "Cannot parse missing list: %s", property);
     return ImmutableList.<String>builder()
         .addAll(new JsonStringArrayIterator(property, node))
         .build();
   }
 
   public static Set<String> getStringSet(String property, JsonNode node) {
-    Preconditions.checkArgument(node.hasNonNull(property), "Cannot parse missing set %s", property);
+    Preconditions.checkArgument(
+        node.hasNonNull(property), "Cannot parse missing set: %s", property);
 
     return ImmutableSet.<String>builder()
         .addAll(new JsonStringArrayIterator(property, node))
@@ -296,7 +297,7 @@ public class JsonUtil {
       JsonNode pNode = node.get(property);
       Preconditions.checkArgument(
           pNode != null && !pNode.isNull() && pNode.isArray(),
-          "Cannot parse %s from non-array value: %s",
+          "Cannot parse from non-array value: %s: %s",
           property,
           pNode);
       this.elements = pNode.elements();
@@ -370,7 +371,7 @@ public class JsonUtil {
     void validate(JsonNode element) {
       Preconditions.checkArgument(
           element.isIntegralNumber() && element.canConvertToLong(),
-          "Cannot parse long from  non-long value: %s",
+          "Cannot parse long from non-long value: %s",
           element);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -675,7 +675,7 @@ public class TestMetadataUpdateParser {
     AssertHelpers.assertThrows(
         "Parsing updates from SetProperties with a property set to null should throw",
         IllegalArgumentException.class,
-        "Cannot parse prop2 to a string value: null",
+        "Cannot parse to a string value: prop2: null",
         () -> MetadataUpdateParser.fromJson(json));
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
@@ -144,7 +144,7 @@ public class TestSnapshotRefParser {
     AssertHelpers.assertThrows(
         "SnapshotRefParser should fail to deserialize ref with invalid snapshot id",
         IllegalArgumentException.class,
-        "Cannot parse snapshot-id to a long value",
+        "Cannot parse to a long value: snapshot-id: \"invalid-snapshot-id\"",
         () -> SnapshotRefParser.fromJson(invalidSnapshotId));
 
     String invalidTagType = "{\"snapshot-id\":1,\"type\":\"not-a-valid-tag-type\"}";
@@ -159,7 +159,7 @@ public class TestSnapshotRefParser {
     AssertHelpers.assertThrows(
         "SnapshotRefParser should fail to deserialize ref with invalid ref age",
         IllegalArgumentException.class,
-        "Cannot parse max-ref-age-ms to a long",
+        "Cannot parse to a long value: max-ref-age-ms: \"not-a-valid-value\"",
         () -> SnapshotRefParser.fromJson(invalidRefAge));
 
     String invalidSnapshotsToKeep =
@@ -168,7 +168,7 @@ public class TestSnapshotRefParser {
     AssertHelpers.assertThrows(
         "SnapshotRefParser should fail to deserialize ref with missing snapshot id",
         IllegalArgumentException.class,
-        "Cannot parse min-snapshots-to-keep to an integer value",
+        "Cannot parse to an integer value: min-snapshots-to-keep: \"invalid-number\"",
         () -> SnapshotRefParser.fromJson(invalidSnapshotsToKeep));
 
     String invalidMaxSnapshotAge =
@@ -176,7 +176,7 @@ public class TestSnapshotRefParser {
     AssertHelpers.assertThrows(
         "SnapshotRefParser should fail to deserialize ref with missing snapshot id",
         IllegalArgumentException.class,
-        "Cannot parse max-snapshot-age-ms to a long value",
+        "Cannot parse to a long value: max-snapshot-age-ms: \"invalid-age\"",
         () -> SnapshotRefParser.fromJson(invalidMaxSnapshotAge));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
@@ -84,7 +84,7 @@ public class TestTableIdentifierParser {
     AssertHelpers.assertThrows(
         "TableIdentifierParser should fail to deserialize an empty JSON string",
         IllegalArgumentException.class,
-        "Cannot parse missing string name",
+        "Cannot parse missing string: name",
         () -> TableIdentifierParser.fromJson(emptyJson));
 
     String emptyJsonArray = "[]";
@@ -101,7 +101,7 @@ public class TestTableIdentifierParser {
     AssertHelpers.assertThrows(
         "TableIdentifierParser should fail to deserialize table with missing name",
         IllegalArgumentException.class,
-        "Cannot parse missing string name",
+        "Cannot parse missing string: name",
         () -> TableIdentifierParser.fromJson(identifierMissingName));
   }
 
@@ -111,14 +111,14 @@ public class TestTableIdentifierParser {
     AssertHelpers.assertThrows(
         "TableIdentifierParser should fail to deserialize table with invalid namespace",
         IllegalArgumentException.class,
-        "Cannot parse namespace from non-array value: \"accounting.tax\"",
+        "Cannot parse from non-array value: namespace: \"accounting.tax\"",
         () -> TableIdentifierParser.fromJson(invalidNamespace));
 
     String invalidName = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":1234}";
     AssertHelpers.assertThrows(
         "TableIdentifierParser should fail to deserialize table with invalid name",
         IllegalArgumentException.class,
-        "Cannot parse name to a string value: 1234",
+        "Cannot parse to a string value: name: 1234",
         () -> TableIdentifierParser.fromJson(invalidName));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRenameTableRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRenameTableRequest.java
@@ -55,7 +55,7 @@ public class TestRenameTableRequest extends RequestResponseTestBase<RenameTableR
     AssertHelpers.assertThrows(
         "A JSON request with an invalid source table identifier, with null for the name, should fail to deserialize",
         JsonProcessingException.class,
-        "Cannot parse name to a string value: null",
+        "Cannot parse to a string value: name: null",
         () -> deserialize(jsonSourceNullName));
 
     String jsonDestinationNullName =
@@ -64,7 +64,7 @@ public class TestRenameTableRequest extends RequestResponseTestBase<RenameTableR
     AssertHelpers.assertThrows(
         "A JSON request with an invalid destination table, with null for the name, should fail to deserialize",
         JsonProcessingException.class,
-        "Cannot parse name to a string value: null",
+        "Cannot parse to a string value: name: null",
         () -> deserialize(jsonDestinationNullName));
 
     String jsonSourceMissingName =
@@ -73,7 +73,7 @@ public class TestRenameTableRequest extends RequestResponseTestBase<RenameTableR
     AssertHelpers.assertThrows(
         "A JSON request with an invalid source table identifier, with no name, should fail to deserialize",
         JsonProcessingException.class,
-        "Cannot parse missing string name",
+        "Cannot parse missing string: name",
         () -> deserialize(jsonSourceMissingName));
 
     String jsonDestinationMissingName =
@@ -82,7 +82,7 @@ public class TestRenameTableRequest extends RequestResponseTestBase<RenameTableR
     AssertHelpers.assertThrows(
         "A JSON request with an invalid destination table identifier, with no name, should fail to deserialize",
         JsonProcessingException.class,
-        "Cannot parse missing string name",
+        "Cannot parse missing string: name",
         () -> deserialize(jsonDestinationMissingName));
 
     String emptyJson = "{}";

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -114,25 +114,25 @@ public class TestOAuthTokenResponse extends RequestResponseTestBase<OAuthTokenRe
     AssertHelpers.assertThrows(
         "Token should be required",
         IllegalArgumentException.class,
-        "missing string access_token",
+        "missing string: access_token",
         () -> deserialize("{\"token_type\":\"bearer\"}"));
 
     AssertHelpers.assertThrows(
         "Token should be string",
         IllegalArgumentException.class,
-        "Cannot parse access_token to a string value: 34",
+        "Cannot parse to a string value: access_token: 34",
         () -> deserialize("{\"access_token\":34,\"token_type\":\"bearer\"}"));
 
     AssertHelpers.assertThrows(
         "Token type should be required",
         IllegalArgumentException.class,
-        "missing string token_type",
+        "missing string: token_type",
         () -> deserialize("{\"access_token\":\"bearer-token\"}"));
 
     AssertHelpers.assertThrows(
         "Token type should be string",
         IllegalArgumentException.class,
-        "Cannot parse token_type to a string value: 34",
+        "Cannot parse to a string value: token_type: 34",
         () -> deserialize("{\"access_token\":\"bearer-token\",\"token_type\":34}"));
   }
 }


### PR DESCRIPTION
Sometimes one has to read the error message twice to figure out which
property name was affected, thus highlighting the property name in the
error message should make this clearer.