### PR TITLE
Python: Add docker-compose for s3 tests

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,4 +54,4 @@ jobs:
       run: make lint
     - name: Tests
       working-directory: ./python
-      run: make test
+      run: make test-s3

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you want to install the library on the host, you can simply run `pip3 install
 To set up IDEA with Poetry ([also on Loom](https://www.loom.com/share/6d36464d45f244729d91003e7f671fd2)):
 
 - Open up the Python project in IntelliJ
-- Make sure that you're on a lastest master (that includes Poetry)
+- Make sure that you're on latest master (that includes Poetry)
 - Go to File -> Project Structure (⌘;)
 - Go to Platform Settings -> SDKs
 - Click the + sign -> Add Python SDK
@@ -70,6 +70,12 @@ For Python, we use pytest in combination with coverage to maintain 90% code cove
 
 ```bash
 make test
+```
+
+By default we ignore the s3 tests that require minio to be running. To run this suite, we can run:
+
+```bash
+make test-s3
 ```
 
 To pass additional arguments to pytest, you can use `PYTEST_ARGS`.

--- a/python/dev/docker-compose.yml
+++ b/python/dev/docker-compose.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+version: "3"
+
+services:
+  minio:
+    image: minio/minio
+    container_name: pyiceberg-minio
+    environment:
+      - MINIO_ROOT_USER=admin
+      - MINIO_ROOT_PASSWORD=password
+    ports:
+      - 9001:9001
+      - 9000:9000
+    command: [ "server", "/data", "--console-address", ":9001" ]
+  mc:
+    depends_on:
+      - minio
+    image: minio/mc
+    container_name: pyiceberg-mc
+    environment:
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=password
+      - AWS_REGION=us-east-1
+    entrypoint: >
+      /bin/sh -c "
+      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      /usr/bin/mc rm -r --force minio/warehouse;
+      /usr/bin/mc mb minio/warehouse;
+      /usr/bin/mc policy set public minio/warehouse;
+      exit 0;
+      "


### PR DESCRIPTION
This PR adds a docker-compose.yml with the right configuration to run the s3 tests