### PR TITLE
AWS: fix the wrong flag used for s3UseArnRegionEnabled

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -96,7 +96,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     this.s3UseArnRegionEnabled =
         PropertyUtil.propertyAsBoolean(
             properties,
-            AwsProperties.S3_ACCESS_POINTS_PREFIX,
+            AwsProperties.S3_USE_ARN_REGION_ENABLED,
             AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
     this.dynamoDbEndpoint = properties.get(AwsProperties.DYNAMODB_ENDPOINT);
     this.httpClientType =


### PR DESCRIPTION
In [aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java, line 99](https://github.com/apache/iceberg/blob/6a1f351414227f5c09235a96ad579fab0e88733a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java#L99),
the `initialize` method use `AwsProperties.S3_ACCESS_POINTS_PREFIX` to update the `this.s3UseArnRegionEnabled` field:
```
this.s3UseArnRegionEnabled =
        PropertyUtil.propertyAsBoolean(
            properties,
            AwsProperties.S3_ACCESS_POINTS_PREFIX,
            AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
```
According to: https://aws.amazon.com/s3/features/access-points/, the `S3_ACCESS_POINTS_PREFIX` contains the name of the access point rather than `true/false` values. Initializing the feature in this way makes this feature `disabled` almost all the time.

Hence, it seems we need to use `S3_USE_ARN_REGION_ENABLED` here instead, like the initialization happens in [aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java, line 152](https://github.com/apache/iceberg/blob/6a1f351414227f5c09235a96ad579fab0e88733a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java#L159). 
```
this.s3UseArnRegionEnabled =
          PropertyUtil.propertyAsBoolean(
              properties,
              AwsProperties.S3_USE_ARN_REGION_ENABLED,
              AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
```