### PR TITLE
Docs: Spark getting started - fix example

### DIFF
--- a/docs/spark-getting-started.md
+++ b/docs/spark-getting-started.md
@@ -60,7 +60,6 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:{{% icebe
     --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
     --conf spark.sql.catalog.spark_catalog.type=hive \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.local.type=hadoop \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
 ```
 


### PR DESCRIPTION
If we follow the getting started tutorial step-by-step and execute the `USE demo;` command, we get the following error: 

```
spark-sql> use demo;
22/09/08 18:51:50 ERROR SparkSQLDriver: Failed in [use demo]
java.lang.IllegalArgumentException: Cannot create catalog demo, both type and catalog-impl are set: type=hadoop, catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:453)

```

If we remove the `type=hadoop` parameter, the command runs successfully. 