### PR TITLE
Build: Enforce logging conventions with errorprone

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -66,6 +66,10 @@ subprojects {
           '-Xep:PreferSafeLoggableExceptions:OFF',
           '-Xep:Slf4jLogsafeArgs:OFF',
           '-Xep:RawTypes:OFF',
+          // enforce logging conventions
+          '-Xep:LoggerEnclosingClass:ERROR',
+          '-Xep:PreferStaticLoggers:ERROR',
+          '-Xep:Slf4jThrowable:ERROR',
           // subclasses are not equal
           '-Xep:EqualsGetClass:OFF',
           // patterns that are allowed


### PR DESCRIPTION
These errorprone checks are just warnings by default:
https://github.com/palantir/gradle-baseline/blob/4.0.0/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/Slf4jThrowable.java#L41
https://github.com/palantir/gradle-baseline/blob/4.0.0/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/LoggerEnclosingClass.java#L41
https://github.com/palantir/gradle-baseline/blob/4.0.0/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/PreferStaticLoggers.java#L43

Since the codebase has no violations we should increase the severity to
ERROR and enforce these conventions automatically going forward (i.e. at compile-time rather than through reviews).