### PR TITLE
Fix message pattern in checkArgument invocation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -150,7 +150,7 @@ public class MetadataUpdateParser {
     // which is required
     Preconditions.checkArgument(
         updateAction != null,
-        "Cannot convert metadata update to json. Unrecognized metadata update type: {}",
+        "Cannot convert metadata update to json. Unrecognized metadata update type: %s",
         metadataUpdate.getClass().getName());
 
     generator.writeStartObject();


### PR DESCRIPTION
It was using `{}` instead of `%s` as a placeholder.