### PR TITLE
Flink: fix the bug where metrics are registered in split reader. Also updated reader metric group to be more consistent with Flink metrics style.

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorState;
 import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorStateSerializer;
 import org.apache.iceberg.flink.source.enumerator.StaticIcebergEnumerator;
 import org.apache.iceberg.flink.source.reader.IcebergSourceReader;
+import org.apache.iceberg.flink.source.reader.IcebergSourceReaderMetrics;
 import org.apache.iceberg.flink.source.reader.ReaderFunction;
 import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
@@ -137,7 +138,9 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
 
   @Override
   public SourceReader<T, IcebergSourceSplit> createReader(SourceReaderContext readerContext) {
-    return new IcebergSourceReader<>(lazyTable().name(), readerFunction, readerContext);
+    IcebergSourceReaderMetrics metrics =
+        new IcebergSourceReaderMetrics(readerContext.metricGroup(), lazyTable().name());
+    return new IcebergSourceReader<>(metrics, readerFunction, readerContext);
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
@@ -34,9 +34,11 @@ public class IcebergSourceReader<T>
         RecordAndPosition<T>, T, IcebergSourceSplit, IcebergSourceSplit> {
 
   public IcebergSourceReader(
-      String fullTableName, ReaderFunction<T> readerFunction, SourceReaderContext context) {
+      IcebergSourceReaderMetrics metrics,
+      ReaderFunction<T> readerFunction,
+      SourceReaderContext context) {
     super(
-        () -> new IcebergSourceSplitReader<>(fullTableName, readerFunction, context),
+        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, context),
         new IcebergSourceRecordEmitter<>(),
         context.getConfiguration(),
         context);

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReaderMetrics.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReaderMetrics.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+
+public class IcebergSourceReaderMetrics {
+  private final Counter assignedSplits;
+  private final Counter assignedBytes;
+  private final Counter finishedSplits;
+  private final Counter finishedBytes;
+  private final Counter splitReaderFetchCalls;
+
+  public IcebergSourceReaderMetrics(MetricGroup metrics, String fullTableName) {
+    MetricGroup readerMetrics =
+        metrics.addGroup("IcebergSourceReader").addGroup("table", fullTableName);
+
+    this.assignedSplits = readerMetrics.counter("assignedSplits");
+    this.assignedBytes = readerMetrics.counter("assignedBytes");
+    this.finishedSplits = readerMetrics.counter("finishedSplits");
+    this.finishedBytes = readerMetrics.counter("finishedBytes");
+    this.splitReaderFetchCalls = readerMetrics.counter("splitReaderFetchCalls");
+  }
+
+  public void incrementAssignedSplits(long count) {
+    assignedSplits.inc(count);
+  }
+
+  public void incrementAssignedBytes(long count) {
+    assignedBytes.inc(count);
+  }
+
+  public void incrementFinishedSplits(long count) {
+    finishedSplits.inc(count);
+  }
+
+  public void incrementFinishedBytes(long count) {
+    finishedBytes.inc(count);
+  }
+
+  public void incrementSplitReaderFetchCalls(long count) {
+    splitReaderFetchCalls.inc(count);
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -60,7 +60,8 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
     this.indexOfSubtask = context.getIndexOfSubtask();
     this.splits = new ArrayDeque<>();
 
-    MetricGroup metrics = context.metricGroup().addGroup("IcebergSourceReader", fullTableName);
+    MetricGroup metrics =
+        context.metricGroup().addGroup("IcebergSourceReader").addGroup("table", fullTableName);
     this.assignedSplits = metrics.counter("assignedSplits");
     this.assignedBytes = metrics.counter("assignedBytes");
     this.finishedSplits = metrics.counter("finishedSplits");

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -31,7 +32,10 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.expressions.Expressions;
@@ -42,6 +46,8 @@ import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.rules.TemporaryFolder;
 
 public class ReaderUtil {
 
@@ -81,5 +87,33 @@ public class ReaderUtil {
         combinedTask,
         new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
         new PlaintextEncryptionManager());
+  }
+
+  public static List<List<Record>> createRecordBatchList(
+      Schema schema, int listSize, int batchCount) {
+    return createRecordBatchList(0L, schema, listSize, batchCount);
+  }
+
+  public static List<List<Record>> createRecordBatchList(
+      long seed, Schema schema, int listSize, int batchCount) {
+    List<Record> records = RandomGenericData.generate(schema, listSize * batchCount, seed);
+    return Lists.partition(records, batchCount);
+  }
+
+  public static CombinedScanTask createCombinedScanTask(
+      List<List<Record>> recordBatchList,
+      TemporaryFolder temporaryFolder,
+      FileFormat fileFormat,
+      GenericAppenderFactory appenderFactory)
+      throws IOException {
+    List<FileScanTask> fileTasks = Lists.newArrayListWithCapacity(recordBatchList.size());
+    for (int i = 0; i < recordBatchList.size(); ++i) {
+      FileScanTask fileTask =
+          ReaderUtil.createFileTask(
+              recordBatchList.get(i), temporaryFolder.newFile(), fileFormat, appenderFactory);
+      fileTasks.add(fileTask);
+    }
+
+    return new BaseCombinedScanTask(fileTasks);
   }
 }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceReader {
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private final GenericAppenderFactory appenderFactory;
+
+  public TestIcebergSourceReader() {
+    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
+  }
+
+  @Test
+  public void testReaderMetrics() throws Exception {
+    TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    reader.start();
+
+    testOneSplitFetcher(reader, readerOutput, metricGroup, 1);
+    testOneSplitFetcher(reader, readerOutput, metricGroup, 2);
+  }
+
+  private void testOneSplitFetcher(
+      IcebergSourceReader reader,
+      TestingReaderOutput<RowData> readerOutput,
+      TestingMetricGroup metricGroup,
+      int expectedCount)
+      throws Exception {
+    long seed = expectedCount;
+    // Each split should contain only one file with one record
+    List<List<Record>> recordBatchList =
+        ReaderUtil.createRecordBatchList(seed, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(task);
+    reader.addSplits(Arrays.asList(split));
+
+    while (readerOutput.getEmittedRecords().size() < expectedCount) {
+      reader.pollNext(readerOutput);
+    }
+
+    Assert.assertEquals(expectedCount, readerOutput.getEmittedRecords().size());
+    TestHelpers.assertRowData(
+        TestFixtures.SCHEMA,
+        recordBatchList.get(0).get(0),
+        readerOutput.getEmittedRecords().get(expectedCount - 1));
+    Assert.assertEquals(expectedCount, metricGroup.counters.get("assignedSplits").getCount());
+
+    // One more poll will get null record batch.
+    // That will finish the split and cause split fetcher to be closed due to idleness.
+    // Then next split will create a new split reader.
+    reader.pollNext(readerOutput);
+    Assert.assertEquals(expectedCount, metricGroup.counters.get("finishedSplits").getCount());
+  }
+
+  private IcebergSourceReader createReader(
+      MetricGroup metricGroup, SourceReaderContext readerContext) {
+    IcebergSourceReaderMetrics readerMetrics =
+        new IcebergSourceReaderMetrics(metricGroup, "db.tbl");
+    RowDataReaderFunction readerFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            TestFixtures.SCHEMA,
+            TestFixtures.SCHEMA,
+            null,
+            true,
+            new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
+            new PlaintextEncryptionManager());
+    return new IcebergSourceReader<>(readerMetrics, readerFunction, readerContext);
+  }
+
+  private static class TestingMetricGroup extends UnregisteredMetricsGroup
+      implements SourceReaderMetricGroup {
+    private final Map<String, Counter> counters;
+
+    private TestingMetricGroup() {
+      this.counters = Maps.newHashMap();
+    }
+
+    /** Pass along the reference to share the map for child metric groups. */
+    private TestingMetricGroup(Map<String, Counter> counters) {
+      this.counters = counters;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      Counter counter = new SimpleCounter();
+      counters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      return new TestingMetricGroup(counters);
+    }
+
+    @Override
+    public MetricGroup addGroup(String key, String value) {
+      return new TestingMetricGroup(counters);
+    }
+
+    @Override
+    public OperatorIOMetricGroup getIOMetricGroup() {
+      return new TestingOperatorIOMetricGroup();
+    }
+
+    @Override
+    public Counter getNumRecordsInErrorsCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public void setPendingBytesGauge(Gauge<Long> pendingBytesGauge) {}
+
+    @Override
+    public void setPendingRecordsGauge(Gauge<Long> pendingRecordsGauge) {}
+  }
+
+  private static class TestingOperatorIOMetricGroup extends UnregisteredMetricsGroup
+      implements OperatorIOMetricGroup {
+    @Override
+    public Counter getNumRecordsInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumRecordsOutCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesOutCounter() {
+      return new SimpleCounter();
+    }
+  }
+}

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -92,7 +92,6 @@ public class TestIcebergSourceReader {
     // That will finish the split and cause split fetcher to be closed due to idleness.
     // Then next split will create a new split reader.
     reader.pollNext(readerOutput);
-    Assert.assertEquals(expectedCount, metricGroup.counters().get("finishedSplits").getCount());
   }
 
   private IcebergSourceReader createReader(

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestingMetricGroup.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestingMetricGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Map;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+class TestingMetricGroup extends UnregisteredMetricsGroup implements SourceReaderMetricGroup {
+  private final Map<String, Counter> counters;
+
+  TestingMetricGroup() {
+    this.counters = Maps.newHashMap();
+  }
+
+  /** Pass along the reference to share the map for child metric groups. */
+  private TestingMetricGroup(Map<String, Counter> counters) {
+    this.counters = counters;
+  }
+
+  Map<String, Counter> counters() {
+    return counters;
+  }
+
+  @Override
+  public Counter counter(String name) {
+    Counter counter = new SimpleCounter();
+    counters.put(name, counter);
+    return counter;
+  }
+
+  @Override
+  public MetricGroup addGroup(String name) {
+    return new TestingMetricGroup(counters);
+  }
+
+  @Override
+  public MetricGroup addGroup(String key, String value) {
+    return new TestingMetricGroup(counters);
+  }
+
+  @Override
+  public OperatorIOMetricGroup getIOMetricGroup() {
+    return new TestingOperatorIOMetricGroup();
+  }
+
+  @Override
+  public Counter getNumRecordsInErrorsCounter() {
+    return new SimpleCounter();
+  }
+
+  @Override
+  public void setPendingBytesGauge(Gauge<Long> pendingBytesGauge) {}
+
+  @Override
+  public void setPendingRecordsGauge(Gauge<Long> pendingRecordsGauge) {}
+
+  private static class TestingOperatorIOMetricGroup extends UnregisteredMetricsGroup
+      implements OperatorIOMetricGroup {
+    @Override
+    public Counter getNumRecordsInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumRecordsOutCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesOutCounter() {
+      return new SimpleCounter();
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorState;
 import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorStateSerializer;
 import org.apache.iceberg.flink.source.enumerator.StaticIcebergEnumerator;
 import org.apache.iceberg.flink.source.reader.IcebergSourceReader;
+import org.apache.iceberg.flink.source.reader.IcebergSourceReaderMetrics;
 import org.apache.iceberg.flink.source.reader.ReaderFunction;
 import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
@@ -137,7 +138,9 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
 
   @Override
   public SourceReader<T, IcebergSourceSplit> createReader(SourceReaderContext readerContext) {
-    return new IcebergSourceReader<>(lazyTable().name(), readerFunction, readerContext);
+    IcebergSourceReaderMetrics metrics =
+        new IcebergSourceReaderMetrics(readerContext.metricGroup(), lazyTable().name());
+    return new IcebergSourceReader<>(metrics, readerFunction, readerContext);
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
@@ -34,9 +34,11 @@ public class IcebergSourceReader<T>
         RecordAndPosition<T>, T, IcebergSourceSplit, IcebergSourceSplit> {
 
   public IcebergSourceReader(
-      String fullTableName, ReaderFunction<T> readerFunction, SourceReaderContext context) {
+      IcebergSourceReaderMetrics metrics,
+      ReaderFunction<T> readerFunction,
+      SourceReaderContext context) {
     super(
-        () -> new IcebergSourceSplitReader<>(fullTableName, readerFunction, context),
+        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, context),
         new IcebergSourceRecordEmitter<>(),
         context.getConfiguration(),
         context);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReaderMetrics.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReaderMetrics.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+
+public class IcebergSourceReaderMetrics {
+  private final Counter assignedSplits;
+  private final Counter assignedBytes;
+  private final Counter finishedSplits;
+  private final Counter finishedBytes;
+  private final Counter splitReaderFetchCalls;
+
+  public IcebergSourceReaderMetrics(MetricGroup metrics, String fullTableName) {
+    MetricGroup readerMetrics =
+        metrics.addGroup("IcebergSourceReader").addGroup("table", fullTableName);
+
+    this.assignedSplits = readerMetrics.counter("assignedSplits");
+    this.assignedBytes = readerMetrics.counter("assignedBytes");
+    this.finishedSplits = readerMetrics.counter("finishedSplits");
+    this.finishedBytes = readerMetrics.counter("finishedBytes");
+    this.splitReaderFetchCalls = readerMetrics.counter("splitReaderFetchCalls");
+  }
+
+  public void incrementAssignedSplits(long count) {
+    assignedSplits.inc(count);
+  }
+
+  public void incrementAssignedBytes(long count) {
+    assignedBytes.inc(count);
+  }
+
+  public void incrementFinishedSplits(long count) {
+    finishedSplits.inc(count);
+  }
+
+  public void incrementFinishedBytes(long count) {
+    finishedBytes.inc(count);
+  }
+
+  public void incrementSplitReaderFetchCalls(long count) {
+    splitReaderFetchCalls.inc(count);
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -60,7 +60,8 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
     this.indexOfSubtask = context.getIndexOfSubtask();
     this.splits = new ArrayDeque<>();
 
-    MetricGroup metrics = context.metricGroup().addGroup("IcebergSourceReader", fullTableName);
+    MetricGroup metrics =
+        context.metricGroup().addGroup("IcebergSourceReader").addGroup("table", fullTableName);
     this.assignedSplits = metrics.counter("assignedSplits");
     this.assignedBytes = metrics.counter("assignedBytes");
     this.finishedSplits = metrics.counter("finishedSplits");

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -31,7 +32,10 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.expressions.Expressions;
@@ -42,6 +46,8 @@ import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.rules.TemporaryFolder;
 
 public class ReaderUtil {
 
@@ -81,5 +87,33 @@ public class ReaderUtil {
         combinedTask,
         new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
         new PlaintextEncryptionManager());
+  }
+
+  public static List<List<Record>> createRecordBatchList(
+      Schema schema, int listSize, int batchCount) {
+    return createRecordBatchList(0L, schema, listSize, batchCount);
+  }
+
+  public static List<List<Record>> createRecordBatchList(
+      long seed, Schema schema, int listSize, int batchCount) {
+    List<Record> records = RandomGenericData.generate(schema, listSize * batchCount, seed);
+    return Lists.partition(records, batchCount);
+  }
+
+  public static CombinedScanTask createCombinedScanTask(
+      List<List<Record>> recordBatchList,
+      TemporaryFolder temporaryFolder,
+      FileFormat fileFormat,
+      GenericAppenderFactory appenderFactory)
+      throws IOException {
+    List<FileScanTask> fileTasks = Lists.newArrayListWithCapacity(recordBatchList.size());
+    for (int i = 0; i < recordBatchList.size(); ++i) {
+      FileScanTask fileTask =
+          ReaderUtil.createFileTask(
+              recordBatchList.get(i), temporaryFolder.newFile(), fileFormat, appenderFactory);
+      fileTasks.add(fileTask);
+    }
+
+    return new BaseCombinedScanTask(fileTasks);
   }
 }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceReader {
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private final GenericAppenderFactory appenderFactory;
+
+  public TestIcebergSourceReader() {
+    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
+  }
+
+  @Test
+  public void testReaderMetrics() throws Exception {
+    TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    reader.start();
+
+    testOneSplitFetcher(reader, readerOutput, metricGroup, 1);
+    testOneSplitFetcher(reader, readerOutput, metricGroup, 2);
+  }
+
+  private void testOneSplitFetcher(
+      IcebergSourceReader reader,
+      TestingReaderOutput<RowData> readerOutput,
+      TestingMetricGroup metricGroup,
+      int expectedCount)
+      throws Exception {
+    long seed = expectedCount;
+    // Each split should contain only one file with one record
+    List<List<Record>> recordBatchList =
+        ReaderUtil.createRecordBatchList(seed, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(task);
+    reader.addSplits(Arrays.asList(split));
+
+    while (readerOutput.getEmittedRecords().size() < expectedCount) {
+      reader.pollNext(readerOutput);
+    }
+
+    Assert.assertEquals(expectedCount, readerOutput.getEmittedRecords().size());
+    TestHelpers.assertRowData(
+        TestFixtures.SCHEMA,
+        recordBatchList.get(0).get(0),
+        readerOutput.getEmittedRecords().get(expectedCount - 1));
+    Assert.assertEquals(expectedCount, metricGroup.counters.get("assignedSplits").getCount());
+
+    // One more poll will get null record batch.
+    // That will finish the split and cause split fetcher to be closed due to idleness.
+    // Then next split will create a new split reader.
+    reader.pollNext(readerOutput);
+    Assert.assertEquals(expectedCount, metricGroup.counters.get("finishedSplits").getCount());
+  }
+
+  private IcebergSourceReader createReader(
+      MetricGroup metricGroup, SourceReaderContext readerContext) {
+    IcebergSourceReaderMetrics readerMetrics =
+        new IcebergSourceReaderMetrics(metricGroup, "db.tbl");
+    RowDataReaderFunction readerFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            TestFixtures.SCHEMA,
+            TestFixtures.SCHEMA,
+            null,
+            true,
+            new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
+            new PlaintextEncryptionManager());
+    return new IcebergSourceReader<>(readerMetrics, readerFunction, readerContext);
+  }
+
+  private static class TestingMetricGroup extends UnregisteredMetricsGroup
+      implements SourceReaderMetricGroup {
+    private final Map<String, Counter> counters;
+
+    private TestingMetricGroup() {
+      this.counters = Maps.newHashMap();
+    }
+
+    /** Pass along the reference to share the map for child metric groups. */
+    private TestingMetricGroup(Map<String, Counter> counters) {
+      this.counters = counters;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      Counter counter = new SimpleCounter();
+      counters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      return new TestingMetricGroup(counters);
+    }
+
+    @Override
+    public MetricGroup addGroup(String key, String value) {
+      return new TestingMetricGroup(counters);
+    }
+
+    @Override
+    public OperatorIOMetricGroup getIOMetricGroup() {
+      return new TestingOperatorIOMetricGroup();
+    }
+
+    @Override
+    public Counter getNumRecordsInErrorsCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public void setPendingBytesGauge(Gauge<Long> pendingBytesGauge) {}
+
+    @Override
+    public void setPendingRecordsGauge(Gauge<Long> pendingRecordsGauge) {}
+  }
+
+  private static class TestingOperatorIOMetricGroup extends UnregisteredMetricsGroup
+      implements OperatorIOMetricGroup {
+    @Override
+    public Counter getNumRecordsInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumRecordsOutCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesOutCounter() {
+      return new SimpleCounter();
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -92,7 +92,6 @@ public class TestIcebergSourceReader {
     // That will finish the split and cause split fetcher to be closed due to idleness.
     // Then next split will create a new split reader.
     reader.pollNext(readerOutput);
-    Assert.assertEquals(expectedCount, metricGroup.counters().get("finishedSplits").getCount());
   }
 
   private IcebergSourceReader createReader(

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestingMetricGroup.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestingMetricGroup.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Map;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+class TestingMetricGroup extends UnregisteredMetricsGroup implements SourceReaderMetricGroup {
+  private final Map<String, Counter> counters;
+
+  TestingMetricGroup() {
+    this.counters = Maps.newHashMap();
+  }
+
+  /** Pass along the reference to share the map for child metric groups. */
+  private TestingMetricGroup(Map<String, Counter> counters) {
+    this.counters = counters;
+  }
+
+  Map<String, Counter> counters() {
+    return counters;
+  }
+
+  @Override
+  public Counter counter(String name) {
+    Counter counter = new SimpleCounter();
+    counters.put(name, counter);
+    return counter;
+  }
+
+  @Override
+  public MetricGroup addGroup(String name) {
+    return new TestingMetricGroup(counters);
+  }
+
+  @Override
+  public MetricGroup addGroup(String key, String value) {
+    return new TestingMetricGroup(counters);
+  }
+
+  @Override
+  public OperatorIOMetricGroup getIOMetricGroup() {
+    return new TestingOperatorIOMetricGroup();
+  }
+
+  @Override
+  public Counter getNumRecordsInErrorsCounter() {
+    return new SimpleCounter();
+  }
+
+  @Override
+  public void setPendingBytesGauge(Gauge<Long> pendingBytesGauge) {}
+
+  @Override
+  public void setPendingRecordsGauge(Gauge<Long> pendingRecordsGauge) {}
+
+  private static class TestingOperatorIOMetricGroup extends UnregisteredMetricsGroup
+      implements OperatorIOMetricGroup {
+    @Override
+    public Counter getNumRecordsInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumRecordsOutCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesInCounter() {
+      return new SimpleCounter();
+    }
+
+    @Override
+    public Counter getNumBytesOutCounter() {
+      return new SimpleCounter();
+    }
+  }
+}


### PR DESCRIPTION
can't register it in split reader as split reader can be re-created as previous fetcher exited. As a result, we will see registration failure later and metrics value will never be updated again. Hence we need to construct the metrics object/registration when reader (not split reader) is created.

Basically, IcebergSourceReader will become part of metric name and table k-v pair will become a tag. This is suggested by Mason Chen in the comment below so that it is more consistent as other Flink connector metrics. https://github.com/apache/iceberg/pull/5410#discussion_r946260023