### PR TITLE
API/Core: Don't track name in Counter/Timer API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/Counter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/Counter.java
@@ -59,13 +59,6 @@ public interface Counter {
   }
 
   /**
-   * The name of the counter.
-   *
-   * @return The name of the counter.
-   */
-  String name();
-
-  /**
    * Determines whether this counter is a NOOP counter.
    *
    * @return Whether this counter is a NOOP counter.

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultCounter.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 /** A default {@link Counter} implementation that uses an {@link AtomicLong} to count events. */
 public class DefaultCounter implements Counter {
   public static final Counter NOOP =
-      new DefaultCounter("undefined", Unit.UNDEFINED) {
+      new DefaultCounter(Unit.UNDEFINED) {
         @Override
         public void increment() {}
 
@@ -41,15 +41,12 @@ public class DefaultCounter implements Counter {
       };
 
   private final LongAdder counter;
-  private final String name;
   private final MetricsContext.Unit unit;
   private AsIntCounter asIntCounter = null;
   private AsLongCounter asLongCounter = null;
 
-  DefaultCounter(String name, MetricsContext.Unit unit) {
-    Preconditions.checkArgument(null != name, "Invalid counter name: null");
+  DefaultCounter(MetricsContext.Unit unit) {
     Preconditions.checkArgument(null != unit, "Invalid count unit: null");
-    this.name = name;
     this.unit = unit;
     this.counter = new LongAdder();
   }
@@ -72,17 +69,12 @@ public class DefaultCounter implements Counter {
 
   @Override
   public String toString() {
-    return String.format("%s{%s=%s}", name(), unit().displayName(), value());
+    return String.format("{%s=%s}", unit().displayName(), value());
   }
 
   @Override
   public MetricsContext.Unit unit() {
     return unit;
-  }
-
-  @Override
-  public String name() {
-    return name;
   }
 
   MetricsContext.Counter<Integer> asIntCounter() {
@@ -128,11 +120,6 @@ public class DefaultCounter implements Counter {
     public MetricsContext.Unit unit() {
       return unit;
     }
-
-    @Override
-    public String name() {
-      return name;
-    }
   }
 
   private class AsLongCounter implements MetricsContext.Counter<Long> {
@@ -160,11 +147,6 @@ public class DefaultCounter implements Counter {
     @Override
     public MetricsContext.Unit unit() {
       return unit;
-    }
-
-    @Override
-    public String name() {
-      return name;
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
@@ -28,11 +28,11 @@ public class DefaultMetricsContext implements MetricsContext {
   @SuppressWarnings("unchecked")
   public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
     if (Integer.class.equals(type)) {
-      return (Counter<T>) new DefaultCounter(name, unit).asIntCounter();
+      return (Counter<T>) new DefaultCounter(unit).asIntCounter();
     }
 
     if (Long.class.equals(type)) {
-      return (Counter<T>) new DefaultCounter(name, unit).asLongCounter();
+      return (Counter<T>) new DefaultCounter(unit).asLongCounter();
     }
     throw new IllegalArgumentException(
         String.format("Counter for type %s is not supported", type.getName()));
@@ -40,11 +40,11 @@ public class DefaultMetricsContext implements MetricsContext {
 
   @Override
   public Timer timer(String name, TimeUnit unit) {
-    return new DefaultTimer(name, unit);
+    return new DefaultTimer(unit);
   }
 
   @Override
   public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
-    return new DefaultCounter(name, unit);
+    return new DefaultCounter(unit);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultTimer.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultTimer.java
@@ -36,12 +36,9 @@ public class DefaultTimer implements Timer {
   private final TimeUnit timeUnit;
   private final LongAdder count = new LongAdder();
   private final LongAdder totalTime = new LongAdder();
-  private final String name;
 
-  public DefaultTimer(String name, TimeUnit timeUnit) {
-    Preconditions.checkArgument(null != name, "Invalid timer name: null");
+  public DefaultTimer(TimeUnit timeUnit) {
     Preconditions.checkArgument(null != timeUnit, "Invalid time unit: null");
-    this.name = name;
     this.timeUnit = timeUnit;
   }
 
@@ -98,18 +95,13 @@ public class DefaultTimer implements Timer {
   }
 
   @Override
-  public String name() {
-    return name;
-  }
-
-  @Override
   public TimeUnit unit() {
     return timeUnit;
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(name())
+    return MoreObjects.toStringHelper(DefaultTimer.class)
         .add("duration", totalDuration())
         .add("count", count)
         .add("timeUnit", timeUnit)

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -92,15 +92,6 @@ public interface MetricsContext extends Serializable {
     default Unit unit() {
       return Unit.UNDEFINED;
     }
-
-    /**
-     * The name of the counter.
-     *
-     * @return The name of the counter.
-     */
-    default String name() {
-      return "undefined";
-    }
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
@@ -137,7 +137,6 @@ public class ScanReport {
 
   /** A serializable version of a {@link Timer} that carries its result. */
   public static class TimerResult {
-    private final String name;
     private final TimeUnit timeUnit;
     private final Duration totalDuration;
     private final long count;
@@ -147,21 +146,15 @@ public class ScanReport {
       if (Timer.NOOP.equals(timer)) {
         return null;
       }
-      return new TimerResult(timer.name(), timer.unit(), timer.totalDuration(), timer.count());
+      return new TimerResult(timer.unit(), timer.totalDuration(), timer.count());
     }
 
-    TimerResult(String name, TimeUnit timeUnit, Duration totalDuration, long count) {
-      Preconditions.checkArgument(null != name, "Invalid timer name: null");
+    TimerResult(TimeUnit timeUnit, Duration totalDuration, long count) {
       Preconditions.checkArgument(null != timeUnit, "Invalid time unit: null");
       Preconditions.checkArgument(null != totalDuration, "Invalid duration: null");
-      this.name = name;
       this.timeUnit = timeUnit;
       this.totalDuration = totalDuration;
       this.count = count;
-    }
-
-    public String name() {
-      return name;
     }
 
     public TimeUnit timeUnit() {
@@ -178,7 +171,7 @@ public class ScanReport {
 
     @Override
     public String toString() {
-      return MoreObjects.toStringHelper(name())
+      return MoreObjects.toStringHelper(TimerResult.class)
           .add("duration", totalDuration())
           .add("count", count)
           .add("timeUnit", timeUnit)
@@ -197,20 +190,18 @@ public class ScanReport {
 
       TimerResult that = (TimerResult) o;
       return count == that.count
-          && Objects.equal(name, that.name)
           && timeUnit == that.timeUnit
           && Objects.equal(totalDuration, that.totalDuration);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(name, timeUnit, totalDuration, count);
+      return Objects.hashCode(timeUnit, totalDuration, count);
     }
   }
 
   /** A serializable version of a {@link Counter} that carries its result. */
   public static class CounterResult {
-    private final String name;
     private final MetricsContext.Unit unit;
     private final long value;
 
@@ -219,19 +210,13 @@ public class ScanReport {
       if (counter.isNoop()) {
         return null;
       }
-      return new CounterResult(counter.name(), counter.unit(), counter.value());
+      return new CounterResult(counter.unit(), counter.value());
     }
 
-    CounterResult(String name, Unit unit, long value) {
-      Preconditions.checkArgument(null != name, "Invalid counter name: null");
+    CounterResult(Unit unit, long value) {
       Preconditions.checkArgument(null != unit, "Invalid counter unit: null");
-      this.name = name;
       this.unit = unit;
       this.value = value;
-    }
-
-    public String name() {
-      return name;
     }
 
     public Unit unit() {
@@ -244,7 +229,7 @@ public class ScanReport {
 
     @Override
     public String toString() {
-      return String.format("%s{%s=%s}", name(), unit().displayName(), value());
+      return String.format("{%s=%s}", unit().displayName(), value());
     }
 
     @Override
@@ -258,14 +243,12 @@ public class ScanReport {
       }
 
       CounterResult that = (CounterResult) o;
-      return Objects.equal(name, that.name)
-          && unit == that.unit
-          && Objects.equal(value, that.value);
+      return unit == that.unit && Objects.equal(value, that.value);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(name, unit, value);
+      return Objects.hashCode(unit, value);
     }
   }
 
@@ -355,15 +338,15 @@ public class ScanReport {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .addValue(totalPlanningDuration)
-          .addValue(resultDataFiles)
-          .addValue(resultDeleteFiles)
-          .addValue(scannedDataManifests)
-          .addValue(skippedDataManifests)
-          .addValue(totalDataManifests)
-          .addValue(totalDeleteManifests)
-          .addValue(totalFileSizeInBytes)
-          .addValue(totalDeleteFileSizeInBytes)
+          .add("totalPlanningDuration", totalPlanningDuration)
+          .add("resultDataFiles", resultDataFiles)
+          .add("resultDeleteFiles", resultDeleteFiles)
+          .add("totalDataManifests", totalDataManifests)
+          .add("totalDeleteManifests", totalDeleteManifests)
+          .add("scannedDataManifests", scannedDataManifests)
+          .add("skippedDataManifests", skippedDataManifests)
+          .add("totalFileSizeInBytes", totalFileSizeInBytes)
+          .add("totalDeleteFileSizeInBytes", totalDeleteFileSizeInBytes)
           .toString();
     }
 
@@ -486,15 +469,15 @@ public class ScanReport {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
-          .addValue(totalPlanningDuration)
-          .addValue(resultDataFiles)
-          .addValue(resultDeleteFiles)
-          .addValue(scannedDataManifests)
-          .addValue(skippedDataManifests)
-          .addValue(totalDataManifests)
-          .addValue(totalDeleteManifests)
-          .addValue(totalFileSizeInBytes)
-          .addValue(totalDeleteFileSizeInBytes)
+          .add("totalPlanningDuration", totalPlanningDuration)
+          .add("resultDataFiles", resultDataFiles)
+          .add("resultDeleteFiles", resultDeleteFiles)
+          .add("totalDataManifests", totalDataManifests)
+          .add("totalDeleteManifests", totalDeleteManifests)
+          .add("scannedDataManifests", scannedDataManifests)
+          .add("skippedDataManifests", skippedDataManifests)
+          .add("totalFileSizeInBytes", totalFileSizeInBytes)
+          .add("totalDeleteFileSizeInBytes", totalDeleteFileSizeInBytes)
           .toString();
     }
   }

--- a/api/src/main/java/org/apache/iceberg/metrics/Timer.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/Timer.java
@@ -52,15 +52,6 @@ public interface Timer {
   Timed start();
 
   /**
-   * The name of the timer.
-   *
-   * @return The name of the timer.
-   */
-  default String name() {
-    return "undefined";
-  }
-
-  /**
    * The {@link TimeUnit} of the timer.
    *
    * @return The {@link TimeUnit} of the timer.

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultCounter.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultCounter.java
@@ -26,17 +26,13 @@ public class TestDefaultCounter {
 
   @Test
   public void nullCheck() {
-    Assertions.assertThatThrownBy(() -> new DefaultCounter(null, MetricsContext.Unit.BYTES))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid counter name: null");
-    Assertions.assertThatThrownBy(() -> new DefaultMetricsContext().counter("name", null))
+    Assertions.assertThatThrownBy(() -> new DefaultMetricsContext().counter("test", null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid count unit: null");
   }
 
   @Test
   public void noop() {
-    Assertions.assertThat(DefaultCounter.NOOP.name()).isEqualTo("undefined");
     Assertions.assertThat(DefaultCounter.NOOP.unit()).isEqualTo(Unit.UNDEFINED);
     Assertions.assertThat(DefaultCounter.NOOP.isNoop()).isTrue();
     Assertions.assertThatThrownBy(DefaultCounter.NOOP::value)
@@ -46,18 +42,17 @@ public class TestDefaultCounter {
 
   @Test
   public void count() {
-    Counter counter = new DefaultCounter("test", Unit.BYTES);
+    Counter counter = new DefaultCounter(Unit.BYTES);
     counter.increment();
     counter.increment(5L);
     Assertions.assertThat(counter.value()).isEqualTo(6L);
-    Assertions.assertThat(counter.name()).isEqualTo("test");
     Assertions.assertThat(counter.unit()).isEqualTo(MetricsContext.Unit.BYTES);
     Assertions.assertThat(counter.isNoop()).isFalse();
   }
 
   @Test
   public void counterOverflow() {
-    Counter counter = new DefaultCounter("test", MetricsContext.Unit.COUNT);
+    Counter counter = new DefaultCounter(MetricsContext.Unit.COUNT);
     counter.increment(Long.MAX_VALUE);
     Assertions.assertThatThrownBy(counter::increment)
         .isInstanceOf(ArithmeticException.class)

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMetricsContext.java
@@ -37,11 +37,6 @@ public class TestDefaultMetricsContext {
   @Test
   public void intCounterNullCheck() {
     Assertions.assertThatThrownBy(
-            () ->
-                new DefaultMetricsContext().counter(null, Integer.class, MetricsContext.Unit.BYTES))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid counter name: null");
-    Assertions.assertThatThrownBy(
             () -> new DefaultMetricsContext().counter("name", Integer.class, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid count unit: null");
@@ -54,7 +49,6 @@ public class TestDefaultMetricsContext {
         metricsContext.counter("intCounter", Integer.class, MetricsContext.Unit.BYTES);
     counter.increment(5);
     Assertions.assertThat(counter.value()).isEqualTo(5);
-    Assertions.assertThat(counter.name()).isEqualTo("intCounter");
     Assertions.assertThat(counter.unit()).isEqualTo(MetricsContext.Unit.BYTES);
   }
 
@@ -73,10 +67,6 @@ public class TestDefaultMetricsContext {
   @Test
   public void longCounterNullCheck() {
     Assertions.assertThatThrownBy(
-            () -> new DefaultMetricsContext().counter(null, Long.class, MetricsContext.Unit.BYTES))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid counter name: null");
-    Assertions.assertThatThrownBy(
             () -> new DefaultMetricsContext().counter("name", Long.class, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid count unit: null");
@@ -89,7 +79,6 @@ public class TestDefaultMetricsContext {
         metricsContext.counter("longCounter", Long.class, MetricsContext.Unit.COUNT);
     counter.increment(5L);
     Assertions.assertThat(counter.value()).isEqualTo(5L);
-    Assertions.assertThat(counter.name()).isEqualTo("longCounter");
     Assertions.assertThat(counter.unit()).isEqualTo(MetricsContext.Unit.COUNT);
   }
 

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultTimer.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultTimer.java
@@ -38,24 +38,20 @@ public class TestDefaultTimer {
 
   @Test
   public void nullCheck() {
-    Assertions.assertThatThrownBy(() -> new DefaultTimer(null, TimeUnit.NANOSECONDS))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid timer name: null");
-    Assertions.assertThatThrownBy(() -> new DefaultTimer("name", null))
+    Assertions.assertThatThrownBy(() -> new DefaultTimer(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid time unit: null");
   }
 
   @Test
   public void nameAndUnit() {
-    DefaultTimer timer = new DefaultTimer("timerName", TimeUnit.MINUTES);
-    Assertions.assertThat(timer.name()).isEqualTo("timerName");
+    DefaultTimer timer = new DefaultTimer(TimeUnit.MINUTES);
     Assertions.assertThat(timer.unit()).isEqualTo(TimeUnit.MINUTES);
   }
 
   @Test
   public void recordNegativeAmount() {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Assertions.assertThat(timer.count()).isEqualTo(0);
     Assertions.assertThatThrownBy(() -> timer.record(-1, TimeUnit.NANOSECONDS))
         .isInstanceOf(IllegalArgumentException.class)
@@ -66,7 +62,7 @@ public class TestDefaultTimer {
 
   @Test
   public void multipleStops() {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Timer.Timed timed = timer.start();
     timed.stop();
     // we didn't start the timer again
@@ -77,7 +73,7 @@ public class TestDefaultTimer {
 
   @Test
   public void closeableTimer() throws InterruptedException {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Assertions.assertThat(timer.count()).isEqualTo(0);
     Assertions.assertThat(timer.totalDuration()).isEqualTo(Duration.ZERO);
     try (Timer.Timed sample = timer.start()) {
@@ -89,7 +85,7 @@ public class TestDefaultTimer {
 
   @Test
   public void measureRunnable() {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Runnable runnable =
         () -> {
           try {
@@ -114,7 +110,7 @@ public class TestDefaultTimer {
 
   @Test
   public void measureCallable() throws Exception {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Callable<Boolean> callable =
         () -> {
           try {
@@ -140,7 +136,7 @@ public class TestDefaultTimer {
 
   @Test
   public void measureSupplier() {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Supplier<Boolean> supplier =
         () -> {
           try {
@@ -166,8 +162,8 @@ public class TestDefaultTimer {
 
   @Test
   public void measureNestedRunnables() {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
-    Timer innerTimer = new DefaultTimer("inner", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
+    Timer innerTimer = new DefaultTimer(TimeUnit.NANOSECONDS);
     Runnable inner =
         () -> {
           try {
@@ -204,7 +200,7 @@ public class TestDefaultTimer {
 
   @Test
   public void multiThreadedStarts() throws InterruptedException {
-    Timer timer = new DefaultTimer("timer", TimeUnit.NANOSECONDS);
+    Timer timer = new DefaultTimer(TimeUnit.NANOSECONDS);
 
     int threads = 10;
     CyclicBarrier barrier = new CyclicBarrier(threads);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -155,11 +155,6 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
       public long value() {
         return supplier.getAsLong();
       }
-
-      @Override
-      public String name() {
-        return "ignored";
-      }
     };
   }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/CounterResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/CounterResultParser.java
@@ -31,7 +31,6 @@ class CounterResultParser {
   private static final String MISSING_FIELD_ERROR_MSG =
       "Cannot parse counter from '%s': Missing field '%s'";
 
-  private static final String NAME = "name";
   private static final String UNIT = "unit";
   private static final String VALUE = "value";
 
@@ -46,19 +45,9 @@ class CounterResultParser {
   }
 
   static void toJson(CounterResult counter, JsonGenerator gen) throws IOException {
-    toJson(counter, gen, true);
-  }
-
-  static void toJson(CounterResult counter, JsonGenerator gen, boolean includeName)
-      throws IOException {
     Preconditions.checkArgument(null != counter, "Invalid counter: null");
 
     gen.writeStartObject();
-    // ScanMetricsResultParser mainly uses this with includeName=false, since it includes the name
-    // in a parent structure
-    if (includeName) {
-      gen.writeStringField(NAME, counter.name());
-    }
     gen.writeStringField(UNIT, counter.unit().displayName());
     gen.writeNumberField(VALUE, counter.value());
     gen.writeEndObject();
@@ -72,10 +61,9 @@ class CounterResultParser {
     Preconditions.checkArgument(null != json, "Cannot parse counter from null object");
     Preconditions.checkArgument(json.isObject(), "Cannot parse counter from non-object: %s", json);
 
-    String name = JsonUtil.getString(NAME, json);
     String unit = JsonUtil.getString(UNIT, json);
     long value = JsonUtil.getLong(VALUE, json);
-    return new CounterResult(name, Unit.fromDisplayName(unit), value);
+    return new CounterResult(Unit.fromDisplayName(unit), value);
   }
 
   /**
@@ -100,6 +88,6 @@ class CounterResultParser {
 
     String unit = JsonUtil.getString(UNIT, counter);
     long value = JsonUtil.getLong(VALUE, counter);
-    return new CounterResult(counterName, Unit.fromDisplayName(unit), value);
+    return new CounterResult(Unit.fromDisplayName(unit), value);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
@@ -40,55 +40,51 @@ class ScanMetricsResultParser {
   static void toJson(ScanMetricsResult metrics, JsonGenerator gen) throws IOException {
     Preconditions.checkArgument(null != metrics, "Invalid scan metrics: null");
 
-    // we are including the metric name here, so tell the TimerResultParser/CounterResultParser
-    // to not include it as well
-    boolean withMetricName = false;
-
     gen.writeStartObject();
 
     if (null != metrics.totalPlanningDuration()) {
       gen.writeFieldName(ScanMetrics.TOTAL_PLANNING_DURATION);
-      TimerResultParser.toJson(metrics.totalPlanningDuration(), gen, withMetricName);
+      TimerResultParser.toJson(metrics.totalPlanningDuration(), gen);
     }
 
     if (null != metrics.resultDataFiles()) {
       gen.writeFieldName(ScanMetrics.RESULT_DATA_FILES);
-      CounterResultParser.toJson(metrics.resultDataFiles(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.resultDataFiles(), gen);
     }
 
     if (null != metrics.resultDeleteFiles()) {
       gen.writeFieldName(ScanMetrics.RESULT_DELETE_FILES);
-      CounterResultParser.toJson(metrics.resultDeleteFiles(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.resultDeleteFiles(), gen);
     }
 
     if (null != metrics.totalDataManifests()) {
       gen.writeFieldName(ScanMetrics.TOTAL_DATA_MANIFESTS);
-      CounterResultParser.toJson(metrics.totalDataManifests(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.totalDataManifests(), gen);
     }
 
     if (null != metrics.totalDeleteManifests()) {
       gen.writeFieldName(ScanMetrics.TOTAL_DELETE_MANIFESTS);
-      CounterResultParser.toJson(metrics.totalDeleteManifests(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.totalDeleteManifests(), gen);
     }
 
     if (null != metrics.scannedDataManifests()) {
       gen.writeFieldName(ScanMetrics.SCANNED_DATA_MANIFESTS);
-      CounterResultParser.toJson(metrics.scannedDataManifests(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.scannedDataManifests(), gen);
     }
 
     if (null != metrics.skippedDataManifests()) {
       gen.writeFieldName(ScanMetrics.SKIPPED_DATA_MANIFESTS);
-      CounterResultParser.toJson(metrics.skippedDataManifests(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.skippedDataManifests(), gen);
     }
 
     if (null != metrics.totalFileSizeInBytes()) {
       gen.writeFieldName(ScanMetrics.TOTAL_FILE_SIZE_IN_BYTES);
-      CounterResultParser.toJson(metrics.totalFileSizeInBytes(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.totalFileSizeInBytes(), gen);
     }
 
     if (null != metrics.totalDeleteFileSizeInBytes()) {
       gen.writeFieldName(ScanMetrics.TOTAL_DELETE_FILE_SIZE_IN_BYTES);
-      CounterResultParser.toJson(metrics.totalDeleteFileSizeInBytes(), gen, withMetricName);
+      CounterResultParser.toJson(metrics.totalDeleteFileSizeInBytes(), gen);
     }
 
     gen.writeEndObject();

--- a/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
@@ -34,7 +34,6 @@ class TimerResultParser {
   private static final String MISSING_FIELD_ERROR_MSG =
       "Cannot parse timer from '%s': Missing field '%s'";
 
-  private static final String NAME = "name";
   private static final String TIME_UNIT = "time-unit";
   private static final String COUNT = "count";
   private static final String TOTAL_DURATION = "total-duration";
@@ -50,18 +49,9 @@ class TimerResultParser {
   }
 
   static void toJson(TimerResult timer, JsonGenerator gen) throws IOException {
-    toJson(timer, gen, true);
-  }
-
-  static void toJson(TimerResult timer, JsonGenerator gen, boolean includeName) throws IOException {
     Preconditions.checkArgument(null != timer, "Invalid timer: null");
 
     gen.writeStartObject();
-    // ScanMetricsResultParser mainly uses this with includeName=false, since it includes the name
-    // in a parent structure
-    if (includeName) {
-      gen.writeStringField(NAME, timer.name());
-    }
     gen.writeNumberField(COUNT, timer.count());
     gen.writeStringField(TIME_UNIT, timer.timeUnit().name().toLowerCase(Locale.ROOT));
     gen.writeNumberField(TOTAL_DURATION, fromDuration(timer.totalDuration(), timer.timeUnit()));
@@ -76,11 +66,10 @@ class TimerResultParser {
     Preconditions.checkArgument(null != json, "Cannot parse timer from null object");
     Preconditions.checkArgument(json.isObject(), "Cannot parse timer from non-object: %s", json);
 
-    String name = JsonUtil.getString(NAME, json);
     long count = JsonUtil.getLong(COUNT, json);
     TimeUnit unit = TimeUnit.valueOf(JsonUtil.getString(TIME_UNIT, json).toUpperCase(Locale.ROOT));
     long duration = JsonUtil.getLong(TOTAL_DURATION, json);
-    return new TimerResult(name, unit, toDuration(duration, unit), count);
+    return new TimerResult(unit, toDuration(duration, unit), count);
   }
 
   /**
@@ -109,7 +98,7 @@ class TimerResultParser {
     long count = JsonUtil.getLong(COUNT, timer);
     TimeUnit unit = TimeUnit.valueOf(JsonUtil.getString(TIME_UNIT, timer).toUpperCase(Locale.ROOT));
     long duration = JsonUtil.getLong(TOTAL_DURATION, timer);
-    return new TimerResult(timerName, unit, toDuration(duration, unit), count);
+    return new TimerResult(unit, toDuration(duration, unit), count);
   }
 
   @VisibleForTesting

--- a/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
@@ -47,19 +47,14 @@ public class TestScanMetricsResultParser {
     Assertions.assertThat(ScanMetricsResultParser.fromJson("{}"))
         .isEqualTo(new ScanMetricsResult(null, null, null, null, null, null, null, null, null));
 
-    TimerResult totalPlanningDuration =
-        new TimerResult("total-planning-duration", TimeUnit.HOURS, Duration.ofHours(10), 3L);
-    CounterResult resultDataFiles = new CounterResult("result-data-files", Unit.COUNT, 5L);
-    CounterResult resultDeleteFiles = new CounterResult("result-delete-files", Unit.COUNT, 5L);
-    CounterResult totalDataManifests = new CounterResult("total-data-manifests", Unit.COUNT, 5L);
-    CounterResult totalDeleteManifests =
-        new CounterResult("total-delete-manifests", Unit.COUNT, 0L);
-    CounterResult scannedDataManifests =
-        new CounterResult("scanned-data-manifests", Unit.COUNT, 5L);
-    CounterResult skippedDataManifests =
-        new CounterResult("skipped-data-manifests", Unit.COUNT, 5L);
-    CounterResult totalFileSizeInBytes =
-        new CounterResult("total-file-size-in-bytes", Unit.BYTES, 1069L);
+    TimerResult totalPlanningDuration = new TimerResult(TimeUnit.HOURS, Duration.ofHours(10), 3L);
+    CounterResult resultDataFiles = new CounterResult(Unit.COUNT, 5L);
+    CounterResult resultDeleteFiles = new CounterResult(Unit.COUNT, 5L);
+    CounterResult totalDataManifests = new CounterResult(Unit.COUNT, 5L);
+    CounterResult totalDeleteManifests = new CounterResult(Unit.COUNT, 0L);
+    CounterResult scannedDataManifests = new CounterResult(Unit.COUNT, 5L);
+    CounterResult skippedDataManifests = new CounterResult(Unit.COUNT, 5L);
+    CounterResult totalFileSizeInBytes = new CounterResult(Unit.BYTES, 1069L);
 
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(

--- a/core/src/test/java/org/apache/iceberg/metrics/TestTimerResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestTimerResultParser.java
@@ -43,21 +43,14 @@ public class TestTimerResultParser {
   public void missingFields() {
     Assertions.assertThatThrownBy(() -> TimerResultParser.fromJson("{}"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing string: name");
-
-    Assertions.assertThatThrownBy(() -> TimerResultParser.fromJson("{\"name\":\"timer-example\"}"))
-        .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing long: count");
 
-    Assertions.assertThatThrownBy(
-            () -> TimerResultParser.fromJson("{\"name\":\"timer-example\",\"count\":44}"))
+    Assertions.assertThatThrownBy(() -> TimerResultParser.fromJson("{\"count\":44}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing string: time-unit");
 
     Assertions.assertThatThrownBy(
-            () ->
-                TimerResultParser.fromJson(
-                    "{\"name\":\"timer-example\",\"count\":44,\"time-unit\":\"hours\"}"))
+            () -> TimerResultParser.fromJson("{\"count\":44,\"time-unit\":\"hours\"}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse missing long: total-duration");
   }
@@ -66,8 +59,8 @@ public class TestTimerResultParser {
   public void extraFields() {
     Assertions.assertThat(
             TimerResultParser.fromJson(
-                "{\"name\":\"timer-example\",\"count\":44,\"time-unit\":\"hours\",\"total-duration\":24,\"extra\": \"value\"}"))
-        .isEqualTo(new TimerResult("timer-example", TimeUnit.HOURS, Duration.ofHours(24), 44));
+                "{\"count\":44,\"time-unit\":\"hours\",\"total-duration\":24,\"extra\": \"value\"}"))
+        .isEqualTo(new TimerResult(TimeUnit.HOURS, Duration.ofHours(24), 44));
   }
 
   @Test
@@ -75,7 +68,7 @@ public class TestTimerResultParser {
     Assertions.assertThatThrownBy(
             () ->
                 TimerResultParser.fromJson(
-                    "{\"name\":\"timer-example\",\"count\":44,\"time-unit\":\"hours\",\"total-duration\":\"xx\"}"))
+                    "{\"count\":44,\"time-unit\":\"hours\",\"total-duration\":\"xx\"}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a long value: total-duration: \"xx\"");
   }
@@ -85,7 +78,7 @@ public class TestTimerResultParser {
     Assertions.assertThatThrownBy(
             () ->
                 TimerResultParser.fromJson(
-                    "{\"name\":\"timer-example\",\"count\":44,\"time-unit\":\"unknown\",\"total-duration\":24}"))
+                    "{\"count\":44,\"time-unit\":\"unknown\",\"total-duration\":24}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("No enum constant java.util.concurrent.TimeUnit.UNKNOWN");
   }
@@ -95,35 +88,19 @@ public class TestTimerResultParser {
     Assertions.assertThatThrownBy(
             () ->
                 TimerResultParser.fromJson(
-                    "{\"name\":\"timer-example\",\"count\":\"illegal\",\"time-unit\":\"hours\",\"total-duration\":24}"))
+                    "{\"count\":\"illegal\",\"time-unit\":\"hours\",\"total-duration\":24}"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot parse to a long value: count: \"illegal\"");
   }
 
   @Test
-  public void invalidName() {
-    Assertions.assertThatThrownBy(
-            () ->
-                TimerResultParser.fromJson(
-                    "{\"name\":23,\"count\":44,\"time-unit\":\"hours\",\"total-duration\":24}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse to a string value: name: 23");
-  }
-
-  @Test
   public void roundTripSerde() {
-    TimerResult timer = new TimerResult("timer-example", TimeUnit.HOURS, Duration.ofHours(23), 44);
-    String expectedJson =
-        "{\n"
-            + "  \"name\" : \"timer-example\",\n"
-            + "  \"count\" : 44,\n"
-            + "  \"time-unit\" : \"hours\",\n"
-            + "  \"total-duration\" : 23\n"
-            + "}";
+    TimerResult timer = new TimerResult(TimeUnit.HOURS, Duration.ofHours(23), 44);
 
-    String json = TimerResultParser.toJson(timer, true);
+    String json = TimerResultParser.toJson(timer);
     Assertions.assertThat(TimerResultParser.fromJson(json)).isEqualTo(timer);
-    Assertions.assertThat(json).isEqualTo(expectedJson);
+    Assertions.assertThat(json)
+        .isEqualTo("{\"count\":44,\"time-unit\":\"hours\",\"total-duration\":23}");
   }
 
   @Test


### PR DESCRIPTION
`name()` was added to the Counter/Timer API in order to make their
results serializable. In #5427 we realized that we don't necessarily
need to track the name of a particular metric in order to serialize
counter/timer results, thus we're simplifying the Counter/Timer API by
removing `name()`.

Looking at other metric frameworks, they don't track the name of a
metric within the counter/timer itself, but rather in the metric
registry.

In our case this metric registry would be `DefaultMetricsContext` or any
other subclass that implements `MetricsContext`, so tracking the name of
a metric should be the responsibility of this registry rather than the
actual metric itself.