### PR TITLE
API: Extend FileIO in optional interfaces

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
+++ b/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
@@ -26,7 +26,7 @@ package org.apache.iceberg.io;
  * the configured credential as a string, and use the credential for file access via other IO
  * libraries.
  */
-public interface CredentialSupplier {
+public interface CredentialSupplier extends FileIO {
   /** Returns the credential string */
   String getCredential();
 }

--- a/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
+++ b/api/src/main/java/org/apache/iceberg/io/CredentialSupplier.java
@@ -26,7 +26,7 @@ package org.apache.iceberg.io;
  * the configured credential as a string, and use the credential for file access via other IO
  * libraries.
  */
-public interface CredentialSupplier extends FileIO {
+public interface CredentialSupplier {
   /** Returns the credential string */
   String getCredential();
 }

--- a/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.io;
 
-public interface SupportsBulkOperations {
+public interface SupportsBulkOperations extends FileIO {
   /**
    * Delete the files at the given paths.
    *

--- a/api/src/main/java/org/apache/iceberg/io/SupportsPrefixOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsPrefixOperations.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.io;
  * This interface is intended as an extension for FileIO implementations to provide additional
  * prefix based operations that may be useful in performing supporting operations.
  */
-public interface SupportsPrefixOperations {
+public interface SupportsPrefixOperations extends FileIO {
 
   /**
    * Return an iterable of all files under a prefix.


### PR DESCRIPTION
This PR extends `FileIO` in its optional interfaces. This way, we we can access all methods available in `FileIO` if we have a reference to the optional interface. Otherwise, we have to cast back.