### PR TITLE
Spark: Remove backup table after a successful MigrateTable action.

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseMigrateTableSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseMigrateTableSparkAction.java
@@ -143,6 +143,8 @@ public class BaseMigrateTableSparkAction
             LOG.error("Cannot abort staged changes", abortException);
           }
         }
+      } else {
+        removeBackupTable();
       }
     }
 
@@ -220,5 +222,9 @@ public class BaseMigrateTableSparkAction
           backupIdent,
           e);
     }
+  }
+
+  private void removeBackupTable() {
+    destCatalog().dropTable(backupIdent);
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -129,6 +129,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
   private String tableLocation;
   private final String type;
   private final TableCatalog catalog;
+  private static final String BACKUP_SUFFIX = "_BACKUP_";
 
   public TestCreateActions(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
@@ -179,6 +180,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -202,6 +204,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     sql("ALTER TABLE %s ADD PARTITION(id=0)", source);
 
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -226,6 +229,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         "ALTER TABLE %s ADD PARTITION(id=0) LOCATION '%s'",
         source, partitionDataLoc.toURI().toString());
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -241,6 +245,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -279,6 +284,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
     List<Object[]> expected = sql("select id, null, data from %s order by id", source);
@@ -324,6 +330,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -369,6 +376,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
 
     // drop column
     sql("ALTER TABLE %s DROP COLUMN %s", dest, "col1");
@@ -390,6 +398,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -447,6 +456,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -588,6 +598,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -635,6 +646,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -707,6 +719,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -732,6 +745,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -759,6 +773,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -783,6 +798,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -142,6 +142,8 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
             LOG.error("Cannot abort staged changes", abortException);
           }
         }
+      } else {
+        removeBackupTable();
       }
     }
 
@@ -219,5 +221,9 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
           backupIdent,
           e);
     }
+  }
+
+  private void removeBackupTable() {
+    destCatalog().dropTable(backupIdent);
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -142,6 +142,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
   private String tableLocation;
   private final String type;
   private final TableCatalog catalog;
+  private static final String BACKUP_SUFFIX = "_BACKUP_";
 
   public TestCreateActions(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
@@ -216,6 +217,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     sql("ALTER TABLE %s ADD PARTITION(id=0)", source);
 
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -240,6 +242,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         "ALTER TABLE %s ADD PARTITION(id=0) LOCATION '%s'",
         source, partitionDataLoc.toURI().toString());
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -255,6 +258,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -293,6 +297,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
     List<Object[]> expected = sql("select id, null, data from %s order by id", source);
@@ -338,6 +343,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -383,6 +389,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
 
     // drop column
     sql("ALTER TABLE %s DROP COLUMN %s", dest, "col1");
@@ -404,6 +411,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -461,6 +469,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -619,6 +628,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -666,6 +676,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -800,6 +811,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -822,6 +834,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -847,6 +860,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -874,6 +888,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -898,6 +913,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -142,6 +142,8 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
             LOG.error("Cannot abort staged changes", abortException);
           }
         }
+      } else {
+        removeBackupTable();
       }
     }
 
@@ -219,5 +221,9 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
           backupIdent,
           e);
     }
+  }
+
+  private void removeBackupTable() {
+    destCatalog().dropTable(backupIdent);
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -142,6 +142,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
   private String tableLocation;
   private final String type;
   private final TableCatalog catalog;
+  private static final String BACKUP_SUFFIX = "_BACKUP_";
 
   public TestCreateActions(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
@@ -193,6 +194,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_PARTITIONED_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -216,6 +218,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     sql("ALTER TABLE %s ADD PARTITION(id=0)", source);
 
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -240,6 +243,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         "ALTER TABLE %s ADD PARTITION(id=0) LOCATION '%s'",
         source, partitionDataLoc.toURI().toString());
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -255,6 +259,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -293,6 +298,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
     List<Object[]> expected = sql("select id, null, data from %s order by id", source);
@@ -338,6 +344,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
     SparkTable sparkTable = loadTable(dest);
     Table table = sparkTable.table();
 
@@ -383,6 +390,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(source).execute();
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
 
     // drop column
     sql("ALTER TABLE %s DROP COLUMN %s", dest, "col1");
@@ -404,6 +412,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -461,6 +470,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String dest = source;
     createSourceTable(CREATE_HIVE_EXTERNAL_PARQUET, source);
     assertMigratedFileCount(SparkActions.get().migrateTable(source), source, dest);
+    Assert.assertFalse(spark.catalog().tableExists(source + BACKUP_SUFFIX));
   }
 
   @Test
@@ -619,6 +629,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -666,6 +677,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // Migrate table
     SparkActions.get().migrateTable(tblName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tblName + BACKUP_SUFFIX));
 
     // check if iceberg and non-iceberg output
     List<Object[]> afterMigarteBeforeAddResults = sql("SELECT * FROM %s ORDER BY col0", tblName);
@@ -800,6 +812,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -822,6 +835,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -847,6 +861,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -874,6 +889,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
@@ -898,6 +914,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // migrate table
     SparkActions.get().migrateTable(tableName).execute();
+    Assert.assertFalse(spark.catalog().tableExists(tableName + BACKUP_SUFFIX));
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);


### PR DESCRIPTION
Once the MigrateTable action is called, a backup table is created. The backup table is used to restore the original table in case the MigrateTable action fails. This restoration is done by renaming the backup table to the original table. Therefore if the migrate operation fails there is no backup table lying around in the catalog. However, if the migration goes through successfully, the backup table is not cleaned up leaving the user to find a new unknown table in their catalog. 

This PR cleans up the backup table after the migrate table action succeeds.

I tested this manually and I also added additional assertions to the existing unit tests to verify that the backup table is cleaned up properly. 