### PR TITLE
[Core]Add EncryptionManagerFactory to configure encryption via catalog properties and table metadata.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/KmsClient.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/KmsClient.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.encryption;
 
+import java.io.Closeable;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
 /** A minimum client interface to connect to a key management service (KMS). */
-public interface KmsClient extends Serializable {
+public interface KmsClient extends Serializable, Closeable {
 
   /**
    * Wrap a secret key, using a wrapping/master key which is stored in KMS and referenced by an ID.
@@ -77,6 +78,13 @@ public interface KmsClient extends Serializable {
    * @param properties kms client properties
    */
   void initialize(Map<String, String> properties);
+
+  /**
+   * Close KMS Client to release underlying resources, this could be triggered in different threads
+   * when KmsClient is shared by multiple encryption manager.
+   */
+  @Override
+  default void close() {}
 
   /**
    * For KMS systems that support key generation, this class keeps the key generation result - the

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -110,6 +111,8 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   private String warehousePath;
   private AwsProperties awsProperties;
   private FileIO fileIO;
+  private EncryptionManagerFactory encryptionManagerFactory;
+
   private CloseableGroup closeableGroup;
 
   public DynamoDbCatalog() {}
@@ -121,12 +124,18 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
         properties.get(CatalogProperties.WAREHOUSE_LOCATION),
         new AwsProperties(properties),
         AwsClientFactories.from(properties).dynamo(),
-        initializeFileIO(properties));
+        initializeFileIO(properties),
+        initializeEncryptionManagerFactory(properties));
   }
 
   @VisibleForTesting
   void initialize(
-      String name, String path, AwsProperties properties, DynamoDbClient client, FileIO io) {
+      String name,
+      String path,
+      AwsProperties properties,
+      DynamoDbClient client,
+      FileIO io,
+      EncryptionManagerFactory encryption) {
     Preconditions.checkArgument(
         path != null && path.length() > 0,
         "Cannot initialize DynamoDbCatalog because warehousePath must not be null or empty");
@@ -136,10 +145,12 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
     this.warehousePath = LocationUtil.stripTrailingSlash(path);
     this.dynamo = client;
     this.fileIO = io;
+    this.encryptionManagerFactory = encryption;
 
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(dynamo);
     closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(encryptionManagerFactory);
     closeableGroup.setSuppressCloseFailure(true);
 
     ensureCatalogTableExistsOrCreate();
@@ -153,7 +164,8 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     validateTableIdentifier(tableIdentifier);
-    return new DynamoDbTableOperations(dynamo, awsProperties, catalogName, fileIO, tableIdentifier);
+    return new DynamoDbTableOperations(
+        dynamo, awsProperties, catalogName, fileIO, encryptionManagerFactory, tableIdentifier);
   }
 
   @Override
@@ -548,6 +560,11 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
     } else {
       return CatalogUtil.loadFileIO(fileIOImpl, properties, hadoopConf);
     }
+  }
+
+  private EncryptionManagerFactory initializeEncryptionManagerFactory(
+      Map<String, String> properties) {
+    return CatalogUtil.loadEncryptionManagerFactory(properties);
   }
 
   private void validateNamespace(Namespace namespace) {

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -52,23 +53,31 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
   private final TableIdentifier tableIdentifier;
   private final String fullTableName;
   private final FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
 
   DynamoDbTableOperations(
       DynamoDbClient dynamo,
       AwsProperties awsProperties,
       String catalogName,
       FileIO fileIO,
+      EncryptionManagerFactory encryptionManagerFactory,
       TableIdentifier tableIdentifier) {
     this.dynamo = dynamo;
     this.awsProperties = awsProperties;
     this.fullTableName = String.format("%s.%s", catalogName, tableIdentifier);
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;
+    this.encryptionManagerFactory = encryptionManagerFactory;
   }
 
   @Override
   protected String tableName() {
     return fullTableName;
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -40,6 +40,8 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
+import org.apache.iceberg.encryption.PlaintextEncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -89,6 +91,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
   private String warehousePath;
   private AwsProperties awsProperties;
   private FileIO fileIO;
+  private EncryptionManagerFactory encryptionManagerFactory;
   private LockManager lockManager;
   private CloseableGroup closeableGroup;
   private Map<String, String> catalogProperties;
@@ -144,7 +147,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
         new AwsProperties(properties),
         awsClientFactory.glue(),
         initializeLockManager(properties),
-        catalogFileIO);
+        catalogFileIO,
+        initializeEncryptionManagerFactory(properties));
   }
 
   private LockManager initializeLockManager(Map<String, String> properties) {
@@ -154,6 +158,11 @@ public class GlueCatalog extends BaseMetastoreCatalog
       return LockManagers.defaultLockManager();
     }
     return null;
+  }
+
+  private EncryptionManagerFactory initializeEncryptionManagerFactory(
+      Map<String, String> properties) {
+    return CatalogUtil.loadEncryptionManagerFactory(properties);
   }
 
   @VisibleForTesting
@@ -177,6 +186,19 @@ public class GlueCatalog extends BaseMetastoreCatalog
       GlueClient client,
       LockManager lock,
       FileIO io) {
+    initialize(
+        name, path, properties, client, lock, io, PlaintextEncryptionManagerFactory.INSTANCE);
+  }
+
+  @VisibleForTesting
+  void initialize(
+      String name,
+      String path,
+      AwsProperties properties,
+      GlueClient client,
+      LockManager lock,
+      FileIO io,
+      EncryptionManagerFactory encryption) {
     Preconditions.checkArgument(
         path != null && path.length() > 0,
         "Cannot initialize GlueCatalog because warehousePath must not be null or empty");
@@ -187,11 +209,13 @@ public class GlueCatalog extends BaseMetastoreCatalog
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;
+    this.encryptionManagerFactory = encryption;
 
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(glue);
     closeableGroup.addCloseable(lockManager);
     closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(encryptionManagerFactory);
     closeableGroup.setSuppressCloseFailure(true);
   }
 
@@ -234,6 +258,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
           awsProperties,
           tableSpecificCatalogPropertiesBuilder.buildOrThrow(),
           hadoopConf,
+          encryptionManagerFactory,
           tableIdentifier);
     }
 
@@ -244,6 +269,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
         awsProperties,
         catalogProperties,
         hadoopConf,
+        encryptionManagerFactory,
         tableIdentifier);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -74,6 +75,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   private final Object hadoopConf;
   private final LockManager lockManager;
   private FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
+
 
   // Attempt to set versionId if available on the path
   private static final DynMethods.UnboundMethod SET_VERSION_ID =
@@ -90,6 +93,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       AwsProperties awsProperties,
       Map<String, String> tableCatalogProperties,
       Object hadoopConf,
+      EncryptionManagerFactory encryptionManagerFactory,
       TableIdentifier tableIdentifier) {
     this.glue = glue;
     this.awsProperties = awsProperties;
@@ -103,6 +107,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     this.commitLockEntityId = String.format("%s.%s", databaseName, tableName);
     this.tableCatalogProperties = tableCatalogProperties;
     this.hadoopConf = hadoopConf;
+    this.encryptionManagerFactory = encryptionManagerFactory;
     this.lockManager = lockManager;
   }
 
@@ -117,6 +122,11 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   @Override
   protected String tableName() {
     return fullTableName;
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -77,7 +77,6 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   private FileIO fileIO;
   private final EncryptionManagerFactory encryptionManagerFactory;
 
-
   // Attempt to set versionId if available on the path
   private static final DynMethods.UnboundMethod SET_VERSION_ID =
       DynMethods.builder("versionId")

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -273,7 +273,7 @@ public class TestS3FileIO {
   }
 
   @Test
-  public void testMissingTableMetadata() {
+  public void testMissingTableMetadata() throws IOException {
     Map<String, String> conf = Maps.newHashMap();
     conf.put(
         CatalogProperties.URI,

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -33,6 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -73,6 +75,8 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
    * @return The full name
    */
   protected abstract String tableName();
+
+  protected abstract EncryptionManagerFactory encryptionManagerFactory();
 
   @Override
   public TableMetadata current() {
@@ -235,6 +239,17 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   @Override
   public LocationProvider locationProvider() {
     return LocationProviders.locationsFor(current().location(), current().properties());
+  }
+
+  @Override
+  public EncryptionManager encryption() {
+    TableMetadata metadata = current();
+    EncryptionManagerFactory factory = encryptionManagerFactory();
+    if (null != metadata && null != factory) {
+      return factory.create(metadata);
+    } else {
+      return new PlaintextEncryptionManager();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -246,7 +246,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     TableMetadata metadata = current();
     EncryptionManagerFactory factory = encryptionManagerFactory();
     if (null != metadata && null != factory) {
-      return factory.create(metadata);
+      return factory.create(metadata.properties(), metadata.schema());
     } else {
       return new PlaintextEncryptionManager();
     }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -146,4 +146,7 @@ public class CatalogProperties {
 
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
+
+  public static final String ENCRYPTION_MANAGER_FACTORY_IMPL = "encryption.manager.factory-impl";
+  public static final String ENCRYPTION_KMS_CLIENT_IMPL = "encryption.kms.client-impl";
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -30,6 +30,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
+import org.apache.iceberg.encryption.PlaintextEncryptionManagerFactory;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
@@ -322,6 +324,49 @@ public class CatalogUtil {
 
     fileIO.initialize(properties);
     return fileIO;
+  }
+
+  /**
+   * Load encryption manager factory from catalog properties, if not configured, will load {@link
+   * PlaintextEncryptionManagerFactory}
+   *
+   * @param properties catalog properties
+   * @return Encryption manager factory class.
+   */
+  public static EncryptionManagerFactory loadEncryptionManagerFactory(
+      Map<String, String> properties) {
+    String impl =
+        PropertyUtil.propertyAsString(
+            properties,
+            CatalogProperties.ENCRYPTION_MANAGER_FACTORY_IMPL,
+            PlaintextEncryptionManagerFactory.class.getName());
+    DynConstructors.Ctor<EncryptionManagerFactory> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(EncryptionManagerFactory.class)
+              .loader(CatalogUtil.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize EncryptionManagerFactory, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    EncryptionManagerFactory factory;
+    try {
+      factory = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize EncryptionManagerFactory, %s does not implement EncryptionManagerFactory.",
+              impl),
+          e);
+    }
+
+    factory.initialize(properties);
+    return factory;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -91,7 +91,7 @@ public class StaticTableOperations implements TableOperations {
   public EncryptionManager encryption() {
     TableMetadata metadata = current();
     if (null != metadata) {
-      return encryptionManagerFactory.create(metadata);
+      return encryptionManagerFactory.create(metadata.properties(), metadata.schema());
     } else {
       return new PlaintextEncryptionManager();
     }

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.encryption;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.TableMetadata;
 
@@ -31,6 +30,7 @@ public interface EncryptionManagerFactory extends Closeable {
    * @param properties catalog properties
    */
   default void initialize(Map<String, String> properties) {}
+
   /**
    * Create encryption manager from table metadata.
    *
@@ -38,14 +38,4 @@ public interface EncryptionManagerFactory extends Closeable {
    * @return created encryption manager instance.
    */
   EncryptionManager create(TableMetadata tableMetadata);
-
-  /**
-   * Close EncryptionManagerFactory to release underlying resources.
-   *
-   * <p>Calling this method is only required when this EncryptionManagerFactory instance is no
-   * longer expected to be used, and the resources it holds need to be explicitly released to avoid
-   * resource leaks.
-   */
-  @Override
-  default void close() throws IOException {}
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+
+public interface EncryptionManagerFactory extends Closeable {
+
+  /**
+   * Initialize EncryptionManagerFactory from catalog properties.
+   *
+   * @param properties catalog properties
+   */
+  default void initialize(Map<String, String> properties) {}
+  /**
+   * Create encryption manager from table metadata.
+   *
+   * @param tableMetadata table metadata
+   * @return created encryption manager instance.
+   */
+  EncryptionManager create(TableMetadata tableMetadata);
+
+  /**
+   * Close EncryptionManagerFactory to release underlying resources.
+   *
+   * <p>Calling this method is only required when this EncryptionManagerFactory instance is no
+   * longer expected to be used, and the resources it holds need to be explicitly released to avoid
+   * resource leaks.
+   */
+  @Override
+  default void close() throws IOException {}
+}

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionManagerFactory.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.encryption;
 
 import java.io.Closeable;
 import java.util.Map;
-import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.Schema;
 
 public interface EncryptionManagerFactory extends Closeable {
 
@@ -34,8 +34,9 @@ public interface EncryptionManagerFactory extends Closeable {
   /**
    * Create encryption manager from table metadata.
    *
-   * @param tableMetadata table metadata
-   * @return created encryption manager instance.
+   * @param tableProperties table properties
+   * @param schema table schema
+   * @return created encryption manager instance
    */
-  EncryptionManager create(TableMetadata tableMetadata);
+  EncryptionManager create(Map<String, String> tableProperties, Schema schema);
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.encryption;
 
+import java.io.IOException;
 import org.apache.iceberg.TableMetadata;
 
 public class PlaintextEncryptionManagerFactory implements EncryptionManagerFactory {
@@ -27,4 +28,7 @@ public class PlaintextEncryptionManagerFactory implements EncryptionManagerFacto
   public EncryptionManager create(TableMetadata tableMetadata) {
     return new PlaintextEncryptionManager();
   }
+
+  @Override
+  public void close() throws IOException {}
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import org.apache.iceberg.TableMetadata;
+
+public class PlaintextEncryptionManagerFactory implements EncryptionManagerFactory {
+  public static final EncryptionManagerFactory INSTANCE = new PlaintextEncryptionManagerFactory();
+
+  @Override
+  public EncryptionManager create(TableMetadata tableMetadata) {
+    return new PlaintextEncryptionManager();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/PlaintextEncryptionManagerFactory.java
@@ -19,13 +19,14 @@
 package org.apache.iceberg.encryption;
 
 import java.io.IOException;
-import org.apache.iceberg.TableMetadata;
+import java.util.Map;
+import org.apache.iceberg.Schema;
 
 public class PlaintextEncryptionManagerFactory implements EncryptionManagerFactory {
   public static final EncryptionManagerFactory INSTANCE = new PlaintextEncryptionManagerFactory();
 
   @Override
-  public EncryptionManager create(TableMetadata tableMetadata) {
+  public EncryptionManager create(Map<String, String> tableProperties, Schema schema) {
     return new PlaintextEncryptionManager();
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -93,6 +94,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
   private String warehouseLocation;
   private FileSystem fs;
   private FileIO fileIO;
+  private EncryptionManagerFactory encryptionManagerFactory;
   private LockManager lockManager;
   private boolean suppressPermissionError = false;
   private Map<String, String> catalogProperties;
@@ -117,10 +119,14 @@ public class HadoopCatalog extends BaseMetastoreCatalog
             ? new HadoopFileIO(conf)
             : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
 
+    this.encryptionManagerFactory = CatalogUtil.loadEncryptionManagerFactory(properties);
+
     this.lockManager = LockManagers.from(properties);
 
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(lockManager);
+    closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(encryptionManagerFactory);
     closeableGroup.setSuppressCloseFailure(true);
 
     this.suppressPermissionError =
@@ -226,7 +232,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog
   @Override
   protected TableOperations newTableOps(TableIdentifier identifier) {
     return new HadoopTableOperations(
-        new Path(defaultWarehouseLocation(identifier)), fileIO, conf, lockManager);
+        new Path(defaultWarehouseLocation(identifier)),
+        fileIO,
+        encryptionManagerFactory,
+        conf,
+        lockManager);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -189,7 +189,7 @@ public class HadoopTableOperations implements TableOperations {
   public EncryptionManager encryption() {
     TableMetadata metadata = current();
     if (null != metadata) {
-      return encryptionManagerFactory.create(metadata);
+      return encryptionManagerFactory.create(metadata.properties(), metadata.schema());
     } else {
       return new PlaintextEncryptionManager();
     }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -208,8 +208,7 @@ public class HadoopTables implements Tables, Configurable {
     Map<String, String> props = Maps.newHashMap();
     // this map could be big as we are copying hadoop conf to map
     // we don't filter out encryption related conf because this will make the code hard to track if
-    // we want to add
-    // new encryption related conf property
+    // we want to add new encryption related conf property
     for (Map.Entry<String, String> entry : conf) {
       props.put(entry.getKey(), entry.getValue());
     }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -50,18 +51,21 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   private final String catalogName;
   private final TableIdentifier tableIdentifier;
   private final FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
   private final JdbcClientPool connections;
   private final Map<String, String> catalogProperties;
 
   protected JdbcTableOperations(
       JdbcClientPool dbConnPool,
       FileIO fileIO,
+      EncryptionManagerFactory encryptionManagerFactory,
       String catalogName,
       TableIdentifier tableIdentifier,
       Map<String, String> catalogProperties) {
     this.catalogName = catalogName;
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;
+    this.encryptionManagerFactory = encryptionManagerFactory;
     this.connections = dbConnPool;
     this.catalogProperties = catalogProperties;
   }
@@ -221,6 +225,11 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   @Override
   protected String tableName() {
     return tableIdentifier.toString();
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   private Map<String, String> getTable()

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -172,7 +172,7 @@ class RESTTableOperations implements TableOperations {
   public EncryptionManager encryption() {
     TableMetadata metadata = current();
     if (null != metadata) {
-      return encryptionManagerFactory.create(metadata);
+      return encryptionManagerFactory.create(metadata.properties(), metadata.schema());
     } else {
       return new PlaintextEncryptionManager();
     }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -628,7 +628,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
   }
 
   @Test
-  public void testCreateTableInNonExistingNamespace() {
+  public void testCreateTableInNonExistingNamespace() throws IOException {
     try (JdbcCatalog jdbcCatalog = initCatalog("non_strict_jdbc_catalog", ImmutableMap.of())) {
       Namespace namespace = Namespace.of("testDb", "ns1", "ns2");
       TableIdentifier identifier = TableIdentifier.of(namespace, "someTable");
@@ -642,7 +642,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
   }
 
   @Test
-  public void testCreateTableInNonExistingNamespaceStrictMode() {
+  public void testCreateTableInNonExistingNamespaceStrictMode() throws IOException {
     try (JdbcCatalog jdbcCatalog =
         initCatalog(
             "strict_jdbc_catalog", ImmutableMap.of(JdbcUtil.STRICT_MODE_PROPERTY, "true"))) {

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.dell.DellClientFactories;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -83,6 +84,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
   private EcsURI warehouseLocation;
 
   private FileIO fileIO;
+  private EncryptionManagerFactory encryptionManagerFactory;
   private CloseableGroup closeableGroup;
 
   /**
@@ -103,10 +105,12 @@ public class EcsCatalog extends BaseMetastoreCatalog
     this.warehouseLocation = new EcsURI(LocationUtil.stripTrailingSlash(inputWarehouseLocation));
     this.client = DellClientFactories.from(properties).ecsS3();
     this.fileIO = initializeFileIO(properties);
+    this.encryptionManagerFactory = CatalogUtil.loadEncryptionManagerFactory(properties);
 
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(client::destroy);
     closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(encryptionManagerFactory);
     closeableGroup.setSuppressCloseFailure(true);
   }
 
@@ -127,6 +131,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
         String.format("%s.%s", catalogName, tableIdentifier),
         tableURI(tableIdentifier),
         fileIO,
+        encryptionManagerFactory,
         this);
   }
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsTableOperations.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsTableOperations.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.dell.ecs;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
@@ -33,6 +34,7 @@ public class EcsTableOperations extends BaseMetastoreTableOperations {
 
   private final String tableName;
   private final FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
   private final EcsCatalog catalog;
   private final EcsURI tableObject;
 
@@ -45,16 +47,26 @@ public class EcsTableOperations extends BaseMetastoreTableOperations {
   private String eTag;
 
   public EcsTableOperations(
-      String tableName, EcsURI tableObject, FileIO fileIO, EcsCatalog catalog) {
+      String tableName,
+      EcsURI tableObject,
+      FileIO fileIO,
+      EncryptionManagerFactory encryptionManagerFactory,
+      EcsCatalog catalog) {
     this.tableName = tableName;
     this.tableObject = tableObject;
     this.fileIO = fileIO;
+    this.encryptionManagerFactory = encryptionManagerFactory;
     this.catalog = catalog;
   }
 
   @Override
   protected String tableName() {
     return tableName;
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   @Override

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -63,6 +63,8 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
+import org.apache.iceberg.encryption.PlaintextEncryptionManagerFactory;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -165,6 +167,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final long maxHiveTablePropertySize;
   private final int metadataRefreshMaxRetries;
   private final FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
   private final ScheduledExecutorService exitingScheduledExecutorService;
 
@@ -175,9 +178,28 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       String catalogName,
       String database,
       String table) {
+    this(
+        conf,
+        metaClients,
+        fileIO,
+        PlaintextEncryptionManagerFactory.INSTANCE,
+        catalogName,
+        database,
+        table);
+  }
+
+  protected HiveTableOperations(
+      Configuration conf,
+      ClientPool metaClients,
+      FileIO fileIO,
+      EncryptionManagerFactory encryptionManagerFactory,
+      String catalogName,
+      String database,
+      String table) {
     this.conf = conf;
     this.metaClients = metaClients;
     this.fileIO = fileIO;
+    this.encryptionManagerFactory = encryptionManagerFactory;
     this.fullName = catalogName + "." + database + "." + table;
     this.database = database;
     this.tableName = table;
@@ -209,6 +231,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   @Override
   protected String tableName() {
     return fullName;
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionManagerFactory;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -59,6 +60,7 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
   private final ContentKey key;
   private IcebergTable table;
   private final FileIO fileIO;
+  private final EncryptionManagerFactory encryptionManagerFactory;
   private final Map<String, String> catalogOptions;
 
   /** Create a nessie table operations given a table identifier. */
@@ -66,16 +68,23 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
       ContentKey key,
       NessieIcebergClient client,
       FileIO fileIO,
+      EncryptionManagerFactory encryptionManagerFactory,
       Map<String, String> catalogOptions) {
     this.key = key;
     this.client = client;
     this.fileIO = fileIO;
+    this.encryptionManagerFactory = encryptionManagerFactory;
     this.catalogOptions = catalogOptions;
   }
 
   @Override
   protected String tableName() {
     return key.toString();
+  }
+
+  @Override
+  protected EncryptionManagerFactory encryptionManagerFactory() {
+    return encryptionManagerFactory;
   }
 
   private TableMetadata loadTableMetadata(String metadataLocation, Reference reference) {


### PR DESCRIPTION
And also make KmsClient `Closeable` to clean up underlying resources when necessary, ref the design of `FileIO`.  For some cases, KmsClient implementation is expensive to be initialised per encryption manager call, when using shared KmsClient for multiple encryption managers we need to close underlying resources to avoid potential leak. 