### PR TITLE
Build - Remove unused global flink dependency from versions.props

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,6 @@
 org.slf4j:* = 1.7.36
 org.apache.avro:avro = 1.11.1
 org.apache.calcite:* = 1.10.0
-org.apache.flink:* = 1.14.3
 org.apache.hadoop:* = 2.7.3
 org.apache.hive:* = 2.3.8
 org.apache.httpcomponents.client5:* = 5.1


### PR DESCRIPTION
The Flink version is picked for each subproject in its respective build file.

Removing a specific Flink version from the global versions.props file as the version hint is unused - happened upon this when catching up on changes since I've been out for surgery =)