### PR TITLE
Spark 3.3 - Support bucket in FunctionCatalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.BucketHashUtil;
+import org.apache.iceberg.util.BucketUtil;
 
 abstract class Bucket<T> implements Transform<T, Integer> {
   private static final HashFunction MURMUR3 = Hashing.murmur3_32_fixed();
@@ -166,7 +166,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Integer value) {
-      return BucketHashUtil.forInteger(value);
+      return BucketUtil.hashInteger(value);
     }
 
     @Override
@@ -182,7 +182,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Long value) {
-      return BucketHashUtil.forLong(value);
+      return BucketUtil.hashLong(value);
     }
 
     @Override
@@ -202,7 +202,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Float value) {
-      return BucketHashUtil.forFloat(value);
+      return BucketUtil.hashFloat(value);
     }
 
     @Override
@@ -220,7 +220,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Double value) {
-      return BucketHashUtil.forDouble(value);
+      return BucketUtil.hashDouble(value);
     }
 
     @Override
@@ -236,7 +236,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(CharSequence value) {
-      return BucketHashUtil.forCharSequence(value);
+      return BucketUtil.hashCharSequence(value);
     }
 
     @Override
@@ -254,7 +254,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(ByteBuffer value) {
-      return BucketHashUtil.forByteBuffer(value);
+      return BucketUtil.hashByteBuffer(value);
     }
 
     @Override
@@ -270,7 +270,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(UUID value) {
-      return BucketHashUtil.forUUID(value);
+      return BucketUtil.hashUUID(value);
     }
 
     @Override
@@ -286,7 +286,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(BigDecimal value) {
-      return BucketHashUtil.forDecimal(value);
+      return BucketUtil.hashDecimal(value);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -22,7 +22,6 @@ import static org.apache.iceberg.types.Type.TypeID;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.expressions.BoundPredicate;
@@ -38,6 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BucketHashUtil;
 
 abstract class Bucket<T> implements Transform<T, Integer> {
   private static final HashFunction MURMUR3 = Hashing.murmur3_32_fixed();
@@ -166,7 +166,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Integer value) {
-      return MURMUR3.hashLong(value.longValue()).asInt();
+      return BucketHashUtil.forInteger(value);
     }
 
     @Override
@@ -182,7 +182,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Long value) {
-      return MURMUR3.hashLong(value).asInt();
+      return BucketHashUtil.forLong(value);
     }
 
     @Override
@@ -202,7 +202,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Float value) {
-      return MURMUR3.hashLong(Double.doubleToLongBits((double) value)).asInt();
+      return BucketHashUtil.forFloat(value);
     }
 
     @Override
@@ -220,7 +220,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Double value) {
-      return MURMUR3.hashLong(Double.doubleToLongBits(value)).asInt();
+      return BucketHashUtil.forDouble(value);
     }
 
     @Override
@@ -236,7 +236,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(CharSequence value) {
-      return MURMUR3.hashString(value, StandardCharsets.UTF_8).asInt();
+      return BucketHashUtil.forCharSequence(value);
     }
 
     @Override
@@ -254,24 +254,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(ByteBuffer value) {
-      if (value.hasArray()) {
-        return MURMUR3
-            .hashBytes(
-                value.array(),
-                value.arrayOffset() + value.position(),
-                value.arrayOffset() + value.remaining())
-            .asInt();
-      } else {
-        int position = value.position();
-        byte[] copy = new byte[value.remaining()];
-        try {
-          value.get(copy);
-        } finally {
-          // make sure the buffer position is unchanged
-          value.position(position);
-        }
-        return MURMUR3.hashBytes(copy).asInt();
-      }
+      return BucketHashUtil.forByteBuffer(value);
     }
 
     @Override
@@ -287,12 +270,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(UUID value) {
-      return MURMUR3
-          .newHasher(16)
-          .putLong(Long.reverseBytes(value.getMostSignificantBits()))
-          .putLong(Long.reverseBytes(value.getLeastSignificantBits()))
-          .hash()
-          .asInt();
+      return BucketHashUtil.forUUID(value);
     }
 
     @Override
@@ -308,7 +286,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(BigDecimal value) {
-      return MURMUR3.hashBytes(value.unscaledValue().toByteArray()).asInt();
+      return BucketHashUtil.forDecimal(value);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -166,7 +166,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Integer value) {
-      return BucketUtil.hashInteger(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -182,7 +182,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Long value) {
-      return BucketUtil.hashLong(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -202,7 +202,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Float value) {
-      return BucketUtil.hashFloat(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -220,7 +220,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(Double value) {
-      return BucketUtil.hashDouble(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -236,7 +236,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(CharSequence value) {
-      return BucketUtil.hashCharSequence(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -254,7 +254,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(ByteBuffer value) {
-      return BucketUtil.hashByteBuffer(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -270,7 +270,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(UUID value) {
-      return BucketUtil.hashUUID(value);
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -286,7 +286,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
     @Override
     public int hash(BigDecimal value) {
-      return BucketUtil.hashDecimal(value);
+      return BucketUtil.hash(value);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/util/BucketHashUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketHashUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
+import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
+
+/**
+ * Contains the logic for hashing various types for use with the {@code bucket} partition
+ * transformations
+ */
+public class BucketHashUtil {
+
+  private static final HashFunction MURMUR3 = Hashing.murmur3_32_fixed();
+
+  private BucketHashUtil() {}
+
+  public static int forInteger(Integer value) {
+    return MURMUR3.hashLong(value.longValue()).asInt();
+  }
+
+  public static int forLong(Long value) {
+    return MURMUR3.hashLong(value).asInt();
+  }
+
+  public static int forFloat(Float value) {
+    return MURMUR3.hashLong(Double.doubleToLongBits((double) value)).asInt();
+  }
+
+  public static int forDouble(Double value) {
+    return MURMUR3.hashLong(Double.doubleToLongBits(value)).asInt();
+  }
+
+  public static int forCharSequence(CharSequence value) {
+    return MURMUR3.hashString(value, StandardCharsets.UTF_8).asInt();
+  }
+
+  public static int forByteBuffer(ByteBuffer value) {
+    if (value.hasArray()) {
+      return MURMUR3
+          .hashBytes(
+              value.array(),
+              value.arrayOffset() + value.position(),
+              value.arrayOffset() + value.remaining())
+          .asInt();
+    } else {
+      int position = value.position();
+      byte[] copy = new byte[value.remaining()];
+      try {
+        value.get(copy);
+      } finally {
+        // make sure the buffer position is unchanged
+        value.position(position);
+      }
+      return MURMUR3.hashBytes(copy).asInt();
+    }
+  }
+
+  public static int forUUID(UUID value) {
+    return MURMUR3
+        .newHasher(16)
+        .putLong(Long.reverseBytes(value.getMostSignificantBits()))
+        .putLong(Long.reverseBytes(value.getLeastSignificantBits()))
+        .hash()
+        .asInt();
+  }
+
+  public static int forDecimal(BigDecimal value) {
+    return MURMUR3.hashBytes(value.unscaledValue().toByteArray()).asInt();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -29,33 +29,33 @@ import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
  * Contains the logic for hashing various types for use with the {@code bucket} partition
  * transformations
  */
-public class BucketHashUtil {
+public class BucketUtil {
 
   private static final HashFunction MURMUR3 = Hashing.murmur3_32_fixed();
 
-  private BucketHashUtil() {}
+  private BucketUtil() {}
 
-  public static int forInteger(Integer value) {
+  public static int hashInteger(Integer value) {
     return MURMUR3.hashLong(value.longValue()).asInt();
   }
 
-  public static int forLong(Long value) {
+  public static int hashLong(Long value) {
     return MURMUR3.hashLong(value).asInt();
   }
 
-  public static int forFloat(Float value) {
+  public static int hashFloat(Float value) {
     return MURMUR3.hashLong(Double.doubleToLongBits((double) value)).asInt();
   }
 
-  public static int forDouble(Double value) {
+  public static int hashDouble(Double value) {
     return MURMUR3.hashLong(Double.doubleToLongBits(value)).asInt();
   }
 
-  public static int forCharSequence(CharSequence value) {
+  public static int hashCharSequence(CharSequence value) {
     return MURMUR3.hashString(value, StandardCharsets.UTF_8).asInt();
   }
 
-  public static int forByteBuffer(ByteBuffer value) {
+  public static int hashByteBuffer(ByteBuffer value) {
     if (value.hasArray()) {
       return MURMUR3
           .hashBytes(
@@ -76,7 +76,7 @@ public class BucketHashUtil {
     }
   }
 
-  public static int forUUID(UUID value) {
+  public static int hashUUID(UUID value) {
     return MURMUR3
         .newHasher(16)
         .putLong(Long.reverseBytes(value.getMostSignificantBits()))
@@ -85,7 +85,7 @@ public class BucketHashUtil {
         .asInt();
   }
 
-  public static int forDecimal(BigDecimal value) {
+  public static int hashDecimal(BigDecimal value) {
     return MURMUR3.hashBytes(value.unscaledValue().toByteArray()).asInt();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -35,27 +35,27 @@ public class BucketUtil {
 
   private BucketUtil() {}
 
-  public static int hashInteger(Integer value) {
-    return MURMUR3.hashLong(value.longValue()).asInt();
+  public static int hash(int value) {
+    return MURMUR3.hashLong((long) value).asInt();
   }
 
-  public static int hashLong(Long value) {
+  public static int hash(long value) {
     return MURMUR3.hashLong(value).asInt();
   }
 
-  public static int hashFloat(Float value) {
+  public static int hash(float value) {
     return MURMUR3.hashLong(Double.doubleToLongBits((double) value)).asInt();
   }
 
-  public static int hashDouble(Double value) {
+  public static int hash(double value) {
     return MURMUR3.hashLong(Double.doubleToLongBits(value)).asInt();
   }
 
-  public static int hashCharSequence(CharSequence value) {
+  public static int hash(CharSequence value) {
     return MURMUR3.hashString(value, StandardCharsets.UTF_8).asInt();
   }
 
-  public static int hashByteBuffer(ByteBuffer value) {
+  public static int hash(ByteBuffer value) {
     if (value.hasArray()) {
       return MURMUR3
           .hashBytes(
@@ -76,7 +76,7 @@ public class BucketUtil {
     }
   }
 
-  public static int hashUUID(UUID value) {
+  public static int hash(UUID value) {
     return MURMUR3
         .newHasher(16)
         .putLong(Long.reverseBytes(value.getMostSignificantBits()))
@@ -85,7 +85,7 @@ public class BucketUtil {
         .asInt();
   }
 
-  public static int hashDecimal(BigDecimal value) {
+  public static int hash(BigDecimal value) {
     return MURMUR3.hashBytes(value.unscaledValue().toByteArray()).asInt();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -61,7 +61,7 @@ public class BucketUtil {
           .hashBytes(
               value.array(),
               value.arrayOffset() + value.position(),
-              value.arrayOffset() + value.remaining())
+              value.remaining())
           .asInt();
     } else {
       int position = value.position();

--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -58,10 +58,7 @@ public class BucketUtil {
   public static int hash(ByteBuffer value) {
     if (value.hasArray()) {
       return MURMUR3
-          .hashBytes(
-              value.array(),
-              value.arrayOffset() + value.position(),
-              value.remaining())
+          .hashBytes(value.array(), value.arrayOffset() + value.position(), value.remaining())
           .asInt();
     } else {
       int position = value.position();

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -300,6 +300,25 @@ public class TestBucketing {
   }
 
   @Test
+  public void testByteBufferOnHeapArrayOffset() {
+    byte[] bytes = randomBytes(128);
+    ByteBuffer raw = ByteBuffer.wrap(bytes, 5, 100);
+    ByteBuffer buffer = raw.slice();
+    Assert.assertEquals("Buffer arrayOffset should be 5", 5, buffer.arrayOffset());
+
+    Bucket<ByteBuffer> bucketFunc = Bucket.get(Types.BinaryType.get(), 100);
+
+    Assert.assertEquals(
+        "HeapByteBuffer hash should match hash for correct slice",
+        hashBytes(bytes, 5, 100),
+        bucketFunc.hash(buffer));
+
+    // verify that the buffer was not modified
+    Assert.assertEquals("Buffer position should be 0", 0, buffer.position());
+    Assert.assertEquals("Buffer limit should not change", 100, buffer.limit());
+  }
+
+  @Test
   public void testByteBufferOffHeap() {
     byte[] bytes = randomBytes(128);
     ByteBuffer buffer = ByteBuffer.allocateDirect(128);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.functions;
+
+import java.nio.ByteBuffer;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.util.BucketHashUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
+import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DateType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.ShortType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * A Spark function implementation for the Iceberg bucket transform.
+ *
+ * <p>Example usage: {@code SELECT system.bucket(1, 'abc')}, which returns the bucket.
+ *
+ * <p>Note that for performance reasons, the given input number of buckets is not validated in the
+ * implementations used in code-gen. The number of buckets must be positive to give meaningful
+ * results.
+ */
+public class BucketFunction implements UnboundFunction {
+  private static final int NUM_BUCKETS_ORDINAL = 0;
+  private static final int VALUE_ORDINAL = 1;
+  private static final Set<DataType> SUPPORTED_NUM_BUCKETS_TYPES =
+      ImmutableSet.of(DataTypes.ByteType, DataTypes.ShortType, DataTypes.IntegerType);
+
+  @Override
+  public BoundFunction bind(StructType inputType) {
+    if (inputType.size() != 2) {
+      throw new UnsupportedOperationException(
+          "Wrong number of inputs (expected numBuckets and value)");
+    }
+
+    StructField numBucketsField = inputType.fields()[NUM_BUCKETS_ORDINAL];
+    StructField valueField = inputType.fields()[VALUE_ORDINAL];
+
+    if (!SUPPORTED_NUM_BUCKETS_TYPES.contains(numBucketsField.dataType())) {
+      throw new UnsupportedOperationException(
+          "Expected number of buckets to be tinyint, shortint or int");
+    }
+
+    DataType type = valueField.dataType();
+    if (type instanceof DateType) {
+      return new BucketInt(DataTypes.DateType);
+    } else if (type instanceof ByteType
+        || type instanceof ShortType
+        || type instanceof IntegerType) {
+      return new BucketInt(DataTypes.IntegerType);
+    } else if (type instanceof LongType) {
+      return new BucketLong(DataTypes.LongType);
+    } else if (type instanceof TimestampType) {
+      return new BucketLong(DataTypes.TimestampType);
+    } else if (type instanceof DecimalType) {
+      return new BucketDecimal(((DecimalType) type).precision(), ((DecimalType) type).scale());
+    } else if (type instanceof StringType) {
+      return new BucketString();
+    } else if (type instanceof BinaryType) {
+      return new BucketBinary();
+    } else {
+      throw new UnsupportedOperationException(
+          "Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary");
+    }
+  }
+
+  @Override
+  public String description() {
+    return name()
+        + "(numBuckets, col) - Call Iceberg's bucket transform\n"
+        + "  numBuckets :: number of buckets to divide the rows into, e.g. bucket(100, 34) -> 79 (must be a tinyint, smallint, or int)\n"
+        + "  col :: column to bucket (must be a date, integer, long, timestamp, decimal, string, or binary)";
+  }
+
+  @Override
+  public String name() {
+    return "bucket";
+  }
+
+  public abstract static class BucketBase implements ScalarFunction<Integer> {
+    @Override
+    public String name() {
+      return "bucket";
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.IntegerType;
+    }
+  }
+
+  // Used for both int and date - tinyint and smallint are upcasted to int by Spark.
+  public static class BucketInt extends BucketBase {
+    private final DataType sqlType;
+
+    // magic method used in codegen
+    public static int invoke(int numBuckets, int value) {
+      return (BucketHashUtil.forInteger(value) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    public BucketInt(DataType sqlType) {
+      this.sqlType = sqlType;
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getInt(VALUE_ORDINAL));
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, sqlType};
+    }
+
+    @Override
+    public String canonicalName() {
+      return String.format("iceberg.bucket(%s)", sqlType.catalogString());
+    }
+  }
+
+  // Used for both BigInt and Timestamp
+  public static class BucketLong extends BucketBase {
+    private final DataType sqlType;
+
+    // magic function for usage with codegen - needs to be static
+    public static int invoke(int numBuckets, long value) {
+      return (BucketHashUtil.forLong(value) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    public BucketLong(DataType sqlType) {
+      this.sqlType = sqlType;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, sqlType};
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getLong(VALUE_ORDINAL));
+    }
+
+    @Override
+    public String canonicalName() {
+      return String.format("iceberg.bucket(%s)", sqlType.catalogString());
+    }
+  }
+
+  // bucketing by Float is not allowed by the spec, but this has the float hash implementation
+  public static class BucketFloat extends BucketBase {
+
+    public static int invoke(int numBuckets, float value) {
+      return (BucketHashUtil.forFloat(value) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.FloatType};
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.bucket(float)";
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getFloat(VALUE_ORDINAL));
+    }
+  }
+
+  public static class BucketString extends BucketBase {
+    // magic function for usage with codegen
+    public static Integer invoke(int numBuckets, UTF8String value) {
+      if (value == null) {
+        return null;
+      }
+
+      return (BucketHashUtil.forCharSequence(value.toString()) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.StringType};
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.bucket(string)";
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getUTF8String(VALUE_ORDINAL));
+    }
+  }
+
+  public static class BucketBinary extends BucketBase {
+    public static Integer invoke(int numBuckets, byte[] value) {
+      if (value == null) {
+        return null;
+      }
+
+      return (BucketHashUtil.forByteBuffer(ByteBuffer.wrap(value)) & Integer.MAX_VALUE)
+          % numBuckets;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.BinaryType};
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getBinary(VALUE_ORDINAL));
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.bucket(binary)";
+    }
+  }
+
+  public static class BucketDecimal extends BucketBase {
+    private final int precision;
+    private final int scale;
+
+    public BucketDecimal(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    // magic method used in codegen
+    public static Integer invoke(int numBuckets, Decimal value) {
+      if (value == null) {
+        return null;
+      }
+
+      return (BucketHashUtil.forDecimal(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    @Override
+    public DataType[] inputTypes() {
+      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(
+              input.getInt(NUM_BUCKETS_ORDINAL), input.getDecimal(VALUE_ORDINAL, precision, scale));
+    }
+
+    @Override
+    public String canonicalName() {
+      return String.format("iceberg.bucket(decimal(%d,%d))", precision, scale);
+    }
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -178,7 +178,6 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getLong(VALUE_ORDINAL));
@@ -204,7 +203,6 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getFloat(VALUE_ORDINAL));
@@ -233,7 +231,6 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getUTF8String(VALUE_ORDINAL));
@@ -256,7 +253,6 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getBinary(VALUE_ORDINAL));
@@ -293,7 +289,6 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -84,7 +84,7 @@ public class BucketFunction implements UnboundFunction {
     } else if (type instanceof TimestampType) {
       return new BucketLong(DataTypes.TimestampType);
     } else if (type instanceof DecimalType) {
-      return new BucketDecimal(((DecimalType) type).precision(), ((DecimalType) type).scale());
+      return new BucketDecimal(type);
     } else if (type instanceof StringType) {
       return new BucketString();
     } else if (type instanceof BinaryType) {
@@ -243,6 +243,7 @@ public class BucketFunction implements UnboundFunction {
   }
 
   public static class BucketDecimal extends BucketBase {
+    private final DataType sqlType;
     private final int precision;
     private final int scale;
 
@@ -255,14 +256,15 @@ public class BucketFunction implements UnboundFunction {
       return apply(numBuckets, BucketUtil.hash(value.toJavaBigDecimal()));
     }
 
-    public BucketDecimal(int precision, int scale) {
-      this.precision = precision;
-      this.scale = scale;
+    public BucketDecimal(DataType sqlType) {
+      this.sqlType = sqlType;
+      this.precision = ((DecimalType) sqlType).precision();
+      this.scale = ((DecimalType) sqlType).scale();
     }
 
     @Override
     public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.createDecimalType(precision, scale)};
+      return new DataType[] {DataTypes.IntegerType, sqlType};
     }
 
     @Override
@@ -275,7 +277,7 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return String.format("iceberg.bucket(decimal)");
+      return "iceberg.bucket(decimal)";
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.functions;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -130,7 +131,12 @@ public class BucketFunction implements UnboundFunction {
 
     // magic method used in codegen
     public static int invoke(int numBuckets, int value) {
-      return apply(numBuckets, BucketUtil.hash(value));
+      return apply(numBuckets, hash(value));
+    }
+
+    // Visible for testing
+    public static int hash(int value) {
+      return BucketUtil.hash(value);
     }
 
     public BucketInt(DataType sqlType) {
@@ -162,7 +168,12 @@ public class BucketFunction implements UnboundFunction {
 
     // magic function for usage with codegen - needs to be static
     public static int invoke(int numBuckets, long value) {
-      return apply(numBuckets, BucketUtil.hash(value));
+      return apply(numBuckets, hash(value));
+    }
+
+    // Visible for testing
+    public static int hash(long value) {
+      return BucketUtil.hash(value);
     }
 
     public BucketLong(DataType sqlType) {
@@ -195,7 +206,12 @@ public class BucketFunction implements UnboundFunction {
       }
 
       // TODO - We can probably hash the bytes directly given they're already UTF-8 input.
-      return apply(numBuckets, BucketUtil.hash(value.toString()));
+      return apply(numBuckets, hash(value.toString()));
+    }
+
+    // Visible for testing
+    public static int hash(String value) {
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -222,7 +238,12 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return apply(numBuckets, BucketUtil.hash(ByteBuffer.wrap(value)));
+      return apply(numBuckets, hash(ByteBuffer.wrap(value)));
+    }
+
+    // Visible for testing
+    public static int hash(ByteBuffer value) {
+      return BucketUtil.hash(value);
     }
 
     @Override
@@ -254,7 +275,12 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return apply(numBuckets, BucketUtil.hash(value.toJavaBigDecimal()));
+      return apply(numBuckets, hash(value.toJavaBigDecimal()));
+    }
+
+    // Visible for testing
+    public static int hash(BigDecimal value) {
+      return BucketUtil.hash(value);
     }
 
     public BucketDecimal(DataType sqlType) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -109,6 +109,9 @@ public class BucketFunction implements UnboundFunction {
   }
 
   public abstract static class BucketBase implements ScalarFunction<Integer> {
+    public static int apply(int numBuckets, int hashedValue) {
+      return (hashedValue & Integer.MAX_VALUE) % numBuckets;
+    }
     @Override
     public String name() {
       return "bucket";
@@ -126,7 +129,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic method used in codegen
     public static int invoke(int numBuckets, int value) {
-      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
+      return apply(numBuckets, BucketUtil.hash(value));
     }
 
     public BucketInt(DataType sqlType) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -72,6 +72,7 @@ public class BucketFunction implements UnboundFunction {
           "Expected number of buckets to be tinyint, shortint or int");
     }
 
+    // TODO - Support UUID type.
     DataType type = valueField.dataType();
     if (type instanceof DateType) {
       return new BucketInt(DataTypes.DateType);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -184,31 +184,6 @@ public class BucketFunction implements UnboundFunction {
     }
   }
 
-  // bucketing by Float is not allowed by the spec, but this has the float hash implementation
-  public static class BucketFloat extends BucketBase {
-
-    public static int invoke(int numBuckets, float value) {
-      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
-    }
-
-    @Override
-    public DataType[] inputTypes() {
-      return new DataType[] {DataTypes.IntegerType, DataTypes.FloatType};
-    }
-
-    @Override
-    public String canonicalName() {
-      return "iceberg.bucket(float)";
-    }
-
-    @Override
-    public Integer produceResult(InternalRow input) {
-      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getFloat(VALUE_ORDINAL));
-    }
-  }
-
   public static class BucketString extends BucketBase {
     // magic function for usage with codegen
     public static Integer invoke(int numBuckets, UTF8String value) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -91,7 +91,7 @@ public class BucketFunction implements UnboundFunction {
       return new BucketBinary();
     } else {
       throw new UnsupportedOperationException(
-          "Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary");
+          "Expected column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary");
     }
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -74,15 +74,15 @@ public class BucketFunction implements UnboundFunction {
 
     DataType type = valueField.dataType();
     if (type instanceof DateType) {
-      return new BucketInt(DataTypes.DateType);
+      return new BucketInt(type);
     } else if (type instanceof ByteType
         || type instanceof ShortType
         || type instanceof IntegerType) {
       return new BucketInt(DataTypes.IntegerType);
     } else if (type instanceof LongType) {
-      return new BucketLong(DataTypes.LongType);
+      return new BucketLong(type);
     } else if (type instanceof TimestampType) {
-      return new BucketLong(DataTypes.TimestampType);
+      return new BucketLong(type);
     } else if (type instanceof DecimalType) {
       return new BucketDecimal(type);
     } else if (type instanceof StringType) {
@@ -112,6 +112,7 @@ public class BucketFunction implements UnboundFunction {
     public static int apply(int numBuckets, int hashedValue) {
       return (hashedValue & Integer.MAX_VALUE) % numBuckets;
     }
+
     @Override
     public String name() {
       return "bucket";

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -127,7 +127,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic method used in codegen
     public static int invoke(int numBuckets, int value) {
-      return (BucketUtil.hashInteger(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     public BucketInt(DataType sqlType) {
@@ -159,7 +159,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic function for usage with codegen - needs to be static
     public static int invoke(int numBuckets, long value) {
-      return (BucketUtil.hashLong(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     public BucketLong(DataType sqlType) {
@@ -188,7 +188,7 @@ public class BucketFunction implements UnboundFunction {
   public static class BucketFloat extends BucketBase {
 
     public static int invoke(int numBuckets, float value) {
-      return (BucketUtil.hashFloat(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -216,7 +216,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hashCharSequence(value.toString()) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(value.toString()) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -243,7 +243,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hashByteBuffer(ByteBuffer.wrap(value)) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(ByteBuffer.wrap(value)) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -274,7 +274,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hashDecimal(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hash(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
     }
 
     public BucketDecimal(int precision, int scale) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -271,7 +271,7 @@ public class BucketFunction implements UnboundFunction {
 
     @Override
     public String canonicalName() {
-      return String.format("iceberg.bucket(decimal(%d,%d))", precision, scale);
+      return String.format("iceberg.bucket(decimal)");
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -134,14 +134,6 @@ public class BucketFunction implements UnboundFunction {
     }
 
     @Override
-    public Integer produceResult(InternalRow input) {
-      // return null for null input to match what Spark does in the code-generated versions.
-      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
-          ? null
-          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getInt(VALUE_ORDINAL));
-    }
-
-    @Override
     public DataType[] inputTypes() {
       return new DataType[] {DataTypes.IntegerType, sqlType};
     }
@@ -149,6 +141,14 @@ public class BucketFunction implements UnboundFunction {
     @Override
     public String canonicalName() {
       return String.format("iceberg.bucket(%s)", sqlType.catalogString());
+    }
+
+    @Override
+    public Integer produceResult(InternalRow input) {
+      // return null for null input to match what Spark does in the code-generated versions.
+      return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
+          ? null
+          : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getInt(VALUE_ORDINAL));
     }
   }
 
@@ -171,16 +171,16 @@ public class BucketFunction implements UnboundFunction {
     }
 
     @Override
+    public String canonicalName() {
+      return String.format("iceberg.bucket(%s)", sqlType.catalogString());
+    }
+
+    @Override
     public Integer produceResult(InternalRow input) {
       // return null for null input to match what Spark does in the code-generated versions.
       return input.isNullAt(NUM_BUCKETS_ORDINAL) || input.isNullAt(VALUE_ORDINAL)
           ? null
           : invoke(input.getInt(NUM_BUCKETS_ORDINAL), input.getLong(VALUE_ORDINAL));
-    }
-
-    @Override
-    public String canonicalName() {
-      return String.format("iceberg.bucket(%s)", sqlType.catalogString());
     }
   }
 
@@ -271,11 +271,6 @@ public class BucketFunction implements UnboundFunction {
     private final int precision;
     private final int scale;
 
-    public BucketDecimal(int precision, int scale) {
-      this.precision = precision;
-      this.scale = scale;
-    }
-
     // magic method used in codegen
     public static Integer invoke(int numBuckets, Decimal value) {
       if (value == null) {
@@ -283,6 +278,11 @@ public class BucketFunction implements UnboundFunction {
       }
 
       return (BucketUtil.hashDecimal(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
+    }
+
+    public BucketDecimal(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
     }
 
     @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -45,7 +45,7 @@ import org.apache.spark.unsafe.types.UTF8String;
 /**
  * A Spark function implementation for the Iceberg bucket transform.
  *
- * <p>Example usage: {@code SELECT system.bucket(1, 'abc')}, which returns the bucket.
+ * <p>Example usage: {@code SELECT system.bucket(128, 'abc')}, which returns the bucket 122.
  *
  * <p>Note that for performance reasons, the given input number of buckets is not validated in the
  * implementations used in code-gen. The number of buckets must be positive to give meaningful

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -161,7 +161,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic function for usage with codegen - needs to be static
     public static int invoke(int numBuckets, long value) {
-      return (BucketUtil.hash(value) & Integer.MAX_VALUE) % numBuckets;
+      return apply(numBuckets, BucketUtil.hash(value));
     }
 
     public BucketLong(DataType sqlType) {
@@ -193,7 +193,8 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hash(value.toString()) & Integer.MAX_VALUE) % numBuckets;
+      // TODO - We can probably hash the bytes directly given they're already UTF-8 input.
+      return apply(numBuckets, BucketUtil.hash(value.toString()));
     }
 
     @Override
@@ -220,7 +221,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hash(ByteBuffer.wrap(value)) & Integer.MAX_VALUE) % numBuckets;
+      return apply(numBuckets, BucketUtil.hash(ByteBuffer.wrap(value)));
     }
 
     @Override
@@ -251,7 +252,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketUtil.hash(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
+      return apply(numBuckets, BucketUtil.hash(value.toJavaBigDecimal()));
     }
 
     public BucketDecimal(int precision, int scale) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.spark.functions;
 import java.nio.ByteBuffer;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.util.BucketHashUtil;
+import org.apache.iceberg.util.BucketUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction;
@@ -126,7 +126,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic method used in codegen
     public static int invoke(int numBuckets, int value) {
-      return (BucketHashUtil.forInteger(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hashInteger(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     public BucketInt(DataType sqlType) {
@@ -158,7 +158,7 @@ public class BucketFunction implements UnboundFunction {
 
     // magic function for usage with codegen - needs to be static
     public static int invoke(int numBuckets, long value) {
-      return (BucketHashUtil.forLong(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hashLong(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     public BucketLong(DataType sqlType) {
@@ -188,7 +188,7 @@ public class BucketFunction implements UnboundFunction {
   public static class BucketFloat extends BucketBase {
 
     public static int invoke(int numBuckets, float value) {
-      return (BucketHashUtil.forFloat(value) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hashFloat(value) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -217,7 +217,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketHashUtil.forCharSequence(value.toString()) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hashCharSequence(value.toString()) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -245,8 +245,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketHashUtil.forByteBuffer(ByteBuffer.wrap(value)) & Integer.MAX_VALUE)
-          % numBuckets;
+      return (BucketUtil.hashByteBuffer(ByteBuffer.wrap(value)) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override
@@ -283,7 +282,7 @@ public class BucketFunction implements UnboundFunction {
         return null;
       }
 
-      return (BucketHashUtil.forDecimal(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
+      return (BucketUtil.hashDecimal(value.toJavaBigDecimal()) & Integer.MAX_VALUE) % numBuckets;
     }
 
     @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -72,7 +72,6 @@ public class BucketFunction implements UnboundFunction {
           "Expected number of buckets to be tinyint, shortint or int");
     }
 
-    // TODO - Support UUID type.
     DataType type = valueField.dataType();
     if (type instanceof DateType) {
       return new BucketInt(DataTypes.DateType);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -32,6 +32,7 @@ public class SparkFunctions {
   private static final Map<String, UnboundFunction> FUNCTIONS =
       ImmutableMap.of(
           "iceberg_version", new IcebergVersionFunction(),
+          "bucket", new BucketFunction(),
           "truncate", new TruncateFunction());
 
   private static final List<String> FUNCTION_NAMES = ImmutableList.copyOf(FUNCTIONS.keySet());

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -242,22 +242,6 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testMagicFunctionsResolveForTinyIntAndSmallIntNumberOfBuckets() {
-    // Magic functions have staticinvoke in the explain output.
-    // Nonmagic calls use applyfunctionexpression instead and go through produceResults.
-    String tinyIntWidthExplain = (String) scalarSql("EXPLAIN EXTENDED SELECT system.bucket(1Y, 6)");
-    Assertions.assertThat(tinyIntWidthExplain)
-        .contains("cast(1 as int)")
-        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
-
-    String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5S, 6L)");
-    Assertions.assertThat(smallIntWidth)
-        .contains("cast(5 as int)")
-        .contains(
-            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketLong");
-  }
-
-  @Test
   public void testThatMagicFunctionsAreInvoked() {
     // TinyInt
     Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6Y)"))

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.AnalysisException;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
+  public TestSparkBucketFunction() {}
+
+  @Before
+  public void useCatalog() {
+    sql("USE %s", catalogName);
+  }
+
+  @Test
+  public void testBucketIntegers() {
+    Assert.assertEquals(
+        "Byte type should bucket similarly to integer",
+        3,
+        scalarSql("SELECT system.bucket(10, 8Y)"));
+    Assert.assertEquals(
+        "Short type should bucket similarly to integer",
+        3,
+        scalarSql("SELECT system.bucket(10, 8S)"));
+    // Integers
+    Assert.assertEquals(3, scalarSql("SELECT system.bucket(10, 8)"));
+    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, 34)"));
+    Assert.assertNull(scalarSql("SELECT system.bucket(1, CAST(null AS INT))"));
+  }
+
+  @Test
+  public void testBucketDates() {
+    Assert.assertEquals(3, scalarSql("SELECT system.bucket(10, date('1970-01-09'))"));
+    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, date('1970-02-04'))"));
+    Assert.assertNull(scalarSql("SELECT system.bucket(1, CAST(null AS DATE))"));
+  }
+
+  @Test
+  public void testBucketLong() {
+    Assert.assertEquals(79, scalarSql("SELECT system.bucket(100, 34L)"));
+    Assert.assertEquals(76, scalarSql("SELECT system.bucket(100, 0L)"));
+    Assert.assertEquals(97, scalarSql("SELECT system.bucket(100, -34L)"));
+    Assert.assertEquals(0, scalarSql("SELECT system.bucket(2, -1L)"));
+    Assert.assertNull(scalarSql("SELECT system.bucket(2, CAST(null AS LONG))"));
+  }
+
+  @Test
+  public void testBucketDecimal() {
+    Assert.assertEquals(56, scalarSql("SELECT system.bucket(64, CAST('12.34' as DECIMAL(9, 2)))"));
+    Assert.assertEquals(13, scalarSql("SELECT system.bucket(18, CAST('12.30' as DECIMAL(9, 2)))"));
+    Assert.assertEquals(2, scalarSql("SELECT system.bucket(16, CAST('12.999' as DECIMAL(9, 3)))"));
+    Assert.assertEquals(21, scalarSql("SELECT system.bucket(32, CAST('0.05' as DECIMAL(5, 2)))"));
+    Assert.assertEquals(85, scalarSql("SELECT system.bucket(128, CAST('0.05' as DECIMAL(9, 2)))"));
+    Assert.assertEquals(3, scalarSql("SELECT system.bucket(18, CAST('0.05' as DECIMAL(9, 2)))"));
+
+    Assert.assertNull(
+        "Null input should return null",
+        scalarSql("SELECT system.bucket(2, CAST(null AS decimal))"));
+  }
+
+  @Test
+  public void testBucketTimestamp() {
+    Assert.assertEquals(83, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01')"));
+    Assert.assertEquals(
+        85, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-31 09:26:56 UTC+00:00')"));
+    Assert.assertEquals(
+        62, scalarSql("SELECT system.bucket(100, TIMESTAMP '2022-08-08 00:00:00 UTC+00:00')"));
+    Assert.assertNull(scalarSql("SELECT system.bucket(2, CAST(null AS timestamp))"));
+  }
+
+  @Test
+  public void testBucketString() {
+    Assert.assertEquals(4, scalarSql("SELECT system.bucket(5, 'abcdefg')"));
+    Assert.assertEquals(122, scalarSql("SELECT system.bucket(128, 'abc')"));
+    Assert.assertEquals(54, scalarSql("SELECT system.bucket(64, 'abcde')"));
+    Assert.assertEquals(8, scalarSql("SELECT system.bucket(12, '测试')"));
+    Assert.assertEquals(1, scalarSql("SELECT system.bucket(16, '测试raul试测')"));
+    Assert.assertEquals(
+        "Varchar should work like string",
+        1,
+        scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS varchar(8)))"));
+    Assert.assertEquals(
+        "Char should work like string",
+        1,
+        scalarSql("SELECT system.bucket(16, CAST('测试raul试测' AS char(8)))"));
+    Assert.assertEquals(
+        "Should not fail on the empty string", 0, scalarSql("SELECT system.bucket(16, '')"));
+    Assert.assertNull(
+        "Null input should return null as output",
+        scalarSql("SELECT system.bucket(16, CAST(null AS string))"));
+  }
+
+  @Test
+  public void testBucketBinary() {
+    Assert.assertEquals(
+        1, scalarSql("SELECT system.bucket(10, X'0102030405060708090a0b0c0d0e0f')"));
+    Assert.assertEquals(10, scalarSql("SELECT system.bucket(12, %s)", asBytesLiteral("abcdefg")));
+    Assert.assertEquals(13, scalarSql("SELECT system.bucket(18, %s)", asBytesLiteral("abc\0\0")));
+    Assert.assertEquals(42, scalarSql("SELECT system.bucket(48, %s)", asBytesLiteral("abc")));
+    Assert.assertEquals(3, scalarSql("SELECT system.bucket(16, %s)", asBytesLiteral("测试_")));
+
+    Assert.assertNull(
+        "Null input should return null as output",
+        scalarSql("SELECT system.bucket(100, CAST(null AS binary))"));
+  }
+
+  @Test
+  public void testNumBucketsAcceptsShortAndByte() {
+    Assert.assertEquals(
+        "Short types should be usable for the number of buckets field",
+        1,
+        scalarSql("SELECT system.bucket(5S, 1L)"));
+
+    Assert.assertEquals(
+        "Byte types should be allowed for the number of buckets field",
+        1,
+        scalarSql("SELECT system.bucket(5Y, 1)"));
+  }
+
+  @Test
+  public void testWrongNumberOfArguments() {
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with zero arguments",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (): Wrong number of inputs (expected numBuckets and value)",
+        () -> scalarSql("SELECT system.bucket()"));
+
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with only one argument",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int): Wrong number of inputs (expected numBuckets and value)",
+        () -> scalarSql("SELECT system.bucket(1)"));
+
+    AssertHelpers.assertThrows(
+        "Function resolution should not work with more than two arguments",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, bigint, int): Wrong number of inputs (expected numBuckets and value)",
+        () -> scalarSql("SELECT system.bucket(1, 1L, 1)"));
+  }
+
+  @Test
+  public void testInvalidTypesCannotBeUsedForNumberOfBuckets() {
+    AssertHelpers.assertThrows(
+        "Decimal type should not be coercible to the number of buckets",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (decimal(9,2), int): Expected number of buckets to be tinyint, shortint or int",
+        () -> scalarSql("SELECT system.bucket(CAST('12.34' as DECIMAL(9, 2)), 10)"));
+
+    AssertHelpers.assertThrows(
+        "Long type should not be coercible to the number of buckets",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (bigint, int): Expected number of buckets to be tinyint, shortint or int",
+        () -> scalarSql("SELECT system.bucket(12L, 10)"));
+
+    AssertHelpers.assertThrows(
+        "String type should not be coercible to the number of buckets",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (string, int): Expected number of buckets to be tinyint, shortint or int",
+        () -> scalarSql("SELECT system.bucket('5', 10)"));
+
+    AssertHelpers.assertThrows(
+        "Interval year to month  type should not be coercible to the number of buckets",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (interval year to month, int): Expected number of buckets to be tinyint, shortint or int",
+        () -> scalarSql("SELECT system.bucket(INTERVAL '100-00' YEAR TO MONTH, 10)"));
+
+    AssertHelpers.assertThrows(
+        "Interval day-time type should not be coercible to the number of buckets",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (interval day to second, int): Expected number of buckets to be tinyint, shortint or int",
+        () -> scalarSql("SELECT system.bucket(CAST('11 23:4:0' AS INTERVAL DAY TO SECOND), 10)"));
+  }
+
+  @Test
+  public void testInvalidTypesForBucketColumn() {
+    AssertHelpers.assertThrows(
+        "Double type should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, float): Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
+        () -> scalarSql("SELECT system.bucket(10, cast(12.3456 as float))"));
+
+    AssertHelpers.assertThrows(
+        "Double type should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, double): Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
+        () -> scalarSql("SELECT system.bucket(10, cast(12.3456 as double))"));
+
+    AssertHelpers.assertThrows(
+        "Boolean type should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, boolean)",
+        () -> scalarSql("SELECT system.bucket(10, true)"));
+
+    AssertHelpers.assertThrows(
+        "Map types should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, map<int,int>)",
+        () -> scalarSql("SELECT system.bucket(10, map(1, 1))"));
+
+    AssertHelpers.assertThrows(
+        "Array types should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, array<bigint>)",
+        () -> scalarSql("SELECT system.bucket(10, array(1L))"));
+
+    AssertHelpers.assertThrows(
+        "Interval year-to-month type should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, interval year to month)",
+        () -> scalarSql("SELECT system.bucket(10, INTERVAL '100-00' YEAR TO MONTH)"));
+
+    AssertHelpers.assertThrows(
+        "Interval day-time type should not be bucketable",
+        AnalysisException.class,
+        "Function 'bucket' cannot process input: (int, interval day to second)",
+        () -> scalarSql("SELECT system.bucket(10, CAST('11 23:4:0' AS INTERVAL DAY TO SECOND))"));
+  }
+
+  @Test
+  public void testMagicFunctionsResolveForTinyIntAndSmallIntNumberOfBuckets() {
+    // Magic functions have staticinvoke in the explain output.
+    // Nonmagic calls use applyfunctionexpression instead and go through produceResults.
+    String tinyIntWidthExplain = (String) scalarSql("EXPLAIN EXTENDED SELECT system.bucket(1Y, 6)");
+    Assertions.assertThat(tinyIntWidthExplain)
+        .contains("cast(1 as int)")
+        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
+
+    String smallIntWidth = (String) scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5S, 6L)");
+    Assertions.assertThat(smallIntWidth)
+        .contains("cast(5 as int)")
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketLong");
+  }
+
+  @Test
+  public void testThatMagicFunctionsAreInvoked() {
+    // TinyInt
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6Y)"))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
+
+    // SmallInt
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6S)"))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
+
+    // Int
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6)"))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
+
+    // Date
+    Assertions.assertThat(
+            scalarSql("EXPLAIN EXTENDED SELECT system.bucket(100, DATE '2022-08-08')"))
+        .asString()
+        .isNotNull()
+        .contains("staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketInt");
+
+    // Long
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 6L)"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketLong");
+
+    // Timestamp
+    Assertions.assertThat(
+            scalarSql("EXPLAIN EXTENDED SELECT system.bucket(100, TIMESTAMP '2022-08-08')"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketLong");
+
+    // String
+    Assertions.assertThat(scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, 'abcdefg')"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketString");
+
+    // Decimal
+    Assertions.assertThat(
+            scalarSql("EXPLAIN EXTENDED SELECT system.bucket(5, CAST('12.34' AS DECIMAL))"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketDecimal");
+
+    // Binary
+    Assertions.assertThat(
+            scalarSql("EXPLAIN EXTENDED SELECT system.bucket(4, X'0102030405060708')"))
+        .asString()
+        .isNotNull()
+        .contains(
+            "staticinvoke(class org.apache.iceberg.spark.functions.BucketFunction$BucketBinary");
+  }
+
+  private String asBytesLiteral(String value) {
+    byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    return "X'" + BaseEncoding.base16().encode(bytes) + "'";
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -201,13 +201,13 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
     AssertHelpers.assertThrows(
         "Double type should not be bucketable",
         AnalysisException.class,
-        "Function 'bucket' cannot process input: (int, float): Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
+        "Function 'bucket' cannot process input: (int, float): Expected column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
         () -> scalarSql("SELECT system.bucket(10, cast(12.3456 as float))"));
 
     AssertHelpers.assertThrows(
         "Double type should not be bucketable",
         AnalysisException.class,
-        "Function 'bucket' cannot process input: (int, double): Expected bucketed column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
+        "Function 'bucket' cannot process input: (int, double): Expected column to be date, tinyint, smallint, int, bigint, decimal, timestamp, string, or binary",
         () -> scalarSql("SELECT system.bucket(10, cast(12.3456 as double))"));
 
     AssertHelpers.assertThrows(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -84,7 +84,8 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
 
   @Test
   public void testBucketTimestamp() {
-    Assert.assertEquals(83, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01')"));
+    Assert.assertEquals(
+        99, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-01 00:00:00 UTC+00:00')"));
     Assert.assertEquals(
         85, scalarSql("SELECT system.bucket(100, TIMESTAMP '1997-01-31 09:26:56 UTC+00:00')"));
     Assert.assertEquals(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -23,8 +23,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.expressions.Literal;
-import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
-import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.BucketFunction;


### PR DESCRIPTION
Adds a `bucket` function that performs the Iceberg partition transformation to the Spark FunctionCatalog, for usage from SQL and for usage with storage partitioned joins.

This closes https://github.com/apache/iceberg/issues/5349