### PR TITLE
Incremental pull ignore overwrite commit if table property is set

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -221,6 +221,11 @@ public class TableProperties {
   public static final String ORC_BATCH_SIZE = "read.orc.vectorization.batch-size";
   public static final int ORC_BATCH_SIZE_DEFAULT = 5000;
 
+  // This allows incremental pull ignore overwrite snapshot instead of throw exception
+  public static final String INCREMENTAL_PULL_IGNORE_OVERWRITE =
+      "read.incremental-pull-ignore-overwrite";
+  public static final boolean INCREMENTAL_PULL_IGNORE_OVERWRITE_DEFAULT = false;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -145,6 +145,17 @@ public class TestIncrementalDataTableScan extends TableTestBase {
         UnsupportedOperationException.class,
         "Found overwrite operation, cannot support incremental data in snapshots (8, 9]",
         () -> appendsBetweenScan(8, 9));
+
+    // change table property to ignore overwrite
+    table
+        .updateProperties()
+        .set(TableProperties.INCREMENTAL_PULL_IGNORE_OVERWRITE, "true")
+        .commit();
+    Assert.assertTrue("Ignore overwrite snapshot", appendsBetweenScan(8, 9).isEmpty());
+    add(table.newAppend(), files("J")); // 10
+    filesMatch(Lists.newArrayList("J"), appendsBetweenScan(9, 10));
+    filesMatch(Lists.newArrayList("J"), appendsBetweenScan(8, 10));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E", "I", "J"), appendsBetweenScan(1, 10));
   }
 
   @Test


### PR DESCRIPTION
We want to consume an iceberg table as a stream but it throws `UnsupportedOperationException` if table contains overwrite snapshots. I find issue #315 has already commented this problem:

> I think this needs an `else` case that validates we aren't skipping over `overwrite` commits. I think it is okay to skip `rewrite` and `delete`, but `overwrite` adds data so I'm not sure about skipping it. I could be convinced to add a config option to do this later, but it seems dangerous to me to skip it automatically. We can always allow more later, but it's hard to disallow something that always worked.
> 
> _Originally posted by @rdblue in https://github.com/apache/iceberg/pull/315#discussion_r373632112_

So I implement this pr according to the comment. I add a new table property `read.incremental-pull-ignore-overwrite` which default to `false` to keep the same behavior, it can ignore overwrite snapshot when it set to `true`.  We have verified this in our production environment. 