### PR TITLE
Core: Partition filter pushdown for entries table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.util.StructProjection;
+
+/** Base class logic for entries metadata tables */
+abstract class BaseEntriesTable extends BaseMetadataTable {
+
+  BaseEntriesTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public Schema schema() {
+    StructType partitionType = Partitioning.partitionType(table());
+    Schema schema = ManifestEntry.getSchema(partitionType);
+    if (partitionType.fields().size() < 1) {
+      // avoid returning an empty struct, which is not always supported. instead, drop the partition
+      // field (id 102)
+      return TypeUtil.selectNot(schema, Sets.newHashSet(102));
+    } else {
+      return schema;
+    }
+  }
+
+  static CloseableIterable<FileScanTask> planFiles(
+      Table table,
+      CloseableIterable<ManifestFile> manifests,
+      Schema tableSchema,
+      Schema projectedSchema,
+      TableScanContext context) {
+    Expression rowFilter = context.rowFilter();
+    boolean caseSensitive = context.caseSensitive();
+    boolean ignoreResiduals = context.ignoreResiduals();
+
+    LoadingCache<Integer, ManifestEvaluator> evalCache =
+        Caffeine.newBuilder()
+            .build(
+                specId -> {
+                  PartitionSpec spec = table.specs().get(specId);
+                  PartitionSpec transformedSpec = BaseFilesTable.transformSpec(tableSchema, spec);
+                  return ManifestEvaluator.forRowFilter(rowFilter, transformedSpec, caseSensitive);
+                });
+
+    CloseableIterable<ManifestFile> filteredManifests =
+        CloseableIterable.filter(
+            manifests, manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
+
+    String schemaString = SchemaParser.toJson(projectedSchema);
+    String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
+    Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
+
+    return CloseableIterable.transform(
+        filteredManifests,
+        manifest ->
+            new ManifestReadTask(
+                table, manifest, projectedSchema, schemaString, specString, residuals));
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.ALL_ENTRIES;
+  }
+
+  static class ManifestReadTask extends BaseFileScanTask implements DataTask {
+    private final Schema schema;
+    private final Schema fileSchema;
+    private final FileIO io;
+    private final ManifestFile manifest;
+    private final Map<Integer, PartitionSpec> specsById;
+
+    ManifestReadTask(
+        Table table,
+        ManifestFile manifest,
+        Schema schema,
+        String schemaString,
+        String specString,
+        ResidualEvaluator residuals) {
+      super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
+      this.schema = schema;
+      this.io = table.io();
+      this.manifest = manifest;
+      this.specsById = Maps.newHashMap(table.specs());
+
+      Type fileProjection = schema.findType("data_file");
+      this.fileSchema =
+          fileProjection != null
+              ? new Schema(fileProjection.asStructType().fields())
+              : new Schema();
+    }
+
+    @VisibleForTesting
+    ManifestFile manifest() {
+      return manifest;
+    }
+
+    @Override
+    public CloseableIterable<StructLike> rows() {
+      // Project data-file fields
+      CloseableIterable<StructLike> prunedRows;
+      if (manifest.content() == ManifestContent.DATA) {
+        prunedRows =
+            CloseableIterable.transform(
+                ManifestFiles.read(manifest, io).project(fileSchema).entries(),
+                file -> (GenericManifestEntry<DataFile>) file);
+      } else {
+        prunedRows =
+            CloseableIterable.transform(
+                ManifestFiles.readDeleteManifest(manifest, io, specsById)
+                    .project(fileSchema)
+                    .entries(),
+                file -> (GenericManifestEntry<DeleteFile>) file);
+      }
+
+      // Project non-readable fields
+      Schema readSchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
+      StructProjection projection = StructProjection.create(readSchema, schema);
+      return CloseableIterable.transform(prunedRows, projection::wrap);
+    }
+
+    @Override
+    public Iterable<FileScanTask> split(long splitSize) {
+      return ImmutableList.of(this); // don't split
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -50,7 +50,7 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     if (partitionType.fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition
       // field (id 102)
-      return TypeUtil.selectNot(schema, Sets.newHashSet(102));
+      return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     } else {
       return schema;
     }
@@ -89,11 +89,6 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
         manifest ->
             new ManifestReadTask(
                 table, manifest, projectedSchema, schemaString, specString, residuals));
-  }
-
-  @Override
-  MetadataTableType metadataTableType() {
-    return MetadataTableType.ALL_ENTRIES;
   }
 
   static class ManifestReadTask extends BaseFileScanTask implements DataTask {

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -18,19 +18,7 @@
  */
 package org.apache.iceberg;
 
-import java.util.Map;
-import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types.StructType;
-import org.apache.iceberg.util.StructProjection;
 
 /**
  * A {@link Table} implementation that exposes a table's manifest entries as rows, for both delete
@@ -39,7 +27,7 @@ import org.apache.iceberg.util.StructProjection;
  * <p>WARNING: this table exposes internal details, like files that have been deleted. For a table
  * of the live data files, use {@link DataFilesTable}.
  */
-public class ManifestEntriesTable extends BaseMetadataTable {
+public class ManifestEntriesTable extends BaseEntriesTable {
 
   ManifestEntriesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".entries");
@@ -52,19 +40,6 @@ public class ManifestEntriesTable extends BaseMetadataTable {
   @Override
   public TableScan newScan() {
     return new EntriesTableScan(operations(), table(), schema());
-  }
-
-  @Override
-  public Schema schema() {
-    StructType partitionType = Partitioning.partitionType(table());
-    Schema schema = ManifestEntry.getSchema(partitionType);
-    if (partitionType.fields().size() < 1) {
-      // avoid returning an empty struct, which is not always supported. instead, drop the partition
-      // field (id 102)
-      return TypeUtil.selectNot(schema, Sets.newHashSet(102));
-    } else {
-      return schema;
-    }
   }
 
   @Override
@@ -91,76 +66,9 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> doPlanFiles() {
-      // return entries from both data and delete manifests
       CloseableIterable<ManifestFile> manifests =
           CloseableIterable.withNoopClose(snapshot().allManifests(tableOps().io()));
-      String schemaString = SchemaParser.toJson(schema());
-      String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
-
-      return CloseableIterable.transform(
-          manifests,
-          manifest ->
-              new ManifestReadTask(
-                  table(), manifest, schema(), schemaString, specString, residuals));
-    }
-  }
-
-  static class ManifestReadTask extends BaseFileScanTask implements DataTask {
-    private final Schema schema;
-    private final Schema fileSchema;
-    private final FileIO io;
-    private final ManifestFile manifest;
-    private final Map<Integer, PartitionSpec> specsById;
-
-    ManifestReadTask(
-        Table table,
-        ManifestFile manifest,
-        Schema schema,
-        String schemaString,
-        String specString,
-        ResidualEvaluator residuals) {
-      super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
-      this.schema = schema;
-      this.io = table.io();
-      this.manifest = manifest;
-      this.specsById = Maps.newHashMap(table.specs());
-
-      Type fileProjection = schema.findType("data_file");
-      this.fileSchema =
-          fileProjection != null
-              ? new Schema(fileProjection.asStructType().fields())
-              : new Schema();
-    }
-
-    @Override
-    public CloseableIterable<StructLike> rows() {
-      // Project data-file fields
-      CloseableIterable<StructLike> prunedRows;
-      if (manifest.content() == ManifestContent.DATA) {
-        prunedRows =
-            CloseableIterable.transform(
-                ManifestFiles.read(manifest, io).project(fileSchema).entries(),
-                file -> (GenericManifestEntry<DataFile>) file);
-      } else {
-        prunedRows =
-            CloseableIterable.transform(
-                ManifestFiles.readDeleteManifest(manifest, io, specsById)
-                    .project(fileSchema)
-                    .entries(),
-                file -> (GenericManifestEntry<DeleteFile>) file);
-      }
-
-      // Project non-readable fields
-      Schema readSchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
-      StructProjection projection = StructProjection.create(readSchema, schema);
-      return CloseableIterable.transform(prunedRows, projection::wrap);
-    }
-
-    @Override
-    public Iterable<FileScanTask> split(long splitSize) {
-      return ImmutableList.of(this); // don't split
+      return BaseEntriesTable.planFiles(table(), manifests, tableSchema(), schema(), context());
     }
   }
 }


### PR DESCRIPTION
This implements partition filter pushdown for 'entries' and 'all_entries' table. This makes a base class for both and then re-uses the partition filter pushdown logic of 'files' table when doing planning.