### PR TITLE
Restore RuntimeIOException for use

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/RuntimeIOException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/RuntimeIOException.java
@@ -22,11 +22,7 @@ import com.google.errorprone.annotations.FormatMethod;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-/**
- * @deprecated Use java.io.UncheckedIOException directly instead.
- *     <p>Exception used to wrap {@link IOException} as a {@link RuntimeException} and add context.
- */
-@Deprecated
+/** Exception used to wrap {@link IOException} as a {@link RuntimeException} and add context. */
 public class RuntimeIOException extends UncheckedIOException {
 
   public RuntimeIOException(IOException cause) {


### PR DESCRIPTION
I'd like to open this proposal to restore `RuntimeIOException` for continued use and remove the deprecation.

This was originally marked deprecated when java introduced the `UncheckedIOException` which initially seemed like a more standard replacement, but there are a few issues.

1.  UncheckedIOException requires a `cause`, which is not present in a number of usages of RuntimeIOException.  This complicates the code or requires us to change the exception handling.  For example:

```java 
      if (!file.getParentFile().isDirectory() && !file.getParentFile().mkdirs()) {
        throw new RuntimeIOException(
            "Failed to create the file's directory at %s.", file.getParentFile().getAbsolutePath());
      }
```
becomes
```java
      if (!file.getParentFile().isDirectory() && !file.getParentFile().mkdirs()) {
        throw new UncheckedIOException(new IOException(
            String.format("Failed to create the file's directory at %s.", file.getParentFile().getAbsolutePath())));
      }
```

2. `RuntimeIOException` also allows for string formatting which is used extensively in creating messages (also seen in the example above.
3. This class is used pervasively, so there there's a lot of change to deprecate, but `RuntimeIOException` already extends `UncheckedIOException`, so there is very little practical improvement.

### Alternatives:
Another option for deprecation would be to remove the constructors for `RuntimeIOException` that take a cause and update any existing usages that actually have an IO cause to use `UncheckedIOException`.  This would leave `RuntimeIOException as a thin wrapper for cases where we want to throw IOException without an originating cause to keep those usages clean
 