### PR TITLE
Flink: Delete the data when UPDATE_BEFORE

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -88,8 +88,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
 
       case UPDATE_BEFORE:
         if (upsert) {
-          break; // UPDATE_BEFORE is not necessary for UPSERT, we do nothing to prevent delete one
-          // row twice
+          writer.deleteKey(keyProjection.wrap(row));
+          break; // UPDATE_BEFORE is also necessary for UPSERT, when there have not UPDATE_AFTER
         }
         writer.delete(row);
         break;


### PR DESCRIPTION
Usually when we update data, we have an -U and +U in Changelog.But When we add a condition in CDC synchronization, such as rate>10, we insert a data greater than 10 in the source, such as mysql, and the condition will be met. When we modify the data less than 10, the condition will not be met, and only a -U will be transmitted. If does not delete the data when UPDATE_BEFORE, our results will be incorrect,so I think UPDATE_BEFORE is also necessary for UPSERT, when there have not UPDATE_AFTER.
the sql like: insert into hive_catalog.dm_ods.basic_ods select * from dm_mapping.default_catalog.basic_source where rate > 20;