### PR TITLE
Add s3.acceleration-enbled flag to AwsProperties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -94,6 +94,7 @@ public class AwsClientFactories {
     private String s3SessionToken;
     private Boolean s3PathStyleAccess;
     private Boolean s3UseArnRegionEnabled;
+    private Boolean s3AccelerationEnabled;
     private String dynamoDbEndpoint;
     private String httpClientType;
 
@@ -104,7 +105,12 @@ public class AwsClientFactories {
       return S3Client.builder()
           .httpClientBuilder(configureHttpClientBuilder(httpClientType))
           .applyMutation(builder -> configureEndpoint(builder, s3Endpoint))
-          .serviceConfiguration(s3Configuration(s3PathStyleAccess, s3UseArnRegionEnabled))
+          .serviceConfiguration(
+              S3Configuration.builder()
+                  .pathStyleAccessEnabled(s3PathStyleAccess)
+                  .useArnRegionEnabled(s3UseArnRegionEnabled)
+                  .accelerateModeEnabled(s3AccelerationEnabled)
+                  .build())
           .credentialsProvider(
               credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken))
           .build();
@@ -150,6 +156,11 @@ public class AwsClientFactories {
               properties,
               AwsProperties.S3_USE_ARN_REGION_ENABLED,
               AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
+      this.s3AccelerationEnabled =
+          PropertyUtil.propertyAsBoolean(
+              properties,
+              AwsProperties.S3_ACCELERATION_ENABLED,
+              AwsProperties.S3_ACCELERATION_ENABLED_DEFAULT);
 
       ValidationException.check(
           (s3AccessKeyId == null) == (s3SecretAccessKey == null),

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -375,6 +375,16 @@ public class AwsProperties implements Serializable {
   public static final boolean S3_DELETE_ENABLED_DEFAULT = true;
 
   /**
+   * Determines if S3 client will use the Acceleration Mode, default to false.
+   *
+   * <p>For more details, see
+   * https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html
+   */
+  public static final String S3_ACCELERATION_ENABLED = "s3.acceleration-enabled";
+
+  public static final boolean S3_ACCELERATION_ENABLED_DEFAULT = false;
+
+  /**
    * Used by {@link S3FileIO}, prefix used for bucket access point configuration. To set, we can
    * pass a catalog property.
    *

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -492,6 +492,23 @@ access-point for all S3 operations.
 
 For more details on using access-points, please refer [Using access points with compatible Amazon S3 operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-usage-examples.html).
 
+### S3 Acceleration
+
+[S3 Acceleration](https://aws.amazon.com/s3/transfer-acceleration/) can be used to speed up transfers to and from Amazon S3 by as much as 50-500% for long-distance transfer of larger objects.
+
+To use S3 Acceleration, we need to set `s3.acceleration-enabled` catalog property to `true` to enable `S3FileIO` to make accelerated S3 calls.
+
+For example, to use S3 Acceleration with Spark 3.0, you can start the Spark SQL shell with:
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.acceleration-enabled=true
+```
+
+For more details on using S3 Acceleration, please refer to [Configuring fast, secure file transfers using Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html).
+
 ## AWS Client Customization
 
 Many organizations have customized their way of configuring AWS clients with their own credential provider, access proxy, retry strategy, etc.


### PR DESCRIPTION
Compiled iceberg-spark-runtime-3.1 and tested on Glue 3.0. The job is able to read from a DEMO S3 bucket into an S3 bucket that lives in my account. The DEMO bucket is from this blog: https://aws.amazon.com/blogs/big-data/build-an-apache-iceberg-data-lake-using-amazon-athena-amazon-emr-and-aws-glue/

My Spark job used during the testing is listed below.
```
import com.amazonaws.services.glue.GlueContext

import org.apache.spark.SparkContext
import org.apache.spark.sql.SparkSession

object IcebergSparkSQL {
  def main(sysArgs: Array[String]) {
        val sparkContext: SparkContext = new SparkContext()
        val spark: SparkSession = SparkSession.builder.
          config("spark.sql.catalog.demo", "org.apache.iceberg.spark.SparkCatalog").
          config("spark.sql.catalog.demo.warehouse", "s3://iceberg-test-puzhen/glueiceberg").
          config("spark.sql.catalog.demo.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog").
          config("spark.sql.catalog.demo.s3.acceleration-enabled", "true").
          getOrCreate()
        
        // create database
        spark.sql("CREATE DATABASE IF NOT EXISTS demo.reviews")
        
        // load data (Amazon reviews public dataset)
        val book_reviews_location = "s3://amazon-reviews-pds/parquet/product_category=Books/*.parquet"
        val book_reviews = spark.read.parquet(book_reviews_location)
        book_reviews.writeTo("demo.reviews.book_reviews2").
          tableProperty("format-version", "2").
          createOrReplace()
        
        // read using SQL
        spark.sql("SELECT * FROM demo.reviews.book_reviews2").show()
  }
}
```

Job runtime duration:

Workload run without S3 acceleration: 3 minutes 21 seconds
Workload run with S3 acceleration: 3 minutes 14 seconds