### PR TITLE
Python: Remove unused `# type: ignore`

### DIFF
--- a/python/pyiceberg/serializers.py
+++ b/python/pyiceberg/serializers.py
@@ -35,8 +35,8 @@ class FromByteStream:
             encoding (default "utf-8"): The byte encoder to use for the reader
         """
         reader = codecs.getreader(encoding)
-        metadata = json.load(reader(byte_stream))  # type: ignore
-        return TableMetadata.parse_obj(metadata)  # type: ignore
+        metadata = json.load(reader(byte_stream))
+        return TableMetadata.parse_obj(metadata)
 
 
 class FromInputFile:

--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -22,7 +22,7 @@ class FrozenDict(Dict):
     def __setitem__(self, instance, value):
         raise AttributeError("FrozenDict does not support assignment")
 
-    def update(self, *args: Any, **kwargs: Any) -> None:  # type: ignore
+    def update(self, *args: Any, **kwargs: Any) -> None:
         raise AttributeError("FrozenDict does not support .update()")
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -91,6 +91,7 @@ all = true
 no_implicit_optional = true
 warn_redundant_casts = true
 warn_unreachable = true
+warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
 module = "pyarrow.*"


### PR DESCRIPTION
Noticed this while coding. Reduces visual noise