### PR TITLE
Doc: Update doc to display the results of the table partitions query 

### DIFF
--- a/docs/spark-queries.md
+++ b/docs/spark-queries.md
@@ -318,12 +318,15 @@ To show a table's current partitions:
 SELECT * FROM prod.db.table.partitions
 ```
 
-| partition | record_count | file_count |
-| -- | -- | -- |
-|  {20211001, 11}|           1|         1|
-|  {20211002, 11}|           1|         1|
-|  {20211001, 10}|           1|         1|
-|  {20211002, 10}|           1|         1|
+| partition | record_count | file_count | spec_id |
+| -- | -- | -- | -- |
+|  {20211001, 11}|           1|         1|         0|
+|  {20211002, 11}|           1|         1|         0|
+|  {20211001, 10}|           1|         1|         0|
+|  {20211002, 10}|           1|         1|         0|
+
+Note:
+For unpartitioned tables, the partitions table will contain only the record_count and file_count columns.
 
 ### All Metadata Tables
 


### PR DESCRIPTION
In the pr of https://github.com/apache/iceberg/pull/4516, we added specId for partitions metadata table, but the document of query(https://iceberg.apache.org/docs/latest/spark-queries/#partitions ) hasn't been changed to adapt to that. 
What's more, the ResultSet structures are not the same between partitioned and not-partitioned tables.

query example:
```shell
0: jdbc:hive2://host:10000> create table p (id int, age int) using iceberg partitioned by (id);
0: jdbc:hive2://host:10000> create table np (id int, age int) using iceberg;
0: jdbc:hive2://host:10000> insert into p(id, age) values (1,1),(2,2),(3,3);
0: jdbc:hive2://host:10000> insert into np(id, age) values (1,1),(2,2),(3,3);
0: jdbc:hive2://host:10000> select * from spark_catalog.kunni_db.p.partitions;
+------------+---------------+-------------+----------+
| partition  | record_count  | file_count  | spec_id  |
+------------+---------------+-------------+----------+
| {"id":2}   | 1             | 1           | 0        |
| {"id":3}   | 1             | 1           | 0        |
| {"id":1}   | 1             | 1           | 0        |
+------------+---------------+-------------+----------+
3 rows selected (0.185 seconds)
0: jdbc:hive2://host:10000> select * from spark_catalog.kunni_db.np.partitions;
+---------------+-------------+
| record_count  | file_count  |
+---------------+-------------+
| 3             | 3           |
+---------------+-------------+
1 row selected (0.126 seconds)
```