### PR TITLE
Flink: Refactoring StreamingReaderOperator to read data nonblocking

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
@@ -19,7 +19,13 @@
 package org.apache.iceberg.flink.source;
 
 import java.io.IOException;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
+import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -38,9 +44,13 @@ import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.function.RunnableWithException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,61 +69,193 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
 
   private static final Logger LOG = LoggerFactory.getLogger(StreamingReaderOperator.class);
 
+  private enum SplitState {
+    IDLE {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) {
+        throw new IllegalStateException("not processing any records in IDLE state");
+      }
+    },
+    /** A message is enqueued to process split, but no split is opened. */
+    OPENING {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) throws IOException {
+        if (op.splits.isEmpty()) {
+          op.switchState(SplitState.IDLE);
+          return false;
+        } else {
+          op.loadSplit(op.splits.poll());
+          op.switchState(SplitState.READING);
+          return true;
+        }
+      }
+    },
+    /** A message is enqueued to process split and its processing was started. */
+    READING {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) {
+        return true;
+      }
+
+      @Override
+      public void onNoMoreData(StreamingReaderOperator op) {
+        op.switchState(SplitState.IDLE);
+      }
+    },
+    /**
+     * No further processing can be done; only state disposal transition to {@link #FINISHED}
+     * allowed.
+     */
+    FAILED {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) {
+        throw new IllegalStateException("not processing any records in ERRORED state");
+      }
+    },
+    /**
+     * {@link #close()} was called but unprocessed data (records and splits) remains and needs to be
+     * processed. {@link #close()} caller is blocked.
+     */
+    FINISHING {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) throws IOException {
+        if (op.currentSplit == null && !op.splits.isEmpty()) {
+          op.loadSplit(op.splits.poll());
+        }
+        return true;
+      }
+
+      @Override
+      public void onNoMoreData(StreamingReaderOperator op) {
+        // need one more mail to unblock possible yield() in close() method (todo: wait with timeout
+        // in yield)
+        op.enqueueProcessRecord();
+        op.switchState(FINISHED);
+      }
+    },
+    FINISHED {
+      @Override
+      public boolean prepareToProcessRecord(StreamingReaderOperator op) {
+        LOG.warn("not processing any records while closed");
+        return false;
+      }
+    };
+
+    private static final Set<SplitState> ACCEPT_SPLITS = EnumSet.of(IDLE, OPENING, READING);
+    /** Possible transition FROM each state. */
+    private static final Map<SplitState, Set<SplitState>> VALID_TRANSITIONS;
+
+    static {
+      Map<SplitState, Set<SplitState>> tmpTransitions = Maps.newHashMap();
+      tmpTransitions.put(IDLE, EnumSet.of(OPENING, FINISHED, FAILED));
+      tmpTransitions.put(OPENING, EnumSet.of(READING, FINISHING, FAILED));
+      tmpTransitions.put(READING, EnumSet.of(IDLE, OPENING, FINISHING, FAILED));
+      tmpTransitions.put(FINISHING, EnumSet.of(FINISHED, FAILED));
+      tmpTransitions.put(FAILED, EnumSet.of(FINISHED));
+      tmpTransitions.put(FINISHED, EnumSet.noneOf(SplitState.class));
+      VALID_TRANSITIONS = new EnumMap<>(tmpTransitions);
+    }
+
+    public boolean isAcceptingSplits() {
+      return ACCEPT_SPLITS.contains(this);
+    }
+
+    public final boolean isTerminal() {
+      return this == FINISHED;
+    }
+
+    public boolean canSwitchTo(SplitState next) {
+      return VALID_TRANSITIONS.getOrDefault(this, EnumSet.noneOf(SplitState.class)).contains(next);
+    }
+
+    /**
+     * Prepare to process new record OR split.
+     *
+     * @return true if should read the record
+     */
+    public abstract boolean prepareToProcessRecord(StreamingReaderOperator op) throws IOException;
+
+    public void onNoMoreData(StreamingReaderOperator op) {}
+  }
+
   // It's the same thread that is running this operator and checkpoint actions. we use this executor
   // to schedule only
   // one split for future reading, so that a new checkpoint could be triggered without blocking long
   // time for exhausting
   // all scheduled splits.
-  private final MailboxExecutor executor;
-  private FlinkInputFormat format;
+  private transient MailboxExecutorImpl executor;
+  private transient FlinkInputFormat format;
 
   private transient SourceFunction.SourceContext<RowData> sourceContext;
 
-  private transient ListState<FlinkInputSplit> inputSplitsState;
-  private transient Queue<FlinkInputSplit> splits;
+  private transient ListState<FlinkInputSplit> checkpointedState;
+  private transient SplitState state;
 
-  // Splits are read by the same thread that calls processElement. Each read task is submitted to
-  // that thread by adding
-  // them to the executor. This state is used to ensure that only one read task is in that queue at
-  // a time, so that read
-  // tasks do not accumulate ahead of checkpoint tasks. When there is a read task in the queue, this
-  // is set to RUNNING.
-  // When there are no more files to read, this will be set to IDLE.
-  private transient SplitState currentSplitState;
+  private transient Queue<FlinkInputSplit> splits = Lists.newLinkedList();
+  private transient FlinkInputSplit
+      currentSplit; // can't work just on queue tail because it can change because it's PQ
+
+  private final transient RunnableWithException processRecordAction =
+      () -> {
+        try {
+          processRecord();
+        } catch (Exception e) {
+          switchState(SplitState.FAILED);
+          throw e;
+        }
+      };
 
   private StreamingReaderOperator(
       FlinkInputFormat format, ProcessingTimeService timeService, MailboxExecutor mailboxExecutor) {
-    this.format = Preconditions.checkNotNull(format, "The InputFormat should not be null.");
-    this.processingTimeService = timeService;
+    this.format = Preconditions.checkNotNull(format, "The format should not be null.");
+    this.processingTimeService =
+        Preconditions.checkNotNull(timeService, "The timeService should not be null.");
+
     this.executor =
-        Preconditions.checkNotNull(mailboxExecutor, "The mailboxExecutor should not be null.");
+        (MailboxExecutorImpl)
+            Preconditions.checkNotNull(mailboxExecutor, "The mailboxExecutor should not be null.");
   }
 
   @Override
   public void initializeState(StateInitializationContext context) throws Exception {
     super.initializeState(context);
 
+    Preconditions.checkArgument(
+        checkpointedState == null, "The state has already been initialized.");
+
     // TODO Replace Java serialization with Avro approach to keep state compatibility.
     // See issue: https://github.com/apache/iceberg/issues/1698
-    inputSplitsState =
+    checkpointedState =
         context
             .getOperatorStateStore()
             .getListState(new ListStateDescriptor<>("splits", new JavaSerializer<>()));
 
-    // Initialize the current split state to IDLE.
-    currentSplitState = SplitState.IDLE;
-
-    // Recover splits state from flink state backend if possible.
-    splits = Lists.newLinkedList();
-    if (context.isRestored()) {
-      int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
-      LOG.info("Restoring state for the {} (taskIdx: {}).", getClass().getSimpleName(), subtaskIdx);
-
-      for (FlinkInputSplit split : inputSplitsState.get()) {
-        splits.add(split);
-      }
+    int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
+    if (!context.isRestored()) {
+      LOG.info(
+          "No state to restore for the {} (taskIdx={}).", getClass().getSimpleName(), subtaskIdx);
+      return;
     }
 
+    LOG.info("Restoring state for the {} (taskIdx={}).", getClass().getSimpleName(), subtaskIdx);
+
+    splits = splits == null ? Lists.newLinkedList() : splits;
+
+    for (FlinkInputSplit split : checkpointedState.get()) {
+      splits.add(split);
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("{} (taskIdx={}) restored {}.", getClass().getSimpleName(), subtaskIdx, splits);
+    }
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+
+    // Initialize the current split state to IDLE.
+    state = SplitState.IDLE;
     this.sourceContext =
         StreamSourceContexts.getSourceContext(
             getOperatorConfig().getTimeCharacteristic(),
@@ -124,52 +266,104 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
             -1,
             true);
 
+    this.splits = this.splits == null ? Lists.newLinkedList() : this.splits;
+
     // Enqueue to process the recovered input splits.
-    enqueueProcessSplits();
-  }
-
-  @Override
-  public void snapshotState(StateSnapshotContext context) throws Exception {
-    super.snapshotState(context);
-
-    inputSplitsState.clear();
-    inputSplitsState.addAll(Lists.newArrayList(splits));
+    if (!splits.isEmpty()) {
+      enqueueProcessRecord();
+    }
   }
 
   @Override
   public void processElement(StreamRecord<FlinkInputSplit> element) {
-    splits.add(element.getValue());
-    enqueueProcessSplits();
-  }
-
-  private void enqueueProcessSplits() {
-    if (currentSplitState == SplitState.IDLE && !splits.isEmpty()) {
-      currentSplitState = SplitState.RUNNING;
-      executor.execute(this::processSplits, this.getClass().getSimpleName());
+    Preconditions.checkState(state.isAcceptingSplits());
+    splits.offer(element.getValue());
+    if (state == SplitState.IDLE) {
+      enqueueProcessRecord();
     }
   }
 
-  private void processSplits() throws IOException {
-    FlinkInputSplit split = splits.poll();
-    if (split == null) {
-      currentSplitState = SplitState.IDLE;
+  private void enqueueProcessRecord() {
+    Preconditions.checkState(!state.isTerminal(), "can't enqueue mail in terminal state %s", state);
+    executor.execute(processRecordAction, "StreamingReaderOperator");
+    if (state == SplitState.IDLE) {
+      switchState(SplitState.OPENING);
+    }
+  }
+
+  private void processRecord() throws IOException {
+    do {
+      if (!state.prepareToProcessRecord(this)) {
+        return;
+      }
+
+      readAndCollectRecord();
+
+      if (format.reachedEnd()) {
+        onSplitProcessed();
+        return;
+      }
+    } while (executor.isIdle());
+    // todo: consider moving this loop into MailboxProcessor (return boolean "re-execute" from
+    // enqueued action)
+
+    enqueueProcessRecord();
+  }
+
+  private void onSplitProcessed() throws IOException {
+    LOG.debug("split processed: {}", currentSplit);
+    format.close();
+    currentSplit = null;
+
+    if (splits.isEmpty()) {
+      state.onNoMoreData(this);
       return;
     }
 
-    format.open(split);
-    try {
-      RowData nextElement = null;
-      while (!format.reachedEnd()) {
-        nextElement = format.nextRecord(nextElement);
-        sourceContext.collect(nextElement);
-      }
-    } finally {
-      currentSplitState = SplitState.IDLE;
-      format.close();
+    if (state == SplitState.READING) {
+      switchState(SplitState.OPENING);
     }
 
-    // Re-schedule to process the next split.
-    enqueueProcessSplits();
+    enqueueProcessRecord();
+  }
+
+  private void readAndCollectRecord() throws IOException {
+    Preconditions.checkState(
+        state == SplitState.READING || state == SplitState.FINISHING,
+        "can't process record in state %s",
+        state);
+
+    if (format.reachedEnd()) {
+      return;
+    }
+
+    RowData out = format.nextRecord(null);
+    if (out != null) {
+      sourceContext.collect(out);
+    }
+  }
+
+  private void loadSplit(FlinkInputSplit split) throws IOException {
+    Preconditions.checkState(
+        state != SplitState.READING && state != SplitState.FINISHED,
+        "can't load split in state %s",
+        state);
+    Preconditions.checkNotNull(split, "split is null");
+    LOG.debug("load split: {}", split);
+    currentSplit = split;
+    format.open(currentSplit);
+  }
+
+  private void switchState(SplitState newState) {
+    if (state != newState) {
+      Preconditions.checkState(
+          state.canSwitchTo(newState),
+          "can't switch state from terminal state %s to %s",
+          state,
+          newState);
+      LOG.debug("switch state: {} -> {}", state, newState);
+      state = newState;
+    }
   }
 
   @Override
@@ -178,36 +372,121 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
   }
 
   @Override
-  public void close() throws Exception {
-    super.close();
+  public void finish() throws Exception {
+    LOG.debug("finishing");
+    super.finish();
 
-    if (format != null) {
-      format.close();
-      format.closeInputFormat();
-      format = null;
+    switch (state) {
+      case IDLE:
+        switchState(SplitState.FINISHED);
+        break;
+      case FINISHED:
+        LOG.warn("operator is already closed, doing nothing");
+        return;
+      default:
+        switchState(SplitState.FINISHING);
+        while (!state.isTerminal()) {
+          executor.yield();
+        }
     }
 
-    sourceContext = null;
+    try {
+      sourceContext.emitWatermark(Watermark.MAX_WATERMARK);
+    } catch (Exception e) {
+      LOG.warn("unable to emit watermark while closing", e);
+    }
   }
 
   @Override
-  public void finish() throws Exception {
-    super.finish();
-    output.close();
-    if (sourceContext != null) {
-      sourceContext.emitWatermark(Watermark.MAX_WATERMARK);
-      sourceContext.close();
-      sourceContext = null;
+  public void close() throws Exception {
+    Exception exc = null;
+    try {
+      cleanUp();
+    } catch (Exception ex) {
+      exc = ex;
     }
+
+    checkpointedState = null;
+    currentSplit = null;
+    executor = null;
+    format = null;
+    sourceContext = null;
+    splits = null;
+
+    try {
+      super.close();
+    } catch (Exception ex) {
+      exc = ExceptionUtils.firstOrSuppressed(ex, exc);
+    }
+
+    if (exc != null) {
+      throw exc;
+    }
+  }
+
+  private void cleanUp() throws Exception {
+    LOG.debug("cleanup, state={}", state);
+
+    RunnableWithException[] runClose = {
+      () -> sourceContext.close(),
+      () -> format.close(),
+      () -> {
+        if (this.format instanceof RichInputFormat) {
+          ((RichInputFormat<?, ?>) this.format).closeInputFormat();
+        }
+      }
+    };
+
+    Exception firstException = null;
+
+    for (RunnableWithException r : runClose) {
+      try {
+        r.run();
+      } catch (Exception e) {
+        firstException = ExceptionUtils.firstOrSuppressed(e, firstException);
+      }
+    }
+
+    currentSplit = null;
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    Preconditions.checkState(
+        checkpointedState != null, "The operator state has not been properly initialized.");
+
+    int subtaskIdx = getRuntimeContext().getIndexOfThisSubtask();
+
+    List<FlinkInputSplit> readerState = getReaderState();
+    checkpointedState.clear();
+    checkpointedState.addAll(readerState);
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug(
+          "{} (taskIdx={}) checkpointed {} splits: {}.",
+          getClass().getSimpleName(),
+          subtaskIdx,
+          readerState.size(),
+          readerState);
+    }
+  }
+
+  private List<FlinkInputSplit> getReaderState() throws IOException {
+    List<FlinkInputSplit> snapshot = Lists.newArrayList();
+    if (currentSplit != null) {
+      snapshot.add(currentSplit);
+    }
+
+    snapshot.addAll(splits);
+    return snapshot;
   }
 
   static OneInputStreamOperatorFactory<FlinkInputSplit, RowData> factory(FlinkInputFormat format) {
     return new OperatorFactory(format);
-  }
-
-  private enum SplitState {
-    IDLE,
-    RUNNING
   }
 
   private static class OperatorFactory extends AbstractStreamOperatorFactory<RowData>

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -100,7 +100,9 @@ public class TestStreamingReaderOperator extends TableTestBase {
         harness.processElement(splits.get(i), -1);
 
         // Run the mail-box once to read all records from the given split.
-        Assert.assertTrue("Should processed 1 split", processor.runMailboxStep());
+        for (int l = 0; l < expectedRecords.get(i).size(); l++) {
+          Assert.assertTrue("Should processed 1 split", processor.runMailboxStep());
+        }
 
         // Assert the output has expected elements.
         expected.addAll(expectedRecords.get(i));
@@ -130,20 +132,27 @@ public class TestStreamingReaderOperator extends TableTestBase {
       harness.processElement(splits.get(1), ++timestamp);
       harness.processElement(splits.get(2), ++timestamp);
 
-      // Trigger snapshot state, it will start to work once all records from split0 are read.
+      // Trigger snapshot state, it will start to work once one record from split0 are read.
       processor.getMainMailboxExecutor().execute(() -> harness.snapshot(1, 3), "Trigger snapshot");
 
       Assert.assertTrue("Should have processed the split0", processor.runMailboxStep());
-      Assert.assertTrue(
-          "Should have processed the snapshot state action", processor.runMailboxStep());
+
+      for (int i = 0; i < expectedRecords.get(0).size(); i++) {
+        Assert.assertTrue(
+            "Should have processed the snapshot state action", processor.runMailboxStep());
+      }
 
       TestHelpers.assertRecords(readOutputValues(harness), expectedRecords.get(0), SCHEMA);
 
       // Read records from split1.
-      Assert.assertTrue("Should have processed the split1", processor.runMailboxStep());
+      for (int i = 0; i < expectedRecords.get(1).size(); i++) {
+        Assert.assertTrue("Should have processed the split1", processor.runMailboxStep());
+      }
 
       // Read records from split2.
-      Assert.assertTrue("Should have processed the split2", processor.runMailboxStep());
+      for (int i = 0; i < expectedRecords.get(2).size(); i++) {
+        Assert.assertTrue("Should have processed the split2", processor.runMailboxStep());
+      }
 
       TestHelpers.assertRecords(
           readOutputValues(harness), Lists.newArrayList(Iterables.concat(expectedRecords)), SCHEMA);
@@ -172,7 +181,9 @@ public class TestStreamingReaderOperator extends TableTestBase {
       SteppingMailboxProcessor localMailbox = createLocalMailbox(harness);
       for (int i = 0; i < 5; i++) {
         expected.addAll(expectedRecords.get(i));
-        Assert.assertTrue("Should have processed the split#" + i, localMailbox.runMailboxStep());
+        for (int l = 0; l < expectedRecords.get(i).size(); l++) {
+          Assert.assertTrue("Should have processed the split#" + i, localMailbox.runMailboxStep());
+        }
 
         TestHelpers.assertRecords(readOutputValues(harness), expected, SCHEMA);
       }
@@ -192,7 +203,9 @@ public class TestStreamingReaderOperator extends TableTestBase {
 
       for (int i = 5; i < 10; i++) {
         expected.addAll(expectedRecords.get(i));
-        Assert.assertTrue("Should have processed one split#" + i, localMailbox.runMailboxStep());
+        for (int l = 0; l < expectedRecords.get(i).size(); l++) {
+          Assert.assertTrue("Should have processed one split#" + i, localMailbox.runMailboxStep());
+        }
 
         TestHelpers.assertRecords(readOutputValues(harness), expected, SCHEMA);
       }
@@ -201,8 +214,10 @@ public class TestStreamingReaderOperator extends TableTestBase {
       for (int i = 10; i < 15; i++) {
         expected.addAll(expectedRecords.get(i));
         harness.processElement(splits.get(i), 1);
+        for (int l = 0; l < expectedRecords.get(i).size(); l++) {
+          Assert.assertTrue("Should have processed the split#" + i, localMailbox.runMailboxStep());
+        }
 
-        Assert.assertTrue("Should have processed the split#" + i, localMailbox.runMailboxStep());
         TestHelpers.assertRecords(readOutputValues(harness), expected, SCHEMA);
       }
     }


### PR DESCRIPTION
Co-authored-by: xuwei <xuwei132@huawei.com>

We currently have hundreds of billions of data in some of our tables, the old one needed to get all the data at once during one checkpoint, which caused job to get stuck for long time. Finally, a series of error such as checkpoint timeout occur.

<img width="1536" alt="image" src="https://user-images.githubusercontent.com/59213263/183982266-215e9858-927f-4dbb-9541-85686eb3a6f8.png">

The new one solves this problem.

![image](https://user-images.githubusercontent.com/59213263/183933898-bb0b98b0-daa8-4d35-89d5-399bfb608362.png)