### PR TITLE
Spark 3.3: Fix failing jmh benchmarks under org.apache.iceberg.spark.data.parquet package

### DIFF
--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersFlatDataBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersFlatDataBenchmark.java
@@ -154,6 +154,7 @@ public class SparkParquetReadersFlatDataBenchmark {
             .set("org.apache.spark.sql.parquet.row.requested_schema", sparkSchema.json())
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
+            .set("spark.sql.caseSensitive", "false")
             .callInit()
             .build()) {
 
@@ -211,6 +212,7 @@ public class SparkParquetReadersFlatDataBenchmark {
             .set("org.apache.spark.sql.parquet.row.requested_schema", sparkSchema.json())
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
+            .set("spark.sql.caseSensitive", "false")
             .callInit()
             .build()) {
 

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersNestedDataBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersNestedDataBenchmark.java
@@ -152,6 +152,7 @@ public class SparkParquetReadersNestedDataBenchmark {
             .set("org.apache.spark.sql.parquet.row.requested_schema", sparkSchema.json())
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
+            .set("spark.sql.caseSensitive", "false")
             .callInit()
             .build()) {
 
@@ -209,6 +210,7 @@ public class SparkParquetReadersNestedDataBenchmark {
             .set("org.apache.spark.sql.parquet.row.requested_schema", sparkSchema.json())
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
+            .set("spark.sql.caseSensitive", "false")
             .callInit()
             .build()) {
 

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -119,6 +119,7 @@ public class SparkParquetWritersFlatDataBenchmark {
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
             .set("spark.sql.parquet.outputTimestampType", "TIMESTAMP_MICROS")
+            .set("spark.sql.caseSensitive", "false")
             .schema(SCHEMA)
             .build()) {
 

--- a/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.3/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -119,6 +119,7 @@ public class SparkParquetWritersNestedDataBenchmark {
             .set("spark.sql.parquet.binaryAsString", "false")
             .set("spark.sql.parquet.int96AsTimestamp", "false")
             .set("spark.sql.parquet.outputTimestampType", "TIMESTAMP_MICROS")
+            .set("spark.sql.caseSensitive", "false")
             .schema(SCHEMA)
             .build()) {
 


### PR DESCRIPTION
The `ParquetToSparkSchemaConverter` class in Spark3.3 expects `SQLConf.CASE_SENSITIVE` in the Configuration.
However, the above config is not specified while instantiating the `ReadBuilder` and `WriteBuilder` thereby resulting in the `IllegalArgumentException` exception.

Adding `spark.sql.caseSensitive=false` to ReadBuilder and WriteBuilder properties resolves the issue.

Closes #5634
