### PR TITLE
CI: Enable dependabot for gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,4 +30,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 5
 


### PR DESCRIPTION
Even though dependabot isn't currently able to pick up the dependencies defined in `versions.props`, it can be at least used for Gradle plugin updates and any other dependencies that are defined in the default gradle files.