### PR TITLE
Core: Avoid reading ManifestFile when create ManifestReader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -164,7 +164,13 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     InputFile toCopy = ops.io().newInputFile(manifest.path());
     OutputFile newFile = newManifestOutput();
     return ManifestFiles.copyRewriteManifest(
-        current.formatVersion(), toCopy, specsById, newFile, snapshotId(), summaryBuilder);
+        current.formatVersion(),
+        manifest.partitionSpecId(),
+        toCopy,
+        specsById,
+        newFile,
+        snapshotId(),
+        summaryBuilder);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -133,6 +133,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
     OutputFile newManifestPath = newManifestOutput();
     return ManifestFiles.copyAppendManifest(
         current.formatVersion(),
+        manifest.partitionSpecId(),
         toCopy,
         current.specsById(),
         newManifestPath,

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -54,7 +54,11 @@ abstract class FileCleanupStrategy {
   private static final Schema MANIFEST_PROJECTION =
       ManifestFile.schema()
           .select(
-              "manifest_path", "manifest_length", "added_snapshot_id", "deleted_data_files_count");
+              "manifest_path",
+              "manifest_length",
+              "partition_spec_id",
+              "added_snapshot_id",
+              "deleted_data_files_count");
 
   protected CloseableIterable<ManifestFile> readManifests(Snapshot snapshot) {
     if (snapshot.manifestListLocation() != null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -127,7 +127,8 @@ public class ManifestFiles {
         manifest);
     InputFile file = newInputFile(io, manifest.path(), manifest.length());
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.fromManifest(manifest);
-    return new ManifestReader<>(file, specsById, inheritableMetadata, FileType.DATA_FILES);
+    return new ManifestReader<>(
+        file, manifest.partitionSpecId(), specsById, inheritableMetadata, FileType.DATA_FILES);
   }
 
   /**
@@ -181,7 +182,8 @@ public class ManifestFiles {
         manifest);
     InputFile file = newInputFile(io, manifest.path(), manifest.length());
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.fromManifest(manifest);
-    return new ManifestReader<>(file, specsById, inheritableMetadata, FileType.DELETE_FILES);
+    return new ManifestReader<>(
+        file, manifest.partitionSpecId(), specsById, inheritableMetadata, FileType.DELETE_FILES);
   }
 
   /**
@@ -248,6 +250,7 @@ public class ManifestFiles {
 
   static ManifestFile copyAppendManifest(
       int formatVersion,
+      int specId,
       InputFile toCopy,
       Map<Integer, PartitionSpec> specsById,
       OutputFile outputFile,
@@ -256,7 +259,7 @@ public class ManifestFiles {
     // use metadata that will add the current snapshot's ID for the rewrite
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.forCopy(snapshotId);
     try (ManifestReader<DataFile> reader =
-        new ManifestReader<>(toCopy, specsById, inheritableMetadata, FileType.DATA_FILES)) {
+        new ManifestReader<>(toCopy, specId, specsById, inheritableMetadata, FileType.DATA_FILES)) {
       return copyManifestInternal(
           formatVersion,
           reader,
@@ -271,6 +274,7 @@ public class ManifestFiles {
 
   static ManifestFile copyRewriteManifest(
       int formatVersion,
+      int specId,
       InputFile toCopy,
       Map<Integer, PartitionSpec> specsById,
       OutputFile outputFile,
@@ -280,7 +284,7 @@ public class ManifestFiles {
     // exception if it is not
     InheritableMetadata inheritableMetadata = InheritableMetadataFactory.empty();
     try (ManifestReader<DataFile> reader =
-        new ManifestReader<>(toCopy, specsById, inheritableMetadata, FileType.DATA_FILES)) {
+        new ManifestReader<>(toCopy, specId, specsById, inheritableMetadata, FileType.DATA_FILES)) {
       return copyManifestInternal(
           formatVersion,
           reader,

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -108,17 +108,16 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     this.inheritableMetadata = inheritableMetadata;
     this.content = content;
 
-    if (specsById != null && specsById.containsKey(specId)) {
+    if (specsById != null) {
       this.spec = specsById.get(specId);
     } else {
-      this.spec = readPartitionSpec(file, specsById);
+      this.spec = readPartitionSpec(file);
     }
 
     this.fileSchema = new Schema(DataFile.getType(spec.partitionType()).fields());
   }
 
-  private <T extends ContentFile<T>> PartitionSpec readPartitionSpec(
-      InputFile inputFile, Map<Integer, PartitionSpec> specsById) {
+  private <T extends ContentFile<T>> PartitionSpec readPartitionSpec(InputFile inputFile) {
     Map<String, String> metadata;
     try {
       try (AvroIterable<ManifestEntry<T>> headerReader =
@@ -138,12 +137,8 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
       specId = Integer.parseInt(specProperty);
     }
 
-    if (specsById != null && specsById.containsKey(specId)) {
-      return specsById.get(specId);
-    } else {
-      Schema schema = SchemaParser.fromJson(metadata.get("schema"));
-      return PartitionSpecParser.fromJsonFields(schema, specId, metadata.get("partition-spec"));
-    }
+    Schema schema = SchemaParser.fromJson(metadata.get("schema"));
+    return PartitionSpecParser.fromJsonFields(schema, specId, metadata.get("partition-spec"));
   }
 
   public boolean isDeleteManifestReader() {

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -260,6 +260,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     OutputFile newManifestPath = newManifestOutput();
     return ManifestFiles.copyAppendManifest(
         current.formatVersion(),
+        manifest.partitionSpecId(),
         toCopy,
         current.specsById(),
         newManifestPath,


### PR DESCRIPTION
This patch aims to reduce the time of Iceberg task planning. We notice the task plan could not benefit from ParallelIterator a lot when there are many manifest files to read. The problem is the ManifestReader needs to read the manifest file to get the PartitionSpec which is not needed for most cases (because the ManifestFile object has the PartitionSpec Id and the Table has the mapping from PartitionSpec Id to PartitionSpec). It needs to read all these manifest files in serial when the following code of ParallelIterator is initing. And this is very slow when the HDFS traffic is busy. 

https://github.com/apache/iceberg/blob/dbb8a404f6632a55acb36e949f0e7b84b643cede/core/src/main/java/org/apache/iceberg/util/ParallelIterable.java#L62

https://github.com/apache/iceberg/blob/af1d405204c1d8d242d02e658f7ef3cea4217595/core/src/main/java/org/apache/iceberg/ManifestGroup.java#L207

After this change, we could get several times (depending on the number of driver threads and count of manifest files) time reduction.