### PR TITLE
API - Do not validate input length to String Truncate Transform on every call

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -252,7 +252,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return UnicodeUtil.truncateStringUnsafe(value, length);
+      return UnicodeUtil.truncateStringWithoutLengthValidation(value, length);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -252,7 +252,7 @@ abstract class Truncate<T> implements Transform<T, T> {
         return null;
       }
 
-      return UnicodeUtil.truncateString(value, length);
+      return UnicodeUtil.truncateStringUnsafe(value, length);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -40,7 +40,7 @@ public class UnicodeUtil {
    */
   public static CharSequence truncateString(CharSequence input, int length) {
     Preconditions.checkArgument(length > 0, "Truncate length should be positive");
-    return truncateStringUnsafe(input, length);
+    return truncateStringWithoutLengthValidation(input, length);
   }
 
   /**
@@ -51,7 +51,7 @@ public class UnicodeUtil {
    * <p>This function provides the same behavior as {@link #truncateString(CharSequence, int)}, but
    * skips validating the truncation length for situations where it is already validated.
    */
-  public static CharSequence truncateStringUnsafe(CharSequence input, int length) {
+  public static CharSequence truncateStringWithoutLengthValidation(CharSequence input, int length) {
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());

--- a/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UnicodeUtil.java
@@ -40,6 +40,18 @@ public class UnicodeUtil {
    */
   public static CharSequence truncateString(CharSequence input, int length) {
     Preconditions.checkArgument(length > 0, "Truncate length should be positive");
+    return truncateStringUnsafe(input, length);
+  }
+
+  /**
+   * Truncates the input charSequence such that the truncated charSequence is a valid unicode string
+   * and the number of unicode characters in the truncated charSequence is lesser than or equal to
+   * length.
+   *
+   * <p>This function provides the same behavior as {@link #truncateString(CharSequence, int)}, but
+   * skips validating the truncation length for situations where it is already validated.
+   */
+  public static CharSequence truncateStringUnsafe(CharSequence input, int length) {
     StringBuilder sb = new StringBuilder(input);
     // Get the number of unicode characters in the input
     int numUniCodeCharacters = sb.codePointCount(0, sb.length());


### PR DESCRIPTION
Working on #5431, I noticed that we are validating the input length to the String truncate transform in every call for every value.

However, the input length has already been validated when the transform is instantiated.

Given that this code runs in the per-record path of each string truncate transformation, I've separated the validation logic from the truncation logic to allow skipping length validation for the case when it's already been validated / is constant after validation.