### PR TITLE
Python: Remove copy_on_shallow

### DIFF
--- a/python/pyiceberg/utils/iceberg_base_model.py
+++ b/python/pyiceberg/utils/iceberg_base_model.py
@@ -37,7 +37,6 @@ class IcebergBaseModel(BaseModel):
     class Config:
         keep_untouched = (cached_property,)
         allow_population_by_field_name = True
-        copy_on_model_validation = False
         frozen = True
 
     def dict(self, exclude_none: bool = True, **kwargs):


### PR DESCRIPTION
A breaking change has been reverted:
https://github.com/pydantic/pydantic/releases/tag/v1.9.2

This means that it is now a str instead of a bool.
It defaults to shallow, which is fine for us.

```
tests/catalog/test_base.py::test_rename_table
  /Users/fokkodriesprong/Desktop/iceberg/python/tests/catalog/test_base.py:117: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
    self.__tables[to_identifier] = Table(

tests/catalog/test_hive.py::test_create_table
tests/catalog/test_hive.py::test_create_table
tests/catalog/test_hive.py::test_create_table
  /Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/catalog/hive.py:308: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
    metadata = TableMetadataV2(

tests/catalog/test_hive.py: 16 warnings
  /Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/catalog/hive.py:258: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
    return Table(identifier=(table.dbName, table.tableName), metadata=metadata, metadata_location=metadata_location)

tests/catalog/test_hive.py::test_create_table
tests/catalog/test_hive.py::test_create_table
tests/catalog/test_hive.py::test_create_table
  /Users/fokkodriesprong/Desktop/iceberg/python/tests/catalog/test_hive.py:261: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
    assert metadata == TableMetadataV2(

tests/catalog/test_hive.py: 1 warning
tests/catalog/test_rest.py: 2 warnings
tests/table/test_metadata.py: 1 warning
tests/table/test_partitioning.py: 9 warnings
  /Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/table/partitioning.py:96: DeprecationWarning: `copy_on_model_validation` should be a string: 'deep', 'shallow' or 'none'
    super().__init__(**data)
```