### PR TITLE
Python: Fix CLI after properties refactor

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -133,23 +133,6 @@ class Catalog(ABC):
         self.name = name
         self.properties = properties
 
-    def property(self, key: str) -> str:
-        """Returns a property from the properties variable. If it doesn't exist, it will raise an error.
-
-        Args:
-            key: The key of the property
-
-        Returns: The value of the property
-
-        Raises:
-            ValueError: When the property cannot be found, with a pointer on how to set the property.
-        """
-        if key not in self.properties:
-            raise ValueError(
-                f"{type(self).__name__} expects an {key} property. Please set in config or using environment variable PYICEBERG_CATALOG__{self.name.upper()}__{key.upper()}"
-            )
-        return self.properties[key]
-
     @abstractmethod
     def create_table(
         self,

--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -237,7 +237,7 @@ class HiveCatalog(Catalog):
 
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
-        self._client = _HiveClient(self.property("uri"))
+        self._client = _HiveClient(properties["uri"])
 
     def _convert_hive_into_iceberg(self, table: HiveTable, io: FileIO) -> Table:
         properties: Dict[str, str] = table.parameters

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -424,12 +424,12 @@ class RestCatalog(Catalog):
             ),
             headers=self.headers,
         )
-        namespaces = ListNamespaceResponse(**response.json())
         try:
             response.raise_for_status()
         except HTTPError as exc:
             self._handle_non_200_response(exc, {})
 
+        namespaces = ListNamespaceResponse(**response.json())
         return [namespace_tuple + child_namespace for child_namespace in namespaces.namespaces]
 
     def load_namespace_properties(self, namespace: Union[str, Identifier]) -> Properties:

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -179,10 +179,9 @@ class RestCatalog(Catalog):
             name: Name to identify the catalog
             properties: Properties that are passed along to the configuration
         """
-        super().__init__(name, **properties)
-
-        self.uri = self.property("uri")
-        if credential := self.properties.get("credential"):
+        self.properties = properties
+        self.uri = properties["uri"]
+        if credential := properties.get("credential"):
             properties["token"] = self._fetch_access_token(credential)
         super().__init__(name, **self._fetch_config(properties))
 
@@ -238,7 +237,10 @@ class RestCatalog(Catalog):
 
     def _fetch_config(self, properties: Properties) -> Properties:
         response = requests.get(self.url(Endpoints.get_config, prefixed=False), headers=self.headers)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except HTTPError as exc:
+            self._handle_non_200_response(exc, {})
         config_response = ConfigResponse(**response.json())
         config = config_response.defaults
         config.update(properties)
@@ -422,7 +424,6 @@ class RestCatalog(Catalog):
             ),
             headers=self.headers,
         )
-        response.raise_for_status()
         namespaces = ListNamespaceResponse(**response.json())
         try:
             response.raise_for_status()
@@ -448,9 +449,7 @@ class RestCatalog(Catalog):
         namespace_tuple = self._check_valid_namespace_identifier(namespace)
         namespace = NAMESPACE_SEPARATOR.join(namespace_tuple)
         payload = {"removals": list(removals or []), "updates": updates}
-        print(f"{payload}")
         response = requests.post(self.url(Endpoints.update_properties, namespace=namespace), json=payload, headers=self.headers)
-        print(f"{response.json()}")
         try:
             response.raise_for_status()
         except HTTPError as exc:

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -55,11 +55,12 @@ def catch_exception():
 
 @click.group()
 @click.option("--catalog", default="default")
+@click.option("--verbose", type=click.BOOL)
 @click.option("--output", type=click.Choice(["text", "json"]), default="text")
 @click.option("--uri")
 @click.option("--credential")
 @click.pass_context
-def run(ctx: Context, catalog: str, output: str, uri: Optional[str], credential: Optional[str]):
+def run(ctx: Context, catalog: str, verbose: bool, output: str, uri: Optional[str], credential: Optional[str]):
     properties = {}
     if uri:
         properties["uri"] = uri
@@ -68,9 +69,9 @@ def run(ctx: Context, catalog: str, output: str, uri: Optional[str], credential:
 
     ctx.ensure_object(dict)
     if output == "text":
-        ctx.obj["output"] = ConsoleOutput()
+        ctx.obj["output"] = ConsoleOutput(verbose=verbose)
     else:
-        ctx.obj["output"] = JsonOutput()
+        ctx.obj["output"] = JsonOutput(verbose=verbose)
 
     try:
         try:

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -68,6 +68,8 @@ class Output(ABC):
 class ConsoleOutput(Output):
     """Writes to the console"""
 
+    verbose: bool
+
     def __init__(self, **properties: Any):
         self.verbose = properties.get("verbose", False)
 
@@ -139,6 +141,8 @@ class ConsoleOutput(Output):
 
 class JsonOutput(Output):
     """Writes json to stdout"""
+
+    verbose: bool
 
     def __init__(self, **properties: Any):
         self.verbose = properties.get("verbose", False)

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -68,7 +68,7 @@ class Output(ABC):
 class ConsoleOutput(Output):
     """Writes to the console"""
 
-    def __init__(self, **properties: str):
+    def __init__(self, **properties: Any):
         self.verbose = properties.get("verbose", False)
 
     @property
@@ -139,6 +139,9 @@ class ConsoleOutput(Output):
 
 class JsonOutput(Output):
     """Writes json to stdout"""
+
+    def __init__(self, **properties: Any):
+        self.verbose = properties.get("verbose", False)
 
     def _out(self, d: Any) -> None:
         print(json.dumps(d))

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -73,7 +73,7 @@ class ConsoleOutput(Output):
         return RichTable.grid(padding=(0, 2))
 
     def exception(self, ex: Exception):
-        Console(stderr=True).print(ex)
+        Console(stderr=True).print_exception()
 
     def identifiers(self, identifiers: List[Identifier]):
         table = self._table

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -68,12 +68,18 @@ class Output(ABC):
 class ConsoleOutput(Output):
     """Writes to the console"""
 
+    def __init__(self, **properties: str):
+        self.verbose = properties.get("verbose", False)
+
     @property
     def _table(self) -> RichTable:
         return RichTable.grid(padding=(0, 2))
 
     def exception(self, ex: Exception):
-        Console(stderr=True).print_exception()
+        if self.verbose:
+            Console(stderr=True).print_exception()
+        else:
+            Console(stderr=True).print(ex)
 
     def identifiers(self, identifiers: List[Identifier]):
         table = self._table

--- a/python/tests/catalog/test_hive.py
+++ b/python/tests/catalog/test_hive.py
@@ -166,13 +166,8 @@ def hive_database(tmp_path_factory) -> HiveDatabase:
 
 
 def test_no_uri_supplied():
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(KeyError):
         HiveCatalog("production")
-
-    assert (
-        "HiveCatalog expects an uri property. Please set in config or using environment variable PYICEBERG_CATALOG__PRODUCTION__URI"
-        in str(exc_info.value)
-    )
 
 
 def test_check_number_of_namespaces(table_schema_simple: Schema):

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -64,13 +64,8 @@ def rest_mock(requests_mock: Mocker):
 
 
 def test_no_uri_supplied():
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(KeyError):
         RestCatalog("production")
-
-    assert (
-        "RestCatalog expects an uri property. Please set in config or using environment variable PYICEBERG_CATALOG__PRODUCTION__URI"
-        in str(exc_info.value)
-    )
 
 
 def test_token_200(rest_mock: Mocker):
@@ -84,7 +79,7 @@ def test_token_200(rest_mock: Mocker):
         },
         status_code=200,
     )
-    assert RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS).property("token") == TEST_TOKEN
+    assert RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS).properties["token"] == TEST_TOKEN
 
 
 def test_token_400(rest_mock: Mocker):


### PR DESCRIPTION
The recent refactor of how properties work caused the CLI to stop working with REST catalogs that use tokens. The token was being fetched from properties using `self.property`, but was set in the constructor's local properties map. The two maps were different objects because properties are passed to `__init__` using `**properties`.

The result was a 400 error (missing `Authorization` header). This also fixes the `_fetch_config` method's error handling. It was not parsing the error payload and so the cause message was ignored. This also updates text output to pretty print the stack trace when an exception causes the CLI to fail.