### PR TITLE
SetSnapshotOperation should commit empty operations too

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -123,12 +123,10 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
                       .setBranchSnapshot(snapshot.snapshotId(), SnapshotRef.MAIN_BRANCH)
                       .build();
 
-              if (updated.changes().isEmpty()) {
-                // do not commit if the metadata has not changed. for example, this may happen when
-                // setting the current
-                // snapshot to an ID that is already current. note that this check uses identity.
-                return;
-              }
+              // Do commit this operation even if the metadata has not changed, as we need to
+              // advance the hasLastOpCommited for the transaction's commit to work properly.
+              // (Without any other operations in the transaction, the commitTransaction() call
+              // will be a no-op anyway)
 
               // if the table UUID is missing, add it here. the UUID will be re-created each time
               // this operation retries

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -621,4 +621,15 @@ public class TestSnapshotManager extends TableTestBase {
     Assert.assertEquals(SnapshotRef.branchBuilder(1).build(), actualBranch);
     Assert.assertEquals(SnapshotRef.tagBuilder(1).build(), actualTag);
   }
+
+  @Test
+  public void testAttemptToRollbackToCurrentSnapshot() {
+    table.newAppend().appendFile(FILE_A).commit();
+
+    long currentSnapshotTimestampPlus100 = table.currentSnapshot().timestampMillis() + 100;
+    table.manageSnapshots().rollbackToTime(currentSnapshotTimestampPlus100).commit();
+
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().rollbackTo(currentSnapshotId).commit();
+  }
 }


### PR DESCRIPTION
As discussed in #5507 SetSnapshotOperation currently doesn't commit the operation if the metadata is unchanged. Since this is used in a transaction, it can result in failure of committing the whole transaction as the `hasLastOpCommited` was not advanced.

I propose we commit such empty operations, as the overall transaction commit will result in a no-op anyway in these cases.

cc: @kbendick @amogh-jahagirdar 