### PR TITLE
core: snappy as default for parquet compession

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -142,7 +142,7 @@ public class TableProperties {
 
   public static final String PARQUET_COMPRESSION = "write.parquet.compression-codec";
   public static final String DELETE_PARQUET_COMPRESSION = "write.delete.parquet.compression-codec";
-  public static final String PARQUET_COMPRESSION_DEFAULT = "gzip";
+  public static final String PARQUET_COMPRESSION_DEFAULT = "snappy";
 
   public static final String PARQUET_COMPRESSION_LEVEL = "write.parquet.compression-level";
   public static final String DELETE_PARQUET_COMPRESSION_LEVEL =

--- a/data/src/test/java/org/apache/iceberg/TestSplitScan.java
+++ b/data/src/test/java/org/apache/iceberg/TestSplitScan.java
@@ -94,7 +94,7 @@ public class TestSplitScan {
 
     // With these number of records and the given SCHEMA
     // we can effectively write a file of approximate size 64 MB
-    int numRecords = 2500000;
+    int numRecords = 2000000;
     expectedRecords = RandomGenericData.generate(SCHEMA, numRecords, 0L);
     File file = writeToFile(expectedRecords, format);
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,7 +54,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.parquet.page-size-bytes      | 1048576 (1 MB)     | Parquet page size                                  |
 | write.parquet.page-row-limit       | 20000              | Parquet page row limit                             |
 | write.parquet.dict-size-bytes      | 2097152 (2 MB)     | Parquet dictionary page size                       |
-| write.parquet.compression-codec    | gzip               | Parquet compression codec: zstd, brotli, lz4, gzip, snappy, uncompressed |
+| write.parquet.compression-codec    | snappy             | Parquet compression codec: zstd, brotli, lz4, gzip, snappy, uncompressed |
 | write.parquet.compression-level    | null               | Parquet compression level                          |
 | write.parquet.bloom-filter-enabled.column.col1          | (not set) | Enables writing a bloom filter for the column: col1|
 | write.parquet.bloom-filter-max-bytes | 1048576 (1 MB)   | The maximum number of bytes for a bloom filter bitset |

--- a/python_legacy/iceberg/core/table_properties.py
+++ b/python_legacy/iceberg/core/table_properties.py
@@ -48,7 +48,7 @@ class TableProperties(object):
     PARQUET_DICT_SIZE_BYTES_DEFAULT = "2097152"
 
     PARQUET_COMPRESSION = "write.parquet.compression-codec"
-    PARQUET_COMPRESSION_DEFAULT = "gzip"
+    PARQUET_COMPRESSION_DEFAULT = "snappy"
 
     AVRO_COMPRESSION = "write.avro.compression-codec"
     AVRO_COMPRESSION_DEFAULT = "gzip"


### PR DESCRIPTION
PR to use snappy as default compression for parquet instead of gzip. https://github.com/apache/iceberg/issues/5658 