### PR TITLE
API: Remove source type from Transform

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -18,6 +18,10 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method org.apache.iceberg.RowDelta org.apache.iceberg.RowDelta::validateNoConflictingAppends(org.apache.iceberg.expressions.Expression)"
       justification: "Deprecations for 1.0 release"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.PartitionKey"
+      new: "class org.apache.iceberg.PartitionKey"
+      justification: "Serialization across versions is not supported"
   release-base-0.13.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"

--- a/api/src/main/java/org/apache/iceberg/PartitionKey.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionKey.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.SerializableFunction;
 
 /**
  * A struct of partition values.
@@ -36,7 +37,7 @@ public class PartitionKey implements StructLike, Serializable {
   private final PartitionSpec spec;
   private final int size;
   private final Object[] partitionTuple;
-  private final Function[] transforms;
+  private final SerializableFunction[] transforms;
   private final Accessor<StructLike>[] accessors;
 
   @SuppressWarnings("unchecked")
@@ -46,7 +47,7 @@ public class PartitionKey implements StructLike, Serializable {
     List<PartitionField> fields = spec.fields();
     this.size = fields.size();
     this.partitionTuple = new Object[size];
-    this.transforms = new Function[size];
+    this.transforms = new SerializableFunction[size];
     this.accessors = (Accessor<StructLike>[]) Array.newInstance(Accessor.class, size);
 
     Schema schema = spec.schema();

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -186,8 +186,8 @@ public class PartitionSpec implements Serializable {
     List<Types.NestedField> outputFields = partitionType().fields();
     for (int i = 0; i < javaClasses.length; i += 1) {
       PartitionField field = fields[i];
-      String valueString =
-          field.transform().toHumanString(outputFields.get(i).type(), get(data, i, javaClasses[i]));
+      Type type = outputFields.get(i).type();
+      String valueString = field.transform().toHumanString(type, get(data, i, javaClasses[i]));
 
       if (i > 0) {
         sb.append("/");

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -186,7 +186,8 @@ public class PartitionSpec implements Serializable {
     List<Types.NestedField> outputFields = partitionType().fields();
     for (int i = 0; i < javaClasses.length; i += 1) {
       PartitionField field = fields[i];
-      String valueString = field.transform().toHumanString(outputFields.get(i).type(), get(data, i, javaClasses[i]));
+      String valueString =
+          field.transform().toHumanString(outputFields.get(i).type(), get(data, i, javaClasses[i]));
 
       if (i > 0) {
         sb.append("/");
@@ -421,10 +422,7 @@ public class PartitionSpec implements Serializable {
       checkAndAddPartitionName(targetName, sourceColumn.fieldId());
       PartitionField field =
           new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.identity());
+              sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.identity());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -438,11 +436,7 @@ public class PartitionSpec implements Serializable {
       checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field =
-          new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.year());
+          new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.year());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -456,11 +450,7 @@ public class PartitionSpec implements Serializable {
       checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field =
-          new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.month());
+          new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.month());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -474,11 +464,7 @@ public class PartitionSpec implements Serializable {
       checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field =
-          new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.day());
+          new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.day());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -492,11 +478,7 @@ public class PartitionSpec implements Serializable {
       checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       PartitionField field =
-          new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.hour());
+          new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.hour());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -511,10 +493,7 @@ public class PartitionSpec implements Serializable {
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(
           new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.bucket(numBuckets)));
+              sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.bucket(numBuckets)));
       return this;
     }
 
@@ -527,10 +506,7 @@ public class PartitionSpec implements Serializable {
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       fields.add(
           new PartitionField(
-              sourceColumn.fieldId(),
-              nextFieldId(),
-              targetName,
-              Transforms.truncate(width)));
+              sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.truncate(width)));
       return this;
     }
 

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 
 /** A sort order that defines how data and delete files should be ordered in a table. */
 public class SortOrder implements Serializable {
@@ -254,14 +253,6 @@ public class SortOrder implements Serializable {
     }
 
     Builder addSortField(
-        String transformAsString, int sourceId, SortDirection direction, NullOrder nullOrder) {
-      Types.NestedField column = schema.findField(sourceId);
-      ValidationException.check(column != null, "Cannot find source column: %s", sourceId);
-      Transform<?, ?> transform = Transforms.fromString(column.type(), transformAsString);
-      return addSortField(transform, sourceId, direction, nullOrder);
-    }
-
-    Builder addSortField(
         Transform<?, ?> transform, int sourceId, SortDirection direction, NullOrder nullOrder) {
       SortField sortField = new SortField(transform, sourceId, direction, nullOrder);
       fields.add(sortField);
@@ -293,7 +284,7 @@ public class SortOrder implements Serializable {
 
     private Transform<?, ?> toTransform(BoundTerm<?> term) {
       if (term instanceof BoundReference) {
-        return Transforms.identity(term.type());
+        return Transforms.identity();
       } else if (term instanceof BoundTransform) {
         return ((BoundTransform<?, ?>) term).transform();
       } else {

--- a/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
@@ -20,6 +20,8 @@ package org.apache.iceberg;
 
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
 
 public class UnboundPartitionSpec {
 
@@ -52,9 +54,9 @@ public class UnboundPartitionSpec {
 
     for (UnboundPartitionField field : fields) {
       if (field.partitionId != null) {
-        builder.add(field.sourceId, field.partitionId, field.name, field.transformAsString);
+        builder.add(field.sourceId, field.partitionId, field.name, field.transform);
       } else {
-        builder.add(field.sourceId, field.name, field.transformAsString);
+        builder.add(field.sourceId, field.name, field.transform);
       }
     }
 
@@ -94,13 +96,17 @@ public class UnboundPartitionSpec {
   }
 
   static class UnboundPartitionField {
-    private final String transformAsString;
+    private final Transform<?, ?> transform;
     private final int sourceId;
     private final Integer partitionId;
     private final String name;
 
+    public Transform<?, ?> transform() {
+      return transform;
+    }
+
     public String transformAsString() {
-      return transformAsString;
+      return transform.toString();
     }
 
     public int sourceId() {
@@ -117,7 +123,7 @@ public class UnboundPartitionSpec {
 
     private UnboundPartitionField(
         String transformAsString, int sourceId, Integer partitionId, String name) {
-      this.transformAsString = transformAsString;
+      this.transform = Transforms.fromString(transformAsString);
       this.sourceId = sourceId;
       this.partitionId = partitionId;
       this.name = name;

--- a/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
 
 public class UnboundSortOrder {
   private static final UnboundSortOrder UNSORTED_ORDER =
@@ -38,8 +40,7 @@ public class UnboundSortOrder {
     SortOrder.Builder builder = SortOrder.builderFor(schema).withOrderId(orderId);
 
     for (UnboundSortField field : fields) {
-      builder.addSortField(
-          field.transformAsString, field.sourceId, field.direction, field.nullOrder);
+      builder.addSortField(field.transform, field.sourceId, field.direction, field.nullOrder);
     }
 
     return builder.build();
@@ -49,8 +50,7 @@ public class UnboundSortOrder {
     SortOrder.Builder builder = SortOrder.builderFor(schema).withOrderId(orderId);
 
     for (UnboundSortField field : fields) {
-      builder.addSortField(
-          field.transformAsString, field.sourceId, field.direction, field.nullOrder);
+      builder.addSortField(field.transform, field.sourceId, field.direction, field.nullOrder);
     }
 
     return builder.buildUnchecked();
@@ -114,21 +114,21 @@ public class UnboundSortOrder {
   }
 
   static class UnboundSortField {
-    private final String transformAsString;
+    private final Transform<?, ?> transform;
     private final int sourceId;
     private final SortDirection direction;
     private final NullOrder nullOrder;
 
     private UnboundSortField(
         String transformAsString, int sourceId, SortDirection direction, NullOrder nullOrder) {
-      this.transformAsString = transformAsString;
+      this.transform = Transforms.fromString(transformAsString);
       this.sourceId = sourceId;
       this.direction = direction;
       this.nullOrder = nullOrder;
     }
 
     public String transformAsString() {
-      return transformAsString;
+      return transform.toString();
     }
 
     public int sourceId() {

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
@@ -18,10 +18,10 @@
  */
 package org.apache.iceberg.expressions;
 
-import java.util.function.Function;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
 
 /**
  * A transform expression.
@@ -32,7 +32,7 @@ import org.apache.iceberg.types.Type;
 public class BoundTransform<S, T> implements BoundTerm<T> {
   private final BoundReference<S> ref;
   private final Transform<S, T> transform;
-  private final Function<S, T> func;
+  private final SerializableFunction<S, T> func;
 
   BoundTransform(BoundReference<S> ref, Transform<S, T> transform) {
     this.ref = ref;

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.function.Function;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Type;
@@ -31,15 +32,17 @@ import org.apache.iceberg.types.Type;
 public class BoundTransform<S, T> implements BoundTerm<T> {
   private final BoundReference<S> ref;
   private final Transform<S, T> transform;
+  private final Function<S, T> func;
 
   BoundTransform(BoundReference<S> ref, Transform<S, T> transform) {
     this.ref = ref;
     this.transform = transform;
+    this.func = transform.bind(ref.type());
   }
 
   @Override
   public T eval(StructLike struct) {
-    return transform.apply(ref.eval(struct));
+    return func.apply(ref.eval(struct));
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -18,17 +18,17 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 
 /** Expression utility methods. */
 public class ExpressionUtil {
-  private static final Transform<CharSequence, Integer> HASH_FUNC =
-      Transforms.bucket(Types.StringType.get(), Integer.MAX_VALUE);
+  private static final Function<Object, Integer> HASH_FUNC =
+      Transforms.bucket(Integer.MAX_VALUE).bind(Types.StringType.get());
   private static final Pattern DATE = Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\d");
   private static final Pattern TIME = Pattern.compile("\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?");
   private static final Pattern TIMESTAMP =

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Types;
 
 /** Factory methods for creating {@link Expression expressions}. */
 public class Expressions {
@@ -74,37 +73,36 @@ public class Expressions {
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> bucket(String name, int numBuckets) {
-    Transform<?, T> transform =
-        (Transform<?, T>) Transforms.bucket(Types.StringType.get(), numBuckets);
+    Transform<?, T> transform = (Transform<?, T>) Transforms.bucket(numBuckets);
     return new UnboundTransform<>(ref(name), transform);
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> year(String name) {
     return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.year(Types.TimestampType.withZone()));
+        ref(name), (Transform<?, T>) Transforms.year());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> month(String name) {
     return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.month(Types.TimestampType.withZone()));
+        ref(name), (Transform<?, T>) Transforms.month());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> day(String name) {
     return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.day(Types.TimestampType.withZone()));
+        ref(name), (Transform<?, T>) Transforms.day());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> hour(String name) {
     return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.hour(Types.TimestampType.withZone()));
+        ref(name), (Transform<?, T>) Transforms.hour());
   }
 
   public static <T> UnboundTerm<T> truncate(String name, int width) {
-    return new UnboundTransform<>(ref(name), Transforms.truncate(Types.LongType.get(), width));
+    return new UnboundTransform<>(ref(name), Transforms.truncate(width));
   }
 
   public static <T> UnboundPredicate<T> isNull(String name) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -79,26 +79,22 @@ public class Expressions {
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> year(String name) {
-    return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.year());
+    return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.year());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> month(String name) {
-    return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.month());
+    return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.month());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> day(String name) {
-    return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.day());
+    return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.day());
   }
 
   @SuppressWarnings("unchecked")
   public static <T> UnboundTerm<T> hour(String name) {
-    return new UnboundTransform<>(
-        ref(name), (Transform<?, T>) Transforms.hour());
+    return new UnboundTransform<>(ref(name), (Transform<?, T>) Transforms.hour());
   }
 
   public static <T> UnboundTerm<T> truncate(String name, int width) {

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundTransform.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundTransform.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.expressions;
 
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.transforms.Transform;
-import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 
 public class UnboundTransform<S, T> implements UnboundTerm<T>, Term {
@@ -41,18 +40,13 @@ public class UnboundTransform<S, T> implements UnboundTerm<T>, Term {
     return transform;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public BoundTransform<S, T> bind(Types.StructType struct, boolean caseSensitive) {
     BoundReference<S> boundRef = ref.bind(struct, caseSensitive);
 
-    Transform<S, T> typeTransform;
     try {
-      // TODO: Avoid using toString/fromString
-      typeTransform =
-          (Transform<S, T>) Transforms.fromString(boundRef.type(), transform.toString());
       ValidationException.check(
-          typeTransform.canTransform(boundRef.type()),
+          transform.canTransform(boundRef.type()),
           "Cannot bind: %s cannot transform %s values from '%s'",
           transform,
           boundRef.type(),
@@ -63,7 +57,7 @@ public class UnboundTransform<S, T> implements UnboundTerm<T>, Term {
           transform, boundRef.type(), ref.name());
     }
 
-    return new BoundTransform<>(boundRef, typeTransform);
+    return new BoundTransform<>(boundRef, transform);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -82,7 +82,7 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
 
   @Override
   public SerializableFunction<T, Integer> bind(Type type) {
-    Preconditions.checkArgument(canTransform(type), "Cannot bind to unsupported type: %s", type);
+    Preconditions.checkArgument(canTransform(type), "Cannot bucket by type: %s", type);
     return get(type, numBuckets);
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -86,7 +86,8 @@ class Bucket<T> implements Transform<T, Integer> {
 
   @VisibleForTesting
   protected int hash(T value) {
-    throw new UnsupportedOperationException("hash(value) is not supported on the base Bucket class");
+    throw new UnsupportedOperationException(
+        "hash(value) is not supported on the base Bucket class");
   }
 
   @Override
@@ -195,7 +196,8 @@ class Bucket<T> implements Transform<T, Integer> {
     }
   }
 
-  private static class BucketString extends Bucket<CharSequence> implements Function<CharSequence, Integer> {
+  private static class BucketString extends Bucket<CharSequence>
+      implements Function<CharSequence, Integer> {
     private BucketString(int numBuckets) {
       super(numBuckets);
     }
@@ -206,7 +208,8 @@ class Bucket<T> implements Transform<T, Integer> {
     }
   }
 
-  private static class BucketByteBuffer extends Bucket<ByteBuffer> implements Function<ByteBuffer, Integer> {
+  private static class BucketByteBuffer extends Bucket<ByteBuffer>
+      implements Function<ByteBuffer, Integer> {
     private BucketByteBuffer(int numBuckets) {
       super(numBuckets);
     }
@@ -228,7 +231,8 @@ class Bucket<T> implements Transform<T, Integer> {
     }
   }
 
-  private static class BucketDecimal extends Bucket<BigDecimal> implements Function<BigDecimal, Integer> {
+  private static class BucketDecimal extends Bucket<BigDecimal>
+      implements Function<BigDecimal, Integer> {
     private BucketDecimal(int numBuckets) {
       super(numBuckets);
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.expressions.BoundTransform;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
@@ -84,7 +83,6 @@ class Bucket<T> implements Transform<T, Integer> {
     return (Function<T, Integer>) get(type, numBuckets);
   }
 
-  @VisibleForTesting
   protected int hash(T value) {
     throw new UnsupportedOperationException(
         "hash(value) is not supported on the base Bucket class");
@@ -129,7 +127,7 @@ class Bucket<T> implements Transform<T, Integer> {
   public UnboundPredicate<Integer> project(String name, BoundPredicate<T> predicate) {
     Function<T, Integer> apply = this.bind(predicate.term().type());
     if (predicate.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, name, predicate);
+      return ProjectionUtil.projectTransformPredicate(this, name, predicate);
     }
 
     if (predicate.isUnaryPredicate()) {
@@ -152,7 +150,7 @@ class Bucket<T> implements Transform<T, Integer> {
   public UnboundPredicate<Integer> projectStrict(String name, BoundPredicate<T> predicate) {
     Function<T, Integer> apply = this.bind(predicate.term().type());
     if (predicate.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, name, predicate);
+      return ProjectionUtil.projectTransformPredicate(this, name, predicate);
     }
 
     if (predicate.isUnaryPredicate()) {
@@ -180,7 +178,7 @@ class Bucket<T> implements Transform<T, Integer> {
     }
 
     @Override
-    public int hash(Integer value) {
+    protected int hash(Integer value) {
       return BucketUtil.hash(value);
     }
   }
@@ -191,7 +189,7 @@ class Bucket<T> implements Transform<T, Integer> {
     }
 
     @Override
-    public int hash(Long value) {
+    protected int hash(Long value) {
       return BucketUtil.hash(value);
     }
   }
@@ -203,7 +201,7 @@ class Bucket<T> implements Transform<T, Integer> {
     }
 
     @Override
-    public int hash(CharSequence value) {
+    protected int hash(CharSequence value) {
       return BucketUtil.hash(value);
     }
   }
@@ -215,7 +213,7 @@ class Bucket<T> implements Transform<T, Integer> {
     }
 
     @Override
-    public int hash(ByteBuffer value) {
+    protected int hash(ByteBuffer value) {
       return BucketUtil.hash(value);
     }
   }
@@ -238,7 +236,7 @@ class Bucket<T> implements Transform<T, Integer> {
     }
 
     @Override
-    public int hash(BigDecimal value) {
+    protected int hash(BigDecimal value) {
       return BucketUtil.hash(value);
     }
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -101,7 +101,20 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
 
   @Override
   public boolean canTransform(Type type) {
-    return type.isPrimitiveType();
+    switch (type.typeId()) {
+      case INTEGER:
+      case LONG:
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case STRING:
+      case BINARY:
+      case FIXED:
+      case DECIMAL:
+      case UUID:
+        return true;
+    }
+    return false;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -18,26 +18,26 @@
  */
 package org.apache.iceberg.transforms;
 
-import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundTransform;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
 
 enum Dates implements Transform<Integer, Integer> {
   YEAR(ChronoUnit.YEARS, "year"),
   MONTH(ChronoUnit.MONTHS, "month"),
   DAY(ChronoUnit.DAYS, "day");
 
-  static class Apply implements Function<Integer, Integer>, Serializable {
+  static class Apply implements SerializableFunction<Integer, Integer> {
     private final ChronoUnit granularity;
 
     Apply(ChronoUnit granularity) {
@@ -85,7 +85,8 @@ enum Dates implements Transform<Integer, Integer> {
   }
 
   @Override
-  public Function<Integer, Integer> bind(Type type) {
+  public SerializableFunction<Integer, Integer> bind(Type type) {
+    Preconditions.checkArgument(canTransform(type), "Cannot bind to unsupported type: %s", type);
     return apply;
   }
 
@@ -187,7 +188,7 @@ enum Dates implements Transform<Integer, Integer> {
   }
 
   @Override
-  public String toHumanString(Type alwaysDate, Integer value) {
+  public String toHumanString(Type outputType, Integer value) {
     if (value == null) {
       return "null";
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -59,8 +59,7 @@ enum Dates implements Transform<Integer, Integer> {
         return (int) granularity.between(EPOCH, date);
       } else {
         // add 1 day to the value to account for the case where there is exactly 1 unit between the
-        // date and epoch
-        // because the result will always be decremented.
+        // date and epoch because the result will always be decremented.
         LocalDate date = EPOCH.plusDays(days + 1);
         return (int) granularity.between(EPOCH, date) - 1;
       }

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -127,7 +127,7 @@ enum Dates implements Transform<Integer, Integer> {
   @Override
   public UnboundPredicate<Integer> project(String fieldName, BoundPredicate<Integer> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {
@@ -158,7 +158,7 @@ enum Dates implements Transform<Integer, Integer> {
   @Override
   public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Integer> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -65,6 +65,11 @@ public class Days<T> extends TimeTransform<T> {
   }
 
   @Override
+  public String toHumanString(Type alwaysDate, Integer value) {
+    return TransformUtil.humanDay(value);
+  }
+
+  @Override
   public String toString() {
     return "day";
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -16,65 +16,61 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
-import java.util.function.Function;
-import org.apache.iceberg.expressions.BoundPredicate;
-import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 
-class VoidTransform<S> implements Transform<S, Void> {
-  private static final VoidTransform<Object> INSTANCE = new VoidTransform<>();
+public class Days<T> extends TimeTransform<T> {
+  private static final Days<?> INSTANCE = new Days<>();
 
   @SuppressWarnings("unchecked")
-  static <T> VoidTransform<T> get() {
-    return (VoidTransform<T>) INSTANCE;
-  }
-
-  private VoidTransform() {}
-
-  @Override
-  public Void apply(Object value) {
-    return null;
+  static <T> Days<T> get() {
+    return (Days<T>) INSTANCE;
   }
 
   @Override
-  public Function<S, Void> bind(Type type) {
-    return any -> null;
-  }
-
-  @Override
-  public boolean canTransform(Type type) {
-    return true;
+  @SuppressWarnings("unchecked")
+  protected Transform<T, Integer> toEnum(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+        return (Transform<T, Integer>) Dates.DAY;
+      case TIMESTAMP:
+        return (Transform<T, Integer>) Timestamps.DAY;
+    }
+    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override
   public Type getResultType(Type sourceType) {
-    return sourceType;
+    return Types.DateType.get();
   }
 
   @Override
-  public UnboundPredicate<Void> projectStrict(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    if (this == other) {
+      return true;
+    }
 
-  @Override
-  public UnboundPredicate<Void> project(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+    if (other instanceof Timestamps) {
+      return Timestamps.DAY.satisfiesOrderOf(other);
+    } else if (other instanceof Dates) {
+      return Dates.DAY.satisfiesOrderOf(other);
+    } else if (other instanceof Days || other instanceof Months || other instanceof Years) {
+      return true;
+    }
 
-  @Override
-  public String toHumanString(Void value) {
-    return "null";
+    return false;
   }
 
   @Override
   public String toString() {
-    return "void";
+    return "day";
   }
 
   Object writeReplace() throws ObjectStreamException {
-    return SerializationProxies.VoidTransformProxy.get();
+    return SerializationProxies.DaysTransformProxy.get();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -38,8 +38,9 @@ public class Days<T> extends TimeTransform<T> {
         return (Transform<T, Integer>) Dates.DAY;
       case TIMESTAMP:
         return (Transform<T, Integer>) Timestamps.DAY;
+      default:
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
-    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Days.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Days.java
@@ -66,7 +66,7 @@ public class Days<T> extends TimeTransform<T> {
 
   @Override
   public String toHumanString(Type alwaysDate, Integer value) {
-    return TransformUtil.humanDay(value);
+    return value != null ? TransformUtil.humanDay(value) : "null";
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -41,6 +41,11 @@ public class Hours<T> extends TimeTransform<T> {
   }
 
   @Override
+  public boolean canTransform(Type type) {
+    return type.typeId() == Type.TypeID.TIMESTAMP;
+  }
+
+  @Override
   public Type getResultType(Type sourceType) {
     return Types.IntegerType.get();
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -64,6 +64,11 @@ public class Hours<T> extends TimeTransform<T> {
   }
 
   @Override
+  public String toHumanString(Type alwaysInt, Integer value) {
+    return TransformUtil.humanHour(value);
+  }
+
+  @Override
   public String toString() {
     return "hour";
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
@@ -54,7 +53,10 @@ public class Hours<T> extends TimeTransform<T> {
 
     if (other instanceof Timestamps) {
       return other == Timestamps.HOUR;
-    } else if (other instanceof Hours || other instanceof Days || other instanceof Months || other instanceof Years) {
+    } else if (other instanceof Hours
+        || other instanceof Days
+        || other instanceof Months
+        || other instanceof Years) {
       return true;
     }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -70,7 +70,7 @@ public class Hours<T> extends TimeTransform<T> {
 
   @Override
   public String toHumanString(Type alwaysInt, Integer value) {
-    return TransformUtil.humanHour(value);
+    return value != null ? TransformUtil.humanHour(value) : "null";
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Hours.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Hours.java
@@ -16,65 +16,57 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
-import java.util.function.Function;
-import org.apache.iceberg.expressions.BoundPredicate;
-import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 
-class VoidTransform<S> implements Transform<S, Void> {
-  private static final VoidTransform<Object> INSTANCE = new VoidTransform<>();
+public class Hours<T> extends TimeTransform<T> {
+  private static final Hours<?> INSTANCE = new Hours<>();
 
   @SuppressWarnings("unchecked")
-  static <T> VoidTransform<T> get() {
-    return (VoidTransform<T>) INSTANCE;
-  }
-
-  private VoidTransform() {}
-
-  @Override
-  public Void apply(Object value) {
-    return null;
+  static <T> Hours<T> get() {
+    return (Hours<T>) INSTANCE;
   }
 
   @Override
-  public Function<S, Void> bind(Type type) {
-    return any -> null;
-  }
+  @SuppressWarnings("unchecked")
+  protected Transform<T, Integer> toEnum(Type type) {
+    if (type.typeId() == Type.TypeID.TIMESTAMP) {
+      return (Transform<T, Integer>) Timestamps.HOUR;
+    }
 
-  @Override
-  public boolean canTransform(Type type) {
-    return true;
+    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override
   public Type getResultType(Type sourceType) {
-    return sourceType;
+    return Types.IntegerType.get();
   }
 
   @Override
-  public UnboundPredicate<Void> projectStrict(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    if (this == other) {
+      return true;
+    }
 
-  @Override
-  public UnboundPredicate<Void> project(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+    if (other instanceof Timestamps) {
+      return other == Timestamps.HOUR;
+    } else if (other instanceof Hours || other instanceof Days || other instanceof Months || other instanceof Years) {
+      return true;
+    }
 
-  @Override
-  public String toHumanString(Void value) {
-    return "null";
+    return false;
   }
 
   @Override
   public String toString() {
-    return "void";
+    return "hour";
   }
 
   Object writeReplace() throws ObjectStreamException {
-    return SerializationProxies.VoidTransformProxy.get();
+    return SerializationProxies.HoursTransformProxy.get();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -19,12 +19,12 @@
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
-import java.io.Serializable;
-import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
 
 class Identity<T> implements Transform<T, T> {
   private static final Identity<?> INSTANCE = new Identity<>();
@@ -34,7 +34,7 @@ class Identity<T> implements Transform<T, T> {
     return (Identity<I>) INSTANCE;
   }
 
-  private static class Apply<T> implements Function<T, T>, Serializable {
+  private static class Apply<T> implements SerializableFunction<T, T> {
     private static final Apply<?> APPLY_INSTANCE = new Apply<>();
 
     @SuppressWarnings("unchecked")
@@ -56,7 +56,8 @@ class Identity<T> implements Transform<T, T> {
   }
 
   @Override
-  public Function<T, T> bind(Type type) {
+  public SerializableFunction<T, T> bind(Type type) {
+    Preconditions.checkArgument(canTransform(type), "Cannot bind to unsupported type: %s", type);
     return Apply.get();
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -33,8 +33,7 @@ class Identity<T> implements Transform<T, T> {
     return (Identity<I>) INSTANCE;
   }
 
-  private Identity() {
-  }
+  private Identity() {}
 
   @Override
   public T apply(T value) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Expressions;
@@ -33,6 +34,20 @@ class Identity<T> implements Transform<T, T> {
     return (Identity<I>) INSTANCE;
   }
 
+  private static class Apply<T> implements Function<T, T>, Serializable {
+    private static final Apply<?> APPLY_INSTANCE = new Apply<>();
+
+    @SuppressWarnings("unchecked")
+    private static <T> Apply<T> get() {
+      return (Apply<T>) APPLY_INSTANCE;
+    }
+
+    @Override
+    public T apply(T t) {
+      return t;
+    }
+  }
+
   private Identity() {}
 
   @Override
@@ -42,7 +57,7 @@ class Identity<T> implements Transform<T, T> {
 
   @Override
   public Function<T, T> bind(Type type) {
-    return Function.identity();
+    return Apply.get();
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -65,6 +65,11 @@ public class Months<T> extends TimeTransform<T> {
   }
 
   @Override
+  public String toHumanString(Type alwaysInt, Integer value) {
+    return TransformUtil.humanMonth(value);
+  }
+
+  @Override
   public String toString() {
     return "month";
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -16,65 +16,61 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
-import java.util.function.Function;
-import org.apache.iceberg.expressions.BoundPredicate;
-import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 
-class VoidTransform<S> implements Transform<S, Void> {
-  private static final VoidTransform<Object> INSTANCE = new VoidTransform<>();
+public class Months<T> extends TimeTransform<T> {
+  private static final Months<?> INSTANCE = new Months<>();
 
   @SuppressWarnings("unchecked")
-  static <T> VoidTransform<T> get() {
-    return (VoidTransform<T>) INSTANCE;
-  }
-
-  private VoidTransform() {}
-
-  @Override
-  public Void apply(Object value) {
-    return null;
+  static <T> Months<T> get() {
+    return (Months<T>) INSTANCE;
   }
 
   @Override
-  public Function<S, Void> bind(Type type) {
-    return any -> null;
-  }
-
-  @Override
-  public boolean canTransform(Type type) {
-    return true;
+  @SuppressWarnings("unchecked")
+  protected Transform<T, Integer> toEnum(Type type) {
+    switch (type.typeId()) {
+      case DATE:
+        return (Transform<T, Integer>) Dates.MONTH;
+      case TIMESTAMP:
+        return (Transform<T, Integer>) Timestamps.MONTH;
+    }
+    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override
   public Type getResultType(Type sourceType) {
-    return sourceType;
+    return Types.IntegerType.get();
   }
 
   @Override
-  public UnboundPredicate<Void> projectStrict(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    if (this == other) {
+      return true;
+    }
 
-  @Override
-  public UnboundPredicate<Void> project(String name, BoundPredicate<S> predicate) {
-    return null;
-  }
+    if (other instanceof Timestamps) {
+      return Timestamps.MONTH.satisfiesOrderOf(other);
+    } else if (other instanceof Dates) {
+      return Dates.MONTH.satisfiesOrderOf(other);
+    } else if (other instanceof Months || other instanceof Years) {
+      return true;
+    }
 
-  @Override
-  public String toHumanString(Void value) {
-    return "null";
+    return false;
   }
 
   @Override
   public String toString() {
-    return "void";
+    return "month";
   }
 
   Object writeReplace() throws ObjectStreamException {
-    return SerializationProxies.VoidTransformProxy.get();
+    return SerializationProxies.MonthsTransformProxy.get();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -66,7 +66,7 @@ public class Months<T> extends TimeTransform<T> {
 
   @Override
   public String toHumanString(Type alwaysInt, Integer value) {
-    return TransformUtil.humanMonth(value);
+    return value != null ? TransformUtil.humanMonth(value) : "null";
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Months.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Months.java
@@ -38,8 +38,9 @@ public class Months<T> extends TimeTransform<T> {
         return (Transform<T, Integer>) Dates.MONTH;
       case TIMESTAMP:
         return (Transform<T, Integer>) Timestamps.MONTH;
+      default:
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
-    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -121,9 +121,13 @@ public interface PartitionSpecVisitor<T> {
     } else if (transform instanceof Truncate) {
       int width = ((Truncate<?>) transform).width();
       return visitor.truncate(field.fieldId(), sourceName, field.sourceId(), width);
-    } else if (transform == Dates.YEAR || transform == Timestamps.YEAR || transform instanceof Years) {
+    } else if (transform == Dates.YEAR
+        || transform == Timestamps.YEAR
+        || transform instanceof Years) {
       return visitor.year(field.fieldId(), sourceName, field.sourceId());
-    } else if (transform == Dates.MONTH || transform == Timestamps.MONTH || transform instanceof Months) {
+    } else if (transform == Dates.MONTH
+        || transform == Timestamps.MONTH
+        || transform instanceof Months) {
       return visitor.month(field.fieldId(), sourceName, field.sourceId());
     } else if (transform == Dates.DAY || transform == Timestamps.DAY || transform instanceof Days) {
       return visitor.day(field.fieldId(), sourceName, field.sourceId());

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -121,13 +121,13 @@ public interface PartitionSpecVisitor<T> {
     } else if (transform instanceof Truncate) {
       int width = ((Truncate<?>) transform).width();
       return visitor.truncate(field.fieldId(), sourceName, field.sourceId(), width);
-    } else if (transform == Dates.YEAR || transform == Timestamps.YEAR) {
+    } else if (transform == Dates.YEAR || transform == Timestamps.YEAR || transform instanceof Years) {
       return visitor.year(field.fieldId(), sourceName, field.sourceId());
-    } else if (transform == Dates.MONTH || transform == Timestamps.MONTH) {
+    } else if (transform == Dates.MONTH || transform == Timestamps.MONTH || transform instanceof Months) {
       return visitor.month(field.fieldId(), sourceName, field.sourceId());
-    } else if (transform == Dates.DAY || transform == Timestamps.DAY) {
+    } else if (transform == Dates.DAY || transform == Timestamps.DAY || transform instanceof Days) {
       return visitor.day(field.fieldId(), sourceName, field.sourceId());
-    } else if (transform == Timestamps.HOUR) {
+    } else if (transform == Timestamps.HOUR || transform instanceof Hours) {
       return visitor.hour(field.fieldId(), sourceName, field.sourceId());
     } else if (transform instanceof VoidTransform) {
       return visitor.alwaysNull(field.fieldId(), sourceName, field.sourceId());

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -229,7 +229,7 @@ class ProjectionUtil {
    */
   @SuppressWarnings("unchecked")
   static <T> UnboundPredicate<T> projectTransformPredicate(
-      Function<?, T> transform, String partitionName, BoundPredicate<?> pred) {
+      Transform<?, T> transform, String partitionName, BoundPredicate<?> pred) {
     if (pred.term() instanceof BoundTransform
         && transform.equals(((BoundTransform<?, ?>) pred.term()).transform())) {
       // the bound value must be a T because the transform matches

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.expressions.Expressions.predicate;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Set;
+import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundLiteralPredicate;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundSetPredicate;
@@ -39,7 +40,7 @@ class ProjectionUtil {
   private ProjectionUtil() {}
 
   static <T> UnboundPredicate<T> truncateInteger(
-      String name, BoundLiteralPredicate<Integer> pred, Transform<Integer, T> transform) {
+      String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
     int boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -60,7 +61,7 @@ class ProjectionUtil {
   }
 
   static <T> UnboundPredicate<T> truncateIntegerStrict(
-      String name, BoundLiteralPredicate<Integer> pred, Transform<Integer, T> transform) {
+      String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
     int boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -83,7 +84,7 @@ class ProjectionUtil {
   }
 
   static <T> UnboundPredicate<T> truncateLongStrict(
-      String name, BoundLiteralPredicate<Long> pred, Transform<Long, T> transform) {
+      String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
     long boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -106,7 +107,7 @@ class ProjectionUtil {
   }
 
   static <T> UnboundPredicate<T> truncateLong(
-      String name, BoundLiteralPredicate<Long> pred, Transform<Long, T> transform) {
+      String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
     long boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -127,7 +128,7 @@ class ProjectionUtil {
   }
 
   static <T> UnboundPredicate<T> truncateDecimal(
-      String name, BoundLiteralPredicate<BigDecimal> pred, Transform<BigDecimal, T> transform) {
+      String name, BoundLiteralPredicate<BigDecimal> pred, Function<BigDecimal, T> transform) {
     BigDecimal boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -152,7 +153,7 @@ class ProjectionUtil {
   }
 
   static <T> UnboundPredicate<T> truncateDecimalStrict(
-      String name, BoundLiteralPredicate<BigDecimal> pred, Transform<BigDecimal, T> transform) {
+      String name, BoundLiteralPredicate<BigDecimal> pred, Function<BigDecimal, T> transform) {
     BigDecimal boundary = pred.literal().value();
 
     BigDecimal minusOne =
@@ -182,7 +183,7 @@ class ProjectionUtil {
   }
 
   static <S, T> UnboundPredicate<T> truncateArray(
-      String name, BoundLiteralPredicate<S> pred, Transform<S, T> transform) {
+      String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
     S boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -203,7 +204,7 @@ class ProjectionUtil {
   }
 
   static <S, T> UnboundPredicate<T> truncateArrayStrict(
-      String name, BoundLiteralPredicate<S> pred, Transform<S, T> transform) {
+      String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
     S boundary = pred.literal().value();
     switch (pred.op()) {
       case LT:
@@ -228,7 +229,7 @@ class ProjectionUtil {
    */
   @SuppressWarnings("unchecked")
   static <T> UnboundPredicate<T> projectTransformPredicate(
-      Transform<?, T> transform, String partitionName, BoundPredicate<?> pred) {
+      Function<?, T> transform, String partitionName, BoundPredicate<?> pred) {
     if (pred.term() instanceof BoundTransform
         && transform.equals(((BoundTransform<?, ?>) pred.term()).transform())) {
       // the bound value must be a T because the transform matches
@@ -251,7 +252,7 @@ class ProjectionUtil {
   }
 
   static <S, T> UnboundPredicate<T> transformSet(
-      String fieldName, BoundSetPredicate<S> predicate, Transform<S, T> transform) {
+      String fieldName, BoundSetPredicate<S> predicate, Function<S, T> transform) {
     return predicate(
         predicate.op(),
         fieldName,

--- a/api/src/main/java/org/apache/iceberg/transforms/SerializationProxies.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SerializationProxies.java
@@ -43,4 +43,79 @@ class SerializationProxies {
       return VoidTransform.get();
     }
   }
+
+  static class IdentityTransformProxy implements Serializable {
+    private static final IdentityTransformProxy INSTANCE = new IdentityTransformProxy();
+
+    static IdentityTransformProxy get() {
+      return INSTANCE;
+    }
+
+    /** Constructor for Java serialization. */
+    IdentityTransformProxy() {}
+
+    Object readResolve() throws ObjectStreamException {
+      return Identity.get();
+    }
+  }
+
+  static class YearsTransformProxy implements Serializable {
+    private static final YearsTransformProxy INSTANCE = new YearsTransformProxy();
+
+    static YearsTransformProxy get() {
+      return INSTANCE;
+    }
+
+    /** Constructor for Java serialization. */
+    YearsTransformProxy() {}
+
+    Object readResolve() throws ObjectStreamException {
+      return Years.get();
+    }
+  }
+
+  static class MonthsTransformProxy implements Serializable {
+    private static final MonthsTransformProxy INSTANCE = new MonthsTransformProxy();
+
+    static MonthsTransformProxy get() {
+      return INSTANCE;
+    }
+
+    /** Constructor for Java serialization. */
+    MonthsTransformProxy() {}
+
+    Object readResolve() throws ObjectStreamException {
+      return Months.get();
+    }
+  }
+
+  static class DaysTransformProxy implements Serializable {
+    private static final DaysTransformProxy INSTANCE = new DaysTransformProxy();
+
+    static DaysTransformProxy get() {
+      return INSTANCE;
+    }
+
+    /** Constructor for Java serialization. */
+    DaysTransformProxy() {}
+
+    Object readResolve() throws ObjectStreamException {
+      return Days.get();
+    }
+  }
+
+  static class HoursTransformProxy implements Serializable {
+    private static final HoursTransformProxy INSTANCE = new HoursTransformProxy();
+
+    static HoursTransformProxy get() {
+      return INSTANCE;
+    }
+
+    /** Constructor for Java serialization. */
+    HoursTransformProxy() {}
+
+    Object readResolve() throws ObjectStreamException {
+      return Hours.get();
+    }
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
@@ -84,16 +84,16 @@ public interface SortOrderVisitor<T> {
         results.add(
             visitor.truncate(
                 sourceName, field.sourceId(), width, field.direction(), field.nullOrder()));
-      } else if (transform == Dates.YEAR || transform == Timestamps.YEAR) {
+      } else if (transform == Dates.YEAR || transform == Timestamps.YEAR || transform instanceof Years) {
         results.add(
             visitor.year(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
-      } else if (transform == Dates.MONTH || transform == Timestamps.MONTH) {
+      } else if (transform == Dates.MONTH || transform == Timestamps.MONTH || transform instanceof Months) {
         results.add(
             visitor.month(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
-      } else if (transform == Dates.DAY || transform == Timestamps.DAY) {
+      } else if (transform == Dates.DAY || transform == Timestamps.DAY || transform instanceof Days) {
         results.add(
             visitor.day(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
-      } else if (transform == Timestamps.HOUR) {
+      } else if (transform == Timestamps.HOUR || transform instanceof Hours) {
         results.add(
             visitor.hour(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
       } else if (transform instanceof UnknownTransform) {

--- a/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
@@ -84,13 +84,19 @@ public interface SortOrderVisitor<T> {
         results.add(
             visitor.truncate(
                 sourceName, field.sourceId(), width, field.direction(), field.nullOrder()));
-      } else if (transform == Dates.YEAR || transform == Timestamps.YEAR || transform instanceof Years) {
+      } else if (transform == Dates.YEAR
+          || transform == Timestamps.YEAR
+          || transform instanceof Years) {
         results.add(
             visitor.year(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
-      } else if (transform == Dates.MONTH || transform == Timestamps.MONTH || transform instanceof Months) {
+      } else if (transform == Dates.MONTH
+          || transform == Timestamps.MONTH
+          || transform instanceof Months) {
         results.add(
             visitor.month(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
-      } else if (transform == Dates.DAY || transform == Timestamps.DAY || transform instanceof Days) {
+      } else if (transform == Dates.DAY
+          || transform == Timestamps.DAY
+          || transform instanceof Days) {
         results.add(
             visitor.day(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
       } else if (transform == Timestamps.HOUR || transform instanceof Hours) {

--- a/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.transforms;
 
 import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundTransform;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -44,11 +45,19 @@ abstract class TimeTransform<S> implements Transform<S, Integer> {
 
   @Override
   public UnboundPredicate<Integer> project(String name, BoundPredicate<S> predicate) {
+    if (predicate.term() instanceof BoundTransform) {
+      return ProjectionUtil.projectTransformPredicate(this, name, predicate);
+    }
+
     return toEnum(predicate.term().type()).project(name, predicate);
   }
 
   @Override
   public UnboundPredicate<Integer> projectStrict(String name, BoundPredicate<S> predicate) {
+    if (predicate.term() instanceof BoundTransform) {
+      return ProjectionUtil.projectTransformPredicate(this, name, predicate);
+    }
+
     return toEnum(predicate.term().type()).projectStrict(name, predicate);
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import java.util.function.Function;

--- a/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
@@ -18,18 +18,17 @@
  */
 package org.apache.iceberg.transforms;
 
-import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundTransform;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
 
 abstract class TimeTransform<S> implements Transform<S, Integer> {
   protected abstract Transform<S, Integer> toEnum(Type type);
 
   @Override
-  public Function<S, Integer> bind(Type type) {
+  public SerializableFunction<S, Integer> bind(Type type) {
     return toEnum(type).bind(type);
   }
 
@@ -59,12 +58,6 @@ abstract class TimeTransform<S> implements Transform<S, Integer> {
     }
 
     return toEnum(predicate.term().type()).projectStrict(name, predicate);
-  }
-
-  @Override
-  public String toHumanString(Type type, Integer value) {
-    // the incoming type doesn't matter, so always use timestamp without time zone
-    return toEnum(Types.TimestampType.withoutZone()).toHumanString(type, value);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -132,7 +132,7 @@ enum Timestamps implements Transform<Long, Integer> {
   @Override
   public UnboundPredicate<Integer> project(String fieldName, BoundPredicate<Long> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {
@@ -155,7 +155,7 @@ enum Timestamps implements Transform<Long, Integer> {
   @Override
   public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Long> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -60,9 +60,7 @@ enum Timestamps implements Transform<Long, Integer> {
         return (int) granularity.between(EPOCH, timestamp);
       } else {
         // add 1 micro to the value to account for the case where there is exactly 1 unit between
-        // the
-        // timestamp and epoch
-        // because the result will always be decremented.
+        // the timestamp and epoch because the result will always be decremented.
         OffsetDateTime timestamp =
             Instant.ofEpochSecond(
                     Math.floorDiv(timestampMicros, 1_000_000),

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -59,7 +59,8 @@ enum Timestamps implements Transform<Long, Integer> {
                 .atOffset(ZoneOffset.UTC);
         return (int) granularity.between(EPOCH, timestamp);
       } else {
-        // add 1 micro to the value to account for the case where there is exactly 1 unit between the
+        // add 1 micro to the value to account for the case where there is exactly 1 unit between
+        // the
         // timestamp and epoch
         // because the result will always be decremented.
         OffsetDateTime timestamp =

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.transforms;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundTransform;
 import org.apache.iceberg.expressions.Expression;
@@ -36,39 +38,59 @@ enum Timestamps implements Transform<Long, Integer> {
   DAY(ChronoUnit.DAYS, "day"),
   HOUR(ChronoUnit.HOURS, "hour");
 
+  static class Apply implements Function<Long, Integer>, Serializable {
+    private final ChronoUnit granularity;
+
+    Apply(ChronoUnit granularity) {
+      this.granularity = granularity;
+    }
+
+    @Override
+    public Integer apply(Long timestampMicros) {
+      if (timestampMicros == null) {
+        return null;
+      }
+
+      if (timestampMicros >= 0) {
+        OffsetDateTime timestamp =
+            Instant.ofEpochSecond(
+                    Math.floorDiv(timestampMicros, 1_000_000),
+                    Math.floorMod(timestampMicros, 1_000_000) * 1000)
+                .atOffset(ZoneOffset.UTC);
+        return (int) granularity.between(EPOCH, timestamp);
+      } else {
+        // add 1 micro to the value to account for the case where there is exactly 1 unit between the
+        // timestamp and epoch
+        // because the result will always be decremented.
+        OffsetDateTime timestamp =
+            Instant.ofEpochSecond(
+                    Math.floorDiv(timestampMicros, 1_000_000),
+                    Math.floorMod(timestampMicros + 1, 1_000_000) * 1000)
+                .atOffset(ZoneOffset.UTC);
+        return (int) granularity.between(EPOCH, timestamp) - 1;
+      }
+    }
+  }
+
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
   private final ChronoUnit granularity;
   private final String name;
+  private final Function<Long, Integer> apply;
 
   Timestamps(ChronoUnit granularity, String name) {
     this.granularity = granularity;
     this.name = name;
+    this.apply = new Apply(granularity);
   }
 
   @Override
   public Integer apply(Long timestampMicros) {
-    if (timestampMicros == null) {
-      return null;
-    }
+    return apply.apply(timestampMicros);
+  }
 
-    if (timestampMicros >= 0) {
-      OffsetDateTime timestamp =
-          Instant.ofEpochSecond(
-                  Math.floorDiv(timestampMicros, 1_000_000),
-                  Math.floorMod(timestampMicros, 1_000_000) * 1000)
-              .atOffset(ZoneOffset.UTC);
-      return (int) granularity.between(EPOCH, timestamp);
-    } else {
-      // add 1 micro to the value to account for the case where there is exactly 1 unit between the
-      // timestamp and epoch
-      // because the result will always be decremented.
-      OffsetDateTime timestamp =
-          Instant.ofEpochSecond(
-                  Math.floorDiv(timestampMicros, 1_000_000),
-                  Math.floorMod(timestampMicros + 1, 1_000_000) * 1000)
-              .atOffset(ZoneOffset.UTC);
-      return (int) granularity.between(EPOCH, timestamp) - 1;
-    }
+  @Override
+  public Function<Long, Integer> bind(Type type) {
+    return apply;
   }
 
   @Override
@@ -109,7 +131,7 @@ enum Timestamps implements Transform<Long, Integer> {
   @Override
   public UnboundPredicate<Integer> project(String fieldName, BoundPredicate<Long> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {
@@ -117,12 +139,12 @@ enum Timestamps implements Transform<Long, Integer> {
 
     } else if (pred.isLiteralPredicate()) {
       UnboundPredicate<Integer> projected =
-          ProjectionUtil.truncateLong(fieldName, pred.asLiteralPredicate(), this);
+          ProjectionUtil.truncateLong(fieldName, pred.asLiteralPredicate(), apply);
       return ProjectionUtil.fixInclusiveTimeProjection(projected);
 
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.IN) {
       UnboundPredicate<Integer> projected =
-          ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+          ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), apply);
       return ProjectionUtil.fixInclusiveTimeProjection(projected);
     }
 
@@ -132,7 +154,7 @@ enum Timestamps implements Transform<Long, Integer> {
   @Override
   public UnboundPredicate<Integer> projectStrict(String fieldName, BoundPredicate<Long> pred) {
     if (pred.term() instanceof BoundTransform) {
-      return ProjectionUtil.projectTransformPredicate(this, fieldName, pred);
+      return ProjectionUtil.projectTransformPredicate(apply, fieldName, pred);
     }
 
     if (pred.isUnaryPredicate()) {
@@ -140,12 +162,12 @@ enum Timestamps implements Transform<Long, Integer> {
 
     } else if (pred.isLiteralPredicate()) {
       UnboundPredicate<Integer> projected =
-          ProjectionUtil.truncateLongStrict(fieldName, pred.asLiteralPredicate(), this);
+          ProjectionUtil.truncateLongStrict(fieldName, pred.asLiteralPredicate(), apply);
       return ProjectionUtil.fixStrictTimeProjection(projected);
 
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.NOT_IN) {
       UnboundPredicate<Integer> projected =
-          ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+          ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), apply);
       return ProjectionUtil.fixStrictTimeProjection(projected);
     }
 
@@ -153,7 +175,7 @@ enum Timestamps implements Transform<Long, Integer> {
   }
 
   @Override
-  public String toHumanString(Integer value) {
+  public String toHumanString(Type alwaysTimestamp, Integer value) {
     if (value == null) {
       return "null";
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
 
 /**
  * A transform function used for partitioning.
@@ -55,7 +56,7 @@ public interface Transform<S, T> extends Serializable {
    * @param type an Iceberg {@link Type}
    * @return a {@link Function} that applies this transform to values of the given type.
    */
-  default Function<S, T> bind(Type type) {
+  default SerializableFunction<S, T> bind(Type type) {
     throw new UnsupportedOperationException("bind is not implemented");
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -19,9 +19,12 @@
 package org.apache.iceberg.transforms;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 
 /**
  * A transform function used for partitioning.
@@ -38,8 +41,22 @@ public interface Transform<S, T> extends Serializable {
    *
    * @param value a source value
    * @return a transformed partition value
+   * @deprecated use {@link #bind(Type)} instead; will be removed in 2.0.0
    */
-  T apply(S value);
+  @Deprecated
+  default T apply(S value) {
+    throw new UnsupportedOperationException("apply(value) is deprecated, use bind(Type).apply(value)");
+  }
+
+  /**
+   * Returns a function that applies this transform to values of the given {@link Type type}.
+   *
+   * @param type an Iceberg {@link Type}
+   * @return a {@link Function} that applies this transform to values of the given type.
+   */
+  default Function<S, T> bind(Type type) {
+    throw new UnsupportedOperationException("bind is not implemented");
+  }
 
   /**
    * Checks whether this function can be applied to the given {@link Type}.
@@ -84,7 +101,7 @@ public interface Transform<S, T> extends Serializable {
 
   /**
    * Transforms a {@link BoundPredicate predicate} to an inclusive predicate on the partition values
-   * produced by {@link #apply(Object)}.
+   * produced by the transform.
    *
    * <p>This inclusive transform guarantees that if pred(v) is true, then projected(apply(v)) is
    * true.
@@ -97,7 +114,7 @@ public interface Transform<S, T> extends Serializable {
 
   /**
    * Transforms a {@link BoundPredicate predicate} to a strict predicate on the partition values
-   * produced by {@link #apply(Object)}.
+   * produced by the transform.
    *
    * <p>This strict transform guarantees that if strict(apply(v)) is true, then pred(v) is also
    * true.
@@ -124,9 +141,47 @@ public interface Transform<S, T> extends Serializable {
    *
    * @param value a transformed value
    * @return a human-readable String representation of the value
+   * @deprecated use {@link #toHumanString(Type, Object)} instead; will be removed in 2.0.0
    */
+  @Deprecated
   default String toHumanString(T value) {
-    return String.valueOf(value);
+    if (value instanceof ByteBuffer) {
+      return TransformUtil.base64encode(((ByteBuffer) value).duplicate());
+    } else if (value instanceof byte[]) {
+      return TransformUtil.base64encode(ByteBuffer.wrap((byte[]) value));
+    } else {
+      return String.valueOf(value);
+    }
+  }
+
+  default String toHumanString(Type type, T value) {
+    if (value == null) {
+      return "null";
+    }
+
+    switch (type.typeId()) {
+      case DATE:
+        return TransformUtil.humanDay((Integer) value);
+      case TIME:
+        return TransformUtil.humanTime((Long) value);
+      case TIMESTAMP:
+        if (((Types.TimestampType) type).shouldAdjustToUTC()) {
+          return TransformUtil.humanTimestampWithZone((Long) value);
+        } else {
+          return TransformUtil.humanTimestampWithoutZone((Long) value);
+        }
+      case FIXED:
+      case BINARY:
+        if (value instanceof ByteBuffer) {
+          return TransformUtil.base64encode(((ByteBuffer) value).duplicate());
+        } else if (value instanceof byte[]) {
+          return TransformUtil.base64encode(ByteBuffer.wrap((byte[]) value));
+        } else {
+          throw new UnsupportedOperationException("Unsupported binary type: " + value.getClass());
+        }
+      default:
+        return value.toString();
+    }
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -45,7 +45,8 @@ public interface Transform<S, T> extends Serializable {
    */
   @Deprecated
   default T apply(S value) {
-    throw new UnsupportedOperationException("apply(value) is deprecated, use bind(Type).apply(value)");
+    throw new UnsupportedOperationException(
+        "apply(value) is deprecated, use bind(Type).apply(value)");
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -74,9 +74,9 @@ public class Transforms {
       String name = widthMatcher.group(1);
       int parsedWidth = Integer.parseInt(widthMatcher.group(2));
       if (name.equalsIgnoreCase("truncate")) {
-        return Truncate.get(type, parsedWidth);
+        return (Transform<?, ?>) Truncate.get(type, parsedWidth);
       } else if (name.equals("bucket")) {
-        return Bucket.get(type, parsedWidth);
+        return (Transform<?, ?>) Bucket.get(type, parsedWidth);
       }
     }
 
@@ -218,7 +218,7 @@ public class Transforms {
    */
   @Deprecated
   public static <T> Transform<T, T> truncate(Type type, int width) {
-    return Truncate.get(type, width);
+    return (Transform<T, T>) Truncate.get(type, width);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -39,6 +39,35 @@ public class Transforms {
 
   private static final Pattern HAS_WIDTH = Pattern.compile("(\\w+)\\[(\\d+)\\]");
 
+  public static Transform<?, ?> fromString(String transform) {
+    Matcher widthMatcher = HAS_WIDTH.matcher(transform);
+    if (widthMatcher.matches()) {
+      String name = widthMatcher.group(1);
+      int parsedWidth = Integer.parseInt(widthMatcher.group(2));
+      if (name.equalsIgnoreCase("truncate")) {
+        return Truncate.get(parsedWidth);
+      } else if (name.equals("bucket")) {
+        return Bucket.get(parsedWidth);
+      }
+    }
+
+    if (transform.equalsIgnoreCase("identity")) {
+      return Identity.get();
+    } else if (transform.equalsIgnoreCase("year")) {
+      return Years.get();
+    } else if (transform.equalsIgnoreCase("month")) {
+      return Months.get();
+    } else if (transform.equalsIgnoreCase("day")) {
+      return Days.get();
+    } else if (transform.equalsIgnoreCase("hour")) {
+      return Hours.get();
+    } else if (transform.equalsIgnoreCase("void")) {
+      return VoidTransform.get();
+    }
+
+    return new UnknownTransform<>(transform);
+  }
+
   public static Transform<?, ?> fromString(Type type, String transform) {
     Matcher widthMatcher = HAS_WIDTH.matcher(transform);
     if (widthMatcher.matches()) {
@@ -52,7 +81,7 @@ public class Transforms {
     }
 
     if (transform.equalsIgnoreCase("identity")) {
-      return Identity.get(type);
+      return Identity.get();
     }
 
     try {
@@ -69,7 +98,7 @@ public class Transforms {
       return VoidTransform.get();
     }
 
-    return new UnknownTransform<>(type, transform);
+    return new UnknownTransform<>(transform);
   }
 
   /**
@@ -78,9 +107,11 @@ public class Transforms {
    * @param type the {@link Type source type} for the transform
    * @param <T> Java type passed to this transform
    * @return an identity transform
+   * @deprecated use {@link #identity()} instead; will be removed in 2.0.0
    */
+  @Deprecated
   public static <T> Transform<T, T> identity(Type type) {
-    return Identity.get(type);
+    return Identity.get();
   }
 
   /**
@@ -89,7 +120,9 @@ public class Transforms {
    * @param type the {@link Type source type} for the transform
    * @param <T> Java type passed to this transform
    * @return a year transform
+   * @deprecated use {@link #year()} instead; will be removed in 2.0.0
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public static <T> Transform<T, Integer> year(Type type) {
     switch (type.typeId()) {
@@ -108,7 +141,9 @@ public class Transforms {
    * @param type the {@link Type source type} for the transform
    * @param <T> Java type passed to this transform
    * @return a month transform
+   * @deprecated use {@link #month()} instead; will be removed in 2.0.0
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public static <T> Transform<T, Integer> month(Type type) {
     switch (type.typeId()) {
@@ -127,7 +162,9 @@ public class Transforms {
    * @param type the {@link Type source type} for the transform
    * @param <T> Java type passed to this transform
    * @return a day transform
+   * @deprecated use {@link #day()} instead; will be removed in 2.0.0
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public static <T> Transform<T, Integer> day(Type type) {
     switch (type.typeId()) {
@@ -146,7 +183,9 @@ public class Transforms {
    * @param type the {@link Type source type} for the transform
    * @param <T> Java type passed to this transform
    * @return a hour transform
+   * @deprecated use {@link #hour()} instead; will be removed in 2.0.0
    */
+  @Deprecated
   @SuppressWarnings("unchecked")
   public static <T> Transform<T, Integer> hour(Type type) {
     Preconditions.checkArgument(
@@ -161,7 +200,9 @@ public class Transforms {
    * @param numBuckets the number of buckets for the transform to produce
    * @param <T> Java type passed to this transform
    * @return a transform that buckets values into numBuckets
+   * @deprecated use {@link #bucket(int)} instead; will be removed in 2.0.0
    */
+  @Deprecated
   public static <T> Transform<T, Integer> bucket(Type type, int numBuckets) {
     return Bucket.get(type, numBuckets);
   }
@@ -173,9 +214,83 @@ public class Transforms {
    * @param width the width to truncate data values
    * @param <T> Java type passed to this transform
    * @return a transform that truncates the given type to width
+   * @deprecated use {@link #truncate(int)} instead; will be removed in 2.0.0
    */
+  @Deprecated
   public static <T> Transform<T, T> truncate(Type type, int width) {
     return Truncate.get(type, width);
+  }
+
+  /**
+   * Returns an identity {@link Transform} that can be used for any type.
+   *
+   * @param <T> Java type passed to this transform
+   * @return an identity transform
+   */
+  public static <T> Transform<T, T> identity() {
+    return Identity.get();
+  }
+
+  /**
+   * Returns a year {@link Transform} for date or timestamp types.
+   *
+   * @param <T> Java type passed to this transform
+   * @return a year transform
+   */
+  public static <T> Transform<T, Integer> year() {
+    return Years.get();
+  }
+
+  /**
+   * Returns a year {@link Transform} for date or timestamp types.
+   *
+   * @param <T> Java type passed to this transform
+   * @return a year transform
+   */
+  public static <T> Transform<T, Integer> month() {
+    return Months.get();
+  }
+
+  /**
+   * Returns a year {@link Transform} for date or timestamp types.
+   *
+   * @param <T> Java type passed to this transform
+   * @return a year transform
+   */
+  public static <T> Transform<T, Integer> day() {
+    return Days.get();
+  }
+
+  /**
+   * Returns a year {@link Transform} for date or timestamp types.
+   *
+   * @param <T> Java type passed to this transform
+   * @return a year transform
+   */
+  public static <T> Transform<T, Integer> hour() {
+    return Hours.get();
+  }
+
+  /**
+   * Returns a bucket {@link Transform} for the given number of buckets.
+   *
+   * @param numBuckets the number of buckets for the transform to produce
+   * @param <T> Java type passed to this transform
+   * @return a transform that buckets values into numBuckets
+   */
+  public static <T> Transform<T, Integer> bucket(int numBuckets) {
+    return Bucket.get(numBuckets);
+  }
+
+  /**
+   * Returns a truncate {@link Transform} for the given width.
+   *
+   * @param width the width to truncate data values
+   * @param <T> Java type passed to this transform
+   * @return a transform that truncates the given type to width
+   */
+  public static <T> Transform<T, T> truncate(int width) {
+    return Truncate.get(width);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -75,7 +75,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
 
   @Override
   public T apply(T value) {
-    throw new UnsupportedOperationException("apply(value) is deprecated, use bind(Type).apply(value)");
+    throw new UnsupportedOperationException(
+        "apply(value) is deprecated, use bind(Type).apply(value)");
   }
 
   @Override
@@ -154,7 +155,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     return "truncate[" + width + "]";
   }
 
-  private static class TruncateInteger extends Truncate<Integer> implements Function<Integer, Integer> {
+  private static class TruncateInteger extends Truncate<Integer>
+      implements Function<Integer, Integer> {
     private TruncateInteger(int width) {
       super(width);
     }
@@ -275,7 +277,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     }
   }
 
-  private static class TruncateString extends Truncate<CharSequence> implements Function<CharSequence, CharSequence> {
+  private static class TruncateString extends Truncate<CharSequence>
+      implements Function<CharSequence, CharSequence> {
     private TruncateString(int length) {
       super(length);
     }
@@ -390,7 +393,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     }
   }
 
-  private static class TruncateByteBuffer extends Truncate<ByteBuffer> implements Function<ByteBuffer, ByteBuffer> {
+  private static class TruncateByteBuffer extends Truncate<ByteBuffer>
+      implements Function<ByteBuffer, ByteBuffer> {
     private TruncateByteBuffer(int length) {
       super(length);
     }
@@ -448,7 +452,8 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     }
   }
 
-  private static class TruncateDecimal extends Truncate<BigDecimal> implements Function<BigDecimal, BigDecimal> {
+  private static class TruncateDecimal extends Truncate<BigDecimal>
+      implements Function<BigDecimal, BigDecimal> {
     private final BigInteger unscaledWidth;
 
     private TruncateDecimal(int unscaledWidth) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -63,6 +63,7 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     }
   }
 
+  @SuppressWarnings("checkstyle:VisibilityModifier")
   protected final int width;
 
   Truncate(int width) {

--- a/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.transforms;
 
 import java.util.Objects;
+import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
@@ -26,11 +27,9 @@ import org.apache.iceberg.types.Types;
 
 public class UnknownTransform<S, T> implements Transform<S, T> {
 
-  private final Type sourceType;
   private final String transform;
 
-  UnknownTransform(Type sourceType, String transform) {
-    this.sourceType = sourceType;
+  UnknownTransform(String transform) {
     this.transform = transform;
   }
 
@@ -41,11 +40,15 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
   }
 
   @Override
+  public Function<S, T> bind(Type type) {
+    throw new UnsupportedOperationException(
+        String.format("Cannot bind unsupported transform: %s", transform));
+  }
+
+  @Override
   public boolean canTransform(Type type) {
-    // assume the transform function can be applied for this type because unknown transform is only
-    // used when parsing
-    // a transform in an existing table. a different Iceberg version must have already validated it.
-    return this.sourceType.equals(type);
+    // assume the transform function can be applied for any type
+    return true;
   }
 
   @Override
@@ -78,11 +81,11 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
     }
 
     UnknownTransform<?, ?> that = (UnknownTransform<?, ?>) other;
-    return sourceType.equals(that.sourceType) && transform.equals(that.transform);
+    return transform.equals(that.transform);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sourceType, transform);
+    return Objects.hash(transform);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
@@ -19,11 +19,11 @@
 package org.apache.iceberg.transforms;
 
 import java.util.Objects;
-import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
 
 public class UnknownTransform<S, T> implements Transform<S, T> {
 
@@ -40,7 +40,7 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
   }
 
   @Override
-  public Function<S, T> bind(Type type) {
+  public SerializableFunction<S, T> bind(Type type) {
     throw new UnsupportedOperationException(
         String.format("Cannot bind unsupported transform: %s", transform));
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
+import java.io.Serializable;
 import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
@@ -32,6 +33,20 @@ class VoidTransform<S> implements Transform<S, Void> {
     return (VoidTransform<T>) INSTANCE;
   }
 
+  private static class Apply<S> implements Function<S, Void>, Serializable {
+    private static final Apply<?> APPLY_INSTANCE = new Apply<>();
+
+    @SuppressWarnings("unchecked")
+    private static <S> Apply<S> get() {
+      return (Apply<S>) APPLY_INSTANCE;
+    }
+
+    @Override
+    public Void apply(S t) {
+      return null;
+    }
+  }
+
   private VoidTransform() {}
 
   @Override
@@ -41,7 +56,7 @@ class VoidTransform<S> implements Transform<S, Void> {
 
   @Override
   public Function<S, Void> bind(Type type) {
-    return any -> null;
+    return Apply.get();
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/VoidTransform.java
@@ -20,10 +20,10 @@ package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.util.function.Function;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.SerializableFunction;
 
 class VoidTransform<S> implements Transform<S, Void> {
   private static final VoidTransform<Object> INSTANCE = new VoidTransform<>();
@@ -33,7 +33,7 @@ class VoidTransform<S> implements Transform<S, Void> {
     return (VoidTransform<T>) INSTANCE;
   }
 
-  private static class Apply<S> implements Function<S, Void>, Serializable {
+  private static class Apply<S> implements SerializableFunction<S, Void>, Serializable {
     private static final Apply<?> APPLY_INSTANCE = new Apply<>();
 
     @SuppressWarnings("unchecked")
@@ -55,7 +55,7 @@ class VoidTransform<S> implements Transform<S, Void> {
   }
 
   @Override
-  public Function<S, Void> bind(Type type) {
+  public SerializableFunction<S, Void> bind(Type type) {
     return Apply.get();
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Years.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Years.java
@@ -66,7 +66,7 @@ class Years<T> extends TimeTransform<T> {
 
   @Override
   public String toHumanString(Type alwaysInt, Integer value) {
-    return TransformUtil.humanYear(value);
+    return value != null ? TransformUtil.humanYear(value) : "null";
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Years.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Years.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import java.io.ObjectStreamException;

--- a/api/src/main/java/org/apache/iceberg/transforms/Years.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Years.java
@@ -65,6 +65,11 @@ class Years<T> extends TimeTransform<T> {
   }
 
   @Override
+  public String toHumanString(Type alwaysInt, Integer value) {
+    return TransformUtil.humanYear(value);
+  }
+
+  @Override
   public String toString() {
     return "year";
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/Years.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Years.java
@@ -38,8 +38,9 @@ class Years<T> extends TimeTransform<T> {
         return (Transform<T, Integer>) Dates.YEAR;
       case TIMESTAMP:
         return (Transform<T, Integer>) Timestamps.YEAR;
+      default:
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
-    throw new IllegalArgumentException("Unsupported type: " + type);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/util/SerializableFunction.java
+++ b/api/src/main/java/org/apache/iceberg/util/SerializableFunction.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/**
+ * A concrete transform function that applies a transform to values of a certain type.
+ *
+ * @param <S> Java class of source values
+ * @param <T> Java class of transformed values
+ */
+public interface SerializableFunction<S, T> extends Function<S, T>, Serializable {}

--- a/api/src/test/java/org/apache/iceberg/PartitionSpecTestBase.java
+++ b/api/src/test/java/org/apache/iceberg/PartitionSpecTestBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
@@ -69,8 +70,8 @@ public class PartitionSpecTestBase {
         PartitionSpec.builderFor(SCHEMA).truncate("l", 10).build(),
         PartitionSpec.builderFor(SCHEMA).truncate("dec", 10).build(),
         PartitionSpec.builderFor(SCHEMA).truncate("s", 10).build(),
-        PartitionSpec.builderFor(SCHEMA).add(6, "dec_unsupported", "unsupported").build(),
-        PartitionSpec.builderFor(SCHEMA).add(6, 1111, "dec_unsupported", "unsupported").build(),
+        PartitionSpec.builderFor(SCHEMA).add(6, "dec_unsupported", Transforms.fromString("unsupported")).build(),
+        PartitionSpec.builderFor(SCHEMA).add(6, 1111, "dec_unsupported", Transforms.fromString("unsupported")).build(),
         PartitionSpec.builderFor(SCHEMA).alwaysNull("ts").build(),
       };
 }

--- a/api/src/test/java/org/apache/iceberg/PartitionSpecTestBase.java
+++ b/api/src/test/java/org/apache/iceberg/PartitionSpecTestBase.java
@@ -70,8 +70,12 @@ public class PartitionSpecTestBase {
         PartitionSpec.builderFor(SCHEMA).truncate("l", 10).build(),
         PartitionSpec.builderFor(SCHEMA).truncate("dec", 10).build(),
         PartitionSpec.builderFor(SCHEMA).truncate("s", 10).build(),
-        PartitionSpec.builderFor(SCHEMA).add(6, "dec_unsupported", Transforms.fromString("unsupported")).build(),
-        PartitionSpec.builderFor(SCHEMA).add(6, 1111, "dec_unsupported", Transforms.fromString("unsupported")).build(),
+        PartitionSpec.builderFor(SCHEMA)
+            .add(6, "dec_unsupported", Transforms.fromString("unsupported"))
+            .build(),
+        PartitionSpec.builderFor(SCHEMA)
+            .add(6, 1111, "dec_unsupported", Transforms.fromString("unsupported"))
+            .build(),
         PartitionSpec.builderFor(SCHEMA).alwaysNull("ts").build(),
       };
 }

--- a/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionPaths.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,17 +34,16 @@ public class TestPartitionPaths {
           Types.NestedField.optional(3, "ts", Types.TimestampType.withoutZone()));
 
   @Test
-  @SuppressWarnings("unchecked")
   public void testPartitionPath() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).hour("ts").bucket("id", 10).build();
 
-    Transform hour = spec.getFieldsBySourceId(3).get(0).transform();
-    Transform bucket = spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<Long, Integer> hour = Transforms.hour();
+    Transform<Integer, Integer> bucket = Transforms.bucket(10);
 
     Literal<Long> ts =
         Literal.of("2017-12-01T10:12:55.038194").to(Types.TimestampType.withoutZone());
-    Object tsHour = hour.apply(ts.value());
-    Object idBucket = bucket.apply(1);
+    Object tsHour = hour.bind(Types.TimestampType.withoutZone()).apply(ts.value());
+    Object idBucket = bucket.bind(Types.IntegerType.get()).apply(1);
 
     Row partition = Row.of(tsHour, idBucket);
 

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.junit.Assert;
@@ -301,7 +302,7 @@ public class TestPartitionSpecValidation {
         PartitionSpec.builderFor(SCHEMA)
             .year("ts", "custom_year")
             .bucket("ts", 4, "custom_bucket")
-            .add(1, "id_partition2", "bucket[4]")
+            .add(1, "id_partition2", Transforms.bucket(4))
             .truncate("s", 1, "custom_truncate")
             .build();
 
@@ -316,9 +317,9 @@ public class TestPartitionSpecValidation {
   public void testAddPartitionFieldsWithFieldIds() {
     PartitionSpec spec =
         PartitionSpec.builderFor(SCHEMA)
-            .add(1, 1005, "id_partition1", "bucket[4]")
-            .add(1, 1006, "id_partition2", "bucket[5]")
-            .add(1, 1002, "id_partition3", "bucket[6]")
+            .add(1, 1005, "id_partition1", Transforms.bucket(4))
+            .add(1, 1006, "id_partition2", Transforms.bucket(5))
+            .add(1, 1002, "id_partition3", Transforms.bucket(6))
             .build();
 
     Assert.assertEquals(1005, spec.fields().get(0).fieldId());
@@ -331,8 +332,8 @@ public class TestPartitionSpecValidation {
   public void testAddPartitionFieldsWithAndWithoutFieldIds() {
     PartitionSpec spec =
         PartitionSpec.builderFor(SCHEMA)
-            .add(1, "id_partition2", "bucket[5]")
-            .add(1, 1005, "id_partition1", "bucket[4]")
+            .add(1, "id_partition2", Transforms.bucket(5))
+            .add(1, 1005, "id_partition1", Transforms.bucket(4))
             .truncate("s", 1, "custom_truncate")
             .build();
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -237,6 +237,6 @@ public class TestExpressionHelpers {
   }
 
   private <T> UnboundTerm<T> self(String name) {
-    return new UnboundTransform<>(ref(name), Transforms.identity(Types.DoubleType.get()));
+    return new UnboundTransform<>(ref(name), Transforms.identity());
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BucketUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -64,83 +65,83 @@ public class TestBucketing {
     Assert.assertEquals(
         "Spec example: hash(true) = 1392991556",
         1392991556,
-        Bucket.<Integer>get(Types.IntegerType.get(), 100).hash(1));
+        BucketUtil.hash(1));
     Assert.assertEquals(
         "Spec example: hash(34) = 2017239379",
         2017239379,
-        Bucket.<Integer>get(Types.IntegerType.get(), 100).hash(34));
+        BucketUtil.hash(34));
     Assert.assertEquals(
         "Spec example: hash(34L) = 2017239379",
         2017239379,
-        Bucket.<Long>get(Types.LongType.get(), 100).hash(34L));
+        BucketUtil.hash(34L));
     Assert.assertEquals(
         "Spec example: hash(17.11F) = -142385009",
         -142385009,
-        new Bucket.BucketFloat(100).hash(1.0F));
+        BucketUtil.hash(1.0F));
     Assert.assertEquals(
         "Spec example: hash(17.11D) = -142385009",
         -142385009,
-        new Bucket.BucketDouble(100).hash(1.0D));
+        BucketUtil.hash(1.0D));
     Assert.assertEquals(
         "Spec example: hash(decimal2(14.20)) = -500754589",
         -500754589,
-        Bucket.<BigDecimal>get(Types.DecimalType.of(9, 2), 100).hash(new BigDecimal("14.20")));
+        BucketUtil.hash(new BigDecimal("14.20")));
     Assert.assertEquals(
         "Spec example: hash(decimal2(14.20)) = -500754589",
         -500754589,
-        Bucket.<BigDecimal>get(Types.DecimalType.of(9, 2), 100).hash(new BigDecimal("14.20")));
+        BucketUtil.hash(new BigDecimal("14.20")));
 
     Literal<Integer> date = Literal.of("2017-11-16").to(Types.DateType.get());
     Assert.assertEquals(
         "Spec example: hash(2017-11-16) = -653330422",
         -653330422,
-        Bucket.<Integer>get(Types.DateType.get(), 100).hash(date.value()));
+        BucketUtil.hash(date.value()));
 
     Literal<Long> timeValue = Literal.of("22:31:08").to(Types.TimeType.get());
     Assert.assertEquals(
         "Spec example: hash(22:31:08) = -662762989",
         -662762989,
-        Bucket.<Long>get(Types.TimeType.get(), 100).hash(timeValue.value()));
+        BucketUtil.hash(timeValue.value()));
 
     Literal<Long> timestampVal =
         Literal.of("2017-11-16T22:31:08").to(Types.TimestampType.withoutZone());
     Assert.assertEquals(
         "Spec example: hash(2017-11-16T22:31:08) = -2047944441",
         -2047944441,
-        Bucket.<Long>get(Types.TimestampType.withoutZone(), 100).hash(timestampVal.value()));
+        BucketUtil.hash(timestampVal.value()));
 
     Literal<Long> timestamptzVal =
         Literal.of("2017-11-16T14:31:08-08:00").to(Types.TimestampType.withZone());
     Assert.assertEquals(
         "Spec example: hash(2017-11-16T14:31:08-08:00) = -2047944441",
         -2047944441,
-        Bucket.<Long>get(Types.TimestampType.withZone(), 100).hash(timestamptzVal.value()));
+        BucketUtil.hash(timestamptzVal.value()));
 
     Assert.assertEquals(
         "Spec example: hash(\"iceberg\") = 1210000089",
         1210000089,
-        Bucket.<String>get(Types.StringType.get(), 100).hash("iceberg"));
+        BucketUtil.hash("iceberg"));
     Assert.assertEquals(
         "Spec example: hash(\"iceberg\") = 1210000089",
         1210000089,
-        Bucket.<Utf8>get(Types.StringType.get(), 100).hash(new Utf8("iceberg")));
+        BucketUtil.hash(new Utf8("iceberg")));
 
     Literal<UUID> uuid =
         Literal.of("f79c3e09-677c-4bbd-a479-3f349cb785e7").to(Types.UUIDType.get());
     Assert.assertEquals(
         "Spec example: hash(f79c3e09-677c-4bbd-a479-3f349cb785e7) = 1488055340",
         1488055340,
-        Bucket.<UUID>get(Types.UUIDType.get(), 100).hash(uuid.value()));
+        BucketUtil.hash(uuid.value()));
 
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
     Assert.assertEquals(
         "Spec example: hash([00 01 02 03]) = -188683207",
         -188683207,
-        Bucket.<ByteBuffer>get(Types.BinaryType.get(), 100).hash(bytes));
+        BucketUtil.hash(bytes));
     Assert.assertEquals(
         "Spec example: hash([00 01 02 03]) = -188683207",
         -188683207,
-        Bucket.<ByteBuffer>get(Types.BinaryType.get(), 100).hash(bytes));
+        BucketUtil.hash(bytes));
   }
 
   @Test
@@ -148,14 +149,12 @@ public class TestBucketing {
     int num = testRandom.nextInt();
     ByteBuffer buffer = ByteBuffer.allocate(8);
     buffer.order(ByteOrder.LITTLE_ENDIAN);
-    buffer.putLong((long) num);
-
-    Bucket<Integer> bucketFunc = Bucket.get(Types.IntegerType.get(), 100);
+    buffer.putLong(num);
 
     Assert.assertEquals(
         "Integer hash should match hash of little-endian bytes",
         hashBytes(buffer.array()),
-        bucketFunc.hash(num));
+        BucketUtil.hash(num));
   }
 
   @Test
@@ -165,68 +164,30 @@ public class TestBucketing {
     buffer.order(ByteOrder.LITTLE_ENDIAN);
     buffer.putLong(num);
 
-    Bucket<Long> bucketFunc = Bucket.get(Types.LongType.get(), 100);
-
     Assert.assertEquals(
         "Long hash should match hash of little-endian bytes",
         hashBytes(buffer.array()),
-        bucketFunc.hash(num));
+        BucketUtil.hash(num));
   }
 
   @Test
   public void testIntegerTypePromotion() {
-    Bucket<Integer> bucketInts = Bucket.get(Types.IntegerType.get(), 100);
-    Bucket<Long> bucketLongs = Bucket.get(Types.LongType.get(), 100);
-
     int randomInt = testRandom.nextInt();
 
     Assert.assertEquals(
         "Integer and Long bucket results should match",
-        bucketInts.apply(randomInt),
-        bucketLongs.apply((long) randomInt));
-  }
-
-  @Test
-  public void testFloat() {
-    float num = testRandom.nextFloat();
-    ByteBuffer buffer = ByteBuffer.allocate(8);
-    buffer.order(ByteOrder.LITTLE_ENDIAN);
-    buffer.putDouble((double) num);
-
-    Bucket<Float> bucketFunc = new Bucket.BucketFloat(100);
-
-    Assert.assertEquals(
-        "Float hash should match hash of little-endian bytes",
-        hashBytes(buffer.array()),
-        bucketFunc.hash(num));
-  }
-
-  @Test
-  public void testDouble() {
-    double num = testRandom.nextDouble();
-    ByteBuffer buffer = ByteBuffer.allocate(8);
-    buffer.order(ByteOrder.LITTLE_ENDIAN);
-    buffer.putDouble(num);
-
-    Bucket<Double> bucketFunc = new Bucket.BucketDouble(100);
-
-    Assert.assertEquals(
-        "Double hash should match hash of little-endian bytes",
-        hashBytes(buffer.array()),
-        bucketFunc.hash(num));
+        BucketUtil.hash(randomInt),
+        BucketUtil.hash((long) randomInt));
   }
 
   @Test
   public void testFloatTypePromotion() {
-    Bucket<Float> bucketFloats = new Bucket.BucketFloat(100);
-    Bucket<Double> bucketDoubles = new Bucket.BucketDouble(100);
-
     float randomFloat = testRandom.nextFloat();
 
     Assert.assertEquals(
         "Float and Double bucket results should match",
-        bucketFloats.apply(randomFloat),
-        bucketDoubles.apply((double) randomFloat));
+        BucketUtil.hash(randomFloat),
+        BucketUtil.hash((double) randomFloat));
   }
 
   @Test
@@ -235,12 +196,10 @@ public class TestBucketing {
     BigDecimal decimal = BigDecimal.valueOf(num);
     byte[] unscaledBytes = decimal.unscaledValue().toByteArray();
 
-    Bucket<BigDecimal> bucketFunc = Bucket.get(Types.DecimalType.of(9, 2), 100);
-
     Assert.assertEquals(
         "Decimal hash should match hash of backing bytes",
         hashBytes(unscaledBytes),
-        bucketFunc.hash(decimal));
+        BucketUtil.hash(decimal));
   }
 
   @Test
@@ -248,12 +207,10 @@ public class TestBucketing {
     String string = "string to test murmur3 hash";
     byte[] asBytes = string.getBytes(StandardCharsets.UTF_8);
 
-    Bucket<CharSequence> bucketFunc = Bucket.get(Types.StringType.get(), 100);
-
     Assert.assertEquals(
         "String hash should match hash of UTF-8 bytes",
         hashBytes(asBytes),
-        bucketFunc.hash(string));
+        BucketUtil.hash(string));
   }
 
   @Test
@@ -263,12 +220,10 @@ public class TestBucketing {
         "string has no surrogate pairs", string.length(), string.codePoints().count());
     byte[] asBytes = string.getBytes(StandardCharsets.UTF_8);
 
-    Bucket<CharSequence> bucketFunc = Bucket.get(Types.StringType.get(), 100);
-
     Assert.assertEquals(
         "String hash should match hash of UTF-8 bytes",
         hashBytes(asBytes),
-        bucketFunc.hash(string));
+        BucketUtil.hash(string));
   }
 
   @Test
@@ -276,10 +231,8 @@ public class TestBucketing {
     Utf8 utf8 = new Utf8("string to test murmur3 hash");
     byte[] asBytes = utf8.toString().getBytes(StandardCharsets.UTF_8);
 
-    Bucket<CharSequence> bucketFunc = Bucket.get(Types.StringType.get(), 100);
-
     Assert.assertEquals(
-        "String hash should match hash of UTF-8 bytes", hashBytes(asBytes), bucketFunc.hash(utf8));
+        "String hash should match hash of UTF-8 bytes", hashBytes(asBytes), BucketUtil.hash(utf8));
   }
 
   @Test
@@ -287,12 +240,10 @@ public class TestBucketing {
     byte[] bytes = randomBytes(128);
     ByteBuffer buffer = ByteBuffer.wrap(bytes, 5, 100);
 
-    Bucket<ByteBuffer> bucketFunc = Bucket.get(Types.BinaryType.get(), 100);
-
     Assert.assertEquals(
         "HeapByteBuffer hash should match hash for correct slice",
         hashBytes(bytes, 5, 100),
-        bucketFunc.hash(buffer));
+        BucketUtil.hash(buffer));
 
     // verify that the buffer was not modified
     Assert.assertEquals("Buffer position should not change", 5, buffer.position());
@@ -306,12 +257,10 @@ public class TestBucketing {
     ByteBuffer buffer = raw.slice();
     Assert.assertEquals("Buffer arrayOffset should be 5", 5, buffer.arrayOffset());
 
-    Bucket<ByteBuffer> bucketFunc = Bucket.get(Types.BinaryType.get(), 100);
-
     Assert.assertEquals(
         "HeapByteBuffer hash should match hash for correct slice",
         hashBytes(bytes, 5, 100),
-        bucketFunc.hash(buffer));
+        BucketUtil.hash(buffer));
 
     // verify that the buffer was not modified
     Assert.assertEquals("Buffer position should be 0", 0, buffer.position());
@@ -330,12 +279,10 @@ public class TestBucketing {
     buffer.put(bytes, 5, 100);
     buffer.reset();
 
-    Bucket<ByteBuffer> bucketFunc = Bucket.get(Types.BinaryType.get(), 100);
-
     Assert.assertEquals(
         "DirectByteBuffer hash should match hash for correct slice",
         hashBytes(bytes, 5, 100),
-        bucketFunc.hash(buffer));
+        BucketUtil.hash(buffer));
 
     // verify that the buffer was not modified
     Assert.assertEquals("Buffer position should not change", 5, buffer.position());
@@ -347,12 +294,10 @@ public class TestBucketing {
     byte[] uuidBytes = randomBytes(16);
     UUID uuid = newUUID(uuidBytes);
 
-    Bucket<UUID> bucketFunc = Bucket.get(Types.UUIDType.get(), 100);
-
     Assert.assertEquals(
         "UUID hash should match hash of backing bytes",
         hashBytes(uuidBytes),
-        bucketFunc.hash(uuid));
+        BucketUtil.hash(uuid));
   }
 
   @Test
@@ -361,7 +306,7 @@ public class TestBucketing {
         "Should fail if numBucket is less than or equal to zero",
         IllegalArgumentException.class,
         "Invalid number of buckets: 0 (must be > 0)",
-        () -> Bucket.get(Types.IntegerType.get(), 0));
+        () -> Bucket.get(0));
   }
 
   private byte[] randomBytes(int length) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -62,26 +62,13 @@ public class TestBucketing {
 
   @Test
   public void testSpecValues() {
+    Assert.assertEquals("Spec example: hash(true) = 1392991556", 1392991556, BucketUtil.hash(1));
+    Assert.assertEquals("Spec example: hash(34) = 2017239379", 2017239379, BucketUtil.hash(34));
+    Assert.assertEquals("Spec example: hash(34L) = 2017239379", 2017239379, BucketUtil.hash(34L));
     Assert.assertEquals(
-        "Spec example: hash(true) = 1392991556",
-        1392991556,
-        BucketUtil.hash(1));
+        "Spec example: hash(17.11F) = -142385009", -142385009, BucketUtil.hash(1.0F));
     Assert.assertEquals(
-        "Spec example: hash(34) = 2017239379",
-        2017239379,
-        BucketUtil.hash(34));
-    Assert.assertEquals(
-        "Spec example: hash(34L) = 2017239379",
-        2017239379,
-        BucketUtil.hash(34L));
-    Assert.assertEquals(
-        "Spec example: hash(17.11F) = -142385009",
-        -142385009,
-        BucketUtil.hash(1.0F));
-    Assert.assertEquals(
-        "Spec example: hash(17.11D) = -142385009",
-        -142385009,
-        BucketUtil.hash(1.0D));
+        "Spec example: hash(17.11D) = -142385009", -142385009, BucketUtil.hash(1.0D));
     Assert.assertEquals(
         "Spec example: hash(decimal2(14.20)) = -500754589",
         -500754589,
@@ -93,9 +80,7 @@ public class TestBucketing {
 
     Literal<Integer> date = Literal.of("2017-11-16").to(Types.DateType.get());
     Assert.assertEquals(
-        "Spec example: hash(2017-11-16) = -653330422",
-        -653330422,
-        BucketUtil.hash(date.value()));
+        "Spec example: hash(2017-11-16) = -653330422", -653330422, BucketUtil.hash(date.value()));
 
     Literal<Long> timeValue = Literal.of("22:31:08").to(Types.TimeType.get());
     Assert.assertEquals(
@@ -118,9 +103,7 @@ public class TestBucketing {
         BucketUtil.hash(timestamptzVal.value()));
 
     Assert.assertEquals(
-        "Spec example: hash(\"iceberg\") = 1210000089",
-        1210000089,
-        BucketUtil.hash("iceberg"));
+        "Spec example: hash(\"iceberg\") = 1210000089", 1210000089, BucketUtil.hash("iceberg"));
     Assert.assertEquals(
         "Spec example: hash(\"iceberg\") = 1210000089",
         1210000089,
@@ -135,13 +118,9 @@ public class TestBucketing {
 
     ByteBuffer bytes = ByteBuffer.wrap(new byte[] {0, 1, 2, 3});
     Assert.assertEquals(
-        "Spec example: hash([00 01 02 03]) = -188683207",
-        -188683207,
-        BucketUtil.hash(bytes));
+        "Spec example: hash([00 01 02 03]) = -188683207", -188683207, BucketUtil.hash(bytes));
     Assert.assertEquals(
-        "Spec example: hash([00 01 02 03]) = -188683207",
-        -188683207,
-        BucketUtil.hash(bytes));
+        "Spec example: hash([00 01 02 03]) = -188683207", -188683207, BucketUtil.hash(bytes));
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketingProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketingProjection.java
@@ -61,19 +61,18 @@ public class TestBucketingProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Bucket transform = (Bucket) spec.getFieldsBySourceId(1).get(0).transform();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(v))
+              .map(String::valueOf)
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString(literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = String.valueOf(literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }
@@ -103,19 +102,18 @@ public class TestBucketingProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Bucket transform = (Bucket) spec.getFieldsBySourceId(1).get(0).transform();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(v))
+              .map(String::valueOf)
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString(literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = String.valueOf(literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
@@ -25,30 +25,29 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestDates {
-  //  @Test
-  //  @SuppressWarnings("deprecation")
-  //  public void testDeprecatedDateTransform() {
-  //    Types.DateType type = Types.DateType.get();
-  //    Literal<Integer> date = Literal.of("2017-12-01").to(type);
-  //    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
-  //    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
-  //
-  //    Transform<Integer, Integer> years = Transforms.year(type);
-  //    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
-  //    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
-  //    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
-  //
-  //    Transform<Integer, Integer> months = Transforms.month(type);
-  //    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int)
-  // months.apply(date.value()));
-  //    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
-  //    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
-  //
-  //    Transform<Integer, Integer> days = Transforms.day(type);
-  //    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
-  //    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
-  //    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
-  //  }
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedDateTransform() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> date = Literal.of("2017-12-01").to(type);
+    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
+    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
+
+    Transform<Integer, Integer> years = Transforms.year(type);
+    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
+    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
+    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
+
+    Transform<Integer, Integer> months = Transforms.month(type);
+    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(date.value()));
+    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
+
+    Transform<Integer, Integer> days = Transforms.day(type);
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
+    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
+  }
 
   @Test
   public void testDateTransform() {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
@@ -25,6 +25,30 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestDates {
+//  @Test
+//  @SuppressWarnings("deprecation")
+//  public void testDeprecatedDateTransform() {
+//    Types.DateType type = Types.DateType.get();
+//    Literal<Integer> date = Literal.of("2017-12-01").to(type);
+//    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
+//    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
+//
+//    Transform<Integer, Integer> years = Transforms.year(type);
+//    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
+//    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
+//    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
+//
+//    Transform<Integer, Integer> months = Transforms.month(type);
+//    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(date.value()));
+//    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
+//    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
+//
+//    Transform<Integer, Integer> days = Transforms.day(type);
+//    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
+//    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
+//    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
+//  }
+
   @Test
   public void testDateTransform() {
     Types.DateType type = Types.DateType.get();
@@ -32,20 +56,26 @@ public class TestDates {
     Literal<Integer> pd = Literal.of("1970-01-01").to(type);
     Literal<Integer> nd = Literal.of("1969-12-31").to(type);
 
-    Transform<Integer, Integer> years = Transforms.year(type);
-    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
-    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
-    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
+    Transform<Integer, Integer> years = Transforms.year();
+    Assert.assertEquals(
+        "Should produce 2017 - 1970 = 47", 47, (int) years.bind(type).apply(date.value()));
+    Assert.assertEquals(
+        "Should produce 1970 - 1970 = 0", 0, (int) years.bind(type).apply(pd.value()));
+    Assert.assertEquals(
+        "Should produce 1969 - 1970 = -1", -1, (int) years.bind(type).apply(nd.value()));
 
-    Transform<Integer, Integer> months = Transforms.month(type);
-    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(date.value()));
-    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
-    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
+    Transform<Integer, Integer> months = Transforms.month();
+    Assert.assertEquals(
+        "Should produce 47 * 12 + 11 = 575", 575, (int) months.bind(type).apply(date.value()));
+    Assert.assertEquals(
+        "Should produce 0 * 12 + 0 = 0", 0, (int) months.bind(type).apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.bind(type).apply(nd.value()));
 
-    Transform<Integer, Integer> days = Transforms.day(type);
-    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
-    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
-    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
+    Transform<Integer, Integer> days = Transforms.day();
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.bind(type).apply(date.value()));
+    Assert.assertEquals(
+        "Should produce 0 * 365 + 0 = 0", 0, (int) days.bind(type).apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.bind(type).apply(nd.value()));
   }
 
   @Test
@@ -53,23 +83,23 @@ public class TestDates {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("2017-12-01").to(type);
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12-01",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
   }
 
   @Test
@@ -77,23 +107,23 @@ public class TestDates {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("1969-12-30").to(type);
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-30",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
   }
 
   @Test
@@ -101,23 +131,23 @@ public class TestDates {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("1970-01-01").to(type);
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1970",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1970-01",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1970-01-01",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
   }
 
   @Test
@@ -125,23 +155,23 @@ public class TestDates {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("1969-01-01").to(type);
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-01",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-01-01",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
   }
 
   @Test
@@ -149,49 +179,49 @@ public class TestDates {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("1969-12-31").to(type);
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-31",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
   }
 
   @Test
   public void testNullHumanString() {
     Types.DateType type = Types.DateType.get();
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.year(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.year().toHumanString(type, null));
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.month(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.month().toHumanString(type, null));
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.day(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.day().toHumanString(type, null));
   }
 
   @Test
   public void testDatesReturnType() {
     Types.DateType type = Types.DateType.get();
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Type yearResultType = year.getResultType(type);
     Assert.assertEquals(Types.IntegerType.get(), yearResultType);
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Type monthResultType = month.getResultType(type);
     Assert.assertEquals(Types.IntegerType.get(), monthResultType);
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Type dayResultType = day.getResultType(type);
     Assert.assertEquals(Types.DateType.get(), dayResultType);
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
@@ -25,29 +25,30 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestDates {
-//  @Test
-//  @SuppressWarnings("deprecation")
-//  public void testDeprecatedDateTransform() {
-//    Types.DateType type = Types.DateType.get();
-//    Literal<Integer> date = Literal.of("2017-12-01").to(type);
-//    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
-//    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
-//
-//    Transform<Integer, Integer> years = Transforms.year(type);
-//    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
-//    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
-//    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
-//
-//    Transform<Integer, Integer> months = Transforms.month(type);
-//    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(date.value()));
-//    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
-//    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
-//
-//    Transform<Integer, Integer> days = Transforms.day(type);
-//    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
-//    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
-//    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
-//  }
+  //  @Test
+  //  @SuppressWarnings("deprecation")
+  //  public void testDeprecatedDateTransform() {
+  //    Types.DateType type = Types.DateType.get();
+  //    Literal<Integer> date = Literal.of("2017-12-01").to(type);
+  //    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
+  //    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
+  //
+  //    Transform<Integer, Integer> years = Transforms.year(type);
+  //    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
+  //    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
+  //    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
+  //
+  //    Transform<Integer, Integer> months = Transforms.month(type);
+  //    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int)
+  // months.apply(date.value()));
+  //    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
+  //    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
+  //
+  //    Transform<Integer, Integer> days = Transforms.day(type);
+  //    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
+  //    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
+  //    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
+  //  }
 
   @Test
   public void testDateTransform() {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -55,7 +55,7 @@ public class TestDatesProjection {
       String expectedLiteral) {
 
     Expression projection = Projections.strict(spec).project(filter);
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+    UnboundPredicate<Integer> predicate = assertAndUnwrapUnbound(projection);
 
     Assert.assertEquals(expectedOp, predicate.op());
 
@@ -66,17 +66,17 @@ public class TestDatesProjection {
         (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
-      Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
+      Iterable<Integer> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(type, (Integer) v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal<?> literal = predicate.literal();
-      String output = transform.toHumanString(type, (int) literal.value());
+      Literal<Integer> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -62,7 +62,8 @@ public class TestDatesProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform =
+        (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
@@ -108,7 +109,8 @@ public class TestDatesProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform =
+        (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -102,7 +102,7 @@ public class TestDatesProjection {
       Expression.Operation expectedOp,
       String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+    UnboundPredicate<Integer> predicate = assertAndUnwrapUnbound(projection);
 
     Assert.assertEquals(expectedOp, predicate.op());
 
@@ -113,17 +113,17 @@ public class TestDatesProjection {
         (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
-      Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
+      Iterable<Integer> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(type, (Integer) v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal<?> literal = predicate.literal();
-      String output = transform.toHumanString(type, (int) literal.value());
+      Literal<Integer> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,6 +47,7 @@ public class TestDatesProjection {
   private static final Types.DateType TYPE = Types.DateType.get();
   private static final Schema SCHEMA = new Schema(optional(1, "date", TYPE));
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionStrict(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -60,19 +62,20 @@ public class TestDatesProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString((Integer) v))
+              .map(v -> transform.toHumanString(type, (Integer) v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString((int) literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, (int) literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }
@@ -91,6 +94,7 @@ public class TestDatesProjection {
     Assert.assertEquals(expectedOp, projection.op());
   }
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionInclusive(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -104,19 +108,20 @@ public class TestDatesProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Dates transform = (Dates) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString((Integer) v))
+              .map(v -> transform.toHumanString(type, (Integer) v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString((int) literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, (int) literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestIdentity.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestIdentity.java
@@ -31,7 +31,8 @@ public class TestIdentity {
     Types.LongType longType = Types.LongType.get();
     Transform<Long, Long> identity = Transforms.identity();
 
-    Assert.assertEquals("Should produce \"null\" for null", "null", identity.toHumanString(longType, null));
+    Assert.assertEquals(
+        "Should produce \"null\" for null", "null", identity.toHumanString(longType, null));
   }
 
   @Test
@@ -51,7 +52,9 @@ public class TestIdentity {
     Transform<byte[], byte[]> identity = Transforms.identity();
 
     Assert.assertEquals(
-        "Should base64-encode binary", "AQID", identity.toHumanString(fixed3, new byte[] {1, 2, 3}));
+        "Should base64-encode binary",
+        "AQID",
+        identity.toHumanString(fixed3, new byte[] {1, 2, 3}));
   }
 
   @Test
@@ -113,7 +116,9 @@ public class TestIdentity {
     Transform<Long, Long> identity = Transforms.identity();
 
     Assert.assertEquals(
-        "Should use Long toString", "-1234567890000", identity.toHumanString(longType, -1234567890000L));
+        "Should use Long toString",
+        "-1234567890000",
+        identity.toHumanString(longType, -1234567890000L));
   }
 
   @Test
@@ -122,7 +127,8 @@ public class TestIdentity {
     Transform<String, String> identity = Transforms.identity();
 
     String withSlash = "a/b/c=d";
-    Assert.assertEquals("Should not modify Strings", withSlash, identity.toHumanString(string, withSlash));
+    Assert.assertEquals(
+        "Should not modify Strings", withSlash, identity.toHumanString(string, withSlash));
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/transforms/TestIdentity.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestIdentity.java
@@ -29,59 +29,59 @@ public class TestIdentity {
   @Test
   public void testNullHumanString() {
     Types.LongType longType = Types.LongType.get();
-    Transform<Long, Long> identity = Transforms.identity(longType);
+    Transform<Long, Long> identity = Transforms.identity();
 
-    Assert.assertEquals("Should produce \"null\" for null", "null", identity.toHumanString(null));
+    Assert.assertEquals("Should produce \"null\" for null", "null", identity.toHumanString(longType, null));
   }
 
   @Test
   public void testBinaryHumanString() {
     Types.BinaryType binary = Types.BinaryType.get();
-    Transform<ByteBuffer, ByteBuffer> identity = Transforms.identity(binary);
+    Transform<ByteBuffer, ByteBuffer> identity = Transforms.identity();
 
     Assert.assertEquals(
         "Should base64-encode binary",
         "AQID",
-        identity.toHumanString(ByteBuffer.wrap(new byte[] {1, 2, 3})));
+        identity.toHumanString(binary, ByteBuffer.wrap(new byte[] {1, 2, 3})));
   }
 
   @Test
   public void testFixedHumanString() {
     Types.FixedType fixed3 = Types.FixedType.ofLength(3);
-    Transform<byte[], byte[]> identity = Transforms.identity(fixed3);
+    Transform<byte[], byte[]> identity = Transforms.identity();
 
     Assert.assertEquals(
-        "Should base64-encode binary", "AQID", identity.toHumanString(new byte[] {1, 2, 3}));
+        "Should base64-encode binary", "AQID", identity.toHumanString(fixed3, new byte[] {1, 2, 3}));
   }
 
   @Test
   public void testDateHumanString() {
     Types.DateType date = Types.DateType.get();
-    Transform<Integer, Integer> identity = Transforms.identity(date);
+    Transform<Integer, Integer> identity = Transforms.identity();
 
     String dateString = "2017-12-01";
     Literal<Integer> dateLit = Literal.of(dateString).to(date);
 
     Assert.assertEquals(
-        "Should produce identical date", dateString, identity.toHumanString(dateLit.value()));
+        "Should produce identical date", dateString, identity.toHumanString(date, dateLit.value()));
   }
 
   @Test
   public void testTimeHumanString() {
     Types.TimeType time = Types.TimeType.get();
-    Transform<Long, Long> identity = Transforms.identity(time);
+    Transform<Long, Long> identity = Transforms.identity();
 
     String timeString = "10:12:55.038194";
     Literal<Long> timeLit = Literal.of(timeString).to(time);
 
     Assert.assertEquals(
-        "Should produce identical time", timeString, identity.toHumanString(timeLit.value()));
+        "Should produce identical time", timeString, identity.toHumanString(time, timeLit.value()));
   }
 
   @Test
   public void testTimestampWithZoneHumanString() {
     Types.TimestampType timestamptz = Types.TimestampType.withZone();
-    Transform<Long, Long> identity = Transforms.identity(timestamptz);
+    Transform<Long, Long> identity = Transforms.identity();
 
     Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194-08:00").to(timestamptz);
 
@@ -89,13 +89,13 @@ public class TestIdentity {
     Assert.assertEquals(
         "Should produce timestamp with time zone adjusted to UTC",
         "2017-12-01T18:12:55.038194Z",
-        identity.toHumanString(ts.value()));
+        identity.toHumanString(timestamptz, ts.value()));
   }
 
   @Test
   public void testTimestampWithoutZoneHumanString() {
     Types.TimestampType timestamp = Types.TimestampType.withoutZone();
-    Transform<Long, Long> identity = Transforms.identity(timestamp);
+    Transform<Long, Long> identity = Transforms.identity();
 
     String tsString = "2017-12-01T10:12:55.038194";
     Literal<Long> ts = Literal.of(tsString).to(timestamp);
@@ -104,35 +104,35 @@ public class TestIdentity {
     Assert.assertEquals(
         "Should produce identical timestamp without time zone",
         tsString,
-        identity.toHumanString(ts.value()));
+        identity.toHumanString(timestamp, ts.value()));
   }
 
   @Test
   public void testLongToHumanString() {
     Types.LongType longType = Types.LongType.get();
-    Transform<Long, Long> identity = Transforms.identity(longType);
+    Transform<Long, Long> identity = Transforms.identity();
 
     Assert.assertEquals(
-        "Should use Long toString", "-1234567890000", identity.toHumanString(-1234567890000L));
+        "Should use Long toString", "-1234567890000", identity.toHumanString(longType, -1234567890000L));
   }
 
   @Test
   public void testStringToHumanString() {
     Types.StringType string = Types.StringType.get();
-    Transform<String, String> identity = Transforms.identity(string);
+    Transform<String, String> identity = Transforms.identity();
 
     String withSlash = "a/b/c=d";
-    Assert.assertEquals("Should not modify Strings", withSlash, identity.toHumanString(withSlash));
+    Assert.assertEquals("Should not modify Strings", withSlash, identity.toHumanString(string, withSlash));
   }
 
   @Test
   public void testBigDecimalToHumanString() {
     Types.DecimalType decimal = Types.DecimalType.of(9, 2);
-    Transform<BigDecimal, BigDecimal> identity = Transforms.identity(decimal);
+    Transform<BigDecimal, BigDecimal> identity = Transforms.identity();
 
     String decimalString = "-1.50";
     BigDecimal bigDecimal = new BigDecimal(decimalString);
     Assert.assertEquals(
-        "Should not modify Strings", decimalString, identity.toHumanString(bigDecimal));
+        "Should not modify Strings", decimalString, identity.toHumanString(decimal, bigDecimal));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
@@ -93,7 +93,7 @@ public class TestNotStartsWith {
 
   @Test
   public void testTruncateStringWhenProjectedPredicateTermIsLongerThanWidth() {
-    Truncate<String> trunc = Truncate.get(Types.StringType.get(), 2);
+    Truncate<String> trunc = Truncate.get(2);
     UnboundPredicate<String> expr = notStartsWith(COLUMN, "abcde");
     BoundPredicate<String> boundExpr =
         (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
@@ -127,7 +127,7 @@ public class TestNotStartsWith {
 
   @Test
   public void testTruncateStringWhenProjectedPredicateTermIsShorterThanWidth() {
-    Truncate<String> trunc = Truncate.get(Types.StringType.get(), 16);
+    Truncate<String> trunc = Truncate.get(16);
     UnboundPredicate<String> expr = notStartsWith(COLUMN, "ab");
     BoundPredicate<String> boundExpr =
         (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);
@@ -153,7 +153,7 @@ public class TestNotStartsWith {
 
   @Test
   public void testTruncateStringWhenProjectedPredicateTermIsEqualToWidth() {
-    Truncate<String> trunc = Truncate.get(Types.StringType.get(), 7);
+    Truncate<String> trunc = Truncate.get(7);
     UnboundPredicate<String> expr = notStartsWith(COLUMN, "abcdefg");
     BoundPredicate<String> boundExpr =
         (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestNotStartsWith.java
@@ -223,6 +223,7 @@ public class TestNotStartsWith {
     assertProjection(spec, expectedLiteral, projection, expectedOp);
   }
 
+  @SuppressWarnings("unchecked")
   private void assertProjection(
       PartitionSpec spec,
       String expectedLiteral,
@@ -232,7 +233,7 @@ public class TestNotStartsWith {
     Literal<?> literal = predicate.literal();
     Truncate<CharSequence> transform =
         (Truncate<CharSequence>) spec.getFieldsBySourceId(1).get(0).transform();
-    String output = transform.toHumanString((String) literal.value());
+    String output = transform.toHumanString(Types.StringType.get(), (String) literal.value());
 
     Assert.assertEquals(expectedOp, predicate.op());
     Assert.assertEquals(expectedLiteral, output);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
@@ -33,6 +33,7 @@ import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.or;
 
+import java.util.function.Function;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestHelpers.Row;
@@ -40,7 +41,6 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
-import org.apache.iceberg.expressions.Predicate;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Types;
@@ -210,10 +210,10 @@ public class TestResiduals {
 
     PartitionSpec spec = PartitionSpec.builderFor(schema).day("ts").build();
 
-    Transform day = spec.getFieldsBySourceId(50).get(0).transform();
-    Integer tsDay = (Integer) day.apply(date20191201);
+    Function<Object, Integer> day = Transforms.day().bind(Types.TimestampType.withoutZone());
+    Integer tsDay = day.apply(date20191201);
 
-    Predicate pred = in("ts", date20191201, date20191202);
+    Expression pred = in("ts", date20191201, date20191202);
     ResidualEvaluator resEval = ResidualEvaluator.of(spec, pred, true);
 
     Expression residual = resEval.residualFor(Row.of(tsDay));
@@ -318,10 +318,10 @@ public class TestResiduals {
 
     PartitionSpec spec = PartitionSpec.builderFor(schema).day("ts").build();
 
-    Transform day = spec.getFieldsBySourceId(50).get(0).transform();
-    Integer tsDay = (Integer) day.apply(date20191201);
+    Function<Object, Integer> day = Transforms.day().bind(Types.TimestampType.withoutZone());
+    Integer tsDay = day.apply(date20191201);
 
-    Predicate pred = notIn("ts", date20191201, date20191202);
+    Expression pred = notIn("ts", date20191201, date20191202);
     ResidualEvaluator resEval = ResidualEvaluator.of(spec, pred, true);
 
     Expression residual = resEval.residualFor(Row.of(tsDay));

--- a/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
@@ -63,7 +63,7 @@ public class TestStartsWith {
   @Test
   @SuppressWarnings("unchecked")
   public void testTruncateString() {
-    Truncate<String> trunc = Truncate.get(Types.StringType.get(), 2);
+    Truncate<String> trunc = Truncate.get(2);
     Expression expr = startsWith(COLUMN, "abcde");
     BoundPredicate<String> boundExpr =
         (BoundPredicate<String>) Binder.bind(SCHEMA.asStruct(), expr, false);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
@@ -61,6 +61,7 @@ public class TestStartsWith {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testTruncateString() {
     Truncate<String> trunc = Truncate.get(Types.StringType.get(), 2);
     Expression expr = startsWith(COLUMN, "abcde");
@@ -93,16 +94,17 @@ public class TestStartsWith {
     assertProjection(spec, expectedLiteral, projection, expectedOp);
   }
 
+  @SuppressWarnings("unchecked")
   private void assertProjection(
       PartitionSpec spec,
       String expectedLiteral,
       Expression projection,
       Expression.Operation expectedOp) {
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
-    Literal literal = predicate.literal();
+    Literal<?> literal = predicate.literal();
     Truncate<CharSequence> transform =
         (Truncate<CharSequence>) spec.getFieldsBySourceId(1).get(0).transform();
-    String output = transform.toHumanString((String) literal.value());
+    String output = transform.toHumanString(Types.StringType.get(), (String) literal.value());
 
     Assert.assertEquals(expectedOp, predicate.op());
     Assert.assertEquals(expectedLiteral, output);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
@@ -25,34 +25,36 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTimestamps {
-//  @Test
-//  @SuppressWarnings("deprecation")
-//  public void testDeprecatedTimestampTransform() {
-//    Types.TimestampType type = Types.TimestampType.withoutZone();
-//    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
-//    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
-//    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
-//
-//    Transform<Long, Integer> years = Transforms.year(type);
-//    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
-//    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
-//    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
-//
-//    Transform<Long, Integer> months = Transforms.month(type);
-//    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(ts.value()));
-//    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
-//    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
-//
-//    Transform<Long, Integer> days = Transforms.day(type);
-//    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
-//    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
-//    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
-//
-//    Transform<Long, Integer> hours = Transforms.hour(type);
-//    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int) hours.apply(ts.value()));
-//    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
-//    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
-//  }
+  //  @Test
+  //  @SuppressWarnings("deprecation")
+  //  public void testDeprecatedTimestampTransform() {
+  //    Types.TimestampType type = Types.TimestampType.withoutZone();
+  //    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
+  //    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
+  //    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
+  //
+  //    Transform<Long, Integer> years = Transforms.year(type);
+  //    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
+  //    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
+  //    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
+  //
+  //    Transform<Long, Integer> months = Transforms.month(type);
+  //    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int)
+  // months.apply(ts.value()));
+  //    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
+  //    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
+  //
+  //    Transform<Long, Integer> days = Transforms.day(type);
+  //    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
+  //    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
+  //    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
+  //
+  //    Transform<Long, Integer> hours = Transforms.hour(type);
+  //    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int)
+  // hours.apply(ts.value()));
+  //    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
+  //    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
+  //  }
 
   @Test
   public void testTimestampTransform() {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
@@ -25,6 +25,35 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTimestamps {
+//  @Test
+//  @SuppressWarnings("deprecation")
+//  public void testDeprecatedTimestampTransform() {
+//    Types.TimestampType type = Types.TimestampType.withoutZone();
+//    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
+//    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
+//    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
+//
+//    Transform<Long, Integer> years = Transforms.year(type);
+//    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
+//    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
+//    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
+//
+//    Transform<Long, Integer> months = Transforms.month(type);
+//    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(ts.value()));
+//    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
+//    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
+//
+//    Transform<Long, Integer> days = Transforms.day(type);
+//    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
+//    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
+//    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
+//
+//    Transform<Long, Integer> hours = Transforms.hour(type);
+//    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int) hours.apply(ts.value()));
+//    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
+//    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
+//  }
+
   @Test
   public void testTimestampTransform() {
     Types.TimestampType type = Types.TimestampType.withoutZone();
@@ -32,25 +61,33 @@ public class TestTimestamps {
     Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
     Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
 
-    Transform<Long, Integer> years = Transforms.year(type);
-    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
-    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
-    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
+    Transform<Long, Integer> years = Transforms.year();
+    Assert.assertEquals(
+        "Should produce 2017 - 1970 = 47", 47, (int) years.bind(type).apply(ts.value()));
+    Assert.assertEquals(
+        "Should produce 1970 - 1970 = 0", 0, (int) years.bind(type).apply(pts.value()));
+    Assert.assertEquals(
+        "Should produce 1969 - 1970 = -1", -1, (int) years.bind(type).apply(nts.value()));
 
-    Transform<Long, Integer> months = Transforms.month(type);
-    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(ts.value()));
-    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
-    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
+    Transform<Long, Integer> months = Transforms.month();
+    Assert.assertEquals(
+        "Should produce 47 * 12 + 11 = 575", 575, (int) months.bind(type).apply(ts.value()));
+    Assert.assertEquals(
+        "Should produce 0 * 12 + 0 = 0", 0, (int) months.bind(type).apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.bind(type).apply(nts.value()));
 
-    Transform<Long, Integer> days = Transforms.day(type);
-    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
-    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
-    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
+    Transform<Long, Integer> days = Transforms.day();
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.bind(type).apply(ts.value()));
+    Assert.assertEquals(
+        "Should produce 0 * 365 + 0 = 0", 0, (int) days.bind(type).apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.bind(type).apply(nts.value()));
 
-    Transform<Long, Integer> hours = Transforms.hour(type);
-    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int) hours.apply(ts.value()));
-    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
-    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
+    Transform<Long, Integer> hours = Transforms.hour();
+    Assert.assertEquals(
+        "Should produce 17501 * 24 + 10", 420034, (int) hours.bind(type).apply(ts.value()));
+    Assert.assertEquals(
+        "Should produce 0 * 24 + 0 = 0", 0, (int) hours.bind(type).apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) hours.bind(type).apply(nts.value()));
   }
 
   @Test
@@ -58,29 +95,29 @@ public class TestTimestamps {
     Types.TimestampType type = Types.TimestampType.withoutZone();
     Literal<Long> date = Literal.of("2017-12-01T10:12:55.038194").to(type);
 
-    Transform<Long, Integer> year = Transforms.year(type);
+    Transform<Long, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> month = Transforms.month(type);
+    Transform<Long, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> day = Transforms.day(type);
+    Transform<Long, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12-01",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> hour = Transforms.hour(type);
+    Transform<Long, Integer> hour = Transforms.hour();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12-01-10",
-        hour.toHumanString(hour.apply(date.value())));
+        hour.toHumanString(type, hour.bind(type).apply(date.value())));
   }
 
   @Test
@@ -88,29 +125,29 @@ public class TestTimestamps {
     Types.TimestampType type = Types.TimestampType.withoutZone();
     Literal<Long> date = Literal.of("1969-12-30T10:12:55.038194").to(type);
 
-    Transform<Long, Integer> year = Transforms.year(type);
+    Transform<Long, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> month = Transforms.month(type);
+    Transform<Long, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> day = Transforms.day(type);
+    Transform<Long, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-30",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> hour = Transforms.hour(type);
+    Transform<Long, Integer> hour = Transforms.hour();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-30-10",
-        hour.toHumanString(hour.apply(date.value())));
+        hour.toHumanString(type, hour.bind(type).apply(date.value())));
   }
 
   @Test
@@ -118,29 +155,29 @@ public class TestTimestamps {
     Types.TimestampType type = Types.TimestampType.withoutZone();
     Literal<Long> date = Literal.of("1969-12-30T00:00:00.000000").to(type);
 
-    Transform<Long, Integer> year = Transforms.year(type);
+    Transform<Long, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> month = Transforms.month(type);
+    Transform<Long, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> day = Transforms.day(type);
+    Transform<Long, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-30",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> hour = Transforms.hour(type);
+    Transform<Long, Integer> hour = Transforms.hour();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-30-00",
-        hour.toHumanString(hour.apply(date.value())));
+        hour.toHumanString(type, hour.bind(type).apply(date.value())));
   }
 
   @Test
@@ -148,29 +185,29 @@ public class TestTimestamps {
     Types.TimestampType type = Types.TimestampType.withoutZone();
     Literal<Long> date = Literal.of("1969-12-31T23:59:59.999999").to(type);
 
-    Transform<Long, Integer> year = Transforms.year(type);
+    Transform<Long, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> month = Transforms.month(type);
+    Transform<Long, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> day = Transforms.day(type);
+    Transform<Long, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-31",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> hour = Transforms.hour(type);
+    Transform<Long, Integer> hour = Transforms.hour();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "1969-12-31-23",
-        hour.toHumanString(hour.apply(date.value())));
+        hour.toHumanString(type, hour.bind(type).apply(date.value())));
   }
 
   @Test
@@ -178,62 +215,62 @@ public class TestTimestamps {
     Types.TimestampType type = Types.TimestampType.withZone();
     Literal<Long> date = Literal.of("2017-12-01T10:12:55.038194-08:00").to(type);
 
-    Transform<Long, Integer> year = Transforms.year(type);
+    Transform<Long, Integer> year = Transforms.year();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017",
-        year.toHumanString(year.apply(date.value())));
+        year.toHumanString(type, year.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> month = Transforms.month(type);
+    Transform<Long, Integer> month = Transforms.month();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12",
-        month.toHumanString(month.apply(date.value())));
+        month.toHumanString(type, month.bind(type).apply(date.value())));
 
-    Transform<Long, Integer> day = Transforms.day(type);
+    Transform<Long, Integer> day = Transforms.day();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12-01",
-        day.toHumanString(day.apply(date.value())));
+        day.toHumanString(type, day.bind(type).apply(date.value())));
 
     // the hour is 18 because the value is always UTC
-    Transform<Long, Integer> hour = Transforms.hour(type);
+    Transform<Long, Integer> hour = Transforms.hour();
     Assert.assertEquals(
         "Should produce the correct Human string",
         "2017-12-01-18",
-        hour.toHumanString(hour.apply(date.value())));
+        hour.toHumanString(type, hour.bind(type).apply(date.value())));
   }
 
   @Test
   public void testNullHumanString() {
     Types.TimestampType type = Types.TimestampType.withZone();
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.year(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.year().toHumanString(type, null));
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.month(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.month().toHumanString(type, null));
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.day(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.day().toHumanString(type, null));
     Assert.assertEquals(
-        "Should produce \"null\" for null", "null", Transforms.hour(type).toHumanString(null));
+        "Should produce \"null\" for null", "null", Transforms.hour().toHumanString(type, null));
   }
 
   @Test
   public void testTimestampsReturnType() {
     Types.TimestampType type = Types.TimestampType.withZone();
 
-    Transform<Integer, Integer> year = Transforms.year(type);
+    Transform<Integer, Integer> year = Transforms.year();
     Type yearResultType = year.getResultType(type);
     Assert.assertEquals(Types.IntegerType.get(), yearResultType);
 
-    Transform<Integer, Integer> month = Transforms.month(type);
+    Transform<Integer, Integer> month = Transforms.month();
     Type monthResultType = month.getResultType(type);
     Assert.assertEquals(Types.IntegerType.get(), monthResultType);
 
-    Transform<Integer, Integer> day = Transforms.day(type);
+    Transform<Integer, Integer> day = Transforms.day();
     Type dayResultType = day.getResultType(type);
     Assert.assertEquals(Types.DateType.get(), dayResultType);
 
-    Transform<Integer, Integer> hour = Transforms.hour(type);
+    Transform<Integer, Integer> hour = Transforms.hour();
     Type hourResultType = hour.getResultType(type);
     Assert.assertEquals(Types.IntegerType.get(), hourResultType);
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
@@ -25,36 +25,34 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTimestamps {
-  //  @Test
-  //  @SuppressWarnings("deprecation")
-  //  public void testDeprecatedTimestampTransform() {
-  //    Types.TimestampType type = Types.TimestampType.withoutZone();
-  //    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
-  //    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
-  //    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
-  //
-  //    Transform<Long, Integer> years = Transforms.year(type);
-  //    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
-  //    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
-  //    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
-  //
-  //    Transform<Long, Integer> months = Transforms.month(type);
-  //    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int)
-  // months.apply(ts.value()));
-  //    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
-  //    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
-  //
-  //    Transform<Long, Integer> days = Transforms.day(type);
-  //    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
-  //    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
-  //    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
-  //
-  //    Transform<Long, Integer> hours = Transforms.hour(type);
-  //    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int)
-  // hours.apply(ts.value()));
-  //    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
-  //    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
-  //  }
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedTimestampTransform() {
+    Types.TimestampType type = Types.TimestampType.withoutZone();
+    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
+    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
+    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
+
+    Transform<Long, Integer> years = Transforms.year(type);
+    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
+    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
+    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
+
+    Transform<Long, Integer> months = Transforms.month(type);
+    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
+
+    Transform<Long, Integer> days = Transforms.day(type);
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
+
+    Transform<Long, Integer> hours = Transforms.hour(type);
+    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int) hours.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
+  }
 
   @Test
   public void testTimestampTransform() {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -55,7 +55,7 @@ public class TestTimestampsProjection {
       String expectedLiteral) {
 
     Expression projection = Projections.strict(spec).project(filter);
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+    UnboundPredicate<Integer> predicate = assertAndUnwrapUnbound(projection);
 
     Assert.assertEquals(expectedOp, predicate.op());
 
@@ -66,17 +66,17 @@ public class TestTimestampsProjection {
         (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
-      Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
+      Iterable<Integer> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(type, (Integer) v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal<?> literal = predicate.literal();
-      String output = transform.toHumanString(type, (int) literal.value());
+      Literal<Integer> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -62,7 +62,8 @@ public class TestTimestampsProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform =
+        (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
@@ -108,7 +109,8 @@ public class TestTimestampsProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform =
+        (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -102,7 +102,7 @@ public class TestTimestampsProjection {
       Expression.Operation expectedOp,
       String expectedLiteral) {
     Expression projection = Projections.inclusive(spec).project(filter);
-    UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
+    UnboundPredicate<Integer> predicate = assertAndUnwrapUnbound(projection);
 
     Assert.assertEquals(expectedOp, predicate.op());
 
@@ -113,17 +113,17 @@ public class TestTimestampsProjection {
         (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
-      Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
+      Iterable<Integer> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(type, (Integer) v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal<?> literal = predicate.literal();
-      String output = transform.toHumanString(type, (int) literal.value());
+      Literal<Integer> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,6 +47,7 @@ public class TestTimestampsProjection {
   private static final Types.TimestampType TYPE = Types.TimestampType.withoutZone();
   private static final Schema SCHEMA = new Schema(optional(1, "timestamp", TYPE));
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionStrict(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -60,19 +62,20 @@ public class TestTimestampsProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString((Integer) v))
+              .map(v -> transform.toHumanString(type, (Integer) v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString((int) literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, (int) literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }
@@ -91,6 +94,7 @@ public class TestTimestampsProjection {
     Assert.assertEquals(expectedOp, projection.op());
   }
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionInclusive(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -104,19 +108,20 @@ public class TestTimestampsProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Timestamps transform = (Timestamps) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<?, Integer> transform = (Transform<?, Integer>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString((Integer) v))
+              .map(v -> transform.toHumanString(type, (Integer) v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString((int) literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, (int) literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTransformSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTransformSerialization.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.transforms;
+
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SerializableFunction;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTransformSerialization {
+  @Test
+  public void testFunctionSerialization() throws Exception {
+    Type[] types = new Type[] {
+        Types.BooleanType.get(),
+        Types.IntegerType.get(),
+        Types.LongType.get(),
+        Types.FloatType.get(),
+        Types.DoubleType.get(),
+        Types.StringType.get(),
+        Types.DateType.get(),
+        Types.TimeType.get(),
+        Types.TimestampType.withoutZone(),
+        Types.TimestampType.withoutZone(),
+        Types.BinaryType.get(),
+        Types.FixedType.ofLength(4),
+        Types.DecimalType.of(9, 4),
+        Types.UUIDType.get(),
+    };
+
+    Transform<?, ?>[] transforms = new Transform<?, ?>[] {
+        Transforms.identity(),
+        Transforms.bucket(1024),
+        Transforms.year(),
+        Transforms.month(),
+        Transforms.day(),
+        Transforms.hour(),
+        Transforms.truncate(16)
+    };
+
+    for (Type type : types) {
+      for (Transform<?, ?> transform : transforms) {
+        Assert.assertEquals(transform, TestHelpers.roundTripSerialize(transform));
+
+        if (transform.canTransform(type)) {
+          SerializableFunction<?, ?> func = transform.bind(type);
+          Assert.assertTrue(func.getClass().isInstance(TestHelpers.roundTripSerialize(func)));
+        }
+      }
+    }
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTransformSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTransformSerialization.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.transforms;
 
 import org.apache.iceberg.TestHelpers;
@@ -29,32 +28,34 @@ import org.junit.Test;
 public class TestTransformSerialization {
   @Test
   public void testFunctionSerialization() throws Exception {
-    Type[] types = new Type[] {
-        Types.BooleanType.get(),
-        Types.IntegerType.get(),
-        Types.LongType.get(),
-        Types.FloatType.get(),
-        Types.DoubleType.get(),
-        Types.StringType.get(),
-        Types.DateType.get(),
-        Types.TimeType.get(),
-        Types.TimestampType.withoutZone(),
-        Types.TimestampType.withoutZone(),
-        Types.BinaryType.get(),
-        Types.FixedType.ofLength(4),
-        Types.DecimalType.of(9, 4),
-        Types.UUIDType.get(),
-    };
+    Type[] types =
+        new Type[] {
+          Types.BooleanType.get(),
+          Types.IntegerType.get(),
+          Types.LongType.get(),
+          Types.FloatType.get(),
+          Types.DoubleType.get(),
+          Types.StringType.get(),
+          Types.DateType.get(),
+          Types.TimeType.get(),
+          Types.TimestampType.withoutZone(),
+          Types.TimestampType.withoutZone(),
+          Types.BinaryType.get(),
+          Types.FixedType.ofLength(4),
+          Types.DecimalType.of(9, 4),
+          Types.UUIDType.get(),
+        };
 
-    Transform<?, ?>[] transforms = new Transform<?, ?>[] {
-        Transforms.identity(),
-        Transforms.bucket(1024),
-        Transforms.year(),
-        Transforms.month(),
-        Transforms.day(),
-        Transforms.hour(),
-        Transforms.truncate(16)
-    };
+    Transform<?, ?>[] transforms =
+        new Transform<?, ?>[] {
+          Transforms.identity(),
+          Transforms.bucket(1024),
+          Transforms.year(),
+          Transforms.month(),
+          Transforms.day(),
+          Transforms.hour(),
+          Transforms.truncate(16)
+        };
 
     for (Type type : types) {
       for (Transform<?, ?> transform : transforms) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 public class TestTruncate {
   @Test
   public void testDeprecatedTruncateInteger() {
-    Truncate<Integer> trunc = Truncate.get(Types.IntegerType.get(), 10);
+    Truncate<Object> trunc = Truncate.get(Types.IntegerType.get(), 10);
     Assert.assertEquals(0, (int) trunc.apply(0));
     Assert.assertEquals(0, (int) trunc.apply(1));
     Assert.assertEquals(0, (int) trunc.apply(5));

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.transforms;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -27,7 +29,7 @@ import org.junit.Test;
 
 public class TestTruncate {
   @Test
-  public void testTruncateInteger() {
+  public void testDeprecatedTruncateInteger() {
     Truncate<Integer> trunc = Truncate.get(Types.IntegerType.get(), 10);
     Assert.assertEquals(0, (int) trunc.apply(0));
     Assert.assertEquals(0, (int) trunc.apply(1));
@@ -42,8 +44,23 @@ public class TestTruncate {
   }
 
   @Test
+  public void testTruncateInteger() {
+    Function<Object, Object> trunc = Truncate.get(10).bind(Types.IntegerType.get());
+    Assert.assertEquals(0, (int) trunc.apply(0));
+    Assert.assertEquals(0, (int) trunc.apply(1));
+    Assert.assertEquals(0, (int) trunc.apply(5));
+    Assert.assertEquals(0, (int) trunc.apply(9));
+    Assert.assertEquals(10, (int) trunc.apply(10));
+    Assert.assertEquals(10, (int) trunc.apply(11));
+    Assert.assertEquals(-10, (int) trunc.apply(-1));
+    Assert.assertEquals(-10, (int) trunc.apply(-5));
+    Assert.assertEquals(-10, (int) trunc.apply(-10));
+    Assert.assertEquals(-20, (int) trunc.apply(-11));
+  }
+
+  @Test
   public void testTruncateLong() {
-    Truncate<Long> trunc = Truncate.get(Types.LongType.get(), 10);
+    Function<Object, Object> trunc = Truncate.get(10).bind(Types.LongType.get());
     Assert.assertEquals(0L, (long) trunc.apply(0L));
     Assert.assertEquals(0L, (long) trunc.apply(1L));
     Assert.assertEquals(0L, (long) trunc.apply(5L));
@@ -59,7 +76,7 @@ public class TestTruncate {
   @Test
   public void testTruncateDecimal() {
     // decimal truncation works by applying the decimal scale to the width: 10 scale 2 = 0.10
-    Truncate<BigDecimal> trunc = Truncate.get(Types.DecimalType.of(9, 2), 10);
+    Function<Object, Object> trunc = Truncate.get(10).bind(Types.DecimalType.of(9, 2));
     Assert.assertEquals(new BigDecimal("12.30"), trunc.apply(new BigDecimal("12.34")));
     Assert.assertEquals(new BigDecimal("12.30"), trunc.apply(new BigDecimal("12.30")));
     Assert.assertEquals(new BigDecimal("12.20"), trunc.apply(new BigDecimal("12.29")));
@@ -69,7 +86,7 @@ public class TestTruncate {
 
   @Test
   public void testTruncateString() {
-    Truncate<String> trunc = Truncate.get(Types.StringType.get(), 5);
+    Function<Object, Object> trunc = Truncate.get(5).bind(Types.StringType.get());
     Assert.assertEquals(
         "Should truncate strings longer than length", "abcde", trunc.apply("abcdefg"));
     Assert.assertEquals("Should not pad strings shorter than length", "abc", trunc.apply("abc"));
@@ -77,16 +94,16 @@ public class TestTruncate {
   }
 
   @Test
-  public void testTruncateByteBuffer() throws Exception {
-    Truncate<ByteBuffer> trunc = Truncate.get(Types.BinaryType.get(), 4);
+  public void testTruncateByteBuffer() {
+    Function<Object, Object> trunc = Truncate.get(4).bind(Types.BinaryType.get());
     Assert.assertEquals(
         "Should truncate binary longer than length",
-        ByteBuffer.wrap("abcd".getBytes("UTF-8")),
-        trunc.apply(ByteBuffer.wrap("abcdefg".getBytes("UTF-8"))));
+        ByteBuffer.wrap("abcd".getBytes(StandardCharsets.UTF_8)),
+        trunc.apply(ByteBuffer.wrap("abcdefg".getBytes(StandardCharsets.UTF_8))));
     Assert.assertEquals(
         "Should not pad binary shorter than length",
-        ByteBuffer.wrap("abc".getBytes("UTF-8")),
-        trunc.apply(ByteBuffer.wrap("abc".getBytes("UTF-8"))));
+        ByteBuffer.wrap("abc".getBytes(StandardCharsets.UTF_8)),
+        trunc.apply(ByteBuffer.wrap("abc".getBytes(StandardCharsets.UTF_8))));
   }
 
   @Test
@@ -95,6 +112,6 @@ public class TestTruncate {
         "Should fail if width is less than or equal to zero",
         IllegalArgumentException.class,
         "Invalid truncate width: 0 (must be > 0)",
-        () -> Truncate.get(Types.IntegerType.get(), 0));
+        () -> Truncate.get(0));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncatesProjection.java
@@ -62,7 +62,8 @@ public class TestTruncatesProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Transform<Object, Object> transform = (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<Object, Object> transform =
+        (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
@@ -108,7 +109,8 @@ public class TestTruncatesProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Transform<Object, Object> transform = (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<Object, Object> transform =
+        (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
     Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncatesProjection.java
@@ -40,12 +40,14 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTruncatesProjection {
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionStrict(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -60,19 +62,20 @@ public class TestTruncatesProjection {
     Assert.assertNotEquals(
         "Strict projection never runs for IN", Expression.Operation.IN, predicate.op());
 
-    Truncate transform = (Truncate) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<Object, Object> transform = (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.NOT_IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString(literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }
@@ -91,6 +94,7 @@ public class TestTruncatesProjection {
     Assert.assertEquals(projection.op(), expectedOp);
   }
 
+  @SuppressWarnings("unchecked")
   public void assertProjectionInclusive(
       PartitionSpec spec,
       UnboundPredicate<?> filter,
@@ -104,19 +108,20 @@ public class TestTruncatesProjection {
     Assert.assertNotEquals(
         "Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
-    Truncate transform = (Truncate) spec.getFieldsBySourceId(1).get(0).transform();
+    Transform<Object, Object> transform = (Transform<Object, Object>) spec.getFieldsBySourceId(1).get(0).transform();
+    Type type = spec.partitionType().field(spec.getFieldsBySourceId(1).get(0).fieldId()).type();
     if (predicate.op() == Expression.Operation.IN) {
       Iterable<?> values = Iterables.transform(predicate.literals(), Literal::value);
       String actual =
           Lists.newArrayList(values).stream()
               .sorted()
-              .map(v -> transform.toHumanString(v))
+              .map(v -> transform.toHumanString(type, v))
               .collect(Collectors.toList())
               .toString();
       Assert.assertEquals(expectedLiteral, actual);
     } else {
-      Literal literal = predicate.literal();
-      String output = transform.toHumanString(literal.value());
+      Literal<?> literal = predicate.literal();
+      String output = transform.toHumanString(type, literal.value());
       Assert.assertEquals(expectedLiteral, output);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -64,8 +64,9 @@ public abstract class BaseMetadataTable implements Table, HasTableOperations, Se
   static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec) {
     PartitionSpec.Builder identitySpecBuilder =
         PartitionSpec.builderFor(metadataTableSchema).checkConflicts(false);
-    spec.fields()
-        .forEach(pf -> identitySpecBuilder.add(pf.fieldId(), pf.name(), Transforms.identity()));
+    for (PartitionField field : spec.fields()) {
+      identitySpecBuilder.add(field.fieldId(), field.name(), Transforms.identity());
+    }
     return identitySpecBuilder.build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.transforms.Transforms;
 
 /**
  * Base class for metadata tables.
@@ -63,7 +64,8 @@ public abstract class BaseMetadataTable implements Table, HasTableOperations, Se
   static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec) {
     PartitionSpec.Builder identitySpecBuilder =
         PartitionSpec.builderFor(metadataTableSchema).checkConflicts(false);
-    spec.fields().forEach(pf -> identitySpecBuilder.add(pf.fieldId(), pf.name(), "identity"));
+    spec.fields()
+        .forEach(pf -> identitySpecBuilder.add(pf.fieldId(), pf.name(), Transforms.identity()));
     return identitySpecBuilder.build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -343,7 +343,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
   private Transform<?, ?> toTransform(BoundTerm<?> term) {
     if (term instanceof BoundReference) {
-      return Transforms.identity(term.type());
+      return Transforms.identity();
     } else if (term instanceof BoundTransform) {
       return ((BoundTransform<?, ?>) term).transform();
     } else {

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -19,11 +19,11 @@
 package org.apache.iceberg;
 
 import java.util.Map;
+import java.util.function.Function;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.LocationUtil;
@@ -104,8 +104,8 @@ public class LocationProviders {
   }
 
   static class ObjectStoreLocationProvider implements LocationProvider {
-    private static final Transform<String, Integer> HASH_FUNC =
-        Transforms.bucket(Types.StringType.get(), Integer.MAX_VALUE);
+    private static final Function<Object, Integer> HASH_FUNC =
+        Transforms.bucket(Integer.MAX_VALUE).bind(Types.StringType.get());
 
     private final String storageLocation;
     private final String context;

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -130,12 +130,14 @@ public class ManifestsTable extends BaseMetadataTable {
                   .get(i)
                   .transform()
                   .toHumanString(
+                      spec.partitionType().fields().get(i).type(),
                       Conversions.fromByteBuffer(
                           spec.partitionType().fields().get(i).type(), summary.lowerBound())),
               spec.fields()
                   .get(i)
                   .transform()
                   .toHumanString(
+                      spec.partitionType().fields().get(i).type(),
                       Conversions.fromByteBuffer(
                           spec.partitionType().fields().get(i).type(), summary.upperBound()))));
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -109,8 +109,7 @@ public class TableMetadata implements Serializable {
       // look up the name of the source field in the old schema to get the new schema's id
       String sourceName = schema.findColumnName(field.sourceId());
       // reassign all partition fields with fresh partition field Ids to ensure consistency
-      specBuilder.add(
-          freshSchema.findField(sourceName).fieldId(), field.name(), field.transform());
+      specBuilder.add(freshSchema.findField(sourceName).fieldId(), field.name(), field.transform());
     }
     PartitionSpec freshSpec = specBuilder.build();
 
@@ -685,7 +684,8 @@ public class TableMetadata implements Serializable {
 
     // add all the fields to the builder. IDs should not change.
     for (SortField field : sortOrder.fields()) {
-      builder.addSortField(field.transform(), field.sourceId(), field.direction(), field.nullOrder());
+      builder.addSortField(
+          field.transform(), field.sourceId(), field.direction(), field.nullOrder());
     }
 
     // build without validation because the schema may have changed in a way that makes this order

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -110,7 +110,7 @@ public class TableMetadata implements Serializable {
       String sourceName = schema.findColumnName(field.sourceId());
       // reassign all partition fields with fresh partition field Ids to ensure consistency
       specBuilder.add(
-          freshSchema.findField(sourceName).fieldId(), field.name(), field.transform().toString());
+          freshSchema.findField(sourceName).fieldId(), field.name(), field.transform());
     }
     PartitionSpec freshSpec = specBuilder.build();
 
@@ -685,8 +685,7 @@ public class TableMetadata implements Serializable {
 
     // add all the fields to the builder. IDs should not change.
     for (SortField field : sortOrder.fields()) {
-      builder.addSortField(
-          field.transform(), field.sourceId(), field.direction(), field.nullOrder());
+      builder.addSortField(field.transform(), field.sourceId(), field.direction(), field.nullOrder());
     }
 
     // build without validation because the schema may have changed in a way that makes this order

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 
@@ -316,7 +315,7 @@ public class ExpressionParser {
   @SuppressWarnings("unchecked")
   private static <T> UnboundPredicate<T> predicateFromJson(
       Expression.Operation op, JsonNode node, Schema schema) {
-    UnboundTerm<T> term = term(JsonUtil.get(TERM, node), schema);
+    UnboundTerm<T> term = term(JsonUtil.get(TERM, node));
 
     Function<JsonNode, T> convertValue;
     if (schema != null) {
@@ -399,7 +398,7 @@ public class ExpressionParser {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> UnboundTerm<T> term(JsonNode node, Schema schema) {
+  private static <T> UnboundTerm<T> term(JsonNode node) {
     if (node.isTextual()) {
       return Expressions.ref(node.asText());
     } else if (node.isObject()) {
@@ -408,11 +407,10 @@ public class ExpressionParser {
         case REFERENCE:
           return Expressions.ref(JsonUtil.getString(TERM, node));
         case TRANSFORM:
-          UnboundTerm<T> child = term(JsonUtil.get(TERM, node), schema);
-          Type termType = schema.findType(child.ref().name());
+          UnboundTerm<T> child = term(JsonUtil.get(TERM, node));
           String transform = JsonUtil.getString(TRANSFORM, node);
           return (UnboundTerm<T>)
-              Expressions.transform(child.ref().name(), Transforms.fromString(termType, transform));
+              Expressions.transform(child.ref().name(), Transforms.fromString(transform));
         default:
           throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
       }

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -96,7 +96,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
     Assert.assertEquals(
         "Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
-    Transform<?, ?> transform = Transforms.identity(Types.IntegerType.get());
+    Transform<?, ?> transform = Transforms.identity();
     Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 import org.assertj.core.api.Assertions;
@@ -1069,8 +1070,8 @@ public class TestTableMetadata {
     PartitionSpec spec =
         PartitionSpec.builderFor(schema)
             .withSpecId(5)
-            .add(3, 1005, "x_partition", "bucket[4]")
-            .add(5, 1003, "z_partition", "bucket[8]")
+            .add(3, 1005, "x_partition", Transforms.bucket(4))
+            .add(5, 1003, "z_partition", Transforms.bucket(8))
             .build();
     String location = "file://tmp/db/table";
     TableMetadata metadata =
@@ -1080,8 +1081,8 @@ public class TestTableMetadata {
     PartitionSpec expected =
         PartitionSpec.builderFor(metadata.schema())
             .withSpecId(0)
-            .add(1, 1000, "x_partition", "bucket[4]")
-            .add(3, 1001, "z_partition", "bucket[8]")
+            .add(1, 1000, "x_partition", Transforms.bucket(4))
+            .add(3, 1001, "z_partition", Transforms.bucket(8))
             .build();
 
     Assert.assertEquals(expected, metadata.spec());
@@ -1094,7 +1095,7 @@ public class TestTableMetadata {
     PartitionSpec spec =
         PartitionSpec.builderFor(schema)
             .withSpecId(5)
-            .add(1, 1005, "x_partition", "bucket[4]")
+            .add(1, 1005, "x_partition", Transforms.bucket(4))
             .build();
     String location = "file://tmp/db/table";
     TableMetadata metadata =
@@ -1135,9 +1136,9 @@ public class TestTableMetadata {
     PartitionSpec expected =
         PartitionSpec.builderFor(updated.schema())
             .withSpecId(1)
-            .add(1, 1000, "x", "identity")
-            .add(2, 1001, "y", "void")
-            .add(3, 1002, "z_bucket", "bucket[8]")
+            .add(1, 1000, "x", Transforms.identity())
+            .add(2, 1001, "y", Transforms.alwaysNull())
+            .add(3, 1002, "z_bucket", Transforms.bucket(8))
             .build();
     Assert.assertEquals(
         "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields",
@@ -1171,8 +1172,8 @@ public class TestTableMetadata {
     PartitionSpec expected =
         PartitionSpec.builderFor(updated.schema())
             .withSpecId(1)
-            .add(3, 1002, "z_bucket", "bucket[8]")
-            .add(1, 1000, "x", "identity")
+            .add(3, 1002, "z_bucket", Transforms.bucket(8))
+            .add(1, 1000, "x", Transforms.identity())
             .build();
     Assert.assertEquals(
         "Should reassign the partition field IDs and reuse any existing IDs for equivalent fields",

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.truncate;
 
+import org.apache.iceberg.transforms.Transforms;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,7 +84,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         "Should hard delete id and data buckets",
         PartitionSpec.builderFor(table.schema())
             .withSpecId(2)
-            .add(2, 1002, "data_trunc_8", "truncate[8]")
+            .add(2, 1002, "data_trunc_8", Transforms.truncate(8))
             .build(),
         table.spec());
 
@@ -179,7 +180,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         "Should hard delete data bucket",
         PartitionSpec.builderFor(table.schema())
             .withSpecId(1)
-            .add(1, 1001, "id_bucket_8", "bucket[8]")
+            .add(1, 1001, "id_bucket_8", Transforms.bucket(8))
             .build(),
         table.spec());
 
@@ -202,7 +203,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         "Should remove and then add a bucket field",
         PartitionSpec.builderFor(table.schema())
             .withSpecId(1)
-            .add(2, 1001, "data_bucket_6", "bucket[6]")
+            .add(2, 1001, "data_bucket_6", Transforms.bucket(6))
             .build(),
         table.spec());
     Assert.assertEquals(1001, table.spec().lastAssignedFieldId());
@@ -243,7 +244,7 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         "Should add a new id bucket",
         PartitionSpec.builderFor(table.schema())
             .withSpecId(2)
-            .add(1, 1001, "id_bucket_8", "bucket[8]")
+            .add(1, 1001, "id_bucket_8", Transforms.bucket(8))
             .build(),
         table.spec());
     Assert.assertEquals(1001, table.spec().lastAssignedFieldId());

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -214,8 +214,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         "Should have a day and an hour time field",
         ImmutableList.of(
             new PartitionField(2, 1000, "ts_day", Transforms.day()),
-            new PartitionField(
-                2, 1001, "ts_hour", Transforms.hour())),
+            new PartitionField(2, 1001, "ts_hour", Transforms.hour())),
         byHour.fields());
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -213,9 +213,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     Assert.assertEquals(
         "Should have a day and an hour time field",
         ImmutableList.of(
-            new PartitionField(2, 1000, "ts_day", Transforms.day(Types.TimestampType.withZone())),
+            new PartitionField(2, 1000, "ts_day", Transforms.day()),
             new PartitionField(
-                2, 1001, "ts_hour", Transforms.hour(Types.TimestampType.withZone()))),
+                2, 1001, "ts_hour", Transforms.hour())),
         byHour.fields());
   }
 
@@ -254,8 +254,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
-            .add(id("ts"), 1001, "ts_day", Transforms.day(Types.TimestampType.withZone()))
-            .add(id("id"), 1002, "shard", Transforms.bucket(Types.LongType.get(), 16))
+            .add(id("ts"), 1001, "ts_day", Transforms.day())
+            .add(id("id"), 1002, "shard", Transforms.bucket(16))
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
@@ -277,8 +277,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
-            .add(id("category"), 1000, "category", Transforms.identity(Types.StringType.get()))
-            .add(id("ts"), 1001, "ts_day", Transforms.day(Types.TimestampType.withZone()))
+            .add(id("category"), 1000, "category", Transforms.identity())
+            .add(id("ts"), 1001, "ts_day", Transforms.day())
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
@@ -302,8 +302,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
-            .add(id("ts"), 1001, "ts_day", Transforms.day(Types.TimestampType.withZone()))
-            .add(id("id"), 1002, "shard", Transforms.bucket(Types.LongType.get(), 16))
+            .add(id("ts"), 1001, "ts_day", Transforms.day())
+            .add(id("id"), 1002, "shard", Transforms.bucket(16))
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
@@ -325,8 +325,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
-            .add(id("category"), 1000, "category", Transforms.identity(Types.StringType.get()))
-            .add(id("id"), 1002, "shard", Transforms.bucket(Types.LongType.get(), 16))
+            .add(id("category"), 1000, "category", Transforms.identity())
+            .add(id("id"), 1002, "shard", Transforms.bucket(16))
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
@@ -388,9 +388,9 @@ public class TestUpdatePartitionSpec extends TableTestBase {
 
     PartitionSpec v2Expected =
         PartitionSpec.builderFor(SCHEMA)
-            .add(id("category"), 1000, "category", Transforms.identity(Types.StringType.get()))
-            .add(id("id"), 1002, "id_bucket", Transforms.bucket(Types.LongType.get(), 16))
-            .add(id("data"), 1003, "prefix", Transforms.truncate(Types.StringType.get(), 4))
+            .add(id("category"), 1000, "category", Transforms.identity())
+            .add(id("id"), 1002, "id_bucket", Transforms.bucket(16))
+            .add(id("data"), 1003, "prefix", Transforms.truncate(4))
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -51,7 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -181,7 +180,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
     Assert.assertEquals(
         "Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
-    Transform<?, ?> transform = Transforms.identity(Types.IntegerType.get());
+    Transform<?, ?> transform = Transforms.identity();
     Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -143,7 +143,7 @@ public class TestHadoopTables {
     Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
     Assert.assertEquals(
         "Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
-    Transform<?, ?> transform = Transforms.identity(Types.IntegerType.get());
+    Transform<?, ?> transform = Transforms.identity();
     Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
   }
 

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -250,7 +250,7 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
     Assert.assertEquals(
         "Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
-    Transform<?, ?> transform = Transforms.identity(Types.IntegerType.get());
+    Transform<?, ?> transform = Transforms.identity();
     Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
   }
 

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -87,8 +87,10 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
     setupSpark();
 
     List<InternalRow> data = Lists.newArrayList(RandomData.generateSpark(SCHEMA, NUM_ROWS, 0L));
-    Transform<Integer, Integer> transform = Transforms.bucket(Types.IntegerType.get(), 32);
-    data.sort(Comparator.comparingInt(row -> transform.apply(row.getInt(1))));
+    Transform<Integer, Integer> transform = Transforms.bucket(32);
+    data.sort(
+        Comparator.comparingInt(
+            row -> transform.bind(Types.IntegerType.get()).apply(row.getInt(1))));
     this.rows = data;
 
     this.positionDeleteRows =

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/IcebergSpark.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/IcebergSpark.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.spark;
 
-import org.apache.iceberg.transforms.Transform;
+import java.util.function.Function;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Type;
 import org.apache.spark.sql.SparkSession;
@@ -32,7 +32,7 @@ public class IcebergSpark {
       SparkSession session, String funcName, DataType sourceType, int numBuckets) {
     SparkTypeToType typeConverter = new SparkTypeToType();
     Type sourceIcebergType = typeConverter.atomic(sourceType);
-    Transform<Object, Integer> bucket = Transforms.bucket(sourceIcebergType, numBuckets);
+    Function<Object, Integer> bucket = Transforms.bucket(numBuckets).bind(sourceIcebergType);
     session
         .udf()
         .register(
@@ -45,7 +45,7 @@ public class IcebergSpark {
       SparkSession session, String funcName, DataType sourceType, int width) {
     SparkTypeToType typeConverter = new SparkTypeToType();
     Type sourceIcebergType = typeConverter.atomic(sourceType);
-    Transform<Object, Object> truncate = Transforms.truncate(sourceIcebergType, width);
+    Function<Object, Object> truncate = Transforms.truncate(width).bind(sourceIcebergType);
     session
         .udf()
         .register(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
@@ -48,7 +49,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.data.GenericsHelpers;
-import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
@@ -116,23 +116,23 @@ public class TestFilteredScan {
     TestFilteredScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
 
     // define UDFs used by partition tests
-    Transform<Long, Integer> bucket4 = Transforms.bucket(Types.LongType.get(), 4);
+    Function<Object, Integer> bucket4 = Transforms.bucket(4).bind(Types.LongType.get());
     spark.udf().register("bucket4", (UDF1<Long, Integer>) bucket4::apply, IntegerType$.MODULE$);
 
-    Transform<Long, Integer> day = Transforms.day(Types.TimestampType.withZone());
+    Function<Object, Integer> day = Transforms.day().bind(Types.TimestampType.withZone());
     spark
         .udf()
         .register(
             "ts_day",
-            (UDF1<Timestamp, Integer>) timestamp -> day.apply((Long) fromJavaTimestamp(timestamp)),
+            (UDF1<Timestamp, Integer>) timestamp -> day.apply(fromJavaTimestamp(timestamp)),
             IntegerType$.MODULE$);
 
-    Transform<Long, Integer> hour = Transforms.hour(Types.TimestampType.withZone());
+    Function<Object, Integer> hour = Transforms.hour().bind(Types.TimestampType.withZone());
     spark
         .udf()
         .register(
             "ts_hour",
-            (UDF1<Timestamp, Integer>) timestamp -> hour.apply((Long) fromJavaTimestamp(timestamp)),
+            (UDF1<Timestamp, Integer>) timestamp -> hour.apply(fromJavaTimestamp(timestamp)),
             IntegerType$.MODULE$);
 
     spark.udf().register("data_ident", (UDF1<String, String>) data -> data, StringType$.MODULE$);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -61,7 +61,8 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
+        results.get(0).getInt(0));
   }
 
   @Test
@@ -70,7 +71,8 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
+        results.get(0).getInt(0));
   }
 
   @Test
@@ -79,7 +81,8 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1),
+        results.get(0).getInt(0));
   }
 
   @Test
@@ -129,7 +132,8 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(16).bind(Types.DateType.get())
+            Transforms.bucket(16)
+                .bind(Types.DateType.get())
                 .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))),
         results.get(0).getInt(0));
   }
@@ -145,7 +149,8 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(16).bind(Types.TimestampType.withZone())
+            Transforms.bucket(16)
+                .bind(Types.TimestampType.withZone())
                 .apply(
                     DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))),
         results.get(0).getInt(0));
@@ -158,7 +163,8 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(16).bind(Types.BinaryType.get())
+            Transforms.bucket(16)
+                .bind(Types.BinaryType.get())
                 .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})),
         results.get(0).getInt(0));
   }
@@ -237,6 +243,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"), results.get(0).getString(0));
+        Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"),
+        results.get(0).getString(0));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -61,7 +61,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_int_16(1)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.IntegerType.get(), 16).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
   }
 
   @Test
@@ -70,7 +70,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_short_16(1S)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.IntegerType.get(), 16).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_byte_16(1Y)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.IntegerType.get(), 16).apply(1), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
   }
 
   @Test
@@ -88,7 +88,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_long_16(1L)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.LongType.get(), 16).apply(1L), results.get(0).getInt(0));
+        (int) Transforms.bucket(16).bind(Types.LongType.get()).apply(1L), results.get(0).getInt(0));
   }
 
   @Test
@@ -97,7 +97,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_string_16('hello')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.StringType.get(), 16).apply("hello"),
+        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
         results.get(0).getInt(0));
   }
 
@@ -107,7 +107,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_char_16('hello')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.StringType.get(), 16).apply("hello"),
+        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
         results.get(0).getInt(0));
   }
 
@@ -117,7 +117,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_varchar_16('hello')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.StringType.get(), 16).apply("hello"),
+        (int) Transforms.bucket(16).bind(Types.StringType.get()).apply("hello"),
         results.get(0).getInt(0));
   }
 
@@ -129,7 +129,7 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(Types.DateType.get(), 16)
+            Transforms.bucket(16).bind(Types.DateType.get())
                 .apply(DateTimeUtils.fromJavaDate(Date.valueOf("2021-06-30"))),
         results.get(0).getInt(0));
   }
@@ -145,7 +145,7 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(Types.TimestampType.withZone(), 16)
+            Transforms.bucket(16).bind(Types.TimestampType.withZone())
                 .apply(
                     DateTimeUtils.fromJavaTimestamp(Timestamp.valueOf("2021-06-30 00:00:00.000"))),
         results.get(0).getInt(0));
@@ -158,7 +158,7 @@ public class TestIcebergSpark {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
         (int)
-            Transforms.bucket(Types.BinaryType.get(), 16)
+            Transforms.bucket(16).bind(Types.BinaryType.get())
                 .apply(ByteBuffer.wrap(new byte[] {0x00, 0x20, 0x00, 0x1F})),
         results.get(0).getInt(0));
   }
@@ -169,7 +169,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_bucket_decimal_16(11.11)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        (int) Transforms.bucket(Types.DecimalType.of(4, 2), 16).apply(new BigDecimal("11.11")),
+        (int) Transforms.bucket(16).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
         results.get(0).getInt(0));
   }
 
@@ -209,7 +209,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        Transforms.truncate(Types.IntegerType.get(), 4).apply(1), results.get(0).getInt(0));
+        Transforms.truncate(4).bind(Types.IntegerType.get()).apply(1), results.get(0).getInt(0));
   }
 
   @Test
@@ -218,7 +218,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        Transforms.truncate(Types.LongType.get(), 4).apply(1L), results.get(0).getLong(0));
+        Transforms.truncate(4).bind(Types.LongType.get()).apply(1L), results.get(0).getLong(0));
   }
 
   @Test
@@ -227,7 +227,7 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        Transforms.truncate(Types.DecimalType.of(4, 2), 4).apply(new BigDecimal("11.11")),
+        Transforms.truncate(4).bind(Types.DecimalType.of(4, 2)).apply(new BigDecimal("11.11")),
         results.get(0).getDecimal(0));
   }
 
@@ -237,6 +237,6 @@ public class TestIcebergSpark {
     List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals(
-        Transforms.truncate(Types.StringType.get(), 4).apply("hello"), results.get(0).getString(0));
+        Transforms.truncate(4).bind(Types.StringType.get()).apply("hello"), results.get(0).getString(0));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -112,9 +112,7 @@ public class TestPartitionPruning {
     CONF.set(optionKey, CountOpenLocalFileSystem.class.getName());
     spark.conf().set(optionKey, CountOpenLocalFileSystem.class.getName());
     spark.conf().set("spark.sql.session.timeZone", "UTC");
-    spark
-        .udf()
-        .register("bucket3", (Integer num) -> BUCKET_FUNC.apply(num), DataTypes.IntegerType);
+    spark.udf().register("bucket3", (Integer num) -> BUCKET_FUNC.apply(num), DataTypes.IntegerType);
     spark
         .udf()
         .register("truncate5", (String str) -> TRUNCATE_FUNC.apply(str), DataTypes.StringType);


### PR DESCRIPTION
This refactors the `Transform` API so that transforms are generic and do not require a `Type` when they are created or loaded.

Initially, `Transform` exposed `apply` to run the transform on a value. This requires knowing the type of the value ahead of time. However, most `Transform` methods are generic and accept a type argument so the API was mixed. In addition, working with `Transform` was more difficult because `Transform` must always have a type when it is created, even though types may change or may not be known. For example, a sort order can reference transformed columns, but does not include the types of those source columns.

This PR is inspired by the Python implementation, which left `Transform` generic and uses a method to run a function that applies the transform based on a type that is known later, when the schema is known. This PR introduces `bind(Type)` that returns `Function<S, T>` to transform values.

This is a large PR that changes the uses in API, core, and Spark 3.3.