### PR TITLE
Spark: Set the current schema id when rolling back a snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1101,6 +1101,7 @@ public class TableMetadata implements Serializable {
           snapshot != null, "Cannot set %s to unknown snapshot: %s", branch, snapshotId);
 
       setBranchSnapshotInternal(snapshot, branch);
+      setCurrentSchema(snapshot.schemaId());
 
       return this;
     }


### PR DESCRIPTION
Resolves #5591