### PR TITLE
Core: Add CommitStateUnknownException handling to REST

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/ServiceFailureException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ServiceFailureException.java
@@ -24,11 +24,11 @@ import com.google.errorprone.annotations.FormatMethod;
 public class ServiceFailureException extends RESTException {
   @FormatMethod
   public ServiceFailureException(String message, Object... args) {
-    super(String.format(message, args));
+    super(message, args);
   }
 
   @FormatMethod
   public ServiceFailureException(Throwable cause, String message, Object... args) {
-    super(String.format(message, args), cause);
+    super(cause, message, args);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
@@ -25,11 +25,11 @@ import com.google.errorprone.annotations.FormatMethod;
 public class ServiceUnavailableException extends RESTException {
   @FormatMethod
   public ServiceUnavailableException(String message, Object... args) {
-    super(String.format(message, args));
+    super(message, args);
   }
 
   @FormatMethod
   public ServiceUnavailableException(Throwable cause, String message, Object... args) {
-    super(String.format(message, args), cause);
+    super(cause, message, args);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
@@ -16,19 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iceberg.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;
 
-/** Exception thrown on HTTP 5XX Server Error. */
-public class ServiceFailureException extends RESTException {
+/** Exception thrown on HTTP 503: service is unavailable */
+public class ServiceUnavailableException extends RESTException {
   @FormatMethod
-  public ServiceFailureException(String message, Object... args) {
+  public ServiceUnavailableException(String message, Object... args) {
     super(String.format(message, args));
   }
 
   @FormatMethod
-  public ServiceFailureException(Throwable cause, String message, Object... args) {
+  public ServiceUnavailableException(Throwable cause, String message, Object... args) {
     super(String.format(message, args), cause);
   }
 }

--- a/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.exceptions;
 
 import com.google.errorprone.annotations.FormatMethod;

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -22,12 +22,14 @@ import java.util.function.Consumer;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.BadRequestException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotAuthorizedException;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.exceptions.ServiceFailureException;
+import org.apache.iceberg.exceptions.ServiceUnavailableException;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 
 /**
@@ -57,6 +59,10 @@ public class ErrorHandlers {
           throw new NoSuchTableException("%s", error.message());
         case 409:
           throw new CommitFailedException("Commit failed: %s", error.message());
+        case 500:
+        case 504:
+          throw new CommitStateUnknownException(
+              new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));
       }
     };
   }
@@ -113,10 +119,12 @@ public class ErrorHandlers {
         case 405:
         case 406:
           break;
-        case 501:
-          throw new UnsupportedOperationException(error.message());
         case 500:
           throw new ServiceFailureException("Server error: %s: %s", error.type(), error.message());
+        case 501:
+          throw new UnsupportedOperationException(error.message());
+        case 503:
+          throw new ServiceUnavailableException("Service unavailable: %s", error.message());
       }
 
       throw new RESTException("Unable to process: %s", error.message());


### PR DESCRIPTION
This updates exception handling for the REST catalog where it deviates from the spec:
* Throws `CommitStateUnknownException` for 500 and 504 for table commits. This is needed to suppress file deletion when a commit may have succeeded
* Throws `ServiceUnavailableException` for 503 on all routes
* Updates `ServiceFailureException` for 500 on non-commit routes to extend `RESTException`