### PR TITLE
Python: Refactor the config passing

### DIFF
--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -29,6 +29,7 @@ from pyiceberg.typedef import Properties
 def _s3(properties: Properties) -> AbstractFileSystem:
     from s3fs import S3FileSystem
 
+    print(f"{properties}")
     return S3FileSystem(**properties.get("s3", {}))
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1127,8 +1127,11 @@ def iceberg_manifest_entry_schema() -> Schema:
 @pytest.fixture
 def fsspec_fileio(request):
     properties = {
-        "s3.endpoint": request.config.getoption("--s3.endpoint"),
-        "s3.access-key-id": request.config.getoption("--s3.access-key-id"),
-        "s3.secret-access-key": request.config.getoption("--s3.secret-access-key"),
+        "key": request.config.getoption("--s3.access-key-id", "admin"),
+        "secret": request.config.getoption("--s3.secret-access-key", "password"),
+        "client_kwargs": {
+            "endpoint_url": request.config.getoption("--s3.endpoint", "http://localhost:9000"),
+            "region_name": "us-east-1"
+        },
     }
     return fsspec.FsspecFileIO(properties=properties)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1127,11 +1127,12 @@ def iceberg_manifest_entry_schema() -> Schema:
 @pytest.fixture
 def fsspec_fileio(request):
     properties = {
-        "key": request.config.getoption("--s3.access-key-id", "admin"),
-        "secret": request.config.getoption("--s3.secret-access-key", "password"),
-        "client_kwargs": {
-            "endpoint_url": request.config.getoption("--s3.endpoint", "http://localhost:9000"),
-            "region_name": "us-east-1"
-        },
+        "s3": {
+            "key": request.config.getoption("--s3.access-key-id", "admin"),
+            "secret": request.config.getoption("--s3.secret-access-key", "password"),
+            "client_kwargs": {
+                "endpoint_url": request.config.getoption("--s3.endpoint", "http://localhost:9000"),
+            },
+        }
     }
     return fsspec.FsspecFileIO(properties=properties)


### PR DESCRIPTION
I wanted to test against my local minio instance, but ran into the issue that I'm unable to set the `key` and `secret`:

![image](https://user-images.githubusercontent.com/1134248/188515742-e5ec136e-249f-491a-a24e-d1d20f7190ad.png)

I would propose the following config:

```yaml
catalog:
    default:
        uri: thrift://localhost:9083
        s3:
            key: admin
            secret: password
            client_kwargs:
                endpoint_url: http://localhost:9000
```

I know we went back and forth a few times on this. This way we can just pass in the `kwargs`, `client_kwargs`, and `config_kwargs` that we need, and we don't need to update static lists.