### PR TITLE
Python: Implement proper `__repr__` for Summary and Operation

### DIFF
--- a/python/pyiceberg/table/snapshots.py
+++ b/python/pyiceberg/table/snapshots.py
@@ -39,6 +39,9 @@ class Operation(Enum):
     OVERWRITE = "overwrite"
     DELETE = "delete"
 
+    def __repr__(self) -> str:
+        return f"Operation.{self.name}"
+
 
 class Summary(IcebergBaseModel):
     """
@@ -78,6 +81,10 @@ class Summary(IcebergBaseModel):
     @property
     def additional_properties(self) -> Dict[str, str]:
         return self._additional_properties
+
+    def __repr__(self) -> str:
+        repr_properties = f", **{repr(self._additional_properties)}" if self._additional_properties else ""
+        return f"Summary({repr(self.operation)}{repr_properties})"
 
 
 class Snapshot(IcebergBaseModel):

--- a/python/tests/table/test_snapshots.py
+++ b/python/tests/table/test_snapshots.py
@@ -14,7 +14,36 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint:disable=redefined-outer-name,eval-used
+import pytest
+
 from pyiceberg.table.snapshots import Operation, Snapshot, Summary
+
+
+@pytest.fixture
+def snapshot() -> Snapshot:
+    return Snapshot(
+        snapshot_id=25,
+        parent_snapshot_id=19,
+        sequence_number=200,
+        timestamp_ms=1602638573590,
+        manifest_list="s3:/a/b/c.avro",
+        summary=Summary(Operation.APPEND),
+        schema_id=3,
+    )
+
+
+@pytest.fixture
+def snapshot_with_properties() -> Snapshot:
+    return Snapshot(
+        snapshot_id=25,
+        parent_snapshot_id=19,
+        sequence_number=200,
+        timestamp_ms=1602638573590,
+        manifest_list="s3:/a/b/c.avro",
+        summary=Summary(Operation.APPEND, foo="bar"),
+        schema_id=3,
+    )
 
 
 def test_serialize_summary():
@@ -25,17 +54,7 @@ def test_serialize_summary_with_properties():
     assert Summary(Operation.APPEND, property="yes").json() == """{"operation": "append", "property": "yes"}"""
 
 
-def test_serialize_snapshot():
-    snapshot = Snapshot(
-        snapshot_id=25,
-        parent_snapshot_id=19,
-        sequence_number=200,
-        timestamp_ms=1602638573590,
-        manifest_list="s3:/a/b/c.avro",
-        summary=Summary(Operation.APPEND),
-        schema_id=3,
-    )
-
+def test_serialize_snapshot(snapshot: Snapshot):
     assert (
         snapshot.json()
         == """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append"}, "schema-id": 3}"""
@@ -51,26 +70,15 @@ def test_serialize_snapshot_without_sequence_number():
         summary=Summary(Operation.APPEND),
         schema_id=3,
     )
-
     actual = snapshot.json()
     expected = """{"snapshot-id": 25, "parent-snapshot-id": 19, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append"}, "schema-id": 3}"""
     assert actual == expected
 
 
-def test_serialize_snapshot_with_properties():
-    snapshot = Snapshot(
-        snapshot_id=25,
-        parent_snapshot_id=19,
-        sequence_number=200,
-        timestamp_ms=1602638573590,
-        manifest_list="s3:/a/b/c.avro",
-        summary=Summary(Operation.APPEND, property="yes"),
-        schema_id=3,
-    )
-
+def test_serialize_snapshot_with_properties(snapshot_with_properties: Snapshot):
     assert (
-        snapshot.json()
-        == """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append", "property": "yes"}, "schema-id": 3}"""
+        snapshot_with_properties.json()
+        == """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append", "foo": "bar"}, "schema-id": 3}"""
     )
 
 
@@ -85,29 +93,29 @@ def test_deserialize_summary_with_properties():
     assert summary.additional_properties == {"property": "yes"}
 
 
-def test_deserialize_snapshot():
+def test_deserialize_snapshot(snapshot: Snapshot):
     payload = """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append"}, "schema-id": 3}"""
-    snapshot = Snapshot.parse_raw(payload)
-    assert snapshot == Snapshot(
-        snapshot_id=25,
-        parent_snapshot_id=19,
-        sequence_number=200,
-        timestamp_ms=1602638573590,
-        manifest_list="s3:/a/b/c.avro",
-        summary=Summary(Operation.APPEND),
-        schema_id=3,
-    )
+    actual = Snapshot.parse_raw(payload)
+    assert actual == snapshot
 
 
-def test_deserialize_snapshot_with_properties():
-    payload = """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append", "property": "yes"}, "schema-id": 3}"""
+def test_deserialize_snapshot_with_properties(snapshot_with_properties: Snapshot):
+    payload = """{"snapshot-id": 25, "parent-snapshot-id": 19, "sequence-number": 200, "timestamp-ms": 1602638573590, "manifest-list": "s3:/a/b/c.avro", "summary": {"operation": "append", "foo": "bar"}, "schema-id": 3}"""
     snapshot = Snapshot.parse_raw(payload)
-    assert snapshot == Snapshot(
-        snapshot_id=25,
-        parent_snapshot_id=19,
-        sequence_number=200,
-        timestamp_ms=1602638573590,
-        manifest_list="s3:/a/b/c.avro",
-        summary=Summary(Operation.APPEND, property="yes"),
-        schema_id=3,
+    assert snapshot == snapshot_with_properties
+
+
+def test_snapshot_repr(snapshot: Snapshot):
+    assert (
+        repr(snapshot)
+        == """Snapshot(snapshot_id=25, parent_snapshot_id=19, sequence_number=200, timestamp_ms=1602638573590, manifest_list='s3:/a/b/c.avro', summary=Summary(Operation.APPEND), schema_id=3)"""
     )
+    assert snapshot == eval(repr(snapshot))
+
+
+def test_snapshot_with_properties_repr(snapshot_with_properties: Snapshot):
+    assert (
+        repr(snapshot_with_properties)
+        == """Snapshot(snapshot_id=25, parent_snapshot_id=19, sequence_number=200, timestamp_ms=1602638573590, manifest_list='s3:/a/b/c.avro', summary=Summary(Operation.APPEND, **{'foo': 'bar'}), schema_id=3)"""
+    )
+    assert snapshot_with_properties == eval(repr(snapshot_with_properties))


### PR DESCRIPTION
It would look like:
```python
Snapshot(
  snapshot_id=25,
  parent_snapshot_id=19,
  sequence_number=200,
  timestamp_ms=1602638573590,
  manifest_list='s3:/a/b/c.avro',
  summary=Summary(
    __root__={'operation': <Operation.APPEND: 'append'>, 'property': 'yes'}
  ),
  schema_id=3
)
```

Which is not valid Python. I also moved the Snapshot in the test to a fixture.