### PR TITLE
[Core] Move logging of table scans to the debug level

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -106,7 +106,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
   public CloseableIterable<FileScanTask> planFiles() {
     Snapshot snapshot = snapshot();
     if (snapshot != null) {
-      LOG.info(
+      LOG.debug(
           "Scanning table {} snapshot {} created at {} with filter {}",
           table(),
           snapshot.snapshotId(),


### PR DESCRIPTION
These logs are fairly noisy. Can they be bumped down to debug level logging?