### PR TITLE
Parquet: Set parquet bloom filter config with compatible column name

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -253,7 +253,10 @@ public class Parquet {
                 Types.NestedField field = schema.caseInsensitiveFindField(columnPath);
                 if (field == null) {
                   LOG.warn(
-                      "Column: {} is not found in the schema: {}, ignore it.", columnPath, schema);
+                      "Invalid bloom filter column configuration, field: {} is not found in the schema: {}, "
+                          + "this column configuration will be ignored.",
+                      columnPath,
+                      schema);
                   return;
                 }
                 Type fieldType = field.type();
@@ -261,9 +264,10 @@ public class Parquet {
                 if (!fieldType.isPrimitiveType()
                     || fieldType.typeId().equals(Type.TypeID.BOOLEAN)) {
                   LOG.warn(
-                      "The type: {} of column: {} is not supported for parquet bloom filter, ignore it",
-                      fieldType,
-                      columnPath);
+                      "Invalid bloom filter column configuration: field {} is of type '{}' which cannot "
+                          + "benefit from a bloom filter. This column configuration will be ignored.",
+                      columnPath,
+                      fieldType);
                   return;
                 }
 


### PR DESCRIPTION
This PR improves the config setting for the parquet bloom filter. 
1. Log warn for those don't exist column or the column type is unsupported (boolean or complex data type).
2. Convert the column name to a compatible one. This is because we make the column name compatible if it contains special character when we write the parquet file.