### PR TITLE
[DOCS] Doris URL Change

### DIFF
--- a/docs/doris/_index.md
+++ b/docs/doris/_index.md
@@ -3,7 +3,7 @@ title: "Doris"
 bookIconImage: ../img/doris-logo.png
 bookFlatSection: true
 weight: 430
-bookExternalUrlNewWindow: https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html
+bookExternalUrlNewWindow: https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris
 ---
 <!--
 

--- a/docs/doris/_index.md
+++ b/docs/doris/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Doris"
+bookIconImage: ../img/doris-logo.png
+bookFlatSection: true
+weight: 430
+bookExternalUrlNewWindow: https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html
+---
+<!--
+
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->


### PR DESCRIPTION
1. doris bookExternalUrlNewWindow url changed from `https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris.html` to `https://doris.apache.org/docs/ecosystem/external-table/iceberg-of-doris`
2. fix bugs when open doris external url is 404