### PR TITLE
Spark: Spark SQL Extensions for branch

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,12 +73,18 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
-    | ALTER TABLE multipartIdentifier CREATE BRANCH identifier (AS OF VERSION snapshotId)?  (WITH SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)))? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #createBranch
-    | ALTER TABLE multipartIdentifier REPLACE BRANCH identifier (AS OF VERSION snapshotId)?  (WITH SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)))? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #replaceBranch
+    | ALTER TABLE multipartIdentifier CREATE BRANCH identifier (AS OF VERSION snapshotId)?  (snapshotRetentionClause)? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #createBranch
+    | ALTER TABLE multipartIdentifier REPLACE BRANCH identifier (AS OF VERSION snapshotId)?  (snapshotRetentionClause)? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #replaceBranch
     | ALTER TABLE multipartIdentifier DROP BRANCH identifier #removeBranch
     | ALTER TABLE multipartIdentifier ALTER BRANCH identifier SET SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)) #alterBranchSnapshotRetention
     | ALTER TABLE multipartIdentifier ALTER BRANCH identifier RETAIN snapshotRefRetain snapshotRefRetainTimeUnit #alterBranchRetention
     | ALTER TABLE multipartIdentifier RENAME BRANCH identifier TO newIdentifier #renameBranch
+    ;
+
+snapshotRetentionClause
+    : WITH SNAPSHOT RETENTION numSnapshots SNAPSHOTS
+    | WITH SNAPSHOT RETENTION snapshotRetain snapshotRetainTimeUnit
+    | WITH SNAPSHOT RETENTION numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit
     ;
 
 writeSpec

--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,6 +73,12 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
+    | ALTER TABLE multipartIdentifier CREATE BRANCH identifier (AS OF VERSION snapshotId)?  (WITH SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)))? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #createBranch
+    | ALTER TABLE multipartIdentifier REPLACE BRANCH identifier (AS OF VERSION snapshotId)?  (WITH SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)))? (RETAIN snapshotRefRetain snapshotRefRetainTimeUnit)?   #replaceBranch
+    | ALTER TABLE multipartIdentifier DROP BRANCH identifier #removeBranch
+    | ALTER TABLE multipartIdentifier ALTER BRANCH identifier SET SNAPSHOT RETENTION (((numSnapshots SNAPSHOTS) | (snapshotRetain snapshotRetainTimeUnit)) | (numSnapshots SNAPSHOTS snapshotRetain snapshotRetainTimeUnit)) #alterBranchSnapshotRetention
+    | ALTER TABLE multipartIdentifier ALTER BRANCH identifier RETAIN snapshotRefRetain snapshotRefRetainTimeUnit #alterBranchRetention
+    | ALTER TABLE multipartIdentifier RENAME BRANCH identifier TO newIdentifier #renameBranch
     ;
 
 writeSpec
@@ -159,6 +165,10 @@ identifier
     | nonReserved             #unquotedIdentifier
     ;
 
+newIdentifier
+    : identifier
+    ;
+
 quotedIdentifier
     : BACKQUOTED_IDENTIFIER
     ;
@@ -168,18 +178,44 @@ fieldList
     ;
 
 nonReserved
-    : ADD | ALTER | AS | ASC | BY | CALL | DESC | DROP | FIELD | FIRST | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
-    | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | WITH | IDENTIFIER_KW | FIELDS | SET
-    | TRUE | FALSE
+    : ADD | ALTER | AS | ASC | BY | CALL | CREATE | BRANCH | DESC | DROP | FIELD | FIRST | LAST | NULLS | OF | ORDERED
+    | PARTITION | TABLE | WRITE | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | VERSION | WITH | IDENTIFIER_KW | FIELDS
+    | SET | SNAPSHOT | SNAPSHOTS | TRUE | FALSE
     | MAP
+    ;
+
+snapshotId
+    : number
+    ;
+
+numSnapshots
+    : number
+    ;
+
+snapshotRetain
+    : number
+    ;
+
+snapshotRefRetain
+    : number
+    ;
+
+snapshotRefRetainTimeUnit
+    : identifier
+    ;
+
+snapshotRetainTimeUnit
+    : identifier
     ;
 
 ADD: 'ADD';
 ALTER: 'ALTER';
 AS: 'AS';
 ASC: 'ASC';
+BRANCH: 'BRANCH';
 BY: 'BY';
 CALL: 'CALL';
+CREATE: 'CREATE';
 DESC: 'DESC';
 DISTRIBUTED: 'DISTRIBUTED';
 DROP: 'DROP';
@@ -189,15 +225,24 @@ FIRST: 'FIRST';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 NULLS: 'NULLS';
+OF: 'OF';
 ORDERED: 'ORDERED';
 PARTITION: 'PARTITION';
 REPLACE: 'REPLACE';
+RETAIN: 'RETAIN';
+RETENTION: 'RETENTION';
 IDENTIFIER_KW: 'IDENTIFIER';
 SET: 'SET';
+SNAPSHOT: 'SNAPSHOT';
+SNAPSHOTS: 'SNAPSHOTS';
 TABLE: 'TABLE';
 UNORDERED: 'UNORDERED';
+VERSION: 'VERSION';
 WITH: 'WITH';
 WRITE: 'WRITE';
+RENAME: 'RENAME';
+TO: 'TO';
+FOR: 'FOR';
 
 TRUE: 'TRUE';
 FALSE: 'FALSE';

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -205,7 +205,12 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
             normalized.contains("write distributed by") ||
             normalized.contains("write unordered") ||
             normalized.contains("set identifier fields") ||
-            normalized.contains("drop identifier fields")))
+            normalized.contains("drop identifier fields") ||
+            normalized.contains("create branch") ||
+            normalized.contains("replace branch") ||
+            normalized.contains("drop branch") ||
+            normalized.contains("alter branch") ||
+            normalized.contains("rename branch")))
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterBranchRefRetention.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterBranchRefRetention.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class AlterBranchRefRetention(table: Seq[String], branch: String,
+                                   snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Alter branch:${branch} reference life cycle for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterBranchSnapshotRetention.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/AlterBranchSnapshotRetention.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class AlterBranchSnapshotRetention(table: Seq[String], branch: String,
+                                        numSnapshots: Option[Long], snapshotRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Alter branch:${branch} snapshot retention for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateBranch.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateBranch.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class CreateBranch(table: Seq[String], branch: String, snapshotId: Option[Long], numSnapshots: Option[Long],
+                        snapshotRetain: Option[Long], snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Create branch:${branch} for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveBranch.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RemoveBranch.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class RemoveBranch(table: Seq[String], branch: String) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Remove branch:${branch} for table:${table.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RenameBranch.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/RenameBranch.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class RenameBranch(table: Seq[String], branch: String,newBranch: String)  extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Rename branch:${branch} to ${newBranch} for table:${table.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceBranch.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceBranch.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class ReplaceBranch(table: Seq[String], branch: String, snapshotId: Option[Long], numSnapshots: Option[Long],
+                         snapshotRetain: Option[Long], snapshotRefRetain: Option[Long]) extends LeafCommand {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"Replace branch:${branch} for table:${table.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterBranchRefRetentionExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterBranchRefRetentionExec.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.AlterBranchRefRetention
+import org.apache.spark.sql.connector.catalog._
+
+case class AlterBranchRefRetentionExec(
+                                        catalog: TableCatalog,
+                                        ident: Identifier,
+                                        alterBranchRef: AlterBranchRefRetention) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+          if(alterBranchRef.snapshotRefRetain.nonEmpty) {
+            val ms =  iceberg.table.manageSnapshots()
+            ms.setMaxRefAgeMs(alterBranchRef.branch, alterBranchRef.snapshotRefRetain.get)
+            ms.commit()
+          }
+      case table =>
+        throw new UnsupportedOperationException(s"alter branch retention to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Alter branch:${alterBranchRef.branch} reference life cycle for table:${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterBranchSnapshotRefRetentionExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AlterBranchSnapshotRefRetentionExec.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.AlterBranchSnapshotRetention
+import org.apache.spark.sql.connector.catalog._
+
+case class AlterBranchSnapshotRefRetentionExec(
+                                                catalog: TableCatalog,
+                                                ident: Identifier,
+                                                alterBranchRef: AlterBranchSnapshotRetention)
+  extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        val ms = iceberg.table.manageSnapshots()
+        val branchName = alterBranchRef.branch
+        if (alterBranchRef.numSnapshots.nonEmpty) {
+          ms.setMinSnapshotsToKeep(branchName, alterBranchRef.numSnapshots.get.toInt)
+        }
+        if (alterBranchRef.snapshotRetain.nonEmpty) {
+          ms.setMaxSnapshotAgeMs(branchName, alterBranchRef.snapshotRetain.get)
+        }
+        ms.commit()
+      case table =>
+        throw new UnsupportedOperationException(s"alter branch retention to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"alter branch:${alterBranchRef.branch} snapshot reference life cycle for table:${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateBranchExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateBranchExec.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.CreateBranch
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+case class CreateBranchExec(
+                             catalog: TableCatalog,
+                             ident: Identifier,
+                             createBranch: CreateBranch) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+
+        val snapshotId = createBranch.snapshotId.getOrElse(iceberg.table.currentSnapshot().snapshotId())
+        iceberg.table.manageSnapshots()
+          .createBranch(createBranch.branch, snapshotId)
+          .setMinSnapshotsToKeep(createBranch.branch, createBranch.numSnapshots.getOrElse(1L).toInt)
+          // 5 days
+          .setMaxSnapshotAgeMs(createBranch.branch, createBranch.snapshotRetain.getOrElse(5 * 24 * 60 * 60 * 1000L))
+          .setMaxRefAgeMs(createBranch.branch, createBranch.snapshotRefRetain.getOrElse(Long.MaxValue))
+          .commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot add branch to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Create branch:${createBranch.branch} operation for table:${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -30,13 +30,19 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
+import org.apache.spark.sql.catalyst.plans.logical.AlterBranchRefRetention
+import org.apache.spark.sql.catalyst.plans.logical.AlterBranchSnapshotRetention
 import org.apache.spark.sql.catalyst.plans.logical.Call
+import org.apache.spark.sql.catalyst.plans.logical.CreateBranch
 import org.apache.spark.sql.catalyst.plans.logical.DeleteFromIcebergTable
 import org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.MergeRows
 import org.apache.spark.sql.catalyst.plans.logical.NoStatsUnaryNode
+import org.apache.spark.sql.catalyst.plans.logical.RemoveBranch
+import org.apache.spark.sql.catalyst.plans.logical.RenameBranch
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceBranch
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData
 import org.apache.spark.sql.catalyst.plans.logical.ReplacePartitionField
 import org.apache.spark.sql.catalyst.plans.logical.SetIdentifierFields
@@ -60,6 +66,24 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
 
     case AddPartitionField(IcebergCatalogAndIdentifier(catalog, ident), transform, name) =>
       AddPartitionFieldExec(catalog, ident, transform, name) :: Nil
+
+    case CreateBranch(IcebergCatalogAndIdentifier(catalog, ident), _, _, _, _, _) =>
+      CreateBranchExec(catalog, ident, plan.asInstanceOf[CreateBranch]) :: Nil
+
+    case ReplaceBranch(IcebergCatalogAndIdentifier(catalog, ident), _, _, _, _, _) =>
+      ReplaceBranchExec(catalog, ident, plan.asInstanceOf[ReplaceBranch]) :: Nil
+
+    case RemoveBranch(IcebergCatalogAndIdentifier(catalog, ident), _) =>
+      RemoveBranchExec(catalog, ident, plan.asInstanceOf[RemoveBranch]) :: Nil
+
+    case RenameBranch(IcebergCatalogAndIdentifier(catalog, ident),_,_) =>
+      RenameBranchExec(catalog,ident,plan.asInstanceOf[RenameBranch]) :: Nil
+
+    case AlterBranchRefRetention(IcebergCatalogAndIdentifier(catalog, ident),_,_) =>
+      AlterBranchRefRetentionExec(catalog,ident,plan.asInstanceOf[AlterBranchRefRetention]) :: Nil
+
+    case AlterBranchSnapshotRetention(IcebergCatalogAndIdentifier(catalog, ident),_,_,_) =>
+      AlterBranchSnapshotRefRetentionExec(catalog,ident,plan.asInstanceOf[AlterBranchSnapshotRetention]) :: Nil;
 
     case DropPartitionField(IcebergCatalogAndIdentifier(catalog, ident), transform) =>
       DropPartitionFieldExec(catalog, ident, transform) :: Nil

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RemoveBranchExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RemoveBranchExec.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.RemoveBranch
+import org.apache.spark.sql.connector.catalog._
+
+case class RemoveBranchExec(
+                             catalog: TableCatalog,
+                             ident: Identifier,
+                             removeBranch: RemoveBranch) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        iceberg.table.manageSnapshots().removeBranch(removeBranch.branch).commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot remove branch to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Remove branch:${removeBranch.branch} for table:${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameBranchExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameBranchExec.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.RenameBranch
+import org.apache.spark.sql.connector.catalog._
+
+case class RenameBranchExec(
+                             catalog: TableCatalog,
+                             ident: Identifier,
+                             renameBranch: RenameBranch) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        iceberg.table().manageSnapshots().renameBranch(renameBranch.branch,renameBranch.newBranch).commit();
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot rename branch to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Rename branch:${renameBranch.branch} to ${renameBranch.newBranch} for table:${ident.quoted} "
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceBranchExec.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceBranchExec.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.CreateBranch
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceBranch
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+case class ReplaceBranchExec(
+                              catalog: TableCatalog,
+                              ident: Identifier,
+                              createBranch: ReplaceBranch) extends LeafV2CommandExec {
+
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+
+        val snapshotId = createBranch.snapshotId.getOrElse(iceberg.table.currentSnapshot().snapshotId())
+        val manageSnapshots = iceberg.table.manageSnapshots().replaceBranch(createBranch.branch, snapshotId)
+        if (createBranch.numSnapshots.nonEmpty) {
+          manageSnapshots.setMinSnapshotsToKeep(createBranch.branch, createBranch.numSnapshots.get.toInt)
+        }
+        if (createBranch.snapshotRetain.nonEmpty) {
+          manageSnapshots.setMaxSnapshotAgeMs(createBranch.branch, createBranch.snapshotRetain.get)
+        }
+        if (createBranch.snapshotRefRetain.nonEmpty) {
+          manageSnapshots.setMaxRefAgeMs(createBranch.branch, createBranch.snapshotRefRetain.get)
+        }
+        manageSnapshots.commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot replace branch to non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"Replace branch:${createBranch.branch} for table:${ident.quoted}"
+  }
+}

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
+  public TestSnapshotRefSQL(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testCreateBranch() throws NoSuchTableException {
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
+    spark.createDataFrame(records, SimpleRecord.class).writeTo(tableName).append();
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String branchName = "b1";
+    Integer minSnapshotsToKeep = 2;
+    long maxSnapshotAge = 2L;
+    long maxRefAge = 10L;
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s AS OF VERSION %d WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS RETAIN %d DAYS",
+        tableName, branchName, snapshotId, minSnapshotsToKeep, maxSnapshotAge, maxRefAge);
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref);
+    Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
+    Assert.assertEquals(maxSnapshotAge * 24 * 60 * 60 * 1000L, ref.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref.maxRefAgeMs().longValue());
+
+    AssertHelpers.assertThrows(
+        "Cannot create an existing branch",
+        IllegalArgumentException.class,
+        "already exists",
+        () -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName));
+
+    String branchName2 = "b2";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName2);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(branchName2);
+    Assert.assertNotNull(ref2);
+    Assert.assertEquals(1L, ref2.minSnapshotsToKeep().longValue());
+    Assert.assertEquals(432000000L, ref2.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(Long.MAX_VALUE, ref2.maxRefAgeMs().longValue());
+
+    String branchName3 = "b3";
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d SNAPSHOTS",
+        tableName, branchName3, minSnapshotsToKeep);
+    table.refresh();
+    SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(branchName3);
+    Assert.assertNotNull(ref3);
+    Assert.assertEquals(minSnapshotsToKeep, ref3.minSnapshotsToKeep());
+    Assert.assertEquals(432000000L, ref3.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(Long.MAX_VALUE, ref3.maxRefAgeMs().longValue());
+
+    String branchName4 = "b4";
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d DAYS",
+        tableName, branchName4, maxSnapshotAge);
+    table.refresh();
+    SnapshotRef ref4 = ((BaseTable) table).operations().current().ref(branchName4);
+    Assert.assertNotNull(ref4);
+    Assert.assertEquals(1L, ref2.minSnapshotsToKeep().longValue());
+    Assert.assertEquals(maxSnapshotAge * 24 * 60 * 60 * 1000L, ref4.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(Long.MAX_VALUE, ref4.maxRefAgeMs().longValue());
+
+    String branchName5 = "b5";
+    sql("ALTER TABLE %s CREATE BRANCH %s RETAIN %d DAYS", tableName, branchName5, maxRefAge);
+    table.refresh();
+    SnapshotRef ref5 = ((BaseTable) table).operations().current().ref(branchName5);
+    Assert.assertNotNull(ref5);
+    Assert.assertEquals(1L, ref5.minSnapshotsToKeep().longValue());
+    Assert.assertEquals(432000000L, ref5.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref5.maxRefAgeMs().longValue());
+  }
+
+  @Test
+  public void testReplaceBranch() throws NoSuchTableException {
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
+    spark.createDataFrame(records, SimpleRecord.class).writeTo(tableName).append();
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String branchName = "b1";
+    Integer minSnapshotsToKeep = 2;
+    long maxSnapshotAge = 2L;
+    long maxRefAge = 10L;
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s AS OF VERSION %d WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS RETAIN %d DAYS",
+        tableName, branchName, snapshotId, minSnapshotsToKeep, maxSnapshotAge, maxRefAge);
+
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref);
+    Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
+    Assert.assertEquals(maxSnapshotAge * 24 * 60 * 60 * 1000L, ref.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge * 24 * 60 * 60 * 1000L, ref.maxRefAgeMs().longValue());
+
+    String branchName2 = "b2";
+    AssertHelpers.assertThrows(
+        "Cannot replace a branch that does not exist",
+        IllegalArgumentException.class,
+        "Branch does not exist",
+        () -> sql("ALTER TABLE %s REPLACE BRANCH %s", tableName, branchName2));
+
+    spark.createDataFrame(records, SimpleRecord.class).writeTo(tableName).append();
+    table.refresh();
+    long snapshotId2 = table.currentSnapshot().snapshotId();
+    Integer minSnapshotsToKeep2 = 3;
+    long maxSnapshotAge2 = 5L;
+    long maxRefAge2 = 20L;
+    sql(
+        "ALTER TABLE %s REPLACE BRANCH %s AS OF VERSION %d WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS RETAIN %d DAYS",
+        tableName, branchName, snapshotId2, minSnapshotsToKeep2, maxSnapshotAge2, maxRefAge2);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref2);
+    Assert.assertEquals(snapshotId2, ref2.snapshotId());
+    Assert.assertEquals(minSnapshotsToKeep2, ref2.minSnapshotsToKeep());
+    Assert.assertEquals(
+        maxSnapshotAge2 * 24 * 60 * 60 * 1000L, ref2.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge2 * 24 * 60 * 60 * 1000L, ref2.maxRefAgeMs().longValue());
+
+    Integer minSnapshotsToKeep3 = 9;
+    sql(
+        "ALTER TABLE %s REPLACE BRANCH %s WITH SNAPSHOT RETENTION %d SNAPSHOTS",
+        tableName, branchName, minSnapshotsToKeep3);
+    table.refresh();
+    SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref3);
+    Assert.assertEquals(minSnapshotsToKeep3, ref3.minSnapshotsToKeep());
+    Assert.assertEquals(
+        maxSnapshotAge2 * 24 * 60 * 60 * 1000L, ref3.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge2 * 24 * 60 * 60 * 1000L, ref3.maxRefAgeMs().longValue());
+
+    long maxSnapshotAge3 = 15L;
+    sql(
+        "ALTER TABLE %s REPLACE BRANCH %s WITH SNAPSHOT RETENTION %d DAYS",
+        tableName, branchName, maxSnapshotAge3);
+    table.refresh();
+    SnapshotRef ref4 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref4);
+    Assert.assertEquals(minSnapshotsToKeep3, ref3.minSnapshotsToKeep());
+    Assert.assertEquals(
+        maxSnapshotAge3 * 24 * 60 * 60 * 1000L, ref4.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge2 * 24 * 60 * 60 * 1000L, ref4.maxRefAgeMs().longValue());
+
+    long maxRefAge3 = 60L;
+    sql("ALTER TABLE %s REPLACE BRANCH %s RETAIN %d DAYS", tableName, branchName, maxRefAge3);
+    table.refresh();
+    SnapshotRef ref5 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref5);
+    Assert.assertEquals(minSnapshotsToKeep3, ref3.minSnapshotsToKeep());
+    Assert.assertEquals(
+        maxSnapshotAge3 * 24 * 60 * 60 * 1000L, ref5.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(maxRefAge3 * 24 * 60 * 60 * 1000L, ref5.maxRefAgeMs().longValue());
+  }
+
+  @Test
+  public void testDropBranch() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    String branchName = "b1";
+
+    AssertHelpers.assertThrows(
+        "Cannot drop a branch that does not exist",
+        IllegalArgumentException.class,
+        "Branch does not exist",
+        () -> sql("ALTER TABLE %s DROP BRANCH %s", tableName, branchName));
+
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    table.refresh();
+    SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref1);
+
+    sql("ALTER TABLE %s DROP BRANCH %s", tableName, branchName);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNull(ref2);
+  }
+
+  @Test
+  public void testRenameBranch() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    String branchName = "b1";
+    String newBranchName = "b2";
+
+    AssertHelpers.assertThrows(
+        "Cannot rename a branch that does not exist",
+        IllegalArgumentException.class,
+        "Branch does not exist",
+        () -> sql("ALTER TABLE %s RENAME BRANCH %s TO %s", tableName, branchName, newBranchName));
+
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNotNull(ref);
+
+    sql("ALTER TABLE %s RENAME BRANCH %s TO %s", tableName, branchName, newBranchName);
+    table.refresh();
+    ref = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertNull(ref);
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(newBranchName);
+    Assert.assertNotNull(ref2);
+  }
+
+  @Test
+  public void testAlterBranchRefRetention() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    String branchName = "b1";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    table.refresh();
+    SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertEquals(
+        "will use default maxRefAgeMs.", Long.MAX_VALUE, ref1.maxRefAgeMs().longValue());
+
+    sql("ALTER TABLE %s ALTER BRANCH %s RETAIN %d MINUTES", tableName, branchName, 1);
+    table.refresh();
+    SnapshotRef ref = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertEquals("Invalid modification time.", 60 * 1000, ref.maxRefAgeMs().longValue());
+
+    String branchName2 = "b2";
+    AssertHelpers.assertThrows(
+        "Cannot alter an not exist branch",
+        IllegalArgumentException.class,
+        "Ref does not exist: " + branchName2,
+        () -> sql("ALTER TABLE %s ALTER BRANCH %s RETAIN %d MINUTES", tableName, branchName2, 1));
+  }
+
+  @Test
+  public void testAlterBranchSnapshotRetention() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    String branchName = "b1";
+    int snapshotNum = 5;
+    int days = 7;
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS",
+        tableName, branchName, snapshotNum, days);
+    table.refresh();
+    SnapshotRef ref1 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertEquals(
+        "Invalid modification snapshot day time.",
+        7 * 24 * 60 * 60 * 1000L,
+        ref1.maxSnapshotAgeMs().longValue());
+
+    snapshotNum = 4;
+    days = 6;
+    sql(
+        "ALTER TABLE %s ALTER BRANCH %s SET SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS",
+        tableName, branchName, snapshotNum, days);
+    table.refresh();
+    SnapshotRef ref2 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertEquals(days * 24 * 60 * 60 * 1000L, ref2.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(snapshotNum, ref2.minSnapshotsToKeep().intValue());
+
+    snapshotNum = 3;
+    sql(
+        "ALTER TABLE %s ALTER BRANCH %s SET SNAPSHOT RETENTION %d SNAPSHOTS",
+        tableName, branchName, snapshotNum);
+    table.refresh();
+    SnapshotRef ref3 = ((BaseTable) table).operations().current().ref(branchName);
+    Assert.assertEquals(days * 24 * 60 * 60 * 1000L, ref3.maxSnapshotAgeMs().longValue());
+    Assert.assertEquals(snapshotNum, ref3.minSnapshotsToKeep().intValue());
+    Assert.assertEquals(snapshotNum, ref3.minSnapshotsToKeep().intValue());
+
+    String branchName2 = "b2";
+    AssertHelpers.assertThrows(
+        "Cannot alter snapshot retention of a branch that doesn't exist!",
+        IllegalArgumentException.class,
+        String.format("Branch does not exist: %s", branchName2),
+        () ->
+            sql(
+                "ALTER TABLE %s ALTER BRANCH %s SET SNAPSHOT RETENTION %d SNAPSHOTS",
+                tableName, "b2", 4));
+
+    AssertHelpers.assertThrows(
+        "Cannot alter snapshot retention with invalid value",
+        IllegalArgumentException.class,
+        "Min snapshots to keep must be greater than 0",
+        () ->
+            sql(
+                "ALTER TABLE %s ALTER BRANCH %s SET SNAPSHOT RETENTION %d SNAPSHOTS",
+                tableName, branchName, 0));
+
+    AssertHelpers.assertThrows(
+        "Cannot alter branch snapshot retention with invalid value",
+        IllegalArgumentException.class,
+        "Max snapshot age must be greater than 0 ms",
+        () ->
+            sql(
+                "ALTER TABLE %s ALTER BRANCH %s SET SNAPSHOT RETENTION %d DAYS",
+                tableName, branchName, -1));
+  }
+
+  private Table createDefaultTableAndInsert2Row() throws NoSuchTableException {
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    List<SimpleRecord> records =
+        ImmutableList.of(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+    df.writeTo(tableName).append();
+    Table table = validationCatalog.loadTable(tableIdent);
+    return table;
+  }
+}


### PR DESCRIPTION
Co-authored-by: liliwei [liliwei14@huawei.com](mailto:liliwei14@huawei.com)
Co-authored-by: xuwei [xuwei132@huawei.com](mailto:xuwei132@huawei.com)
Co-authored-by: chidayong [chidayong2@h-partners.com](mailto:chidayong2@h-partners.com)

base on https://github.com/apache/iceberg/pull/5209#issuecomment-1184719859,  Split https://github.com/apache/iceberg/pull/5209  into TAG(#5281) and Branch(#5535)

## What is the purpose of the change
Implement the syntax in the following documents:
https://docs.google.com/document/d/1tbATFPrKF3vNlzkgZQdaW8CAJmbjvryfrlg6C2Ci_aA/edit


### DDLs for Branch and Retention 

#### Create  Branches
```sql
ALTER TABLE tableName
{CREATE | REPLACE} BRANCH branchName [AS OF {VERSION snapshotId}]
[WITH SNAPSHOT RETENTION {[num_snapshots SNAPSHOTS]
[interval {MONTHS | DAYS | HOURS | MINUTES}]}]}]
[RETAIN interval {MONTHS | DAYS | HOURS | MINUTES}]

ALTER TABLE prod.db.my_table 
CREATE BRANCH test_branch AS OF VERSION 100 WITH SNAPSHOT RETENTION 5
SNAPSHOTS 7 DAYS
RETAIN 12 MONTHS

```

#### Drop Branches

```sql
ALTER TABLE table DROP BRANCH reference
```
#### Updating Branch Snapshot Retention

```sql
ALTER TABLE table 
ALTER BRANCH branchName
SET SNAPSHOT RETENTION
{[numSnapshots SNAPSHOTS] [interval {MONTHS | DAYS | HOURS | MINUTES}]}


ALTER TABLE prod.db.my_table 
ALTER BRANCH branchName
SET SNAPSHOT RETENTION
5 SNAPSHOTS 10 DAYS
```

#### Update Retention for Branches
```sql
ALTER TABLE table 
ALTER BRANCH refName
RETAIN interval {MONTHS | DAYS | HOURS | MINUTES}
```

#### Rename Branches
```sql
ALTER TABLE table RENAME BRANCH oldBranch TO newBranch
```

