### PR TITLE
API: Add rowsCount to ScanTask

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/ContentScanTask.java
@@ -63,4 +63,10 @@ public interface ContentScanTask<F extends ContentFile<F>> extends ScanTask {
    * @return a residual expression to apply to rows from this scan
    */
   Expression residual();
+
+  @Override
+  default long rowsCount() {
+    double scannedFileFraction = ((double) length()) / file().fileSizeInBytes();
+    return (long) (scannedFileFraction * file().recordCount());
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/ScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/ScanTask.java
@@ -32,6 +32,15 @@ public interface ScanTask extends Serializable {
   }
 
   /**
+   * The estimated number of rows produced by this scan task.
+   *
+   * @return the estimated number of produced rows
+   */
+  default long rowsCount() {
+    return 100_000;
+  }
+
+  /**
    * The number of files that will be opened by this scan task.
    *
    * @return the number of files to open

--- a/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
+++ b/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
@@ -35,6 +35,11 @@ public interface ScanTaskGroup<T extends ScanTask> extends ScanTask {
   }
 
   @Override
+  default long rowsCount() {
+    return tasks().stream().mapToLong(ScanTask::rowsCount).sum();
+  }
+
+  @Override
   default int filesCount() {
     return tasks().stream().mapToInt(ScanTask::filesCount).sum();
   }

--- a/core/src/test/java/org/apache/iceberg/TestDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTableScan.java
@@ -18,6 +18,13 @@
  */
 package org.apache.iceberg;
 
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
 public class TestDataTableScan extends ScanTestBase<TableScan, FileScanTask, CombinedScanTask> {
   public TestDataTableScan(int formatVersion) {
     super(formatVersion);
@@ -26,5 +33,57 @@ public class TestDataTableScan extends ScanTestBase<TableScan, FileScanTask, Com
   @Override
   protected TableScan newScan() {
     return table.newScan();
+  }
+
+  @Test
+  public void testTaskRowCounts() {
+    Assume.assumeTrue(formatVersion == 2);
+
+    DataFile dataFile1 = newDataFile("data_bucket=0");
+    table.newFastAppend().appendFile(dataFile1).commit();
+
+    DataFile dataFile2 = newDataFile("data_bucket=1");
+    table.newFastAppend().appendFile(dataFile2).commit();
+
+    DeleteFile deleteFile1 = newDeleteFile("data_bucket=0");
+    table.newRowDelta().addDeletes(deleteFile1).commit();
+
+    DeleteFile deleteFile2 = newDeleteFile("data_bucket=1");
+    table.newRowDelta().addDeletes(deleteFile2).commit();
+
+    TableScan scan = table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(50));
+
+    List<FileScanTask> fileScanTasks = Lists.newArrayList(scan.planFiles());
+    Assert.assertEquals("Must have 2 FileScanTasks", 2, fileScanTasks.size());
+    for (FileScanTask task : fileScanTasks) {
+      Assert.assertEquals("Rows count must match", 10, task.rowsCount());
+    }
+
+    List<CombinedScanTask> combinedScanTasks = Lists.newArrayList(scan.planTasks());
+    Assert.assertEquals("Must have 4 CombinedScanTask", 4, combinedScanTasks.size());
+    for (CombinedScanTask task : combinedScanTasks) {
+      Assert.assertEquals("Rows count must match", 5, task.rowsCount());
+    }
+  }
+
+  protected DataFile newDataFile(String partitionPath) {
+    return DataFiles.builder(table.spec())
+        .withPath("/path/to/data-" + UUID.randomUUID() + ".parquet")
+        .withFormat(FileFormat.PARQUET)
+        .withFileSizeInBytes(100)
+        .withPartitionPath(partitionPath)
+        .withRecordCount(10)
+        .build();
+  }
+
+  protected DeleteFile newDeleteFile(String partitionPath) {
+    return FileMetadata.deleteFileBuilder(table.spec())
+        .ofPositionDeletes()
+        .withPath("/path/to/delete-" + UUID.randomUUID() + ".parquet")
+        .withFormat(FileFormat.PARQUET)
+        .withFileSizeInBytes(100)
+        .withPartitionPath(partitionPath)
+        .withRecordCount(10)
+        .build();
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
@@ -151,18 +152,9 @@ abstract class SparkScan extends SparkBatch implements Scan, SupportsReportStati
       return new Stats(SparkSchemaUtil.estimateSize(readSchema(), totalRecords), totalRecords);
     }
 
-    long numRows = 0L;
-
-    for (CombinedScanTask task : tasks()) {
-      for (FileScanTask file : task.files()) {
-        // TODO: if possible, take deletes also into consideration.
-        double fractionOfFileScanned = ((double) file.length()) / file.file().fileSizeInBytes();
-        numRows += (fractionOfFileScanned * file.file().recordCount());
-      }
-    }
-
-    long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), numRows);
-    return new Stats(sizeInBytes, numRows);
+    long rowsCount = tasks().stream().mapToLong(ScanTaskGroup::rowsCount).sum();
+    long sizeInBytes = SparkSchemaUtil.estimateSize(readSchema(), rowsCount);
+    return new Stats(sizeInBytes, rowsCount);
   }
 
   @Override


### PR DESCRIPTION
This PR adds an estimated number of output rows to `ScanTask`. This change should make it easier to estimate stats for other task types such as `ChangelogScanTask` in alternative scans.