### PR TITLE
Core: Make a shorthand for the rest catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -61,8 +61,11 @@ public class CatalogUtil {
 
   public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
   public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
-  public static final String ICEBERG_CATALOG_HIVE = "org.apache.iceberg.hive.HiveCatalog";
+  public static final String ICEBERG_CATALOG_TYPE_REST = "rest";
+
   public static final String ICEBERG_CATALOG_HADOOP = "org.apache.iceberg.hadoop.HadoopCatalog";
+  public static final String ICEBERG_CATALOG_HIVE = "org.apache.iceberg.hive.HiveCatalog";
+  public static final String ICEBERG_CATALOG_REST = "org.apache.iceberg.rest.RESTCatalog";
 
   private CatalogUtil() {}
 
@@ -237,6 +240,9 @@ public class CatalogUtil {
           break;
         case ICEBERG_CATALOG_TYPE_HADOOP:
           catalogImpl = ICEBERG_CATALOG_HADOOP;
+          break;
+        case ICEBERG_CATALOG_TYPE_REST:
+          catalogImpl = ICEBERG_CATALOG_REST;
           break;
         default:
           throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);


### PR DESCRIPTION
I don't want to memorize the full classpath to the RESTCatalog, but now I already do. Let's make it easier for others in the future.