### PR TITLE
API: Extended some deprecation comments in API folder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
@@ -24,6 +24,9 @@ import java.util.concurrent.TimeUnit;
 public class DefaultMetricsContext implements MetricsContext {
   private static final int DEFAULT_HISTOGRAM_RESERVOIR_SIZE = 10_000;
 
+  /**
+   * @deprecated will be removed in 2.0.0, use {@link org.apache.iceberg.metrics.Counter} instead.
+   */
   @Override
   @Deprecated
   @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -51,7 +51,9 @@ public interface MetricsContext extends Serializable {
 
   default void initialize(Map<String, String> properties) {}
 
-  /** @deprecated Use {@link org.apache.iceberg.metrics.Counter} instead. */
+  /**
+   * @deprecated will be removed in 2.0.0, use {@link org.apache.iceberg.metrics.Counter} instead.
+   */
   @Deprecated
   interface Counter<T extends Number> {
     /** Increment the counter by a single whole number value (i.e. 1). */
@@ -102,7 +104,7 @@ public interface MetricsContext extends Serializable {
    * @param type numeric type of the counter value
    * @param unit the unit designation of the metric
    * @return a counter implementation
-   * @deprecated Use {@link MetricsContext#counter(String, Unit)} instead.
+   * @deprecated will be removed in 2.0.0, use {@link MetricsContext#counter(String, Unit)} instead.
    */
   @Deprecated
   default <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -43,6 +43,7 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
     return new Truncate<>(width);
   }
 
+  /** @deprecated will be removed in 2.0.0 */
   @Deprecated
   @SuppressWarnings("unchecked")
   static <T, R extends Truncate<T> & SerializableFunction<T, T>> R get(Type type, int width) {


### PR DESCRIPTION
There are some deprecation comments added after 0.14.0 in the API folder where there is no indication when the particular functionality is going to be dropped. I marked them to be dropped in 2.0.0.