### PR TITLE
Core: Commit empty op in CatalogHandlers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -339,10 +339,6 @@ public class CatalogHandlers {
                 request.updates().forEach(update -> update.applyTo(metadataBuilder));
 
                 TableMetadata updated = metadataBuilder.build();
-                if (updated.changes().isEmpty()) {
-                  // do not commit if the metadata has not changed
-                  return;
-                }
 
                 // commit
                 taskOps.commit(base, updated);


### PR DESCRIPTION
This is related to #5536 and it probably makes sense to let
`TableOperations` detect that metadata hasn't changed rather than not
calling commit on the operation itself.