### PR TITLE
Python: Add annotations typedef

### DIFF
--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -23,8 +23,8 @@ from typing import (
 )
 
 
-class FrozenDict(Dict):
-    def __setitem__(self, instance, value):
+class FrozenDict(Dict[Any, Any]):
+    def __setitem__(self, instance: Any, value: Any) -> None:
         raise AttributeError("FrozenDict does not support assignment")
 
     def update(self, *args: Any, **kwargs: Any) -> None:

--- a/python/tests/test_typedef.py
+++ b/python/tests/test_typedef.py
@@ -19,13 +19,13 @@ import pytest
 from pyiceberg.typedef import FrozenDict
 
 
-def test_setitem_frozendict():
+def test_setitem_frozendict() -> None:
     d = FrozenDict(foo=1, bar=2)
     with pytest.raises(AttributeError):
         d["foo"] = 3
 
 
-def test_update_frozendict():
+def test_update_frozendict() -> None:
     d = FrozenDict(foo=1, bar=2)
     with pytest.raises(AttributeError):
         d.update({"yes": 2})


### PR DESCRIPTION
One class a day, so we can enable mypy `--strict` one day.