### PR TITLE
Spark: Fix runtime jars packaging scala library files

### DIFF
--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -58,9 +58,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
-      exclude group: 'org.scala-lang', module: 'scala-library'
-    }
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -136,9 +134,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   }
 
   dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
-      exclude group: 'org.scala-lang', module: 'scala-library'
-    }
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
     compileOnly "org.scala-lang:scala-library:${scalaVersion}"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
@@ -203,6 +199,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'org.glassfish'
       exclude group: 'org.abego.treelayout'
       exclude group: 'org.antlr'
+      exclude group: 'org.scala-lang'
+      exclude group: 'org.scala-lang.modules'
     }
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -58,7 +58,9 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
+      exclude group: 'org.scala-lang', module: 'scala-library'
+    }
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -134,7 +136,9 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   }
 
   dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
+      exclude group: 'org.scala-lang', module: 'scala-library'
+    }
 
     compileOnly "org.scala-lang:scala-library:${scalaVersion}"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -47,7 +47,9 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
+      exclude group: 'org.scala-lang', module: 'scala-library'
+    }
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -123,7 +125,9 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   }
 
   dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
+      exclude group: 'org.scala-lang', module: 'scala-library'
+    }
 
     compileOnly "org.scala-lang:scala-library:${scalaVersion}"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -47,9 +47,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
-      exclude group: 'org.scala-lang', module: 'scala-library'
-    }
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -125,9 +123,7 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
   }
 
   dependencies {
-    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}") {
-      exclude group: 'org.scala-lang', module: 'scala-library'
-    }
+    implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}")
 
     compileOnly "org.scala-lang:scala-library:${scalaVersion}"
     compileOnly project(path: ':iceberg-bundled-guava', configuration: 'shadow')
@@ -192,6 +188,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'org.glassfish'
       exclude group: 'org.abego.treelayout'
       exclude group: 'org.antlr'
+      exclude group: 'org.scala-lang'
+      exclude group: 'org.scala-lang.modules'
     }
   }
 


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/4009 adds a dependency on `scala.collection.compat` which is bringing the `scala-library` dependencies and causing the runtime jars to be packaged with scala-library files. 

So far, two issues reported that scala files packaged with run time jar is conflicting with their environment scala files. 

Applicable only to spark-3.3 and spark-3.2 as PR#4009 is present only in these versions. This change also reduces the runtime jar size by 4MB!

Fixes #5732 