### PR TITLE
Remove fs_properties pass-through

### DIFF
--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -26,7 +26,7 @@ from pyiceberg.io import FileIO, InputFile, OutputFile
 from pyiceberg.typedef import Properties
 
 
-def _s3(properties: Properties, **fs_properties) -> AbstractFileSystem:
+def _s3(properties: Properties) -> AbstractFileSystem:
     from s3fs import S3FileSystem
 
     client_kwargs = {
@@ -37,7 +37,7 @@ def _s3(properties: Properties, **fs_properties) -> AbstractFileSystem:
 
     config_kwargs = {"signature_version": properties.get("s3.signer")}
 
-    return S3FileSystem(client_kwargs=client_kwargs, config_kwargs=config_kwargs, **fs_properties)
+    return S3FileSystem(client_kwargs=client_kwargs, config_kwargs=config_kwargs)
 
 
 SCHEME_TO_FS = {
@@ -189,8 +189,4 @@ class FsspecFileIO(FileIO):
         """Get a filesystem for a specific scheme"""
         if scheme not in self._scheme_to_fs:
             raise ValueError(f"No registered filesystem for scheme: {scheme}")
-        return self._scheme_to_fs[scheme](self.properties, **self._fs_properties())
-
-    def _fs_properties(self):
-        """Get fs properties from the file-io property map"""
-        return {k[3:]: v for k, v in self.properties.items() if k.startswith("fs_")}
+        return self._scheme_to_fs[scheme](self.properties)


### PR DESCRIPTION
This removes the fs_properties pass-through map that looks for "fs_" prefixes in the properties.