### PR TITLE
Core: Support bulk table migration from one catalog to another

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogMigrateUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogMigrateUtil.java
@@ -44,31 +44,63 @@ public class CatalogMigrateUtil {
   private CatalogMigrateUtil() {}
 
   /**
-   * Migrates tables from one catalog(source catalog) to another catalog(target catalog).
+   * Migrates tables from one catalog(source catalog) to another catalog(target catalog). After
+   * successful migration, deletes the table entry from source catalog(not applicable for
+   * HadoopCatalog).
    *
-   * <p>Supports bulk migrations with a multi-thread execution. Once the migration is success, table
-   * would be dropped from the source catalog.
+   * <p>Supports bulk migrations with a multi-thread execution.
    *
    * <p>Users must make sure that no in-progress commits on the tables of source catalog during
    * migration.
    *
    * @param tableIdentifiers a list of {@link TableIdentifier} for the tables required to be
-   *     migrated. If not specified, all the tables would be migrated.
+   *     migrated. If not specified, all the tables would be migrated
    * @param sourceCatalog Source {@link Catalog} from which the tables are chosen
    * @param targetCatalog Target {@link Catalog} to which the tables need to be migrated
-   * @param maxConcurrentMigrations Size of the thread pool used for migrate tables (If set to 0, no
+   * @param maxThreadPoolSize Size of the thread pool used for migrate tables (If set to 0, no
    *     thread pool is used)
-   * @param deleteEntriesFromSourceCatalog If set to true, after successful migration, delete the
-   *     table entry from source catalog. This field is not applicable for HadoopCatalog.
    * @return Collection of table identifiers for successfully migrated tables
    */
   public static Collection<TableIdentifier> migrateTables(
       List<TableIdentifier> tableIdentifiers,
       Catalog sourceCatalog,
       Catalog targetCatalog,
-      int maxConcurrentMigrations,
+      int maxThreadPoolSize) {
+    return migrateTables(tableIdentifiers, sourceCatalog, targetCatalog, maxThreadPoolSize, true);
+  }
+
+  /**
+   * Register tables from one catalog(source catalog) to another catalog(target catalog). User has
+   * to take care of deleting the tables from source catalog after registration.
+   *
+   * <p>Supports bulk registration with a multi-thread execution.
+   *
+   * <p>Users must make sure that no in-progress commits on the tables of source catalog during
+   * registration.
+   *
+   * @param tableIdentifiers a list of {@link TableIdentifier} for the tables required to be
+   *     registered. If not specified, all the tables would be registered
+   * @param sourceCatalog Source {@link Catalog} from which the tables are chosen
+   * @param targetCatalog Target {@link Catalog} to which the tables need to be registered
+   * @param maxThreadPoolSize Size of the thread pool used for registering tables (If set to 0, no
+   *     thread pool is used)
+   * @return Collection of table identifiers for successfully registered tables
+   */
+  public static Collection<TableIdentifier> registerTables(
+      List<TableIdentifier> tableIdentifiers,
+      Catalog sourceCatalog,
+      Catalog targetCatalog,
+      int maxThreadPoolSize) {
+    return migrateTables(tableIdentifiers, sourceCatalog, targetCatalog, maxThreadPoolSize, false);
+  }
+
+  private static Collection<TableIdentifier> migrateTables(
+      List<TableIdentifier> tableIdentifiers,
+      Catalog sourceCatalog,
+      Catalog targetCatalog,
+      int maxThreadPoolSize,
       boolean deleteEntriesFromSourceCatalog) {
-    validate(sourceCatalog, targetCatalog, maxConcurrentMigrations);
+    validate(sourceCatalog, targetCatalog, maxThreadPoolSize);
 
     List<TableIdentifier> identifiers;
     if (tableIdentifiers == null || tableIdentifiers.isEmpty()) {
@@ -86,8 +118,8 @@ public class CatalogMigrateUtil {
     }
 
     ExecutorService executorService = null;
-    if (maxConcurrentMigrations > 0) {
-      executorService = ThreadPools.newWorkerPool("migrate-tables", maxConcurrentMigrations);
+    if (maxThreadPoolSize > 0) {
+      executorService = ThreadPools.newWorkerPool("migrate-tables", maxThreadPoolSize);
     }
 
     try {
@@ -103,7 +135,7 @@ public class CatalogMigrateUtil {
           .run(
               tableIdentifier -> {
                 migrate(
-                    sourceCatalog, targetCatalog, tableIdentifier, deleteEntriesFromSourceCatalog);
+                    tableIdentifier, sourceCatalog, targetCatalog, deleteEntriesFromSourceCatalog);
                 migratedTableIdentifiers.add(tableIdentifier);
               });
       return migratedTableIdentifiers;
@@ -115,10 +147,10 @@ public class CatalogMigrateUtil {
   }
 
   private static void validate(
-      Catalog sourceCatalog, Catalog targetCatalog, int maxConcurrentMigrations) {
+      Catalog sourceCatalog, Catalog targetCatalog, int maxThreadPoolSize) {
     Preconditions.checkArgument(
-        maxConcurrentMigrations >= 0,
-        "maxConcurrentMigrations should have value >= 0,  value: " + maxConcurrentMigrations);
+        maxThreadPoolSize >= 0,
+        "maxThreadPoolSize should have value >= 0,  value: " + maxThreadPoolSize);
     Preconditions.checkArgument(sourceCatalog != null, "Invalid source catalog: null");
     Preconditions.checkArgument(targetCatalog != null, "Invalid target catalog: null");
     Preconditions.checkArgument(
@@ -126,13 +158,12 @@ public class CatalogMigrateUtil {
   }
 
   private static void migrate(
+      TableIdentifier tableIdentifier,
       Catalog sourceCatalog,
       Catalog targetCatalog,
-      TableIdentifier tableIdentifier,
       boolean deleteEntriesFromSourceCatalog) {
     // register the table to the target catalog
-    TableOperations ops =
-        ((HasTableOperations) sourceCatalog.loadTable(tableIdentifier)).operations();
+    TableOperations ops = ((BaseTable) sourceCatalog.loadTable(tableIdentifier)).operations();
     targetCatalog.registerTable(tableIdentifier, ops.current().metadataFileLocation());
 
     if (deleteEntriesFromSourceCatalog && !(sourceCatalog instanceof HadoopCatalog)) {

--- a/core/src/main/java/org/apache/iceberg/CatalogMigrateUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogMigrateUtil.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CatalogMigrateUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(CatalogMigrateUtil.class);
+
+  private CatalogMigrateUtil() {}
+
+  /**
+   * Migrates tables from one catalog(source catalog) to another catalog(target catalog).
+   *
+   * <p>Supports bulk migrations with a multi-thread execution. Once the migration is success, table
+   * would be dropped from the source catalog.
+   *
+   * <p>Users must make sure that no in-progress commits on the tables of source catalog during
+   * migration.
+   *
+   * @param tableIdentifiers a list of {@link TableIdentifier} for the tables required to be
+   *     migrated. If not specified, all the tables would be migrated.
+   * @param sourceCatalog Source {@link Catalog} from which the tables are chosen
+   * @param targetCatalog Target {@link Catalog} to which the tables need to be migrated
+   * @param maxConcurrentMigrations Size of the thread pool used for migrate tables (If set to 0, no
+   *     thread pool is used)
+   * @param deleteEntriesFromSourceCatalog If set to true, after successful migration, delete the
+   *     table entry from source catalog. This field is not applicable for HadoopCatalog.
+   * @return Collection of table identifiers for successfully migrated tables
+   */
+  public static Collection<TableIdentifier> migrateTables(
+      List<TableIdentifier> tableIdentifiers,
+      Catalog sourceCatalog,
+      Catalog targetCatalog,
+      int maxConcurrentMigrations,
+      boolean deleteEntriesFromSourceCatalog) {
+    validate(sourceCatalog, targetCatalog, maxConcurrentMigrations);
+
+    List<TableIdentifier> identifiers;
+    if (tableIdentifiers == null || tableIdentifiers.isEmpty()) {
+      // fetch all the table identifiers from all the namespaces.
+      List<Namespace> namespaces =
+          (sourceCatalog instanceof SupportsNamespaces)
+              ? ((SupportsNamespaces) sourceCatalog).listNamespaces()
+              : ImmutableList.of(Namespace.empty());
+      identifiers =
+          namespaces.stream()
+              .flatMap(namespace -> sourceCatalog.listTables(namespace).stream())
+              .collect(Collectors.toList());
+    } else {
+      identifiers = tableIdentifiers;
+    }
+
+    ExecutorService executorService = null;
+    if (maxConcurrentMigrations > 0) {
+      executorService = ThreadPools.newWorkerPool("migrate-tables", maxConcurrentMigrations);
+    }
+
+    try {
+      Collection<TableIdentifier> migratedTableIdentifiers = new ConcurrentLinkedQueue<>();
+      Tasks.foreach(identifiers.stream().filter(Objects::nonNull))
+          .retry(3)
+          .stopRetryOn(NoSuchTableException.class, NoSuchNamespaceException.class)
+          .suppressFailureWhenFinished()
+          .executeWith(executorService)
+          .onFailure(
+              (tableIdentifier, exc) ->
+                  LOG.warn("Unable to migrate table {}", tableIdentifier, exc))
+          .run(
+              tableIdentifier -> {
+                migrate(
+                    sourceCatalog, targetCatalog, tableIdentifier, deleteEntriesFromSourceCatalog);
+                migratedTableIdentifiers.add(tableIdentifier);
+              });
+      return migratedTableIdentifiers;
+    } finally {
+      if (executorService != null) {
+        executorService.shutdown();
+      }
+    }
+  }
+
+  private static void validate(
+      Catalog sourceCatalog, Catalog targetCatalog, int maxConcurrentMigrations) {
+    Preconditions.checkArgument(
+        maxConcurrentMigrations >= 0,
+        "maxConcurrentMigrations should have value >= 0,  value: " + maxConcurrentMigrations);
+    Preconditions.checkArgument(sourceCatalog != null, "Invalid source catalog: null");
+    Preconditions.checkArgument(targetCatalog != null, "Invalid target catalog: null");
+    Preconditions.checkArgument(
+        !targetCatalog.equals(sourceCatalog), "target catalog is same as source catalog");
+  }
+
+  private static void migrate(
+      Catalog sourceCatalog,
+      Catalog targetCatalog,
+      TableIdentifier tableIdentifier,
+      boolean deleteEntriesFromSourceCatalog) {
+    // register the table to the target catalog
+    TableOperations ops =
+        ((HasTableOperations) sourceCatalog.loadTable(tableIdentifier)).operations();
+    targetCatalog.registerTable(tableIdentifier, ops.current().metadataFileLocation());
+
+    if (deleteEntriesFromSourceCatalog && !(sourceCatalog instanceof HadoopCatalog)) {
+      // HadoopCatalog dropTable will delete the table files completely even when purge is false.
+      // So, skip dropTable for HadoopCatalog.
+      sourceCatalog.dropTable(tableIdentifier, false);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -22,33 +22,21 @@ import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
-import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.MapMaker;
@@ -411,95 +399,5 @@ public class CatalogUtil {
     }
 
     setConf.invoke(conf);
-  }
-
-  /**
-   * Migrates tables from one catalog(source catalog) to another catalog(target catalog).
-   *
-   * <p>Supports bulk migrations with a multi-thread execution. Once the migration is success, table
-   * would be dropped from the source catalog.
-   *
-   * @param tableIdentifiers a list of {@link TableIdentifier} for the tables required to be
-   *     migrated. If not specified, all the tables would be migrated.
-   * @param sourceCatalog Source {@link Catalog} from which the tables are chosen
-   * @param targetCatalog Target {@link Catalog} to which the tables need to be migrated
-   * @param maxConcurrentMigrates Size of the thread pool used for migrate tables (If set to 0, no
-   *     thread pool is used)
-   * @return Collection of table identifiers for successfully migrated tables
-   */
-  public static Collection<TableIdentifier> migrateTables(
-      List<TableIdentifier> tableIdentifiers,
-      Catalog sourceCatalog,
-      Catalog targetCatalog,
-      int maxConcurrentMigrates) {
-    validate(sourceCatalog, targetCatalog, maxConcurrentMigrates);
-
-    List<TableIdentifier> identifiers;
-    if (tableIdentifiers == null || tableIdentifiers.isEmpty()) {
-      // fetch all the table identifiers from all the namespaces.
-      List<Namespace> namespaces =
-          (sourceCatalog instanceof SupportsNamespaces)
-              ? ((SupportsNamespaces) sourceCatalog).listNamespaces()
-              : ImmutableList.of(Namespace.empty());
-      identifiers =
-          namespaces.stream()
-              .flatMap(namespace -> sourceCatalog.listTables(namespace).stream())
-              .collect(Collectors.toList());
-    } else {
-      identifiers = tableIdentifiers;
-    }
-
-    ExecutorService executorService = null;
-    if (maxConcurrentMigrates > 0) {
-      executorService = ThreadPools.newWorkerPool("migrate-tables", maxConcurrentMigrates);
-    }
-
-    try {
-      Collection<TableIdentifier> migratedTableIdentifiers = new ConcurrentLinkedQueue<>();
-      Tasks.foreach(identifiers.stream().filter(Objects::nonNull))
-          .retry(3)
-          .stopRetryOn(NoSuchTableException.class, NoSuchNamespaceException.class)
-          .suppressFailureWhenFinished()
-          .executeWith(executorService)
-          .onFailure(
-              (tableIdentifier, exc) ->
-                  LOG.warn("Unable to migrate table {}", tableIdentifier, exc))
-          .run(
-              tableIdentifier -> {
-                migrate(sourceCatalog, targetCatalog, tableIdentifier);
-                migratedTableIdentifiers.add(tableIdentifier);
-              });
-      return migratedTableIdentifiers;
-    } finally {
-      if (executorService != null) {
-        executorService.shutdown();
-      }
-    }
-  }
-
-  private static void validate(
-      Catalog sourceCatalog, Catalog targetCatalog, int maxConcurrentMigrates) {
-    Preconditions.checkArgument(
-        maxConcurrentMigrates >= 0,
-        "maxConcurrentMigrates should have value >= 0,  value: " + maxConcurrentMigrates);
-    Preconditions.checkArgument(sourceCatalog != null, "source catalog should not be null");
-    Preconditions.checkArgument(targetCatalog != null, "target catalog should not be null");
-    Preconditions.checkArgument(
-        !targetCatalog.equals(sourceCatalog), "target catalog is same as source catalog");
-  }
-
-  private static void migrate(
-      Catalog sourceCatalog, Catalog targetCatalog, TableIdentifier tableIdentifier) {
-    // register the table to the target catalog
-    TableOperations ops =
-        ((HasTableOperations) sourceCatalog.loadTable(tableIdentifier)).operations();
-    targetCatalog.registerTable(tableIdentifier, ops.current().metadataFileLocation());
-
-    // drop the table from source catalog
-    if (!(sourceCatalog instanceof HadoopCatalog)) {
-      // HadoopCatalog dropTable will delete the table files completely even when purge is false.
-      // So, skip dropTable for HadoopCatalog.
-      sourceCatalog.dropTable(tableIdentifier, false);
-    }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogMigrateUtil;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
@@ -803,7 +804,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
       List<TableIdentifier> expectedIdentifiers,
       List<TableIdentifier> sourceIdentifiers) {
     Collection<TableIdentifier> migratedIdentifiers =
-        CatalogUtil.migrateTables(sourceIdentifiers, hadoopCatalog, catalog, 3);
+        CatalogMigrateUtil.migrateTables(sourceIdentifiers, hadoopCatalog, catalog, 3, true);
 
     org.assertj.core.api.Assertions.assertThat(expectedIdentifiers)
         .containsExactlyInAnyOrderElementsOf(migratedIdentifiers);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -804,7 +804,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
       List<TableIdentifier> expectedIdentifiers,
       List<TableIdentifier> sourceIdentifiers) {
     Collection<TableIdentifier> migratedIdentifiers =
-        CatalogMigrateUtil.migrateTables(sourceIdentifiers, hadoopCatalog, catalog, 3, true);
+        CatalogMigrateUtil.migrateTables(sourceIdentifiers, hadoopCatalog, catalog, 3);
 
     org.assertj.core.api.Assertions.assertThat(expectedIdentifiers)
         .containsExactlyInAnyOrderElementsOf(migratedIdentifiers);


### PR DESCRIPTION
To support the migration of tables from one catalog to another catalog seamlessly, we have added [#5037 , #4946].
But still, bulk migration is hard as the API user needs to write some extra code as `registerTable()` expects the table Identifier and metadata location of each table. 
Hence, adding a `CatalogUtil` API that can help in bulk migration of tables from one catalog to another.