### PR TITLE
[Flink] Avoid submitting too many empty snapshots

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -138,7 +138,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     maxContinuousEmptyCommits =
         PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
     Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();
@@ -236,7 +236,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
             .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length)
             .sum();
     continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
-    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+    if (totalFiles != 0
+        || (maxContinuousEmptyCommits != 0
+            && continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0)) {
       if (replacePartitions) {
         replacePartitions(pendingResults, newFlinkJobId, checkpointId);
       } else {

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -138,7 +138,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     maxContinuousEmptyCommits =
         PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
     Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
+        maxContinuousEmptyCommits >= 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -172,17 +172,17 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     table.updateProperties().set(MAX_CONTINUOUS_EMPTY_COMMITS, "0").commit();
 
     JobID jobId = new JobID();
-    long checkpointId = 0;
-    long timestamp = 0;
+    long checkpointId = 1;
+    long timestamp = 1;
     try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
       assertSnapshotSize(0);
 
-      for (int i = 1; i <= 9; i++) {
+      for (int i = 1; i <= 9; i++, checkpointId++, timestamp++) {
         harness.processElement(new StreamRecord<>(WriteResult.builder().build()));
-        harness.snapshot(++checkpointId, ++timestamp);
+        harness.snapshot(checkpointId, timestamp);
         harness.notifyOfCompletedCheckpoint(checkpointId);
 
         assertSnapshotSize(0);

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -40,6 +40,7 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.hadoop.conf.Configuration;
@@ -162,6 +163,29 @@ public class TestIcebergFilesCommitter extends TableTestBase {
         harness.notifyOfCompletedCheckpoint(checkpointId);
 
         assertSnapshotSize(i / 3);
+      }
+    }
+  }
+
+  @Test
+  public void testNoneEmptyCommits() throws Exception {
+    table.updateProperties().set(MAX_CONTINUOUS_EMPTY_COMMITS, "0").commit();
+
+    JobID jobId = new JobID();
+    long checkpointId = 0;
+    long timestamp = 0;
+    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+      harness.setup();
+      harness.open();
+
+      assertSnapshotSize(0);
+
+      for (int i = 1; i <= 9; i++) {
+        harness.processElement(new StreamRecord<>(WriteResult.builder().build()));
+        harness.snapshot(++checkpointId, ++timestamp);
+        harness.notifyOfCompletedCheckpoint(checkpointId);
+
+        assertSnapshotSize(0);
       }
     }
   }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -150,7 +150,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     maxContinuousEmptyCommits =
         PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
     Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+        maxContinuousEmptyCommits >= 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();
@@ -250,7 +250,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
             .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length)
             .sum();
     continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
-    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+    if (totalFiles != 0
+        || (maxContinuousEmptyCommits != 0
+            && continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0)) {
       if (replacePartitions) {
         replacePartitions(pendingResults, newFlinkJobId, checkpointId);
       } else {

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.hadoop.conf.Configuration;
@@ -164,6 +165,29 @@ public class TestIcebergFilesCommitter extends TableTestBase {
         harness.notifyOfCompletedCheckpoint(checkpointId);
 
         assertSnapshotSize(i / 3);
+      }
+    }
+  }
+
+  @Test
+  public void testNoneEmptyCommits() throws Exception {
+    table.updateProperties().set(MAX_CONTINUOUS_EMPTY_COMMITS, "0").commit();
+
+    JobID jobId = new JobID();
+    long checkpointId = 0;
+    long timestamp = 0;
+    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+      harness.setup();
+      harness.open();
+
+      assertSnapshotSize(0);
+
+      for (int i = 1; i <= 9; i++) {
+        harness.processElement(new StreamRecord<>(WriteResult.builder().build()));
+        harness.snapshot(++checkpointId, ++timestamp);
+        harness.notifyOfCompletedCheckpoint(checkpointId);
+
+        assertSnapshotSize(0);
       }
     }
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -174,17 +174,17 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     table.updateProperties().set(MAX_CONTINUOUS_EMPTY_COMMITS, "0").commit();
 
     JobID jobId = new JobID();
-    long checkpointId = 0;
-    long timestamp = 0;
+    long checkpointId = 1;
+    long timestamp = 1;
     try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
       assertSnapshotSize(0);
 
-      for (int i = 1; i <= 9; i++) {
+      for (int i = 1; i <= 9; i++, checkpointId++, timestamp++) {
         harness.processElement(new StreamRecord<>(WriteResult.builder().build()));
-        harness.snapshot(++checkpointId, ++timestamp);
+        harness.snapshot(checkpointId, timestamp);
         harness.notifyOfCompletedCheckpoint(checkpointId);
 
         assertSnapshotSize(0);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -150,7 +150,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     maxContinuousEmptyCommits =
         PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
     Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
+        maxContinuousEmptyCommits >= 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -150,7 +150,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     maxContinuousEmptyCommits =
         PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
     Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must not be negative");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
     int attemptId = getRuntimeContext().getAttemptNumber();
@@ -250,7 +250,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
             .mapToInt(r -> r.dataFiles().length + r.deleteFiles().length)
             .sum();
     continuousEmptyCheckpoints = totalFiles == 0 ? continuousEmptyCheckpoints + 1 : 0;
-    if (totalFiles != 0 || continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0) {
+    if (totalFiles != 0
+        || (maxContinuousEmptyCommits != 0
+            && continuousEmptyCheckpoints % maxContinuousEmptyCommits == 0)) {
       if (replacePartitions) {
         replacePartitions(pendingResults, newFlinkJobId, checkpointId);
       } else {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -171,17 +171,17 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     table.updateProperties().set(MAX_CONTINUOUS_EMPTY_COMMITS, "0").commit();
 
     JobID jobId = new JobID();
-    long checkpointId = 0;
-    long timestamp = 0;
+    long checkpointId = 1;
+    long timestamp = 1;
     try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
       assertSnapshotSize(0);
 
-      for (int i = 1; i <= 9; i++) {
+      for (int i = 1; i <= 9; i++, checkpointId++, timestamp++) {
         harness.processElement(new StreamRecord<>(WriteResult.builder().build()));
-        harness.snapshot(++checkpointId, ++timestamp);
+        harness.snapshot(checkpointId, timestamp);
         harness.notifyOfCompletedCheckpoint(checkpointId);
 
         assertSnapshotSize(0);


### PR DESCRIPTION
fix https://github.com/apache/iceberg/issues/5560

**The brief change log:**
- Modified the Flink1.13, Flink1.14 and Flink1.15 `IcebergStreamWriter.emit(WriteResult result)` method;
- Modified the Iceberg-core `WriteResult` and added a new method `isEmpty()`;