### PR TITLE
Core: Avoid useless metadata retries.

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientFactory;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+class StaticClientFactory implements AwsClientFactory {
+  static S3Client client;
+
+  @Override
+  public S3Client s3() {
+    return client;
+  }
+
+  @Override
+  public GlueClient glue() {
+    return null;
+  }
+
+  @Override
+  public KmsClient kms() {
+    return null;
+  }
+
+  @Override
+  public DynamoDbClient dynamo() {
+    return null;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.s3;
 
 import java.util.Map;
@@ -50,6 +49,5 @@ class StaticClientFactory implements AwsClientFactory {
   }
 
   @Override
-  public void initialize(Map<String, String> properties) {
-  }
+  public void initialize(Map<String, String> properties) {}
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -231,7 +231,8 @@ public class TestS3FileIO {
 
     List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
 
-    scaleSizes.parallelStream()
+    scaleSizes
+        .parallelStream()
         .forEach(
             scale -> {
               String scalePrefix = String.format("%s/%s/", prefix, scale);

--- a/build.gradle
+++ b/build.gradle
@@ -393,6 +393,7 @@ project(':iceberg-aws') {
       exclude group: 'junit'
     }
     testImplementation "com.esotericsoftware:kryo"
+    testImplementation "org.xerial:sqlite-jdbc"
   }
 
   sourceSets {

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -195,6 +196,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
           .retry(numRetries)
           .exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
           .throwFailureWhenFinished()
+          .stopRetryOn(NotFoundException.class) // overridden if shouldRetry is non-null
           .shouldRetryTest(shouldRetry)
           .run(metadataLocation -> newMetadata.set(metadataLoader.apply(metadataLocation)));
 


### PR DESCRIPTION
This is an alternative to #5688. Rather than making retries configurable, this stops retrying on `NotFoundException` in `BaseMetastoreTableOperations`. It also updates `S3FileIO` to throw `NotFoundException`.