### PR TITLE
Core: Fix confusing log from RemoveSnapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -310,8 +310,6 @@ class RemoveSnapshots implements ExpireSnapshots {
 
     if (cleanExpiredFiles) {
       cleanExpiredSnapshots();
-    } else {
-      LOG.info("Cleaning up manifest and data files disabled, leaving them in place");
     }
   }
 
@@ -326,6 +324,9 @@ class RemoveSnapshots implements ExpireSnapshots {
     if (incrementalCleanup == null) {
       incrementalCleanup = current.refs().size() == 1;
     }
+
+    LOG.info(
+        "Cleaning up expired files (local, {})", incrementalCleanup ? "incremental" : "reachable");
 
     FileCleanupStrategy cleanupStrategy =
         incrementalCleanup


### PR DESCRIPTION
By default, `ExpireSnapshotsSparkAction` cleans the expired files but the log says not cleaning the files. 

`22/08/09 11:03:43 INFO RemoveSnapshots: Cleaning up manifest and data files disabled, leaving them in place`

So, this log is confusing the users. 

[ExpireSnapshotsSparkAction](https://github.com/apache/iceberg/blob/master/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java#L155) calls some code that is common for non-distributed and distributed expire snapshot job.
So, update the common code to print the clean up logs only if the files are cleaned up. 

 