### PR TITLE
Parquet: close zstd input stream early to avoid memory pressure

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1011,8 +1011,10 @@ public class Parquet {
             conf.unset(property);
           }
           optionsBuilder = HadoopReadOptions.builder(conf);
+          optionsBuilder.withCodecFactory(new ParquetCodecFactory(conf, 0));
         } else {
           optionsBuilder = ParquetReadOptions.builder();
+          optionsBuilder.withCodecFactory(new ParquetCodecFactory(new Configuration(), 0));
         }
 
         for (Map.Entry<String, String> entry : properties.entrySet()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1011,9 +1011,11 @@ public class Parquet {
             conf.unset(property);
           }
           optionsBuilder = HadoopReadOptions.builder(conf);
+          // page size not used by decompressors
           optionsBuilder.withCodecFactory(new ParquetCodecFactory(conf, 0));
         } else {
           optionsBuilder = ParquetReadOptions.builder();
+          // page size not used by decompressors
           optionsBuilder.withCodecFactory(new ParquetCodecFactory(new Configuration(), 0));
         }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetCodecFactory.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetCodecFactory.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.hadoop.CodecFactory;
+import org.apache.parquet.hadoop.codec.ZstandardCodec;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+/**
+ * This class implements a codec factory that is used when reading from Parquet. It adds a
+ * workaround for memory issues encountered when reading from zstd-compressed files.
+ */
+public class ParquetCodecFactory extends CodecFactory {
+
+  public ParquetCodecFactory(Configuration configuration, int pageSize) {
+    super(configuration, pageSize);
+  }
+
+  /** Copied and modified from CodecFactory.HeapBytesDecompressor */
+  class HeapBytesDecompressor extends BytesDecompressor {
+
+    private final CompressionCodec codec;
+    private final Decompressor decompressor;
+
+    HeapBytesDecompressor(CompressionCodecName codecName) {
+      this.codec = getCodec(codecName);
+      if (codec != null) {
+        decompressor = CodecPool.getDecompressor(codec);
+      } else {
+        decompressor = null;
+      }
+    }
+
+    @Override
+    public BytesInput decompress(BytesInput bytes, int uncompressedSize) throws IOException {
+      final BytesInput decompressed;
+      if (codec != null) {
+        if (decompressor != null) {
+          decompressor.reset();
+        }
+        if (codec instanceof ZstandardCodec) {
+          // we need to close the zstd input stream ASAP to free up native resources, so
+          // read everything into a buffer and then close it
+          try (InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor)) {
+            decompressed = BytesInput.copy(BytesInput.from(is, uncompressedSize));
+          }
+        } else {
+          InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
+          decompressed = BytesInput.from(is, uncompressedSize);
+        }
+      } else {
+        decompressed = bytes;
+      }
+      return decompressed;
+    }
+
+    @Override
+    public void decompress(
+        ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize)
+        throws IOException {
+      ByteBuffer decompressed = decompress(BytesInput.from(input), uncompressedSize).toByteBuffer();
+      output.put(decompressed);
+    }
+
+    @Override
+    public void release() {
+      if (decompressor != null) {
+        CodecPool.returnDecompressor(decompressor);
+      }
+    }
+  }
+
+  @Override
+  protected BytesDecompressor createDecompressor(CompressionCodecName codecName) {
+    return new HeapBytesDecompressor(codecName);
+  }
+}


### PR DESCRIPTION
This PR adds a workaround for memory issues encountered when reading Parquet files compressed with zstd. During some load testing on Spark, we encountered various OOM kills when reading from zstd compressed tables. One suggested solution was to set the environment variable `MALLOC_TRIM_THRESHOLD_` to something lower than default, like 8192. This helped in some cases but not all.

Upon further investigation, it appeared that buffers were accumulating...
![Screen Shot 2022-08-30 at 6 59 47 PM](https://user-images.githubusercontent.com/5475421/187738629-a4bcb8e4-80fa-4ea5-84e9-29d471e7ad1f.png)

Disabling the buffer pool resulted in finalizers accumulating instead...
![Screen Shot 2022-08-30 at 8 11 48 PM](https://user-images.githubusercontent.com/5475421/187738803-39ff7c8f-237d-4cb1-b08d-d6bb5044b8fd.png)

The solution is the same being [proposed](https://github.com/apache/parquet-mr/pull/982) in parquet-mr. The current version of Parquet will leave the decompress stream [open](https://github.com/apache/parquet-mr/blob/6add62754b3d53e30376360f8d215da004fa8096/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java#L111). Instead of leaving it open, this PR changes the behavior to read the stream fully into a buffer and then close the stream, allowing native resources to be [freed](https://github.com/luben/zstd-jni/blob/a3b5c4c1a02ddee56f6e2b019d6c8b52f8e63411/src/main/java/com/github/luben/zstd/ZstdInputStreamNoFinalizer.java#L254) immediately rather than waiting for garbage collection, and the buffer to be returned to the pool for reuse.

`MALLOC_TRIM_THRESHOLD_` should no longer be required to be lowered with this change. Anecdotally, this resulted in better performance (compared to setting `MALLOC_TRIM_THRESHOLD_`), but more testing would be needed to validate that.

Alternatively, we could wait for the Parquet PR to be merged, but this is a more targeted fix. Also we could add a flag of some sort if desired. Ideally we would backport this to 0.14.x.

Here's a viz of the heap dump with this change...
![Screen Shot 2022-08-31 at 5 55 41 AM](https://user-images.githubusercontent.com/5475421/187740382-ac8cca06-7530-467f-a824-952c378df97a.png)

