### PR TITLE
CI: Fix names and jobs

### DIFF
--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  tox:
+  openapi-spec-validator:
     runs-on: ubuntu-20.04
 
     steps:
@@ -45,4 +45,7 @@ jobs:
           python-version: 3.9
       - name: Install
         working-directory: ./open-api
-        run: pip install openapi-spec-validator && openapi-spec-validator rest-catalog-open-api.yaml
+        run: pip install openapi-spec-validator
+      - name: Validate
+        working-directory: ./open-api
+        run: openapi-spec-validator rest-catalog-open-api.yaml

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  tox:
+  lint-and-test:
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
I noticed that we still have some jobs called `tox` when there is no tox involved. I also split out the Install and Validate step of the open-api checker to make it more clear what it is actually doing.