### PR TITLE
Python: Require `__enter__` and `__exit__` on `{Input,Output}Stream`

### DIFF
--- a/python/pyiceberg/io/base.py
+++ b/python/pyiceberg/io/base.py
@@ -51,6 +51,14 @@ class InputStream(Protocol):
     def close(self) -> None:
         ...
 
+    @abstractmethod
+    def __enter__(self):
+        ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        ...
+
 
 @runtime_checkable
 class OutputStream(Protocol):  # pragma: no cover
@@ -66,6 +74,14 @@ class OutputStream(Protocol):  # pragma: no cover
 
     @abstractmethod
     def close(self) -> None:
+        ...
+
+    @abstractmethod
+    def __enter__(self):
+        ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb):
         ...
 
 

--- a/python/pyiceberg/io/memory.py
+++ b/python/pyiceberg/io/memory.py
@@ -70,3 +70,9 @@ class MemoryInputStream(InputStream):
     def close(self) -> None:
         del self.buffer
         self.pos = 0
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/python/pyiceberg/serializers.py
+++ b/python/pyiceberg/serializers.py
@@ -54,7 +54,8 @@ class FromInputFile:
             TableMetadata: A table metadata instance
 
         """
-        return FromByteStream.table_metadata(byte_stream=input_file.open(), encoding=encoding)
+        with input_file.open() as input_stream:
+            return FromByteStream.table_metadata(byte_stream=input_stream, encoding=encoding)
 
 
 class ToOutputFile:
@@ -70,6 +71,5 @@ class ToOutputFile:
             output_file (OutputFile): A custom implementation of the iceberg.io.file.OutputFile abstract base class
             overwrite (bool): Where to overwrite the file if it already exists. Defaults to `False`.
         """
-        f = output_file.create(overwrite=overwrite)
-        f.write(metadata.json().encode("utf-8"))
-        f.close()
+        with output_file.create(overwrite=overwrite) as output_stream:
+            output_stream.write(metadata.json().encode("utf-8"))

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -119,6 +119,12 @@ class OneByteAtATimeInputStream(InputStream):
     def close(self) -> None:
         pass
 
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
 
 def test_read_single_byte_at_the_time():
     decoder = BinaryDecoder(OneByteAtATimeInputStream())


### PR DESCRIPTION
This way we can nicely use context managers:

```python
f = PyArrowInputFile(..).open()
f.read()
f.close()
```

turns into:

```python
with PyArrowInputFile('s3://').open() as f:
    f.read()
```

This way we don't forget to close any files. This is very easy to do and was actually happening when reading the metadata.