### PR TITLE
Core: Add expression JSON parser

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1,6 +1,11 @@
 versionOverrides:
   org.apache.iceberg:iceberg-api:apache-iceberg-0.14.0: "0.14.0"
 acceptedBreaks:
+  apache-iceberg-0.14.0:
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method java.lang.String org.apache.iceberg.expressions.Reference<T>::name()"
+      justification: "All subclasses implement name"
   release-base-0.13.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundReference.java
@@ -26,10 +26,12 @@ import org.apache.iceberg.types.Types;
 public class BoundReference<T> implements BoundTerm<T>, Reference<T> {
   private final Types.NestedField field;
   private final Accessor<StructLike> accessor;
+  private final String name;
 
-  BoundReference(Types.NestedField field, Accessor<StructLike> accessor) {
+  BoundReference(Types.NestedField field, Accessor<StructLike> accessor, String name) {
     this.field = field;
     this.accessor = accessor;
+    this.name = name;
   }
 
   @Override
@@ -50,6 +52,11 @@ public class BoundReference<T> implements BoundTerm<T>, Reference<T> {
   @Override
   public Type type() {
     return field.type();
+  }
+
+  @Override
+  public String name() {
+    return name;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -544,11 +544,12 @@ public class ExpressionVisitors {
   }
 
   /**
-   * Traverses the given {@link Expression expression} with a {@link CustomOrderExpressionVisitor visitor}.
+   * Traverses the given {@link Expression expression} with a {@link CustomOrderExpressionVisitor
+   * visitor}.
    *
-   * <p>This passes a {@link Supplier<R>} to each non-leaf {@link CustomOrderExpressionVisitor visitor} method. The supplier
-   * returns the result of traversing child expressions. Getting the result of the supplier allows traversing the
-   * expression in the desired order.
+   * <p>This passes a {@link Supplier<R>} to each non-leaf {@link CustomOrderExpressionVisitor
+   * visitor} method. The supplier returns the result of traversing child expressions. Getting the
+   * result of the supplier allows traversing the expression in the desired order.
    *
    * @param expr an expression to traverse
    * @param visitor a visitor that will be called to handle each node in the expression tree
@@ -559,7 +560,8 @@ public class ExpressionVisitors {
     return visitExpr(expr, visitor).get();
   }
 
-  private static <R> Supplier<R> visitExpr(Expression expr, CustomOrderExpressionVisitor<R> visitor) {
+  private static <R> Supplier<R> visitExpr(
+      Expression expr, CustomOrderExpressionVisitor<R> visitor) {
     if (expr instanceof Predicate) {
       if (expr instanceof BoundPredicate) {
         return () -> visitor.predicate((BoundPredicate<?>) expr);

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -547,9 +547,9 @@ public class ExpressionVisitors {
    * Traverses the given {@link Expression expression} with a {@link CustomOrderExpressionVisitor
    * visitor}.
    *
-   * <p>This passes a {@link Supplier<R>} to each non-leaf {@link CustomOrderExpressionVisitor
-   * visitor} method. The supplier returns the result of traversing child expressions. Getting the
-   * result of the supplier allows traversing the expression in the desired order.
+   * <p>This passes a {@link Supplier} to each non-leaf {@link CustomOrderExpressionVisitor visitor}
+   * method. The supplier returns the result of traversing child expressions. Getting the result of
+   * the supplier allows traversing the expression in the desired order.
    *
    * @param expr an expression to traverse
    * @param visitor a visitor that will be called to handle each node in the expression tree

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -274,6 +274,11 @@ public class Expressions {
     return new UnboundPredicate<>(op, expr, values);
   }
 
+  public static <T> UnboundPredicate<T> predicate(
+      Operation op, UnboundTerm<T> expr) {
+    return new UnboundPredicate<>(op, expr);
+  }
+
   public static True alwaysTrue() {
     return True.INSTANCE;
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -274,8 +274,7 @@ public class Expressions {
     return new UnboundPredicate<>(op, expr, values);
   }
 
-  public static <T> UnboundPredicate<T> predicate(
-      Operation op, UnboundTerm<T> expr) {
+  public static <T> UnboundPredicate<T> predicate(Operation op, UnboundTerm<T> expr) {
     return new UnboundPredicate<>(op, expr);
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
@@ -31,6 +31,7 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
     this.name = name;
   }
 
+  @Override
   public String name() {
     return name;
   }
@@ -44,7 +45,7 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
     ValidationException.check(
         field != null, "Cannot find field '%s' in struct: %s", name, schema.asStruct());
 
-    return new BoundReference<>(field, schema.accessorForField(field.fieldId()));
+    return new BoundReference<>(field, schema.accessorForField(field.fieldId()), name);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Reference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Reference.java
@@ -24,4 +24,6 @@ package org.apache.iceberg.expressions;
  * @see BoundReference
  * @see NamedReference
  */
-public interface Reference<T> extends Term {}
+public interface Reference<T> extends Term {
+  String name();
+}

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -41,8 +41,8 @@ import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.JsonUtil;
 
-public class DefaultValueParser {
-  private DefaultValueParser() {}
+public class SingleValueParser {
+  private SingleValueParser() {}
 
   private static final String KEYS = "keys";
   private static final String VALUES = "values";

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.JsonUtil;
+
+public class ExpressionParser {
+
+  private static final String TYPE = "type";
+  private static final String VALUE = "value";
+  private static final String LITERALS = "literals";
+  private static final String TERM = "term";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
+  private static final String OPERAND = "operand";
+
+  private static final Set<Expression.Operation> ONE_INPUTS =
+      ImmutableSet.of(
+          Expression.Operation.IS_NULL,
+          Expression.Operation.NOT_NULL,
+          Expression.Operation.IS_NAN,
+          Expression.Operation.NOT_NAN);
+
+  private ExpressionParser() {}
+
+  public static String toJson(Expression expression) {
+    return toJson(expression, false);
+  }
+
+  public static String toJson(Expression expression, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(expression, gen), pretty);
+  }
+
+  public static void toJson(Expression expression, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != expression, "Invalid expression: null");
+
+    if (expression instanceof And) {
+      toJson((And) expression, gen);
+    } else if (expression instanceof Or) {
+      toJson((Or) expression, gen);
+    } else if (expression instanceof Not) {
+      toJson((Not) expression, gen);
+    } else if (expression instanceof True) {
+      toJson((True) expression, gen);
+    } else if (expression instanceof False) {
+      toJson((False) expression, gen);
+    } else if (expression instanceof UnboundPredicate) {
+      toJson((UnboundPredicate<?>) expression, gen);
+    } else {
+      throw new IllegalArgumentException(String.format("Unsupported expression: %s", expression));
+    }
+  }
+
+  private static void toJson(And expression, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, Expression.Operation.AND.name().toLowerCase());
+    gen.writeFieldName(LEFT);
+    toJson(expression.left(), gen);
+    gen.writeFieldName(RIGHT);
+    toJson(expression.right(), gen);
+    gen.writeEndObject();
+  }
+
+  private static void toJson(Or expression, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, Expression.Operation.OR.name().toLowerCase());
+    gen.writeFieldName(LEFT);
+    toJson(expression.left(), gen);
+    gen.writeFieldName(RIGHT);
+    toJson(expression.right(), gen);
+    gen.writeEndObject();
+  }
+
+  private static void toJson(Not expression, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, Expression.Operation.NOT.name().toLowerCase());
+    gen.writeFieldName(OPERAND);
+    toJson(expression.child(), gen);
+    gen.writeEndObject();
+  }
+
+  private static void toJson(True expression, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, expression.op().name().toLowerCase());
+    gen.writeEndObject();
+  }
+
+  private static void toJson(False expression, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, expression.op().name().toLowerCase());
+    gen.writeEndObject();
+  }
+
+  private static void toJson(UnboundPredicate<?> predicate, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+    gen.writeStringField(TYPE, predicate.op().name().toLowerCase());
+    toJson(predicate.term(), gen);
+    if (!ONE_INPUTS.contains(predicate.op())) {
+      gen.writeFieldName(LITERALS);
+      gen.writeStartArray();
+      for (Literal<?> literal : predicate.literals()) {
+        toJson(literal, gen);
+      }
+      gen.writeEndArray();
+    }
+
+    gen.writeEndObject();
+  }
+
+  private static void toJson(Term term, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(term instanceof NamedReference, "Unsupported term: %s", term);
+    // TODO: add support for UnboundTransform
+    gen.writeStringField(TERM, ((NamedReference<?>) term).name());
+  }
+
+  private static void toJson(Literal<?> literal, JsonGenerator gen) throws IOException {
+    gen.writeStartObject();
+
+    Object value = literal.value();
+    Type type;
+    if (value instanceof Boolean) {
+      type = Types.BooleanType.get();
+    } else if (value instanceof Integer) {
+      type = Types.IntegerType.get();
+    } else if (value instanceof Long) {
+      type = Types.LongType.get();
+    } else if (value instanceof Float) {
+      type = Types.FloatType.get();
+    } else if (value instanceof Double) {
+      type = Types.DoubleType.get();
+    } else if (value instanceof CharSequence) {
+      type = Types.StringType.get();
+    } else if (value instanceof UUID) {
+      type = Types.UUIDType.get();
+    } else if (value instanceof byte[]) {
+      type = Types.FixedType.ofLength(((byte[]) value).length);
+    } else if (value instanceof ByteBuffer) {
+      if (literal instanceof Literals.FixedLiteral) {
+        type = Types.FixedType.ofLength(((ByteBuffer) value).remaining());
+      } else {
+        type = Types.BinaryType.get();
+      }
+    } else if (value instanceof BigDecimal) {
+      BigDecimal decimal = (BigDecimal) value;
+      type = Types.DecimalType.of(decimal.precision(), decimal.scale());
+    } else {
+      throw new IllegalArgumentException(
+          "Cannot find literal type for value class " + value.getClass().getName());
+    }
+
+    gen.writeStringField(TYPE, type.toString());
+    gen.writeStringField(VALUE, StandardCharsets.UTF_8.decode(literal.toByteBuffer()).toString());
+    gen.writeEndObject();
+  }
+
+  public static Expression fromJson(String json) {
+    return JsonUtil.parse(json, ExpressionParser::fromJson);
+  }
+
+  public static Expression fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse expression from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse expression from non-object: %s", json);
+
+    String expressionType = JsonUtil.getString(TYPE, json);
+
+    if (Expression.Operation.AND.name().toLowerCase().equals(expressionType)) {
+      return new And(fromJson(JsonUtil.get(LEFT, json)), fromJson(JsonUtil.get(RIGHT, json)));
+    } else if (Expression.Operation.OR.name().toLowerCase().equals(expressionType)) {
+      return new Or(fromJson(JsonUtil.get(LEFT, json)), fromJson(JsonUtil.get(RIGHT, json)));
+    } else if (Expression.Operation.NOT.name().toLowerCase().equals(expressionType)) {
+      return new Not(fromJson(JsonUtil.get(OPERAND, json)));
+    } else if (Expression.Operation.TRUE.name().toLowerCase().equals(expressionType)) {
+      return True.INSTANCE;
+    } else if (Expression.Operation.FALSE.name().toLowerCase().equals(expressionType)) {
+      return False.INSTANCE;
+    } else {
+      return fromJsonUnboundPredicate(json);
+    }
+  }
+
+  private static UnboundPredicate<?> fromJsonUnboundPredicate(JsonNode json) {
+    Expression.Operation operationType =
+        Expression.Operation.valueOf(JsonUtil.getString(TYPE, json).toUpperCase());
+
+    if (ONE_INPUTS.contains(operationType)) {
+      return new UnboundPredicate<>(operationType, fromJsonToTerm(json));
+    } else {
+      return new UnboundPredicate(
+          operationType,
+          fromJsonToTerm(json),
+          fromJsonToLiteralValues(JsonUtil.get(LITERALS, json)));
+    }
+  }
+
+  private static UnboundTerm<?> fromJsonToTerm(JsonNode json) {
+    // TODO: support UnboundTransform
+    return new NamedReference<>(JsonUtil.getString(TERM, json));
+  }
+
+  private static List<?> fromJsonToLiteralValues(JsonNode json) {
+    List<Object> literals = Lists.newArrayList();
+    for (int i = 0; i < json.size(); i++) {
+      String literalType = JsonUtil.get(TYPE, json.get(i)).textValue();
+      Type primitiveType = Types.fromPrimitiveString(literalType);
+      Object value =
+          Conversions.fromByteBuffer(
+              primitiveType,
+              StandardCharsets.UTF_8.encode(JsonUtil.get(VALUE, json.get(i)).textValue()));
+      if (primitiveType.typeId() == Type.TypeID.FIXED) {
+        byte[] valueByteArray = new byte[((ByteBuffer) value).remaining()];
+        ((ByteBuffer) value).get(valueByteArray);
+        value = valueByteArray;
+      }
+
+      literals.add(value);
+    }
+
+    return literals;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.util.JsonUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestDefaultValueParser {
+public class TestSingleValueParser {
 
   @Test
   public void testValidDefaults() throws IOException {
@@ -171,8 +171,8 @@ public class TestDefaultValueParser {
 
   // serialize to json and deserialize back should return the same result
   private static String defaultValueParseAndUnParseRoundTrip(Type type, String defaultValue) {
-    Object javaDefaultValue = DefaultValueParser.fromJson(type, defaultValue);
-    return DefaultValueParser.toJson(type, javaDefaultValue);
+    Object javaDefaultValue = SingleValueParser.fromJson(type, defaultValue);
+    return SingleValueParser.toJson(type, javaDefaultValue);
   }
 
   private static void jsonStringEquals(String s1, String s2) throws IOException {

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -173,7 +173,8 @@ public class TestExpressionParser {
                 Expressions.lessThanOrEqual(Expressions.bucket("id", 100), 50), true))
         .isEqualTo(expected);
     // schema is required to parse transform expressions
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected, SCHEMA), true))
+    Assertions.assertThat(
+            ExpressionParser.toJson(ExpressionParser.fromJson(expected, SCHEMA), true))
         .isEqualTo(expected);
   }
 

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -21,9 +21,13 @@ package org.apache.iceberg.expressions;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,7 +43,7 @@ public class TestExpressionParser {
           optional(105, "f", Types.FloatType.get()),
           required(106, "d", Types.DoubleType.get()),
           optional(107, "date", Types.DateType.get()),
-          required(108, "ts", Types.TimestampType.withZone()),
+          required(108, "ts", Types.TimestampType.withoutZone()),
           required(110, "s", Types.StringType.get()),
           required(111, "uuid", Types.UUIDType.get()),
           required(112, "fixed", Types.FixedType.ofLength(7)),
@@ -51,423 +55,498 @@ public class TestExpressionParser {
   private static final Schema SCHEMA = new Schema(SUPPORTED_PRIMITIVES.fields());
 
   @Test
-  public void testExpressionParser() {
-    Expression[] expressions = new Expression[] {
-        Expressions.alwaysFalse(),
-        Expressions.alwaysTrue(),
-        Expressions.equal("id", 100),
-        Expressions.and(
-            Expressions.or(
-                Expressions.equal("data", UUID.randomUUID().toString()),
-                Expressions.isNull("data")),
-            Expressions.greaterThanOrEqual("id", 66)),
-        Expressions.or(
-            Expressions.greaterThan(Expressions.day("ts"), "2022-08-14"),
-            Expressions.equal("date", "2022-08-14")),
-        Expressions.not(Expressions.in("l", 1, 2, 3, 4))
-    };
+  public void testSimpleExpressions() {
+    Expression[] expressions =
+        new Expression[] {
+          Expressions.alwaysFalse(),
+          Expressions.alwaysTrue(),
+          Expressions.equal("id", 100),
+          Expressions.equal("data", "abcd"),
+          Expressions.equal("b", false),
+          Expressions.equal("i", 34),
+          Expressions.equal("l", 34L),
+          Expressions.equal("f", 100.0f),
+          Expressions.equal("d", 100.0d),
+          Expressions.equal("date", "2022-08-14"),
+          Expressions.equal("ts", "2022-08-14T10:00:00.123456"),
+          Expressions.equal("uuid", UUID.randomUUID()),
+          Expressions.equal("fixed", new byte[] {1, 2, 3, 4, 5, 6, 7}),
+          Expressions.equal("bytes", ByteBuffer.wrap(new byte[] {1, 3, 5})),
+          Expressions.equal("dec_11_2", new BigDecimal("34.56")),
+          Expressions.equal("time", "23:59:59.654321"),
+          Expressions.lessThan("id", 100),
+          Expressions.lessThanOrEqual("id", 100),
+          Expressions.greaterThan("id", 100),
+          Expressions.greaterThanOrEqual("id", 100),
+          Expressions.isNull("data"),
+          Expressions.notNull("data"),
+          Expressions.isNaN("d"),
+          Expressions.notNaN("f"),
+          Expressions.startsWith("s", "crackle"),
+          Expressions.notStartsWith("s", "tackle"),
+          Expressions.equal(Expressions.day("date"), "2022-08-14"),
+          Expressions.equal(Expressions.bucket("id", 100), 0),
+          Expressions.and(
+              Expressions.or(
+                  Expressions.equal("data", UUID.randomUUID().toString()),
+                  Expressions.isNull("data")),
+              Expressions.greaterThanOrEqual("id", 66)),
+          Expressions.or(
+              Expressions.greaterThan(Expressions.day("ts"), "2022-08-14"),
+              Expressions.equal("date", "2022-08-14")),
+          Expressions.not(Expressions.in("l", 1, 2, 3, 4))
+        };
 
     for (Expression expr : expressions) {
       Expression bound = Binder.bind(SUPPORTED_PRIMITIVES, expr);
       String boundJson = ExpressionParser.toJson(bound, true);
-      System.err.println("Bound JSON: " + boundJson);
       String unboundJson = ExpressionParser.toJson(expr, true);
-      Assert.assertEquals("Bound and unbound should produce identical json", boundJson, unboundJson);
+
+      Assert.assertEquals(
+          "Bound and unbound should produce identical json", boundJson, unboundJson);
+
       Expression parsed = ExpressionParser.fromJson(boundJson, SCHEMA);
       Assert.assertTrue(
-          "Round-trip value should be equivalent", ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true));
+          "Round-trip value should be equivalent",
+          ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true));
     }
   }
 
-//  @Test
-//  public void nullExpression() {
-//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(null))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Invalid expression: null");
-//
-//    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson((JsonNode) null))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse expression from null object");
-//  }
-//
-//  @Test
-//  public void unsupportedExpression() {
-//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson((Expression) () -> null))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessageStartingWith("Unsupported expression:");
-//
-//    Expression expression =
-//        Binder.bind(
-//            new Schema(required(1, "x", LongType.get())).asStruct(), Expressions.equal("x", 23L));
-//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(expression))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Unsupported expression: ref(id=1, accessor-type=long) == 23");
-//  }
-//
-//  @Test
-//  public void trueExpression() {
-//    String expected = "{\n" + "  \"type\" : \"true\"\n" + "}";
-//    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysTrue(), true))
-//        .isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void falseExpression() {
-//    String expected = "{\n" + "  \"type\" : \"false\"\n" + "}";
-//    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysFalse(), true))
-//        .isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void eqExpression() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"eq\",\n"
-//            + "  \"term\" : \"name\",\n"
-//            + "  \"literals\" : [ {\n"
-//            + "    \"type\" : \"int\",\n"
-//            + "    \"value\" : \"\\u0019\\u0000\\u0000\\u0000\"\n"
-//            + "  } ]\n"
-//            + "}";
-//    Assertions.assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true))
-//        .isEqualTo(expected);
-//    Expression expression = ExpressionParser.fromJson(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void transformsNotSupported() {
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.toJson(
-//                    Expressions.in(Expressions.transform("x", Transforms.day(DateType.get())), 25)))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Unsupported term: day(ref(name=\"x\"))");
-//  }
-//
-//  @Test
-//  public void extraFields() {
-//    Assertions.assertThat(
-//            ExpressionParser.toJson(
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"in\",\n"
-//                        + "  \"term\" : \"column-name\",\n"
-//                        + "  \"extra-one\" : \"x\",\n"
-//                        + "  \"extra-twp\" : \"y\",\n"
-//                        + "  \"literals\" : [ {\n"
-//                        + "    \"type\" : \"int\",\n"
-//                        + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "  } ]\n"
-//                        + "}"),
-//                true))
-//        .isEqualTo(
-//            "{\n"
-//                + "  \"type\" : \"in\",\n"
-//                + "  \"term\" : \"column-name\",\n"
-//                + "  \"literals\" : [ {\n"
-//                + "    \"type\" : \"int\",\n"
-//                + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                + "  } ]\n"
-//                + "}");
-//  }
-//
-//  @Test
-//  public void invalidTerm() {
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"not\",\n"
-//                        + "  \"operand\" : {\n"
-//                        + "    \"type\" : \"lt\",\n"
-//                        + "    \"term\" : 23,\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"int\",\n"
-//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "    } ]\n"
-//                        + "  }\n"
-//                        + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse term to a string value: 23");
-//  }
-//
-//  @Test
-//  public void invalidOperationType() {
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"not\",\n"
-//                        + "  \"operand\" : {\n"
-//                        + "    \"type\" : \"illegal\",\n"
-//                        + "    \"term\" : \"column-name\",\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"int\",\n"
-//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "    } ]\n"
-//                        + "  }\n"
-//                        + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
-//
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"ILLEGAL\",\n"
-//                        + "  \"operand\" : {\n"
-//                        + "    \"type\" : \"lt\",\n"
-//                        + "    \"term\" : \"column-name\",\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"int\",\n"
-//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "    } ]\n"
-//                        + "  }\n"
-//                        + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
-//  }
-//
-//  @Test
-//  public void invalidAnd() {
-//    Assertions.assertThatThrownBy(
-//            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse missing field: left");
-//
-//    Assertions.assertThatThrownBy(
-//            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse missing field: left");
-//
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"and\",\n"
-//                        + "  \"left\" : {\n"
-//                        + "    \"type\" : \"gt_eq\",\n"
-//                        + "    \"term\" : \"column-name-1\",\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"int\",\n"
-//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "    } ]\n"
-//                        + "  }\n"
-//                        + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse missing field: right");
-//
-//    // term is missing from left
-//    Assertions.assertThatThrownBy(
-//            () ->
-//                ExpressionParser.fromJson(
-//                    "{\n"
-//                        + "  \"type\" : \"and\",\n"
-//                        + "  \"left\" : {\n"
-//                        + "    \"type\" : \"gt_eq\",\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"int\",\n"
-//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//                        + "    } ]\n"
-//                        + "  },\n"
-//                        + "  \"right\" : {\n"
-//                        + "    \"type\" : \"in\",\n"
-//                        + "    \"term\" : \"column-name-2\",\n"
-//                        + "    \"literals\" : [ {\n"
-//                        + "      \"type\" : \"string\",\n"
-//                        + "      \"value\" : \"Check\"\n"
-//                        + "    } ]\n"
-//                        + "  }\n"
-//                        + "}"))
-//        .isInstanceOf(IllegalArgumentException.class)
-//        .hasMessage("Cannot parse missing string term");
-//  }
-//
-//  @Test
-//  public void testPredicate() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"in\",\n"
-//            + "  \"term\" : \"column-name\",\n"
-//            + "  \"literals\" : [ {\n"
-//            + "    \"type\" : \"int\",\n"
-//            + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//            + "  } ]\n"
-//            + "}";
-//
-//    Assertions.assertThat(ExpressionParser.toJson(Expressions.in("column-name", 50), true))
-//        .isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testAnd() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"and\",\n"
-//            + "  \"left\" : {\n"
-//            + "    \"type\" : \"gt_eq\",\n"
-//            + "    \"term\" : \"column-name-1\",\n"
-//            + "    \"literals\" : [ {\n"
-//            + "      \"type\" : \"int\",\n"
-//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//            + "    } ]\n"
-//            + "  },\n"
-//            + "  \"right\" : {\n"
-//            + "    \"type\" : \"in\",\n"
-//            + "    \"term\" : \"column-name-2\",\n"
-//            + "    \"literals\" : [ {\n"
-//            + "      \"type\" : \"string\",\n"
-//            + "      \"value\" : \"Check\"\n"
-//            + "    } ]\n"
-//            + "  }\n"
-//            + "}";
-//
-//    Expression expression =
-//        Expressions.and(
-//            Expressions.greaterThanOrEqual("column-name-1", 50),
-//            Expressions.in("column-name-2", "Check"));
-//
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testOr() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"or\",\n"
-//            + "  \"left\" : {\n"
-//            + "    \"type\" : \"lt\",\n"
-//            + "    \"term\" : \"column-name-1\",\n"
-//            + "    \"literals\" : [ {\n"
-//            + "      \"type\" : \"int\",\n"
-//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//            + "    } ]\n"
-//            + "  },\n"
-//            + "  \"right\" : {\n"
-//            + "    \"type\" : \"not_null\",\n"
-//            + "    \"term\" : \"column-name-2\"\n"
-//            + "  }\n"
-//            + "}";
-//
-//    Expression expression =
-//        Expressions.or(
-//            Expressions.lessThan("column-name-1", 50), Expressions.notNull("column-name-2"));
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testNot() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"not\",\n"
-//            + "  \"operand\" : {\n"
-//            + "    \"type\" : \"lt\",\n"
-//            + "    \"term\" : \"column-name-1\",\n"
-//            + "    \"literals\" : [ {\n"
-//            + "      \"type\" : \"int\",\n"
-//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//            + "    } ]\n"
-//            + "  }\n"
-//            + "}";
-//
-//    Expression expression = Expressions.not(Expressions.lessThan("column-name-1", 50));
-//
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testNestedExpression() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"or\",\n"
-//            + "  \"left\" : {\n"
-//            + "    \"type\" : \"and\",\n"
-//            + "    \"left\" : {\n"
-//            + "      \"type\" : \"in\",\n"
-//            + "      \"term\" : \"column-name-1\",\n"
-//            + "      \"literals\" : [ {\n"
-//            + "        \"type\" : \"int\",\n"
-//            + "        \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-//            + "      } ]\n"
-//            + "    },\n"
-//            + "    \"right\" : {\n"
-//            + "      \"type\" : \"eq\",\n"
-//            + "      \"term\" : \"column-name-2\",\n"
-//            + "      \"literals\" : [ {\n"
-//            + "        \"type\" : \"string\",\n"
-//            + "        \"value\" : \"Test\"\n"
-//            + "      } ]\n"
-//            + "    }\n"
-//            + "  },\n"
-//            + "  \"right\" : {\n"
-//            + "    \"type\" : \"is_nan\",\n"
-//            + "    \"term\" : \"column-name-3\"\n"
-//            + "  }\n"
-//            + "}";
-//
-//    Expression and =
-//        Expressions.and(
-//            Expressions.in("column-name-1", 50), Expressions.equal("column-name-2", "Test"));
-//    Expression expression = Expressions.or(and, Expressions.isNaN("column-name-3"));
-//
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testFixedLiteral() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"eq\",\n"
-//            + "  \"term\" : \"column-name\",\n"
-//            + "  \"literals\" : [ {\n"
-//            + "    \"type\" : \"fixed[10]\",\n"
-//            + "    \"value\" : \"testString\"\n"
-//            + "  } ]\n"
-//            + "}";
-//    String testString = "testString";
-//    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(testString);
-//
-//    byte[] byteArray = new byte[byteBuffer.remaining()];
-//    byteBuffer.get(byteArray);
-//
-//    Expression expression = Expressions.equal("column-name", byteArray);
-//
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
-//
-//  @Test
-//  public void testDecimalLiteral() {
-//    String expected =
-//        "{\n"
-//            + "  \"type\" : \"in\",\n"
-//            + "  \"term\" : \"column-name\",\n"
-//            + "  \"literals\" : [ {\n"
-//            + "    \"type\" : \"decimal(3, 2)\",\n"
-//            + "    \"value\" : \"\\u0001:\"\n"
-//            + "  } ]\n"
-//            + "}";
-//
-//    Expression expression = Expressions.in("column-name", new BigDecimal("3.14"));
-//
-//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-//        .isEqualTo(expected);
-//  }
+  @Test
+  public void nullExpression() {
+    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid expression: null");
+
+    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse expression from null object");
+  }
+
+  @Test
+  public void trueExpression() {
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysTrue(), true))
+        .isEqualTo("true");
+    Assertions.assertThat(ExpressionParser.fromJson("true")).isEqualTo(Expressions.alwaysTrue());
+
+    // type=literal is also supported
+    String longJson = "{\n  \"type\" : \"literal\",\n  \"value\" : true\n}";
+    Assertions.assertThat(ExpressionParser.fromJson(longJson)).isEqualTo(Expressions.alwaysTrue());
+  }
+
+  @Test
+  public void falseExpression() {
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysFalse(), true))
+        .isEqualTo("false");
+    Assertions.assertThat(ExpressionParser.fromJson("false")).isEqualTo(Expressions.alwaysFalse());
+
+    // type=literal is also supported
+    String longJson = "{\n  \"type\" : \"literal\",\n  \"value\" : false\n}";
+    Assertions.assertThat(ExpressionParser.fromJson(longJson)).isEqualTo(Expressions.alwaysFalse());
+  }
+
+  @Test
+  public void eqExpression() {
+    String expected =
+        "{\n" + "  \"type\" : \"eq\",\n" + "  \"term\" : \"name\",\n" + "  \"value\" : 25\n" + "}";
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true))
+        .isEqualTo(expected);
+    Expression expression = ExpressionParser.fromJson(expected);
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+  }
+
+  @Test
+  public void testTransform() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : {\n"
+            + "    \"type\" : \"transform\",\n"
+            + "    \"transform\" : \"bucket[100]\",\n"
+            + "    \"term\" : \"id\"\n"
+            + "  },\n"
+            + "  \"value\" : 50\n"
+            + "}";
+
+    Assertions.assertThat(
+            ExpressionParser.toJson(
+                Expressions.lessThanOrEqual(Expressions.bucket("id", 100), 50), true))
+        .isEqualTo(expected);
+    // schema is required to parse transform expressions
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected, SCHEMA), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void extraFields() {
+    Assertions.assertThat(
+            ExpressionParser.toJson(
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"in\",\n"
+                        + "  \"term\" : \"column-name\",\n"
+                        + "  \"extra-one\" : \"x\",\n"
+                        + "  \"extra-twp\" : \"y\",\n"
+                        + "  \"values\" : [ 1, 2, 3 ]\n"
+                        + "}"),
+                true))
+        .isEqualTo(
+            "{\n"
+                + "  \"type\" : \"in\",\n"
+                + "  \"term\" : \"column-name\",\n"
+                + "  \"values\" : [ 1, 2, 3 ]\n"
+                + "}");
+  }
+
+  @Test
+  public void invalidTerm() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not\",\n"
+                        + "  \"child\" : {\n"
+                        + "    \"type\" : \"lt\",\n"
+                        + "    \"term\" : 23,\n"
+                        + "    \"values\" : [ \"a\" ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse reference (requires string or object): 23");
+  }
+
+  @Test
+  public void invalidValues() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not-nan\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"value\" : 34.0\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse NOT_NAN predicate: has invalid value field");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"is-nan\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"values\" : [ 34.0, 35.0 ]\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse IS_NAN predicate: has invalid values field");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"lt\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"values\" : [ 1 ]\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse LT predicate: missing value");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"lt\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"value\" : 34,\n"
+                        + "  \"values\" : [ 1 ]\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse LT predicate: has invalid values field");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not-in\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"value\" : [ 1, 2 ]\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse NOT_IN predicate: missing values");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"in\",\n"
+                        + "  \"term\" : \"x\",\n"
+                        + "  \"value\" : \"min\",\n"
+                        + "  \"values\" : [ 1, 2 ]\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse IN predicate: has invalid value field");
+  }
+
+  @Test
+  public void invalidOperationType() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not\",\n"
+                        + "  \"child\" : {\n"
+                        + "    \"type\" : \"illegal\",\n"
+                        + "    \"term\" : \"column-name\",\n"
+                        + "    \"values\" : [ \"a\" ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"ILLEGAL\",\n"
+                        + "  \"child\" : {\n"
+                        + "    \"type\" : \"lt\",\n"
+                        + "    \"term\" : \"column-name\",\n"
+                        + "    \"values\" : [ \"a\" ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+  }
+
+  @Test
+  public void invalidAnd() {
+    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson("{\n  \"type\" : \"and\"\n}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: left");
+
+    Assertions.assertThatThrownBy(
+            () -> ExpressionParser.fromJson("{\n  \"type\" : \"and\",\n  \"left\": true}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: right");
+
+    Assertions.assertThatThrownBy(
+            () -> ExpressionParser.fromJson("{\n  \"type\" : \"and\",\n  \"right\": true}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: left");
+  }
+
+  @Test
+  public void testPredicate() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : 50\n"
+            + "}";
+
+    Assertions.assertThat(
+            ExpressionParser.toJson(Expressions.lessThanOrEqual("column-name", 50), true))
+        .isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testPredicateWithObjectLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : 50\n"
+            + "}";
+
+    String json =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : {"
+            + "    \"type\" : \"literal\",\n"
+            + "    \"value\" : 50\n"
+            + "  }\n"
+            + "}";
+
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testPredicateWithObjectReference() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : 50\n"
+            + "}";
+
+    String json =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"term\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"value\" : 50\n"
+            + "}";
+
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testAnd() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"and\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"gt-eq\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"value\" : 50\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"in\",\n"
+            + "    \"term\" : \"column-name-2\",\n"
+            + "    \"values\" : [ \"one\", \"two\" ]\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("column-name-1", 50),
+            Expressions.in("column-name-2", "one", "two"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testOr() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"or\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"lt\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"value\" : 50\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"not-null\",\n"
+            + "    \"term\" : \"column-name-2\"\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression =
+        Expressions.or(
+            Expressions.lessThan("column-name-1", 50), Expressions.notNull("column-name-2"));
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNot() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"not\",\n"
+            + "  \"child\" : {\n"
+            + "    \"type\" : \"gt-eq\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"value\" : 50\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression = Expressions.not(Expressions.greaterThanOrEqual("column-name-1", 50));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNestedExpression() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"or\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"and\",\n"
+            + "    \"left\" : {\n"
+            + "      \"type\" : \"in\",\n"
+            + "      \"term\" : \"column-name-1\",\n"
+            + "      \"values\" : [ 50, 51, 52 ]\n"
+            + "    },\n"
+            + "    \"right\" : {\n"
+            + "      \"type\" : \"eq\",\n"
+            + "      \"term\" : \"column-name-2\",\n"
+            + "      \"value\" : \"test\"\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"is-nan\",\n"
+            + "    \"term\" : \"column-name-3\"\n"
+            + "  }\n"
+            + "}";
+
+    Expression and =
+        Expressions.and(
+            Expressions.in("column-name-1", 50, 51, 52),
+            Expressions.equal("column-name-2", "test"));
+    Expression expression = Expressions.or(and, Expressions.isNaN("column-name-3"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testFixedLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"value\" : \"010203\"\n"
+            + "}";
+
+    ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] {1, 2, 3});
+    Expression expression = Expressions.equal("column-name", byteBuffer);
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testDecimalLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"values\" : [ \"3.14\" ]\n"
+            + "}";
+
+    Expression expression = Expressions.in("column-name", new BigDecimal("3.14"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNegativeScaleDecimalLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"values\" : [ \"3.14E+4\" ]\n"
+            + "}";
+
+    Expression expression = Expressions.in("column-name", new BigDecimal("3.14E+4"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -69,9 +69,11 @@ public class TestExpressionParser {
 
     for (Expression expr : expressions) {
       Expression bound = Binder.bind(SUPPORTED_PRIMITIVES, expr);
-      String asJson = ExpressionParser.toJson(bound, true);
-      System.err.println("As JSON: " + asJson);
-      Expression parsed = ExpressionParser.fromJson(asJson, SCHEMA);
+      String boundJson = ExpressionParser.toJson(bound, true);
+      System.err.println("Bound JSON: " + boundJson);
+      String unboundJson = ExpressionParser.toJson(expr, true);
+      Assert.assertEquals("Bound and unbound should produce identical json", boundJson, unboundJson);
+      Expression parsed = ExpressionParser.fromJson(boundJson, SCHEMA);
       Assert.assertTrue(
           "Round-trip value should be equivalent", ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true));
     }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -18,410 +18,454 @@
  */
 package org.apache.iceberg.expressions;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Types.DateType;
-import org.apache.iceberg.types.Types.LongType;
-import org.assertj.core.api.Assertions;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestExpressionParser {
 
-  @Test
-  public void nullExpression() {
-    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid expression: null");
-
-    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson((JsonNode) null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse expression from null object");
-  }
-
-  @Test
-  public void unsupportedExpression() {
-    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson((Expression) () -> null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Unsupported expression:");
-
-    Expression expression =
-        Binder.bind(
-            new Schema(required(1, "x", LongType.get())).asStruct(), Expressions.equal("x", 23L));
-    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(expression))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Unsupported expression: ref(id=1, accessor-type=long) == 23");
-  }
+  private static final Types.StructType SUPPORTED_PRIMITIVES =
+      Types.StructType.of(
+          required(100, "id", Types.LongType.get()),
+          optional(101, "data", Types.StringType.get()),
+          required(102, "b", Types.BooleanType.get()),
+          optional(103, "i", Types.IntegerType.get()),
+          required(104, "l", Types.LongType.get()),
+          optional(105, "f", Types.FloatType.get()),
+          required(106, "d", Types.DoubleType.get()),
+          optional(107, "date", Types.DateType.get()),
+          required(108, "ts", Types.TimestampType.withZone()),
+          required(110, "s", Types.StringType.get()),
+          required(111, "uuid", Types.UUIDType.get()),
+          required(112, "fixed", Types.FixedType.ofLength(7)),
+          optional(113, "bytes", Types.BinaryType.get()),
+          required(114, "dec_9_0", Types.DecimalType.of(9, 0)),
+          required(115, "dec_11_2", Types.DecimalType.of(11, 2)),
+          required(116, "dec_38_10", Types.DecimalType.of(38, 10)), // maximum precision
+          required(117, "time", Types.TimeType.get()));
+  private static final Schema SCHEMA = new Schema(SUPPORTED_PRIMITIVES.fields());
 
   @Test
-  public void trueExpression() {
-    String expected = "{\n" + "  \"type\" : \"true\"\n" + "}";
-    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysTrue(), true))
-        .isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void falseExpression() {
-    String expected = "{\n" + "  \"type\" : \"false\"\n" + "}";
-    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysFalse(), true))
-        .isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void eqExpression() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"eq\",\n"
-            + "  \"term\" : \"name\",\n"
-            + "  \"literals\" : [ {\n"
-            + "    \"type\" : \"int\",\n"
-            + "    \"value\" : \"\\u0019\\u0000\\u0000\\u0000\"\n"
-            + "  } ]\n"
-            + "}";
-    Assertions.assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true))
-        .isEqualTo(expected);
-    Expression expression = ExpressionParser.fromJson(expected);
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-  }
-
-  @Test
-  public void transformsNotSupported() {
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.toJson(
-                    Expressions.in(Expressions.transform("x", Transforms.day(DateType.get())), 25)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Unsupported term: day(ref(name=\"x\"))");
-  }
-
-  @Test
-  public void extraFields() {
-    Assertions.assertThat(
-            ExpressionParser.toJson(
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"in\",\n"
-                        + "  \"term\" : \"column-name\",\n"
-                        + "  \"extra-one\" : \"x\",\n"
-                        + "  \"extra-twp\" : \"y\",\n"
-                        + "  \"literals\" : [ {\n"
-                        + "    \"type\" : \"int\",\n"
-                        + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "  } ]\n"
-                        + "}"),
-                true))
-        .isEqualTo(
-            "{\n"
-                + "  \"type\" : \"in\",\n"
-                + "  \"term\" : \"column-name\",\n"
-                + "  \"literals\" : [ {\n"
-                + "    \"type\" : \"int\",\n"
-                + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                + "  } ]\n"
-                + "}");
-  }
-
-  @Test
-  public void invalidTerm() {
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"not\",\n"
-                        + "  \"operand\" : {\n"
-                        + "    \"type\" : \"lt\",\n"
-                        + "    \"term\" : 23,\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"int\",\n"
-                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "    } ]\n"
-                        + "  }\n"
-                        + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse term to a string value: 23");
-  }
-
-  @Test
-  public void invalidOperationType() {
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"not\",\n"
-                        + "  \"operand\" : {\n"
-                        + "    \"type\" : \"illegal\",\n"
-                        + "    \"term\" : \"column-name\",\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"int\",\n"
-                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "    } ]\n"
-                        + "  }\n"
-                        + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
-
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"ILLEGAL\",\n"
-                        + "  \"operand\" : {\n"
-                        + "    \"type\" : \"lt\",\n"
-                        + "    \"term\" : \"column-name\",\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"int\",\n"
-                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "    } ]\n"
-                        + "  }\n"
-                        + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
-  }
-
-  @Test
-  public void invalidAnd() {
-    Assertions.assertThatThrownBy(
-            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing field: left");
-
-    Assertions.assertThatThrownBy(
-            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing field: left");
-
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"and\",\n"
-                        + "  \"left\" : {\n"
-                        + "    \"type\" : \"gt_eq\",\n"
-                        + "    \"term\" : \"column-name-1\",\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"int\",\n"
-                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "    } ]\n"
-                        + "  }\n"
-                        + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing field: right");
-
-    // term is missing from left
-    Assertions.assertThatThrownBy(
-            () ->
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"and\",\n"
-                        + "  \"left\" : {\n"
-                        + "    \"type\" : \"gt_eq\",\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"int\",\n"
-                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-                        + "    } ]\n"
-                        + "  },\n"
-                        + "  \"right\" : {\n"
-                        + "    \"type\" : \"in\",\n"
-                        + "    \"term\" : \"column-name-2\",\n"
-                        + "    \"literals\" : [ {\n"
-                        + "      \"type\" : \"string\",\n"
-                        + "      \"value\" : \"Check\"\n"
-                        + "    } ]\n"
-                        + "  }\n"
-                        + "}"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing string term");
-  }
-
-  @Test
-  public void testPredicate() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"in\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"literals\" : [ {\n"
-            + "    \"type\" : \"int\",\n"
-            + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-            + "  } ]\n"
-            + "}";
-
-    Assertions.assertThat(ExpressionParser.toJson(Expressions.in("column-name", 50), true))
-        .isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void testAnd() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"and\",\n"
-            + "  \"left\" : {\n"
-            + "    \"type\" : \"gt_eq\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"literals\" : [ {\n"
-            + "      \"type\" : \"int\",\n"
-            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-            + "    } ]\n"
-            + "  },\n"
-            + "  \"right\" : {\n"
-            + "    \"type\" : \"in\",\n"
-            + "    \"term\" : \"column-name-2\",\n"
-            + "    \"literals\" : [ {\n"
-            + "      \"type\" : \"string\",\n"
-            + "      \"value\" : \"Check\"\n"
-            + "    } ]\n"
-            + "  }\n"
-            + "}";
-
-    Expression expression =
+  public void testExpressionParser() {
+    Expression[] expressions = new Expression[] {
+        Expressions.alwaysFalse(),
+        Expressions.alwaysTrue(),
+        Expressions.equal("id", 100),
         Expressions.and(
-            Expressions.greaterThanOrEqual("column-name-1", 50),
-            Expressions.in("column-name-2", "Check"));
-
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void testOr() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"or\",\n"
-            + "  \"left\" : {\n"
-            + "    \"type\" : \"lt\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"literals\" : [ {\n"
-            + "      \"type\" : \"int\",\n"
-            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-            + "    } ]\n"
-            + "  },\n"
-            + "  \"right\" : {\n"
-            + "    \"type\" : \"not_null\",\n"
-            + "    \"term\" : \"column-name-2\"\n"
-            + "  }\n"
-            + "}";
-
-    Expression expression =
+            Expressions.or(
+                Expressions.equal("data", UUID.randomUUID().toString()),
+                Expressions.isNull("data")),
+            Expressions.greaterThanOrEqual("id", 66)),
         Expressions.or(
-            Expressions.lessThan("column-name-1", 50), Expressions.notNull("column-name-2"));
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
+            Expressions.greaterThan(Expressions.day("ts"), "2022-08-14"),
+            Expressions.equal("date", "2022-08-14")),
+        Expressions.not(Expressions.in("l", 1, 2, 3, 4))
+    };
+
+    for (Expression expr : expressions) {
+      Expression bound = Binder.bind(SUPPORTED_PRIMITIVES, expr);
+      String asJson = ExpressionParser.toJson(bound, true);
+      System.err.println("As JSON: " + asJson);
+      Expression parsed = ExpressionParser.fromJson(asJson, SCHEMA);
+      Assert.assertTrue(
+          "Round-trip value should be equivalent", ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true));
+    }
   }
 
-  @Test
-  public void testNot() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"not\",\n"
-            + "  \"operand\" : {\n"
-            + "    \"type\" : \"lt\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"literals\" : [ {\n"
-            + "      \"type\" : \"int\",\n"
-            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-            + "    } ]\n"
-            + "  }\n"
-            + "}";
-
-    Expression expression = Expressions.not(Expressions.lessThan("column-name-1", 50));
-
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void testNestedExpression() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"or\",\n"
-            + "  \"left\" : {\n"
-            + "    \"type\" : \"and\",\n"
-            + "    \"left\" : {\n"
-            + "      \"type\" : \"in\",\n"
-            + "      \"term\" : \"column-name-1\",\n"
-            + "      \"literals\" : [ {\n"
-            + "        \"type\" : \"int\",\n"
-            + "        \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
-            + "      } ]\n"
-            + "    },\n"
-            + "    \"right\" : {\n"
-            + "      \"type\" : \"eq\",\n"
-            + "      \"term\" : \"column-name-2\",\n"
-            + "      \"literals\" : [ {\n"
-            + "        \"type\" : \"string\",\n"
-            + "        \"value\" : \"Test\"\n"
-            + "      } ]\n"
-            + "    }\n"
-            + "  },\n"
-            + "  \"right\" : {\n"
-            + "    \"type\" : \"is_nan\",\n"
-            + "    \"term\" : \"column-name-3\"\n"
-            + "  }\n"
-            + "}";
-
-    Expression and =
-        Expressions.and(
-            Expressions.in("column-name-1", 50), Expressions.equal("column-name-2", "Test"));
-    Expression expression = Expressions.or(and, Expressions.isNaN("column-name-3"));
-
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void testFixedLiteral() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"eq\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"literals\" : [ {\n"
-            + "    \"type\" : \"fixed[10]\",\n"
-            + "    \"value\" : \"testString\"\n"
-            + "  } ]\n"
-            + "}";
-    String testString = "testString";
-    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(testString);
-
-    byte[] byteArray = new byte[byteBuffer.remaining()];
-    byteBuffer.get(byteArray);
-
-    Expression expression = Expressions.equal("column-name", byteArray);
-
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
-
-  @Test
-  public void testDecimalLiteral() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"in\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"literals\" : [ {\n"
-            + "    \"type\" : \"decimal(3, 2)\",\n"
-            + "    \"value\" : \"\\u0001:\"\n"
-            + "  } ]\n"
-            + "}";
-
-    Expression expression = Expressions.in("column-name", new BigDecimal("3.14"));
-
-    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
-    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
-        .isEqualTo(expected);
-  }
+//  @Test
+//  public void nullExpression() {
+//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(null))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Invalid expression: null");
+//
+//    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson((JsonNode) null))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse expression from null object");
+//  }
+//
+//  @Test
+//  public void unsupportedExpression() {
+//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson((Expression) () -> null))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessageStartingWith("Unsupported expression:");
+//
+//    Expression expression =
+//        Binder.bind(
+//            new Schema(required(1, "x", LongType.get())).asStruct(), Expressions.equal("x", 23L));
+//    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(expression))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Unsupported expression: ref(id=1, accessor-type=long) == 23");
+//  }
+//
+//  @Test
+//  public void trueExpression() {
+//    String expected = "{\n" + "  \"type\" : \"true\"\n" + "}";
+//    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysTrue(), true))
+//        .isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void falseExpression() {
+//    String expected = "{\n" + "  \"type\" : \"false\"\n" + "}";
+//    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysFalse(), true))
+//        .isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void eqExpression() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"eq\",\n"
+//            + "  \"term\" : \"name\",\n"
+//            + "  \"literals\" : [ {\n"
+//            + "    \"type\" : \"int\",\n"
+//            + "    \"value\" : \"\\u0019\\u0000\\u0000\\u0000\"\n"
+//            + "  } ]\n"
+//            + "}";
+//    Assertions.assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true))
+//        .isEqualTo(expected);
+//    Expression expression = ExpressionParser.fromJson(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void transformsNotSupported() {
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.toJson(
+//                    Expressions.in(Expressions.transform("x", Transforms.day(DateType.get())), 25)))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Unsupported term: day(ref(name=\"x\"))");
+//  }
+//
+//  @Test
+//  public void extraFields() {
+//    Assertions.assertThat(
+//            ExpressionParser.toJson(
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"in\",\n"
+//                        + "  \"term\" : \"column-name\",\n"
+//                        + "  \"extra-one\" : \"x\",\n"
+//                        + "  \"extra-twp\" : \"y\",\n"
+//                        + "  \"literals\" : [ {\n"
+//                        + "    \"type\" : \"int\",\n"
+//                        + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "  } ]\n"
+//                        + "}"),
+//                true))
+//        .isEqualTo(
+//            "{\n"
+//                + "  \"type\" : \"in\",\n"
+//                + "  \"term\" : \"column-name\",\n"
+//                + "  \"literals\" : [ {\n"
+//                + "    \"type\" : \"int\",\n"
+//                + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                + "  } ]\n"
+//                + "}");
+//  }
+//
+//  @Test
+//  public void invalidTerm() {
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"not\",\n"
+//                        + "  \"operand\" : {\n"
+//                        + "    \"type\" : \"lt\",\n"
+//                        + "    \"term\" : 23,\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"int\",\n"
+//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "    } ]\n"
+//                        + "  }\n"
+//                        + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse term to a string value: 23");
+//  }
+//
+//  @Test
+//  public void invalidOperationType() {
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"not\",\n"
+//                        + "  \"operand\" : {\n"
+//                        + "    \"type\" : \"illegal\",\n"
+//                        + "    \"term\" : \"column-name\",\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"int\",\n"
+//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "    } ]\n"
+//                        + "  }\n"
+//                        + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+//
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"ILLEGAL\",\n"
+//                        + "  \"operand\" : {\n"
+//                        + "    \"type\" : \"lt\",\n"
+//                        + "    \"term\" : \"column-name\",\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"int\",\n"
+//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "    } ]\n"
+//                        + "  }\n"
+//                        + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+//  }
+//
+//  @Test
+//  public void invalidAnd() {
+//    Assertions.assertThatThrownBy(
+//            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse missing field: left");
+//
+//    Assertions.assertThatThrownBy(
+//            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse missing field: left");
+//
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"and\",\n"
+//                        + "  \"left\" : {\n"
+//                        + "    \"type\" : \"gt_eq\",\n"
+//                        + "    \"term\" : \"column-name-1\",\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"int\",\n"
+//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "    } ]\n"
+//                        + "  }\n"
+//                        + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse missing field: right");
+//
+//    // term is missing from left
+//    Assertions.assertThatThrownBy(
+//            () ->
+//                ExpressionParser.fromJson(
+//                    "{\n"
+//                        + "  \"type\" : \"and\",\n"
+//                        + "  \"left\" : {\n"
+//                        + "    \"type\" : \"gt_eq\",\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"int\",\n"
+//                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//                        + "    } ]\n"
+//                        + "  },\n"
+//                        + "  \"right\" : {\n"
+//                        + "    \"type\" : \"in\",\n"
+//                        + "    \"term\" : \"column-name-2\",\n"
+//                        + "    \"literals\" : [ {\n"
+//                        + "      \"type\" : \"string\",\n"
+//                        + "      \"value\" : \"Check\"\n"
+//                        + "    } ]\n"
+//                        + "  }\n"
+//                        + "}"))
+//        .isInstanceOf(IllegalArgumentException.class)
+//        .hasMessage("Cannot parse missing string term");
+//  }
+//
+//  @Test
+//  public void testPredicate() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"in\",\n"
+//            + "  \"term\" : \"column-name\",\n"
+//            + "  \"literals\" : [ {\n"
+//            + "    \"type\" : \"int\",\n"
+//            + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//            + "  } ]\n"
+//            + "}";
+//
+//    Assertions.assertThat(ExpressionParser.toJson(Expressions.in("column-name", 50), true))
+//        .isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testAnd() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"and\",\n"
+//            + "  \"left\" : {\n"
+//            + "    \"type\" : \"gt_eq\",\n"
+//            + "    \"term\" : \"column-name-1\",\n"
+//            + "    \"literals\" : [ {\n"
+//            + "      \"type\" : \"int\",\n"
+//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//            + "    } ]\n"
+//            + "  },\n"
+//            + "  \"right\" : {\n"
+//            + "    \"type\" : \"in\",\n"
+//            + "    \"term\" : \"column-name-2\",\n"
+//            + "    \"literals\" : [ {\n"
+//            + "      \"type\" : \"string\",\n"
+//            + "      \"value\" : \"Check\"\n"
+//            + "    } ]\n"
+//            + "  }\n"
+//            + "}";
+//
+//    Expression expression =
+//        Expressions.and(
+//            Expressions.greaterThanOrEqual("column-name-1", 50),
+//            Expressions.in("column-name-2", "Check"));
+//
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testOr() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"or\",\n"
+//            + "  \"left\" : {\n"
+//            + "    \"type\" : \"lt\",\n"
+//            + "    \"term\" : \"column-name-1\",\n"
+//            + "    \"literals\" : [ {\n"
+//            + "      \"type\" : \"int\",\n"
+//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//            + "    } ]\n"
+//            + "  },\n"
+//            + "  \"right\" : {\n"
+//            + "    \"type\" : \"not_null\",\n"
+//            + "    \"term\" : \"column-name-2\"\n"
+//            + "  }\n"
+//            + "}";
+//
+//    Expression expression =
+//        Expressions.or(
+//            Expressions.lessThan("column-name-1", 50), Expressions.notNull("column-name-2"));
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testNot() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"not\",\n"
+//            + "  \"operand\" : {\n"
+//            + "    \"type\" : \"lt\",\n"
+//            + "    \"term\" : \"column-name-1\",\n"
+//            + "    \"literals\" : [ {\n"
+//            + "      \"type\" : \"int\",\n"
+//            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//            + "    } ]\n"
+//            + "  }\n"
+//            + "}";
+//
+//    Expression expression = Expressions.not(Expressions.lessThan("column-name-1", 50));
+//
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testNestedExpression() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"or\",\n"
+//            + "  \"left\" : {\n"
+//            + "    \"type\" : \"and\",\n"
+//            + "    \"left\" : {\n"
+//            + "      \"type\" : \"in\",\n"
+//            + "      \"term\" : \"column-name-1\",\n"
+//            + "      \"literals\" : [ {\n"
+//            + "        \"type\" : \"int\",\n"
+//            + "        \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+//            + "      } ]\n"
+//            + "    },\n"
+//            + "    \"right\" : {\n"
+//            + "      \"type\" : \"eq\",\n"
+//            + "      \"term\" : \"column-name-2\",\n"
+//            + "      \"literals\" : [ {\n"
+//            + "        \"type\" : \"string\",\n"
+//            + "        \"value\" : \"Test\"\n"
+//            + "      } ]\n"
+//            + "    }\n"
+//            + "  },\n"
+//            + "  \"right\" : {\n"
+//            + "    \"type\" : \"is_nan\",\n"
+//            + "    \"term\" : \"column-name-3\"\n"
+//            + "  }\n"
+//            + "}";
+//
+//    Expression and =
+//        Expressions.and(
+//            Expressions.in("column-name-1", 50), Expressions.equal("column-name-2", "Test"));
+//    Expression expression = Expressions.or(and, Expressions.isNaN("column-name-3"));
+//
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testFixedLiteral() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"eq\",\n"
+//            + "  \"term\" : \"column-name\",\n"
+//            + "  \"literals\" : [ {\n"
+//            + "    \"type\" : \"fixed[10]\",\n"
+//            + "    \"value\" : \"testString\"\n"
+//            + "  } ]\n"
+//            + "}";
+//    String testString = "testString";
+//    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(testString);
+//
+//    byte[] byteArray = new byte[byteBuffer.remaining()];
+//    byteBuffer.get(byteArray);
+//
+//    Expression expression = Expressions.equal("column-name", byteArray);
+//
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
+//
+//  @Test
+//  public void testDecimalLiteral() {
+//    String expected =
+//        "{\n"
+//            + "  \"type\" : \"in\",\n"
+//            + "  \"term\" : \"column-name\",\n"
+//            + "  \"literals\" : [ {\n"
+//            + "    \"type\" : \"decimal(3, 2)\",\n"
+//            + "    \"value\" : \"\\u0001:\"\n"
+//            + "  } ]\n"
+//            + "}";
+//
+//    Expression expression = Expressions.in("column-name", new BigDecimal("3.14"));
+//
+//    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+//    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+//        .isEqualTo(expected);
+//  }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types.DateType;
+import org.apache.iceberg.types.Types.LongType;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestExpressionParser {
+
+  @Test
+  public void nullExpression() {
+    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid expression: null");
+
+    Assertions.assertThatThrownBy(() -> ExpressionParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse expression from null object");
+  }
+
+  @Test
+  public void unsupportedExpression() {
+    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson((Expression) () -> null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Unsupported expression:");
+
+    Expression expression =
+        Binder.bind(
+            new Schema(required(1, "x", LongType.get())).asStruct(), Expressions.equal("x", 23L));
+    Assertions.assertThatThrownBy(() -> ExpressionParser.toJson(expression))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsupported expression: ref(id=1, accessor-type=long) == 23");
+  }
+
+  @Test
+  public void trueExpression() {
+    String expected = "{\n" + "  \"type\" : \"true\"\n" + "}";
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysTrue(), true))
+        .isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void falseExpression() {
+    String expected = "{\n" + "  \"type\" : \"false\"\n" + "}";
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.alwaysFalse(), true))
+        .isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void eqExpression() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"term\" : \"name\",\n"
+            + "  \"literals\" : [ {\n"
+            + "    \"type\" : \"int\",\n"
+            + "    \"value\" : \"\\u0019\\u0000\\u0000\\u0000\"\n"
+            + "  } ]\n"
+            + "}";
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true))
+        .isEqualTo(expected);
+    Expression expression = ExpressionParser.fromJson(expected);
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+  }
+
+  @Test
+  public void transformsNotSupported() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.toJson(
+                    Expressions.in(Expressions.transform("x", Transforms.day(DateType.get())), 25)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsupported term: day(ref(name=\"x\"))");
+  }
+
+  @Test
+  public void extraFields() {
+    Assertions.assertThat(
+            ExpressionParser.toJson(
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"in\",\n"
+                        + "  \"term\" : \"column-name\",\n"
+                        + "  \"extra-one\" : \"x\",\n"
+                        + "  \"extra-twp\" : \"y\",\n"
+                        + "  \"literals\" : [ {\n"
+                        + "    \"type\" : \"int\",\n"
+                        + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "  } ]\n"
+                        + "}"),
+                true))
+        .isEqualTo(
+            "{\n"
+                + "  \"type\" : \"in\",\n"
+                + "  \"term\" : \"column-name\",\n"
+                + "  \"literals\" : [ {\n"
+                + "    \"type\" : \"int\",\n"
+                + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                + "  } ]\n"
+                + "}");
+  }
+
+  @Test
+  public void invalidTerm() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not\",\n"
+                        + "  \"operand\" : {\n"
+                        + "    \"type\" : \"lt\",\n"
+                        + "    \"term\" : 23,\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"int\",\n"
+                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "    } ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse term to a string value: 23");
+  }
+
+  @Test
+  public void invalidOperationType() {
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"not\",\n"
+                        + "  \"operand\" : {\n"
+                        + "    \"type\" : \"illegal\",\n"
+                        + "    \"term\" : \"column-name\",\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"int\",\n"
+                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "    } ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"ILLEGAL\",\n"
+                        + "  \"operand\" : {\n"
+                        + "    \"type\" : \"lt\",\n"
+                        + "    \"term\" : \"column-name\",\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"int\",\n"
+                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "    } ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No enum constant org.apache.iceberg.expressions.Expression.Operation.ILLEGAL");
+  }
+
+  @Test
+  public void invalidAnd() {
+    Assertions.assertThatThrownBy(
+            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: left");
+
+    Assertions.assertThatThrownBy(
+            () -> ExpressionParser.fromJson("{\n" + "  \"type\" : \"and\"\n" + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: left");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"and\",\n"
+                        + "  \"left\" : {\n"
+                        + "    \"type\" : \"gt_eq\",\n"
+                        + "    \"term\" : \"column-name-1\",\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"int\",\n"
+                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "    } ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: right");
+
+    // term is missing from left
+    Assertions.assertThatThrownBy(
+            () ->
+                ExpressionParser.fromJson(
+                    "{\n"
+                        + "  \"type\" : \"and\",\n"
+                        + "  \"left\" : {\n"
+                        + "    \"type\" : \"gt_eq\",\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"int\",\n"
+                        + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+                        + "    } ]\n"
+                        + "  },\n"
+                        + "  \"right\" : {\n"
+                        + "    \"type\" : \"in\",\n"
+                        + "    \"term\" : \"column-name-2\",\n"
+                        + "    \"literals\" : [ {\n"
+                        + "      \"type\" : \"string\",\n"
+                        + "      \"value\" : \"Check\"\n"
+                        + "    } ]\n"
+                        + "  }\n"
+                        + "}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string term");
+  }
+
+  @Test
+  public void testPredicate() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"literals\" : [ {\n"
+            + "    \"type\" : \"int\",\n"
+            + "    \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+            + "  } ]\n"
+            + "}";
+
+    Assertions.assertThat(ExpressionParser.toJson(Expressions.in("column-name", 50), true))
+        .isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testAnd() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"and\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"gt_eq\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"literals\" : [ {\n"
+            + "      \"type\" : \"int\",\n"
+            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+            + "    } ]\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"in\",\n"
+            + "    \"term\" : \"column-name-2\",\n"
+            + "    \"literals\" : [ {\n"
+            + "      \"type\" : \"string\",\n"
+            + "      \"value\" : \"Check\"\n"
+            + "    } ]\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("column-name-1", 50),
+            Expressions.in("column-name-2", "Check"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testOr() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"or\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"lt\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"literals\" : [ {\n"
+            + "      \"type\" : \"int\",\n"
+            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+            + "    } ]\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"not_null\",\n"
+            + "    \"term\" : \"column-name-2\"\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression =
+        Expressions.or(
+            Expressions.lessThan("column-name-1", 50), Expressions.notNull("column-name-2"));
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNot() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"not\",\n"
+            + "  \"operand\" : {\n"
+            + "    \"type\" : \"lt\",\n"
+            + "    \"term\" : \"column-name-1\",\n"
+            + "    \"literals\" : [ {\n"
+            + "      \"type\" : \"int\",\n"
+            + "      \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+            + "    } ]\n"
+            + "  }\n"
+            + "}";
+
+    Expression expression = Expressions.not(Expressions.lessThan("column-name-1", 50));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testNestedExpression() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"or\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"and\",\n"
+            + "    \"left\" : {\n"
+            + "      \"type\" : \"in\",\n"
+            + "      \"term\" : \"column-name-1\",\n"
+            + "      \"literals\" : [ {\n"
+            + "        \"type\" : \"int\",\n"
+            + "        \"value\" : \"2\\u0000\\u0000\\u0000\"\n"
+            + "      } ]\n"
+            + "    },\n"
+            + "    \"right\" : {\n"
+            + "      \"type\" : \"eq\",\n"
+            + "      \"term\" : \"column-name-2\",\n"
+            + "      \"literals\" : [ {\n"
+            + "        \"type\" : \"string\",\n"
+            + "        \"value\" : \"Test\"\n"
+            + "      } ]\n"
+            + "    }\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"is_nan\",\n"
+            + "    \"term\" : \"column-name-3\"\n"
+            + "  }\n"
+            + "}";
+
+    Expression and =
+        Expressions.and(
+            Expressions.in("column-name-1", 50), Expressions.equal("column-name-2", "Test"));
+    Expression expression = Expressions.or(and, Expressions.isNaN("column-name-3"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testFixedLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"literals\" : [ {\n"
+            + "    \"type\" : \"fixed[10]\",\n"
+            + "    \"value\" : \"testString\"\n"
+            + "  } ]\n"
+            + "}";
+    String testString = "testString";
+    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(testString);
+
+    byte[] byteArray = new byte[byteBuffer.remaining()];
+    byteBuffer.get(byteArray);
+
+    Expression expression = Expressions.equal("column-name", byteArray);
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testDecimalLiteral() {
+    String expected =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"literals\" : [ {\n"
+            + "    \"type\" : \"decimal(3, 2)\",\n"
+            + "    \"value\" : \"\\u0001:\"\n"
+            + "  } ]\n"
+            + "}";
+
+    Expression expression = Expressions.in("column-name", new BigDecimal("3.14"));
+
+    Assertions.assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
+    Assertions.assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
+        .isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
This adds a JSON parser for `Expression` based on @nastra's work in #5511, but with a few changes:

1. The format matches what was discussed in #4308
2. Adds a `CustomOrderExpressionVisitor` to visit expressions when converting to JSON
3. Transforms are supported if a schema is passed to `fromJson`
4. Both bound and unbound expressions can be passed to `toJson`. Using a bound expression ensures that the JSON representation for values matches expression's type

Closes #4308
Closes #5511

Co-authored-by: Eduard Tudenhoefner <etudenhoefner@gmail.com>