### PR TITLE
Build - Move global Spark 2.4 dependency in version.props to Spark 2.4 subproject

### DIFF
--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -27,6 +27,10 @@ def sparkProjects = [
 ]
 
 configure(sparkProjects) {
+  project.ext {
+    sparkVersion = '2.4.8'
+  }
+
   configurations {
     all {
       resolutionStrategy {
@@ -64,7 +68,7 @@ project(':iceberg-spark:iceberg-spark-2.4') {
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
-    compileOnly("org.apache.spark:spark-hive_2.11") {
+    compileOnly("org.apache.spark:spark-hive_2.11:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.roaringbitmap'
     }

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,6 @@ org.apache.hive:* = 2.3.8
 org.apache.httpcomponents.client5:* = 5.1
 org.apache.orc:* = 1.8.0
 org.apache.parquet:* = 1.12.3
-org.apache.spark:spark-hive_2.11 = 2.4.8
 org.apache.spark:spark-avro_2.11 = 2.4.8
 org.apache.pig:pig = 0.14.0
 com.fasterxml.jackson.*:* = 2.11.4

--- a/versions.props
+++ b/versions.props
@@ -7,7 +7,6 @@ org.apache.hive:* = 2.3.8
 org.apache.httpcomponents.client5:* = 5.1
 org.apache.orc:* = 1.8.0
 org.apache.parquet:* = 1.12.3
-org.apache.spark:spark-avro_2.11 = 2.4.8
 org.apache.pig:pig = 0.14.0
 com.fasterxml.jackson.*:* = 2.11.4
 com.google.errorprone:error_prone_annotations = 2.3.3


### PR DESCRIPTION
The `version.props` file provides version information to gradle for top-level dependencies.

All of the Spark projects have their dependencies declared in their own subprojects (from when we split the code base up by Spark version a while ago). But Spark 2.4 had one remaining dependency in `version.props` that _is_ still used: `spark-hive`.

Moved the Spark 2.4 version information to the Spark 2.4 subproject, to match the style used in Spark 3.0 subproject (and very similar to the others), and removed an entirely unused version declaration for `spark-avro` 2.4.3.