### PR TITLE
Spark 3.3: Use typed beans in BaseSparkAction

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -150,7 +150,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   @Deprecated
   public Dataset<Row> expire() {
     // rely on the same query execution to reuse shuffles
-    QueryExecution queryExecution = expiredFileDS().queryExecution();
+    QueryExecution queryExecution = expireFiles().queryExecution();
     return new Dataset<>(queryExecution, RowEncoder.apply(queryExecution.analyzed().schema()));
   }
 
@@ -164,10 +164,6 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
    * @return a Dataset of files that are no longer referenced by the table
    */
   public Dataset<FileInfo> expireFiles() {
-    return expiredFileDS();
-  }
-
-  private Dataset<FileInfo> expiredFileDS() {
     if (expiredFileDS == null) {
       // fetch metadata before expiration
       Dataset<FileInfo> originalFileDS = validFileDS(ops.current());
@@ -232,9 +228,9 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
 
   private ExpireSnapshots.Result doExecute() {
     if (streamResults()) {
-      return deleteFiles(expiredFileDS().toLocalIterator());
+      return deleteFiles(expireFiles().toLocalIterator());
     } else {
-      return deleteFiles(expiredFileDS().collectAsList().iterator());
+      return deleteFiles(expireFiles().collectAsList().iterator());
     }
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/FileInfo.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/FileInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
+
+public class FileInfo {
+  public static final Encoder<FileInfo> ENCODER = Encoders.bean(FileInfo.class);
+
+  private String path;
+  private String type;
+
+  public FileInfo(String path, String type) {
+    this.path = path;
+    this.type = type;
+  }
+
+  public FileInfo() {}
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -22,8 +22,12 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.Encoders;
 
 public class ManifestFileBean implements ManifestFile {
+  public static final Encoder<ManifestFileBean> ENCODER = Encoders.bean(ManifestFileBean.class);
+
   private String path = null;
   private Long length = null;
   private Integer partitionSpecId = null;


### PR DESCRIPTION
This PR switches `BaseSparkAction` to use typed beans instead of generic `Row`. This allows us to avoid unreliable index-based access and enables having more typed operations. In a follow-up PR, I will consume these changes in other actions.

This change does not affect the performance as we were previously using `Row` that required converting values from the internal Spark representation anyway.