### PR TITLE
AWS: Cleanup warning about Lambda should be method reference

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
@@ -241,7 +241,7 @@ public class TestLakeFormationMetadataOperations
       AssertHelpers.assertThrows("attempt to alter a table without ALTER permission should fail",
           ForbiddenException.class,
           "Glue cannot access the requested resources",
-          () -> updateProperties.commit());
+          updateProperties::commit);
     } finally {
       lfRegisterPathRoleDeleteTable(testDbName, testTableName);
       lfRegisterPathRoleDeleteDb(testDbName);


### PR DESCRIPTION
Cleans up a warning I see in the build for the AWS integ tests:

```
/Users/jahamogh/workplace/iceberg-jahamogh/iceberg/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java:244: warning: [LambdaMethodReference] Lambda should be a method reference
          () -> updateProperties.commit());
```
          ^