### PR TITLE
WiP: Make the number of metadata refresh retries configurable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -92,4 +92,7 @@ public class CatalogProperties {
 
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
+
+  public static final String NUM_METADATA_REFRESH_RETRIES = "num-metadata-refresh-retries";
+  public static final int NUM_METADATA_REFRESH_RETRIES_DEFAULT = 20;
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -72,11 +72,13 @@ public class JdbcCatalog extends BaseMetastoreCatalog
   private String warehouseLocation;
   private Object conf;
   private JdbcClientPool connections;
+  private Map<String, String> catalogProperties;
 
   public JdbcCatalog() {}
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     String uri = properties.get(CatalogProperties.URI);
     Preconditions.checkNotNull(uri, "JDBC connection URI is required");
 
@@ -154,7 +156,13 @@ public class JdbcCatalog extends BaseMetastoreCatalog
 
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
-    return new JdbcTableOperations(connections, io, catalogName, tableIdentifier);
+    int numMaxMetadataRefreshRetries =
+        catalogProperties.containsKey(CatalogProperties.NUM_METADATA_REFRESH_RETRIES)
+            ? Integer.parseInt(
+                catalogProperties.get(CatalogProperties.NUM_METADATA_REFRESH_RETRIES))
+            : CatalogProperties.NUM_METADATA_REFRESH_RETRIES_DEFAULT;
+    return new JdbcTableOperations(
+        connections, io, catalogName, tableIdentifier, numMaxMetadataRefreshRetries);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -48,16 +48,19 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
   private final TableIdentifier tableIdentifier;
   private final FileIO fileIO;
   private final JdbcClientPool connections;
+  private final int metadataRefreshMaxRetries;
 
   protected JdbcTableOperations(
       JdbcClientPool dbConnPool,
       FileIO fileIO,
       String catalogName,
-      TableIdentifier tableIdentifier) {
+      TableIdentifier tableIdentifier,
+      int metadataRefreshMaxRetries) {
     this.catalogName = catalogName;
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;
     this.connections = dbConnPool;
+    this.metadataRefreshMaxRetries = metadataRefreshMaxRetries;
   }
 
   @Override
@@ -91,7 +94,7 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
         newMetadataLocation != null,
         "Invalid table %s: metadata location is null",
         tableIdentifier);
-    refreshFromMetadataLocation(newMetadataLocation);
+    refreshFromMetadataLocation(newMetadataLocation, metadataRefreshMaxRetries);
   }
 
   @Override


### PR DESCRIPTION
For some catalog implementations the number of retries for the metadata
refresh is hard-coded to 20. For more flexibility this patch adds
support for adjusting this providing a catalog level property.

TODO: This patch covers JDBCCatalog only. Other Catalog implementations
should be taken care.
TODO: This patch doesn't have tests so far.