### PR TITLE
Spark: Add "Iceberg" prefix to SparkTable name string for better observability of Iceberg tables on SparkUI

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -145,14 +145,7 @@ public class SparkTable
 
   @Override
   public String name() {
-    Map<String, String> properties = properties();
-    String tableFormatVersion = properties.get(FORMAT_VERSION);
-    String prefix = "Iceberg";
-    if (tableFormatVersion != null) {
-      return String.format("%s/v%s %s", prefix, tableFormatVersion, icebergTable.name());
-    } else {
-      return String.format("%s %s", prefix, icebergTable.name());
-    }
+    return String.format("Iceberg %s", icebergTable.name());
   }
 
   private Schema snapshotSchema() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -147,11 +147,11 @@ public class SparkTable
   public String name() {
     Map<String, String> properties = properties();
     String tableFormatVersion = properties.get(FORMAT_VERSION);
-    String fileFormat = properties.get("format");
+    String prefix = "Iceberg";
     if (tableFormatVersion != null) {
-      return String.format("%s/v%s %s", fileFormat, tableFormatVersion, icebergTable.name());
+      return String.format("%s/v%s %s", prefix, tableFormatVersion, icebergTable.name());
     } else {
-      return String.format("%s %s", fileFormat, icebergTable.name());
+      return String.format("%s %s", prefix, icebergTable.name());
     }
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -145,7 +145,14 @@ public class SparkTable
 
   @Override
   public String name() {
-    return icebergTable.toString();
+    Map<String, String> properties = properties();
+    String format = properties.get(FORMAT_VERSION);
+    String fileFormat = properties.get("format");
+    if (format != null) {
+      return String.format("%s/v%s %s", fileFormat, format, icebergTable.name());
+    } else {
+      return String.format("%s %s", fileFormat, icebergTable.name());
+    }
   }
 
   private Schema snapshotSchema() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -146,10 +146,10 @@ public class SparkTable
   @Override
   public String name() {
     Map<String, String> properties = properties();
-    String format = properties.get(FORMAT_VERSION);
+    String tableFormatVersion = properties.get(FORMAT_VERSION);
     String fileFormat = properties.get("format");
-    if (format != null) {
-      return String.format("%s/v%s %s", fileFormat, format, icebergTable.name());
+    if (tableFormatVersion != null) {
+      return String.format("%s/v%s %s", fileFormat, tableFormatVersion, icebergTable.name());
     } else {
       return String.format("%s %s", fileFormat, icebergTable.name());
     }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -252,16 +252,6 @@ public abstract class SparkTestBase {
     }
   }
 
-  protected void withTables(Action action, String... tables) {
-    try {
-      action.invoke();
-    } finally {
-      for (String table : tables) {
-        sql(String.format("DROP TABLE IF EXISTS %s", table));
-      }
-    }
-  }
-
   protected Dataset<Row> jsonToDF(String schema, String... records) {
     Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
     return spark.read().schema(schema).json(jsonDF);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -252,6 +252,16 @@ public abstract class SparkTestBase {
     }
   }
 
+  protected void withTables(Action action, String... tables) {
+    try {
+      action.invoke();
+    } finally {
+      for (String table : tables) {
+        sql(String.format("DROP TABLE IF EXISTS %s", table));
+      }
+    }
+  }
+
   protected Dataset<Row> jsonToDF(String schema, String... records) {
     Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
     return spark.read().schema(schema).json(jsonDF);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -18,11 +18,11 @@
  */
 package org.apache.iceberg.spark.source;
 
-import com.google.common.collect.Lists;
 import java.util.Map;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -92,9 +92,7 @@ public class TestSparkTable extends SparkCatalogTestBase {
                 // does not expect any exceptions to be thrown, thus it wrapped inside
                 // RuntimeException.
                 String actualTableName = catalog.loadTable(sparkIdentifier).name();
-                String expectedTableName =
-                    String.format(
-                        "Iceberg/v%s %s.%s", tableFormatVersion, catalogName, icebergIdentifier);
+                String expectedTableName = String.format("Iceberg %s.%s", catalogName, icebergIdentifier);
                 Assert.assertEquals(
                     "Table name mismatched for (%s file format, %s table format version)",
                     expectedTableName, actualTableName);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -94,8 +94,7 @@ public class TestSparkTable extends SparkCatalogTestBase {
                 String actualTableName = catalog.loadTable(sparkIdentifier).name();
                 String expectedTableName =
                     String.format(
-                        "iceberg/%s/v%s %s.%s",
-                        fileFormat, tableFormatVersion, catalogName, icebergIdentifier);
+                        "Iceberg/v%s %s.%s", tableFormatVersion, catalogName, icebergIdentifier);
                 Assert.assertEquals(
                     "Table name mismatched for (%s file format, %s table format version)",
                     expectedTableName, actualTableName);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -96,7 +96,9 @@ public class TestSparkTable extends SparkCatalogTestBase {
                     String.format(
                         "iceberg/%s/v%s %s.%s",
                         fileFormat, tableFormatVersion, catalogName, icebergIdentifier);
-                Assert.assertEquals(expectedTableName, actualTableName);
+                Assert.assertEquals(
+                    "Table name mismatched for (%s file format, %s table format version)",
+                    expectedTableName, actualTableName);
               } catch (NoSuchTableException e) {
                 throw new RuntimeException(e);
               }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -92,7 +92,8 @@ public class TestSparkTable extends SparkCatalogTestBase {
                 // does not expect any exceptions to be thrown, thus it wrapped inside
                 // RuntimeException.
                 String actualTableName = catalog.loadTable(sparkIdentifier).name();
-                String expectedTableName = String.format("Iceberg %s.%s", catalogName, icebergIdentifier);
+                String expectedTableName =
+                    String.format("Iceberg %s.%s", catalogName, icebergIdentifier);
                 Assert.assertEquals(
                     "Table name mismatched for (%s file format, %s table format version)",
                     expectedTableName, actualTableName);


### PR DESCRIPTION
SPARK-40067 added Table#name() to the BatchScan node on SparkUI.
With this improvement in place, for all DSv2 tables, SparkUI shows
`BatchScan <Table#name>` instead of uninformative `BatchScan`.

In its current state, for iceberg table, SparkUI shows
`BatchScan <catalog_name>.<namespace>.<table>`.

This can be further improved by adding the data source name I.e. Iceberg to the table name thereby yielding the final result as
`BatchScan iceberg <catalog_name>.<namespace>.<table>`.

E.g. `BatchScan Iceberg spark_catalog.default.ui_test_parquet`

Note: SPARK-40067 is available from Spark3.4 and onwards. Since it is not a bug fix, we cannot backport the improvement to OSS Spark3.3. So if one is using Iceberg with OSS Spark3.3 then the improvement won't be visible and uninformative `BatchScan` would still be shown on the SparkUI unless they backport it in their fork.

## Iceberg table in SparkUI with OSS Spark3.3
![Screen Shot 2022-08-24 at 6 42 14 PM](https://user-images.githubusercontent.com/7351922/186555010-9ed61da0-f29d-4518-928d-5da10b30cdce.png)

## Iceberg table in SparkUI with SPARK-40067 backported to OSS Spark3.3
![Screen Shot 2022-08-24 at 6 35 19 PM](https://user-images.githubusercontent.com/7351922/186555131-4d39432a-6238-40b3-b0e0-0f4d9d32d47f.png)
This is good but we still cannot tell if the given table is an Iceberg table with just one look.

## Iceberg table in SparkUI with SPARK-40067 backported to OSS Spark3.3 and after this PR

<img width="387" alt="Screen Shot 2022-09-15 at 2 22 31 PM" src="https://user-images.githubusercontent.com/7351922/190516792-885616fc-18bc-4057-8175-ceea0e0daf3d.png">

