### PR TITLE
Build: enforce LambdaMethodReference check at compile-time

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -68,6 +68,8 @@ subprojects {
           '-Xep:RawTypes:OFF',
           // subclasses are not equal
           '-Xep:EqualsGetClass:OFF',
+          // prefer method references over lambdas
+          '-Xep:LambdaMethodReference:ERROR',
           // patterns that are allowed
           '-Xep:MissingCasesInEnumSwitch:OFF',
           //Added because it errors out compile, but we need to figure out if we want it


### PR DESCRIPTION
Follow-up to https://github.com/apache/iceberg/pull/5476 where the last violation was removed

the idea is to reduce review effort by enforcing this preference through a compile-time check instead of an ignorable warning