### PR TITLE
Python: Initialize the properties with a frozendict

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -123,8 +123,16 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "frozendict"
+version = "2.3.4"
+description = "A simple immutable dictionary"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "identify"
-version = "2.5.2"
+version = "2.5.3"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -455,20 +463,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.16.2"
+version = "20.16.3"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-distlib = ">=0.3.1,<1"
-filelock = ">=3.2,<4"
-platformdirs = ">=2,<3"
+distlib = ">=0.3.5,<1"
+filelock = ">=3.4.1,<4"
+platformdirs = ">=2.4,<3"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
+docs = ["proselint (>=0.13)", "sphinx (>=5.1.1)", "sphinx-argparse (>=0.3.1)", "sphinx-rtd-theme (>=1)", "towncrier (>=21.9)"]
+testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=21.3)", "pytest (>=7.0.1)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.2)", "pytest-mock (>=3.6.1)", "pytest-randomly (>=3.10.3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "zipp"
@@ -505,7 +513,7 @@ snappy = ["python-snappy"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fa4637615911260d5d031479bd2e2481d952e1ecb6feaddfe6be6c358132465c"
+content-hash = "e9a83dbee3480646d52a45f1fc3022448dfaa19eba44f31d4db7270303a0ba35"
 
 [metadata.files]
 atomicwrites = []
@@ -603,6 +611,7 @@ filelock = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
     {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
 ]
+frozendict = []
 identify = []
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/python/pyiceberg/catalog/base.py
+++ b/python/pyiceberg/catalog/base.py
@@ -25,6 +25,7 @@ from pyiceberg.schema import Schema
 from pyiceberg.table.base import Table
 from pyiceberg.table.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
+from pyiceberg.typedef import EMPTY_DICT
 
 
 @dataclass
@@ -68,7 +69,7 @@ class Catalog(ABC):
         location: str | None = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
-        properties: Properties | None = None,
+        properties: Properties = EMPTY_DICT,
     ) -> Table:
         """Create a table
 
@@ -78,7 +79,7 @@ class Catalog(ABC):
             location (str): Location for the table. Optional Argument.
             partition_spec (PartitionSpec): PartitionSpec for the table.
             sort_order (SortOrder): SortOrder for the table.
-            properties (Properties | None): Table properties that can be a string based dictionary. Optional Argument.
+            properties (Properties): Table properties that can be a string based dictionary. Optional Argument.
 
         Returns:
             Table: the created table instance
@@ -142,12 +143,12 @@ class Catalog(ABC):
         """
 
     @abstractmethod
-    def create_namespace(self, namespace: str | Identifier, properties: Properties | None = None) -> None:
+    def create_namespace(self, namespace: str | Identifier, properties: Properties = EMPTY_DICT) -> None:
         """Create a namespace in the catalog.
 
         Args:
             namespace (str | Identifier): Namespace identifier
-            properties (Properties | None): A string dictionary of properties for the given namespace
+            properties (Properties): A string dictionary of properties for the given namespace
 
         Raises:
             NamespaceAlreadyExistsError: If a namespace with the given name already exists
@@ -208,14 +209,14 @@ class Catalog(ABC):
 
     @abstractmethod
     def update_namespace_properties(
-        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties | None = None
+        self, namespace: str | Identifier, removals: set[str] | None = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Removes provided property keys and updates properties for a namespace.
 
         Args:
             namespace (str | Identifier): Namespace identifier
             removals (Set[str]): Set of property keys that need to be removed. Optional Argument.
-            updates (Properties | None): Properties to be updated for the given namespace. Optional Argument.
+            updates (Properties): Properties to be updated for the given namespace. Optional Argument.
 
         Raises:
             NoSuchNamespaceError: If a namespace with the given name does not exist

--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -56,6 +56,7 @@ from pyiceberg.schema import Schema
 from pyiceberg.table.base import Table
 from pyiceberg.table.partitioning import PartitionSpec
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
+from pyiceberg.typedef import EMPTY_DICT
 from pyiceberg.types import (
     BinaryType,
     BooleanType,
@@ -209,7 +210,7 @@ class HiveCatalog(Catalog):
         location: Optional[str] = None,
         partition_spec: Optional[PartitionSpec] = None,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
-        properties: Optional[Properties] = None,
+        properties: Properties = EMPTY_DICT,
     ) -> Table:
         """Create a table
 
@@ -322,7 +323,7 @@ class HiveCatalog(Catalog):
             raise NoSuchNamespaceError(f"Database does not exists: {to_database_name}") from e
         return Table()
 
-    def create_namespace(self, namespace: Union[str, Identifier], properties: Optional[Properties] = None) -> None:
+    def create_namespace(self, namespace: Union[str, Identifier], properties: Properties = EMPTY_DICT) -> None:
         """Create a namespace in the catalog.
 
         Args:
@@ -338,7 +339,7 @@ class HiveCatalog(Catalog):
 
         try:
             with self._client as open_client:
-                open_client.create_database(_annotate_namespace(hive_database, properties or {}))
+                open_client.create_database(_annotate_namespace(hive_database, properties))
         except AlreadyExistsException as e:
             raise NamespaceAlreadyExistsError(f"Database {database_name} already exists") from e
 
@@ -413,7 +414,7 @@ class HiveCatalog(Catalog):
             raise NoSuchNamespaceError(f"Database does not exists: {database_name}") from e
 
     def update_namespace_properties(
-        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Optional[Properties] = None
+        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         """Removes provided property keys and updates properties for a namespace.
 

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -52,6 +52,7 @@ from pyiceberg.table.base import Table
 from pyiceberg.table.metadata import TableMetadataV1, TableMetadataV2
 from pyiceberg.table.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
+from pyiceberg.typedef import EMPTY_DICT
 from pyiceberg.utils.iceberg_base_model import IcebergBaseModel
 
 
@@ -299,10 +300,9 @@ class RestCatalog(Catalog):
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
-        properties: Optional[Properties] = None,
+        properties: Properties = EMPTY_DICT,
     ) -> Table:
         namespace_and_table = self._split_identifier_for_path(identifier)
-        properties = properties or {}
         request = CreateTableRequest(
             name=namespace_and_table["table"],
             location=location,
@@ -383,8 +383,8 @@ class RestCatalog(Catalog):
         except HTTPError as exc:
             self._handle_non_200_response(exc, {404: NoSuchTableError, 409: TableAlreadyExistsError})
 
-    def create_namespace(self, namespace: Union[str, Identifier], properties: Optional[Properties] = None) -> None:
-        payload = {"namespace": self.identifier_to_tuple(namespace), "properties": properties or {}}
+    def create_namespace(self, namespace: Union[str, Identifier], properties: Properties = EMPTY_DICT) -> None:
+        payload = {"namespace": self.identifier_to_tuple(namespace), "properties": properties}
         response = requests.post(self.url(Endpoints.create_namespace), json=payload, headers=self.headers)
         try:
             response.raise_for_status()
@@ -420,7 +420,7 @@ class RestCatalog(Catalog):
         return NamespaceResponse(**response.json()).properties
 
     def update_namespace_properties(
-        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Optional[Properties] = None
+        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         namespace = NAMESPACE_SEPARATOR.join(self.identifier_to_tuple(namespace))
         payload = {"removals": list(removals or []), "updates": updates}

--- a/python/pyiceberg/table/metadata.py
+++ b/python/pyiceberg/table/metadata.py
@@ -137,7 +137,7 @@ class TableMetadataCommonFields(IcebergBaseModel):
     are always assigned an unused ID when evolving specs."""
 
     properties: Dict[str, str] = Field(default_factory=dict)
-    """	A string to string map of table properties. This is used to
+    """A string to string map of table properties. This is used to
     control settings that affect reading and writing and is not intended
     to be used for arbitrary metadata. For example, commit.retry.num-retries
     is used to control the number of commit retries."""

--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from frozendict import frozendict
+
+EMPTY_DICT = frozendict()

--- a/python/pyiceberg/utils/iceberg_base_model.py
+++ b/python/pyiceberg/utils/iceberg_base_model.py
@@ -16,6 +16,7 @@
 # under the License.
 from functools import cached_property
 
+from frozendict import frozendict
 from pydantic import BaseModel
 
 
@@ -39,6 +40,9 @@ class IcebergBaseModel(BaseModel):
         allow_population_by_field_name = True
         copy_on_model_validation = False
         frozen = True
+        json_encoders = {
+            frozendict: dict,
+        }
 
     def dict(self, exclude_none: bool = True, **kwargs):
         return super().dict(exclude_none=exclude_none, **kwargs)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+frozendict = "^2.3.4"
 mmh3 = "^3.0.0"
 requests = "^2.28.1"
 
@@ -130,6 +131,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "requests_mock.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "frozendict.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/python/tests/catalog/test_base.py
+++ b/python/tests/catalog/test_base.py
@@ -39,6 +39,7 @@ from pyiceberg.table.base import Table
 from pyiceberg.table.metadata import INITIAL_SPEC_ID
 from pyiceberg.table.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
+from pyiceberg.typedef import EMPTY_DICT
 from tests.table.test_metadata import EXAMPLE_TABLE_METADATA_V1
 
 
@@ -60,7 +61,7 @@ class InMemoryCatalog(Catalog):
         location: Optional[str] = None,
         partition_spec: PartitionSpec = UNPARTITIONED_PARTITION_SPEC,
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
-        properties: Optional[Properties] = None,
+        properties: Properties = EMPTY_DICT,
     ) -> Table:
 
         identifier = Catalog.identifier_to_tuple(identifier)
@@ -108,7 +109,7 @@ class InMemoryCatalog(Catalog):
         self.__tables[to_identifier] = Table(identifier=to_identifier, metadata=table.metadata)
         return self.__tables[to_identifier]
 
-    def create_namespace(self, namespace: Union[str, Identifier], properties: Optional[Properties] = None) -> None:
+    def create_namespace(self, namespace: Union[str, Identifier], properties: Properties = EMPTY_DICT) -> None:
         namespace = Catalog.identifier_to_tuple(namespace)
         if namespace in self.__namespaces:
             raise NamespaceAlreadyExistsError(f"Namespace already exists: {namespace}")
@@ -144,7 +145,7 @@ class InMemoryCatalog(Catalog):
             raise NoSuchNamespaceError(f"Namespace does not exist: {namespace}") from error
 
     def update_namespace_properties(
-        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Optional[Properties] = None
+        self, namespace: Union[str, Identifier], removals: Optional[Set[str]] = None, updates: Properties = EMPTY_DICT
     ) -> PropertiesUpdateSummary:
         removed: Set[str] = set()
         updated: Set[str] = set()

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from textwrap import dedent
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import pytest
 
@@ -24,6 +24,7 @@ from pyiceberg import schema
 from pyiceberg.expressions.base import Accessor
 from pyiceberg.files import StructProtocol
 from pyiceberg.schema import Schema, build_position_accessors
+from pyiceberg.typedef import EMPTY_DICT
 from pyiceberg.types import (
     BooleanType,
     FloatType,
@@ -388,8 +389,8 @@ def test_build_position_accessors(table_schema_nested):
 
 def test_build_position_accessors_with_struct(table_schema_nested: Schema):
     class TestStruct(StructProtocol):
-        def __init__(self, pos: Optional[Dict[int, Any]] = None):
-            self._pos: Dict[int, Any] = pos or {}
+        def __init__(self, pos: Dict[int, Any] = EMPTY_DICT):
+            self._pos: Dict[int, Any] = pos
 
         def set(self, pos: int, value) -> None:
             pass


### PR DESCRIPTION
Instead of having an optional property. I think this is a nicer
API and it also removes the awkward `properties or {}` logic.

We can't use a {} in the constructor since that will always
reference the same object, and therefore is a source of weird bugs.

https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/

Next to that, we can also use the frozendict in the future when
we want to return immutable data: https://pypi.org/project/frozendict/

The frozendict is sometimes faster than the default impl:
https://github.com/Marco-Sulla/python-frozendict#benchmarks
Next to that, it is also hashable, which is also a nice property.

The package itself doesn't depend on anything, so we pull in very little
additional requirements.

I've added it into `typedef.py` which will also be introduced in:

https://github.com/apache/iceberg/pull/5360

I didn't want to create a new file for it, and also didn't find any
places where it could fit in.