### PR TITLE
API: Use hashCode instead of hash

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java
@@ -86,6 +86,6 @@ public class UnknownTransform<S, T> implements Transform<S, T> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(transform);
+    return Objects.hashCode(transform);
   }
 }

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -81,6 +81,8 @@ subprojects {
           '-Xep:TypeParameterShadowing:OFF',
           '-Xep:TypeParameterUnusedInFormals:OFF',
           '-Xep:DangerousThreadPoolExecutorUsage:OFF',
+          // Enforce hashCode over hash
+          '-Xep:ObjectsHashCodeUnnecessaryVarargs:ERROR'
       )
     }
   }


### PR DESCRIPTION
Noticed this in the output, and decided to fix it right away:
```
/Users/fokkodriesprong/Desktop/iceberg/api/src/main/java/org/apache/iceberg/transforms/UnknownTransform.java:89: warning: [ObjectsHashCodeUnnecessaryVarargs] java.util.Objects.hash(non-varargs) should be
replaced with java.util.Objects.hashCode(value) to avoid unnecessary varargs array allocations.
    return Objects.hash(transform);
                       ^
```