### PR TITLE
Core/Spark: Fix memory leaks in vectorized reader for parquet

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.arrow.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -28,8 +29,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  */
 class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
 
-  ArrowBatchReader(List<VectorizedReader<?>> readers) {
+  private final BufferAllocator bufferAllocator;
+
+  ArrowBatchReader(List<VectorizedReader<?>> readers, BufferAllocator allocator) {
     super(readers);
+    this.bufferAllocator = allocator;
   }
 
   @Override
@@ -54,5 +58,11 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
       columnVectors[i] = new ColumnVector(vectorHolders[i]);
     }
     return new ColumnarBatch(numRowsToRead, columnVectors);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    this.bufferAllocator.close();
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -210,6 +210,9 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   }
 
   private void allocateFieldVector(boolean dictionaryEncodedVector) {
+    if (vec != null) {
+      vec.close();
+    }
     if (dictionaryEncodedVector) {
       allocateDictEncodedVector();
     } else {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -25,7 +25,6 @@ import java.util.stream.IntStream;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.arrow.ArrowAllocation;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -41,7 +40,7 @@ import org.apache.parquet.schema.Type;
 public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedReader<?>> {
   private final MessageType parquetSchema;
   private final Schema icebergSchema;
-  private final BufferAllocator rootAllocator;
+  private final BufferAllocator bufferAllocator;
   private final Map<Integer, ?> idToConstant;
   private final boolean setArrowValidityVector;
   private final Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory;
@@ -51,12 +50,11 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
       MessageType parquetSchema,
       boolean setArrowValidityVector,
       Map<Integer, ?> idToConstant,
+      BufferAllocator bufferAllocator,
       Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory) {
     this.parquetSchema = parquetSchema;
     this.icebergSchema = expectedSchema;
-    this.rootAllocator =
-        ArrowAllocation.rootAllocator()
-            .newChildAllocator("VectorizedReadBuilder", 0, Long.MAX_VALUE);
+    this.bufferAllocator = bufferAllocator;
     this.setArrowValidityVector = setArrowValidityVector;
     this.idToConstant = idToConstant;
     this.readerFactory = readerFactory;
@@ -134,6 +132,6 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
       return null;
     }
     // Set the validity buffer if null checking is enabled in arrow
-    return new VectorizedArrowReader(desc, icebergField, rootAllocator, setArrowValidityVector);
+    return new VectorizedArrowReader(desc, icebergField, bufferAllocator, setArrowValidityVector);
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VectorizedReader.java
@@ -24,7 +24,7 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 
 /** Interface for vectorized Iceberg readers. */
-public interface VectorizedReader<T> {
+public interface VectorizedReader<T> extends AutoCloseable {
 
   /**
    * Reads a batch of type @param &lt;T&gt; and of size numRows
@@ -48,5 +48,6 @@ public interface VectorizedReader<T> {
       PageReadStore pages, Map<ColumnPath, ColumnChunkMetaData> metadata, long rowPosition);
 
   /** Release any resources allocated. */
+  @Override
   void close();
 }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.arrow.vectorized.BaseBatchReader;
 import org.apache.iceberg.arrow.vectorized.VectorizedArrowReader;
 import org.apache.iceberg.parquet.VectorizedReader;
@@ -33,8 +34,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
  */
 public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
-  public ColumnarBatchReader(List<VectorizedReader<?>> readers) {
+  private final BufferAllocator bufferAllocator;
+
+  public ColumnarBatchReader(List<VectorizedReader<?>> readers, BufferAllocator allocator) {
     super(readers);
+    this.bufferAllocator = allocator;
   }
 
   @Override
@@ -60,5 +64,11 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
     ColumnarBatch batch = new ColumnarBatch(arrowColumnVectors);
     batch.setNumRows(numRowsToRead);
     return batch;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    this.bufferAllocator.close();
   }
 }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.data.vectorized;
 
 import java.util.List;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.arrow.vectorized.BaseBatchReader;
 import org.apache.iceberg.arrow.vectorized.VectorizedArrowReader;
 import org.apache.iceberg.parquet.VectorizedReader;
@@ -33,8 +34,11 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
  */
 public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
 
-  public ColumnarBatchReader(List<VectorizedReader<?>> readers) {
+  private final BufferAllocator bufferAllocator;
+
+  public ColumnarBatchReader(List<VectorizedReader<?>> readers, BufferAllocator allocator) {
     super(readers);
+    this.bufferAllocator = allocator;
   }
 
   @Override
@@ -60,5 +64,11 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
     ColumnarBatch batch = new ColumnarBatch(arrowColumnVectors);
     batch.setNumRows(numRowsToRead);
     return batch;
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    this.bufferAllocator.close();
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -21,7 +21,9 @@ package org.apache.iceberg.spark.data.vectorized;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.arrow.ArrowAllocation;
 import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
@@ -44,16 +46,25 @@ public class VectorizedSparkParquetReaders {
       MessageType fileSchema,
       boolean setArrowValidityVector,
       Map<Integer, ?> idToConstant) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new VectorizedReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new));
+    BufferAllocator rootAllocator =
+        ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
+    try {
+      // We'll transfer the ownership of rootAllocator to the ColumnarBatchReader object.
+      return (ColumnarBatchReader)
+          TypeWithSchemaVisitor.visit(
+              expectedSchema.asStruct(),
+              fileSchema,
+              new VectorizedReaderBuilder(
+                  expectedSchema,
+                  fileSchema,
+                  setArrowValidityVector,
+                  idToConstant,
+                  rootAllocator,
+                  readers -> new ColumnarBatchReader(readers, rootAllocator)));
+    } catch (Throwable t) {
+      rootAllocator.close();
+      throw t;
+    }
   }
 
   public static ColumnarBatchReader buildReader(
@@ -62,17 +73,25 @@ public class VectorizedSparkParquetReaders {
       boolean setArrowValidityVector,
       Map<Integer, ?> idToConstant,
       DeleteFilter<InternalRow> deleteFilter) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new ReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new,
-                deleteFilter));
+    BufferAllocator rootAllocator =
+        ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
+    try {
+      return (ColumnarBatchReader)
+          TypeWithSchemaVisitor.visit(
+              expectedSchema.asStruct(),
+              fileSchema,
+              new ReaderBuilder(
+                  expectedSchema,
+                  fileSchema,
+                  setArrowValidityVector,
+                  idToConstant,
+                  rootAllocator,
+                  readers -> new ColumnarBatchReader(readers, rootAllocator),
+                  deleteFilter));
+    } catch (Throwable t) {
+      rootAllocator.close();
+      throw t;
+    }
   }
 
   private static class ReaderBuilder extends VectorizedReaderBuilder {
@@ -83,9 +102,16 @@ public class VectorizedSparkParquetReaders {
         MessageType parquetSchema,
         boolean setArrowValidityVector,
         Map<Integer, ?> idToConstant,
+        BufferAllocator bufferAllocator,
         Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
         DeleteFilter<InternalRow> deleteFilter) {
-      super(expectedSchema, parquetSchema, setArrowValidityVector, idToConstant, readerFactory);
+      super(
+          expectedSchema,
+          parquetSchema,
+          setArrowValidityVector,
+          idToConstant,
+          bufferAllocator,
+          readerFactory);
       this.deleteFilter = deleteFilter;
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -21,7 +21,9 @@ package org.apache.iceberg.spark.data.vectorized;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.arrow.ArrowAllocation;
 import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
@@ -44,16 +46,25 @@ public class VectorizedSparkParquetReaders {
       MessageType fileSchema,
       boolean setArrowValidityVector,
       Map<Integer, ?> idToConstant) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new VectorizedReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new));
+    BufferAllocator rootAllocator =
+        ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
+    try {
+      // We'll transfer the ownership of rootAllocator to the ColumnarBatchReader object.
+      return (ColumnarBatchReader)
+          TypeWithSchemaVisitor.visit(
+              expectedSchema.asStruct(),
+              fileSchema,
+              new VectorizedReaderBuilder(
+                  expectedSchema,
+                  fileSchema,
+                  setArrowValidityVector,
+                  idToConstant,
+                  rootAllocator,
+                  readers -> new ColumnarBatchReader(readers, rootAllocator)));
+    } catch (Throwable t) {
+      rootAllocator.close();
+      throw t;
+    }
   }
 
   public static ColumnarBatchReader buildReader(
@@ -62,17 +73,25 @@ public class VectorizedSparkParquetReaders {
       boolean setArrowValidityVector,
       Map<Integer, ?> idToConstant,
       DeleteFilter<InternalRow> deleteFilter) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new ReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new,
-                deleteFilter));
+    BufferAllocator rootAllocator =
+        ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
+    try {
+      return (ColumnarBatchReader)
+          TypeWithSchemaVisitor.visit(
+              expectedSchema.asStruct(),
+              fileSchema,
+              new ReaderBuilder(
+                  expectedSchema,
+                  fileSchema,
+                  setArrowValidityVector,
+                  idToConstant,
+                  rootAllocator,
+                  readers -> new ColumnarBatchReader(readers, rootAllocator),
+                  deleteFilter));
+    } catch (Throwable t) {
+      rootAllocator.close();
+      throw t;
+    }
   }
 
   private static class ReaderBuilder extends VectorizedReaderBuilder {
@@ -83,9 +102,16 @@ public class VectorizedSparkParquetReaders {
         MessageType parquetSchema,
         boolean setArrowValidityVector,
         Map<Integer, ?> idToConstant,
+        BufferAllocator bufferAllocator,
         Function<List<VectorizedReader<?>>, VectorizedReader<?>> readerFactory,
         DeleteFilter<InternalRow> deleteFilter) {
-      super(expectedSchema, parquetSchema, setArrowValidityVector, idToConstant, readerFactory);
+      super(
+          expectedSchema,
+          parquetSchema,
+          setArrowValidityVector,
+          idToConstant,
+          bufferAllocator,
+          readerFactory);
       this.deleteFilter = deleteFilter;
     }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -49,6 +49,7 @@ public class VectorizedSparkParquetReaders {
     BufferAllocator rootAllocator =
         ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
     try {
+      // We'll transfer the ownership of rootAllocator to the ColumnarBatchReader object.
       return (ColumnarBatchReader)
           TypeWithSchemaVisitor.visit(
               expectedSchema.asStruct(),
@@ -75,7 +76,6 @@ public class VectorizedSparkParquetReaders {
     BufferAllocator rootAllocator =
         ArrowAllocation.rootAllocator().newChildAllocator("ColumnarBatchReader", 0, Long.MAX_VALUE);
     try {
-      // We'll transfer the ownership of rootAllocator to the ColumnarBatchReader object.
       return (ColumnarBatchReader)
           TypeWithSchemaVisitor.visit(
               expectedSchema.asStruct(),


### PR DESCRIPTION
This patch fixes native memory leaks in the vectorized reader for parquet, which affects both iceberg-core and iceberg-spark:

1. Arrow `BufferAllocator` will be closed when the vectorized reader was closed, which frees native memory it possesses. The buffer allocator will also check for leaked memory on closing.
2. We've also fixed memory leaks when reading parquet files containing interleaving plain/dictionary pages. Arrow buffer allocator detected this problem and thrown `IllegalStateException` when running the newly added test without this fix:

```
org.apache.iceberg.arrow.vectorized.ArrowReaderTest > testInterleavingPlainAndDictionaryPages FAILED
    java.lang.IllegalStateException: Allocator[ArrowBatchReader] closed with outstanding buffers allocated (6).
    Allocator(ArrowBatchReader) 0/6400/9472/9223372036854775807 (res/actual/peak/limit)
      child allocators: 0
      ledgers: 6
        ledger[1924] allocator: ArrowBatchReader), isOwning: , size: , references: 2, life: 22143564008682936..0, allocatorManager: [, life: ] holds 3 buffers. 
            ArrowBuf[5225], address:140478431376008, length:8
            ArrowBuf[5224], address:140478431375888, length:120
            ArrowBuf[5223], address:140478431375888, length:128
        ledger[1923] allocator: ArrowBatchReader), isOwning: , size: , references: 2, life: 22143564003725139..0, allocatorManager: [, life: ] holds 3 buffers. 
            ArrowBuf[5220], address:140478431392784, length:1024
            ArrowBuf[5222], address:140478431393776, length:32
            ArrowBuf[5221], address:140478431392784, length:992
        ledger[1920] allocator: ArrowBatchReader), isOwning: , size: , references: 2, life: 22143563974533216..0, allocatorManager: [, life: ] holds 3 buffers. 
            ArrowBuf[5215], address:140478431392752, length:32
            ArrowBuf[5214], address:140478431391760, length:992
            ArrowBuf[5213], address:140478431391760, length:1024
        ledger[1922] allocator: ArrowBatchReader), isOwning: , size: , references: 1, life: 22143564003418541..0, allocatorManager: [, life: ] holds 1 buffers. 
            ArrowBuf[5219], address:140478431385616, length:2048
        ledger[1921] allocator: ArrowBatchReader), isOwning: , size: , references: 2, life: 22143563988827959..0, allocatorManager: [, life: ] holds 3 buffers. 
            ArrowBuf[5218], address:140478431375880, length:8
            ArrowBuf[5217], address:140478431375760, length:120
            ArrowBuf[5216], address:140478431375760, length:128
        ledger[1919] allocator: ArrowBatchReader), isOwning: , size: , references: 1, life: 22143563974111982..0, allocatorManager: [, life: ] holds 1 buffers. 
            ArrowBuf[5212], address:140478431383568, length:2048
      reservations: 0
        at org.apache.arrow.memory.BaseAllocator.close(BaseAllocator.java:405)
        at org.apache.iceberg.arrow.vectorized.ArrowBatchReader.close(ArrowBatchReader.java:66)
        at org.apache.iceberg.parquet.VectorizedParquetReader$FileIterator.close(VectorizedParquetReader.java:176)
        at org.apache.iceberg.arrow.vectorized.ArrowReader$VectorizedCombinedScanIterator.hasNext(ArrowReader.java:299)
        at org.apache.iceberg.arrow.vectorized.ArrowReaderTest.testInterleavingPlainAndDictionaryPages(ArrowReaderTest.java:347)
```

Notice: this fix may break existing workflows since `IllegalStateException` will be raised when any memory leak problems lurking in the vectorized readers get triggered.
