### PR TITLE
Spark 3.3: Spark SQL Extensions for query snapshot ref metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -28,6 +28,7 @@ public enum MetadataTableType {
   HISTORY,
   METADATA_LOG_ENTRIES,
   SNAPSHOTS,
+  REFS,
   MANIFESTS,
   PARTITIONS,
   ALL_DATA_FILES,

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -62,6 +62,8 @@ public class MetadataTableUtils {
         return new SnapshotsTable(ops, baseTable, metadataTableName);
       case METADATA_LOG_ENTRIES:
         return new MetadataLogEntriesTable(ops, baseTable, metadataTableName);
+      case REFS:
+        return new RefsTable(ops, baseTable, metadataTableName);
       case MANIFESTS:
         return new ManifestsTable(ops, baseTable, metadataTableName);
       case PARTITIONS:

--- a/core/src/main/java/org/apache/iceberg/RefsTable.java
+++ b/core/src/main/java/org/apache/iceberg/RefsTable.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
+
+/**
+ * A {@link Table} implementation that exposes a table's known reference(branch or tag) as rows.
+ * <p>
+ * This does not include snapshots that have been expired using {@link ExpireSnapshots}.
+ */
+public class RefsTable extends BaseMetadataTable {
+  private static final Schema SNAPSHOT_SCHEMA = new Schema(
+      Types.NestedField.required(1, "reference", Types.StringType.get()),
+      Types.NestedField.required(2, "type", Types.StringType.get()),
+      Types.NestedField.optional(3, "snapshot_id", Types.LongType.get()),
+      Types.NestedField.optional(4, "max_ref_age_ms", Types.LongType.get()),
+      Types.NestedField.optional(5, "min_snapshots_to_keep", Types.IntegerType.get()),
+      Types.NestedField.optional(6, "max_snapshot_age_ms", Types.LongType.get())
+  );
+
+  RefsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".refs");
+  }
+
+  RefsTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new RefsTableScan(operations(), table());
+  }
+
+  @Override
+  public Schema schema() {
+    return SNAPSHOT_SCHEMA;
+  }
+
+  private DataTask task(BaseTableScan scan) {
+    TableOperations ops = operations();
+    return StaticDataTask.of(
+        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        schema(), scan.schema(), ops.current().refs().entrySet(),
+        RefsTable::snapshotRefToRow
+    );
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.REFS;
+  }
+
+  private class RefsTableScan extends StaticTableScan {
+    RefsTableScan(TableOperations ops, Table table) {
+      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.REFS, RefsTable.this::task);
+    }
+
+    RefsTableScan(TableOperations ops, Table table, TableScanContext context) {
+      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.REFS, RefsTable.this::task, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new RefsTableScan(ops, table, context);
+    }
+
+    @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots
+      return CloseableIterable.withNoopClose(RefsTable.this.task(this));
+    }
+  }
+
+  private static StaticDataTask.Row snapshotRefToRow(Map.Entry<String, SnapshotRef> refEntry) {
+    SnapshotRef snapshotRef = refEntry.getValue();
+    return StaticDataTask.Row.of(
+        refEntry.getKey(),
+        snapshotRef.type().name(),
+        snapshotRef.snapshotId(),
+        snapshotRef.maxRefAgeMs(),
+        snapshotRef.minSnapshotsToKeep(),
+        snapshotRef.maxSnapshotAgeMs()
+    );
+  }
+}

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotRefSQL.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class TestSnapshotRefSQL extends SparkExtensionsTestBase {
+  public TestSnapshotRefSQL(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @Test
+  public void testQueryRefsMetadata() throws NoSuchTableException {
+    Table table = createDefaultTableAndInsert2Row();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    String branchName = "b1";
+    Integer minSnapshotsToKeep = 2;
+    long maxSnapshotAge = 2L;
+    long maxRefAge = 10L;
+    sql(
+        "ALTER TABLE %s CREATE BRANCH %s AS OF VERSION %d WITH SNAPSHOT RETENTION %d SNAPSHOTS %d DAYS RETAIN %d DAYS",
+        tableName,
+        branchName,
+        snapshotId,
+        minSnapshotsToKeep,
+        maxSnapshotAge,
+        maxRefAge);
+    table.refresh();
+
+    String tagName = "t1";
+    sql(
+        "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN FOR %d DAYS",
+        tableName, tagName, snapshotId, maxRefAge);
+    table.refresh();
+    // check all result
+    List<Object[]> list = sql("select * from %s.refs", tableName);
+    Assert.assertEquals("we should be able to find three values: main, b1, and t1", 3, list.size());
+    // check branch b1 result
+    List<Object[]> branchRows = sql("select * from %s.refs where reference='%s'", tableName, branchName);
+    Assert.assertEquals(1, branchRows.size());
+    Assert.assertEquals("BRANCH", branchRows.get(0)[1].toString());
+    Assert.assertEquals(
+        snapshotId,
+        Long.parseLong(branchRows.get(0)[2].toString()));
+    Assert.assertEquals(
+        maxRefAge * 24 * 60 * 60 * 1000,
+        Long.parseLong((branchRows.get(0)[3].toString())));
+    Assert.assertEquals(
+        minSnapshotsToKeep.intValue(),
+        Integer.parseInt(branchRows.get(0)[4].toString()));
+    Assert.assertEquals(
+        maxSnapshotAge * 24 * 60 * 60 * 1000,
+        Long.parseLong((branchRows.get(0)[5].toString())));
+    // check tag t1 result
+    List<Object[]> tagRows = sql("select * from %s.refs where type='%s'", tableName, "TAG");
+    Assert.assertEquals(1, tagRows.size());
+    Assert.assertEquals("t1", tagRows.get(0)[0].toString());
+    Assert.assertEquals(snapshotId, Long.parseLong((tagRows.get(0)[2].toString())));
+    Assert.assertEquals(
+        maxRefAge * 24 * 60 * 60 * 1000,
+        Long.parseLong((tagRows.get(0)[3].toString())));
+    // query with snapshot_id
+    List<Object[]> rows3 = sql("select * from %s.refs where snapshot_id=%d", tableName, snapshotId);
+    Assert.assertEquals(3, rows3.size());
+    // query with all condition
+    List<Object[]> rows1 = sql("select * from %s.refs where snapshot_id=%d and max_ref_age_ms=%d and " +
+            "min_snapshots_to_keep=%d and max_snapshot_age_ms=%d", tableName,
+        snapshotId, maxRefAge * 24 * 60 * 60 * 1000, minSnapshotsToKeep, maxSnapshotAge * 24 * 60 * 60 * 1000);
+    Assert.assertEquals(1, rows1.size());
+    // query with null
+    List<Object[]> main1 = sql("select * from %s.refs where max_ref_age_ms is null", tableName);
+    Assert.assertEquals(1, main1.size());
+    // query with error Type
+    List<Object[]> error1 = sql("select * from %s.refs where type='%s'", tableName, "TAG1");
+    Assert.assertEquals(0, error1.size());
+    // query with error field
+    AssertHelpers.assertThrows(
+        "Cannot use unknown column",
+        AnalysisException.class,
+        () -> sql("select * from %s.refs where type1='%s'", tableName, "TAG"));
+  }
+
+  private Table createDefaultTableAndInsert2Row() throws NoSuchTableException {
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+
+    List<SimpleRecord> records = ImmutableList.of(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b")
+    );
+    Dataset<Row> df = spark.createDataFrame(records, SimpleRecord.class);
+    df.writeTo(tableName).append();
+    Table table = validationCatalog.loadTable(tableIdent);
+    return table;
+  }
+}


### PR DESCRIPTION
Co-authored-by: chidayong <cdy18705@163.com>

## What is the purpose of the change
Displaying Branches and Tags

Branches and tags should be able to be queried via Iceberg Metadata Tables. For querying information about refs, syntax like the following could be used:

```sql
SELECT * FROM prod.db.table.refs;
```

The output would look like the following:

Assume the following exist: branch1 at 100, branch2 at 200,
historical_snapshot at 300

```sql
SELECT * FROM prod.db.table.refs;
```

Reference | Type | Snapshot ID | Max Ref Age MS | Min Snapshots To Keep | Max Snapshot Age
-- | -- | -- | -- | -- | --
branch1 | BRANCH | 100 | 9.223e+18 | 10 | 604800000
branch2 | BRANCH | 200 | 9.223e+18 | 15 | 604800000
historical_snapshot | TAG | 300 | 9.223e+18 | NULL | NULL

