### PR TITLE
[0.14][Docs] Update drop table behavior in spark-ddl docs

### DIFF
--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -149,7 +149,7 @@ DROP TABLE prod.db.sample
 
 ### `DROP TABLE PURGE`
 
-To delete a table, run:
+To drop the table from the catalog and delete the table's contents, run:
 
 ```sql
 DROP TABLE prod.db.sample PURGE

--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -132,12 +132,28 @@ The new table properties in the `REPLACE TABLE` command will be merged with any 
 
 ## `DROP TABLE`
 
-To delete a table, run:
+The drop table behavior changed in 0.14.
+
+Prior to 0.14, running `DROP TABLE` would remove the table from the catalog and delete the table contents as well.
+
+From 0.14 onwards, `DROP TABLE` would only remove the table from the catalog.
+In order to delete the table contents `DROP TABLE PURGE` should be used.
+
+### `DROP TABLE`
+
+To drop the table from the catalog, run:
 
 ```sql
 DROP TABLE prod.db.sample
 ```
 
+### `DROP TABLE PURGE`
+
+To delete a table, run:
+
+```sql
+DROP TABLE prod.db.sample PURGE
+```
 
 ## `ALTER TABLE`
 


### PR DESCRIPTION
#3056 added support for `PURGE` flag to Spark.
However, the corresponding `DROP TABLE` doc is outdated.
This PR aims at documenting the updated behavior of the `DROP TABLE` DDL command.

(cherry picked from commit fd7d20a97aef294d76f467c2419d5bc3f775165b)

Closes #5646