### PR TITLE
Python: Make Get Properties CLI options consistent with Set and Remove CLI options.

### DIFF
--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -226,16 +226,18 @@ def rename(ctx, from_identifier: str, to_identifier: str):
 def properties():
     """Properties on tables/namespaces"""
 
+
 @properties.group()
 def get():
     """Fetch properties on tables/namespaces"""
 
-@get.command()
+
+@get.command("namespace")
 @click.argument("identifier")
 @click.argument("property_name", required=False)
 @click.pass_context
 @catch_exception()
-def namespace(ctx: Context, identifier: str, property_name: str):
+def get_namespace(ctx: Context, identifier: str, property_name: str):
     """Fetch properties on a namespace"""
     catalog, output = _catalog_and_output(ctx)
     identifier_tuple = Catalog.identifier_to_tuple(identifier)
@@ -252,12 +254,12 @@ def namespace(ctx: Context, identifier: str, property_name: str):
         output.describe_properties(namespace_properties)
 
 
-@get.command()
+@get.command("table")
 @click.argument("identifier")
 @click.argument("property_name", required=False)
 @click.pass_context
 @catch_exception()
-def table(ctx: Context, identifier: str, property_name: str):
+def get_table(ctx: Context, identifier: str, property_name: str):
     """Fetch properties on a table"""
     catalog, output = _catalog_and_output(ctx)
     identifier_tuple = Catalog.identifier_to_tuple(identifier)

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -226,56 +226,52 @@ def rename(ctx, from_identifier: str, to_identifier: str):
 def properties():
     """Properties on tables/namespaces"""
 
+@properties.group()
+def get():
+    """Fetch properties on tables/namespaces"""
 
-@properties.command()
-@click.option("--entity", type=click.Choice(["any", "namespace", "table"]), default="any")
+@get.command()
 @click.argument("identifier")
 @click.argument("property_name", required=False)
 @click.pass_context
 @catch_exception()
-def get(ctx: Context, entity: Literal["name", "namespace", "table"], identifier: str, property_name: str):
-    """Fetches a property of a namespace or table"""
+def namespace(ctx: Context, identifier: str, property_name: str):
+    """Fetch properties on a namespace"""
     catalog, output = _catalog_and_output(ctx)
     identifier_tuple = Catalog.identifier_to_tuple(identifier)
 
-    is_namespace = False
-    if entity in {"namespace", "any"}:
-        try:
-            namespace_properties = catalog.load_namespace_properties(identifier_tuple)
+    namespace_properties = catalog.load_namespace_properties(identifier_tuple)
+    assert namespace_properties
 
-            if property_name:
-                if property_value := namespace_properties.get(property_name):
-                    output.text(property_value)
-                    is_namespace = True
-                else:
-                    raise NoSuchPropertyException(f"Could not find property {property_name} on namespace {identifier}")
-            else:
-                output.describe_properties(namespace_properties)
-                is_namespace = True
-        except NoSuchNamespaceError as exc:
-            if entity != "any" or len(identifier_tuple) <= 1:  # type: ignore
-                raise exc
-    is_table = False
-    if is_namespace is False and len(identifier_tuple) > 1 and entity in {"table", "any"}:
-        metadata = catalog.load_table(identifier_tuple).metadata
-        assert metadata
-
-        if property_name:
-            if property_value := metadata.properties.get(property_name):
-                output.text(property_value)
-                is_table = True
-            else:
-                raise NoSuchPropertyException(f"Could not find property {property_name} on table {identifier}")
+    if property_name:
+        if property_value := namespace_properties.get(property_name):
+            output.text(property_value)
         else:
-            output.describe_properties(metadata.properties)
-            is_table = True
+            raise NoSuchPropertyException(f"Could not find property {property_name} on namespace {identifier}")
+    else:
+        output.describe_properties(namespace_properties)
 
-    if is_namespace is False and is_table is False:
-        property_err = ""
-        if property_name:
-            property_err = f" with property {property_name}"
 
-        raise NoSuchNamespaceError(f"Table or namespace does not exist: {identifier}{property_err}")
+@get.command()
+@click.argument("identifier")
+@click.argument("property_name", required=False)
+@click.pass_context
+@catch_exception()
+def table(ctx: Context, identifier: str, property_name: str):
+    """Fetch properties on a table"""
+    catalog, output = _catalog_and_output(ctx)
+    identifier_tuple = Catalog.identifier_to_tuple(identifier)
+
+    metadata = catalog.load_table(identifier_tuple).metadata
+    assert metadata
+
+    if property_name:
+        if property_value := metadata.properties.get(property_name):
+            output.text(property_value)
+        else:
+            raise NoSuchPropertyException(f"Could not find property {property_name} on table {identifier}")
+    else:
+        output.describe_properties(metadata.properties)
 
 
 @properties.group()

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -406,6 +406,7 @@ def test_properties_get_namespace_specific_property(_):
     assert result.exit_code == 0
     assert result.output == "s3://warehouse/database/location\n"
 
+
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_namespace_does_not_exist(_):
@@ -413,7 +414,6 @@ def test_properties_get_namespace_does_not_exist(_):
     result = runner.invoke(run, ["properties", "get", "namespace", "doesnotexist"])
     assert result.exit_code == 1
     assert result.output == "Namespace does not exist: doesnotexist\n"
-
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -357,7 +357,7 @@ def test_rename_table_does_not_exists(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_table(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "default.foo"])
+    result = runner.invoke(run, ["properties", "get", "table", "default.foo"])
     assert result.exit_code == 0
     assert result.output == "read.split.target.size  134217728\n"
 
@@ -366,7 +366,7 @@ def test_properties_get_table(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_table_specific_property(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "default.foo", "read.split.target.size"])
+    result = runner.invoke(run, ["properties", "get", "table", "default.foo", "read.split.target.size"])
     assert result.exit_code == 0
     assert result.output == "134217728\n"
 
@@ -375,7 +375,7 @@ def test_properties_get_table_specific_property(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_table_specific_property_that_doesnt_exist(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "default.foo", "doesnotexist"])
+    result = runner.invoke(run, ["properties", "get", "table", "default.foo", "doesnotexist"])
     assert result.exit_code == 1
     assert result.output == "Could not find property doesnotexist on table default.foo\n"
 
@@ -384,16 +384,16 @@ def test_properties_get_table_specific_property_that_doesnt_exist(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_table_does_not_exist(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "doesnotexist"])
+    result = runner.invoke(run, ["properties", "get", "table", "doesnotexist"])
     assert result.exit_code == 1
-    assert result.output == "Namespace does not exist: doesnotexist\n"
+    assert result.output == "Table does not exist: doesnotexist\n"
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_namespace(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "default"])
+    result = runner.invoke(run, ["properties", "get", "namespace", "default"])
     assert result.exit_code == 0
     assert result.output == "location  s3://warehouse/database/location\n"
 
@@ -402,9 +402,18 @@ def test_properties_get_namespace(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_properties_get_namespace_specific_property(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["properties", "get", "default", "location"])
+    result = runner.invoke(run, ["properties", "get", "namespace", "default", "location"])
     assert result.exit_code == 0
     assert result.output == "s3://warehouse/database/location\n"
+
+@mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
+@mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
+def test_properties_get_namespace_does_not_exist(_):
+    runner = CliRunner()
+    result = runner.invoke(run, ["properties", "get", "namespace", "doesnotexist"])
+    assert result.exit_code == 1
+    assert result.output == "Namespace does not exist: doesnotexist\n"
+
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
@@ -683,7 +692,7 @@ def test_json_rename_table_does_not_exists(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_table(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "default.foo"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "table", "default.foo"])
     assert result.exit_code == 0
     assert result.output == """{"read.split.target.size": "134217728"}\n"""
 
@@ -692,7 +701,7 @@ def test_json_properties_get_table(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_table_specific_property(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "default.foo", "read.split.target.size"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "table", "default.foo", "read.split.target.size"])
     assert result.exit_code == 0
     assert result.output == """"134217728"\n"""
 
@@ -701,7 +710,7 @@ def test_json_properties_get_table_specific_property(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_table_specific_property_that_doesnt_exist(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "default.foo", "doesnotexist"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "table", "default.foo", "doesnotexist"])
     assert result.exit_code == 1
     assert (
         result.output
@@ -713,16 +722,16 @@ def test_json_properties_get_table_specific_property_that_doesnt_exist(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_table_does_not_exist(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "doesnotexist"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "table", "doesnotexist"])
     assert result.exit_code == 1
-    assert result.output == """{"type": "NoSuchNamespaceError", "message": "Namespace does not exist: doesnotexist"}\n"""
+    assert result.output == """{"type": "NoSuchTableError", "message": "Table does not exist: doesnotexist"}\n"""
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_namespace(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "default"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "namespace", "default"])
     assert result.exit_code == 0
     assert result.output == """{"location": "s3://warehouse/database/location"}\n"""
 
@@ -731,9 +740,18 @@ def test_json_properties_get_namespace(_):
 @mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
 def test_json_properties_get_namespace_specific_property(_):
     runner = CliRunner()
-    result = runner.invoke(run, ["--output=json", "properties", "get", "default", "location"])
+    result = runner.invoke(run, ["--output=json", "properties", "get", "namespace", "default", "location"])
     assert result.exit_code == 0
     assert result.output == """"s3://warehouse/database/location"\n"""
+
+
+@mock.patch.dict(os.environ, MOCK_ENVIRONMENT)
+@mock.patch("pyiceberg.cli.console.load_catalog", return_value=MOCK_CATALOG)
+def test_json_properties_get_namespace_does_not_exist(_):
+    runner = CliRunner()
+    result = runner.invoke(run, ["--output=json", "properties", "get", "namespace", "doesnotexist"])
+    assert result.exit_code == 1
+    assert result.output == """{"type": "NoSuchNamespaceError", "message": "Namespace does not exist: doesnotexist"}\n"""
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)


### PR DESCRIPTION
The three sub-level options within properties are a bit inconsistent with one-another. 

<img width="951" alt="image" src="https://user-images.githubusercontent.com/11399509/189404842-64c50ff4-0a4b-4db0-a8cb-c1f6179c1536.png">

The Get Properties CLI at present expects a choice option `entity`. 

<img width="954" alt="image" src="https://user-images.githubusercontent.com/11399509/189406369-f1b3a19b-d096-48dc-b880-8c99180ddce6.png">

This is inconsistent with the way we have defined set and remove CLI option, where-in they have two sub-level commands for table and namespace which is much more cleaner IMO.

<img width="947" alt="image" src="https://user-images.githubusercontent.com/11399509/189405688-c8981530-3a42-4215-afeb-e9d9f499e134.png">

This PR makes the Get Properties CLI options consistent with Set and Remove CLI options and look like below.

<img width="951" alt="image" src="https://user-images.githubusercontent.com/11399509/189406114-87ba1e56-5944-4aa6-b383-517eadc3f338.png">
