### PR TITLE
 Core: Add minimum data sequence number to ManifestEntry

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -142,4 +142,17 @@ public interface ContentFile<F> {
   default F copy(boolean withStats) {
     return withStats ? copy() : copyWithoutStats();
   }
+
+  /** Returns the data sequence number of the snapshot in which the file should be applied. */
+  default Long dataSequenceNumber() {
+    return null;
+  }
+
+  /**
+   * Returns the minimum data sequence number of the data files that the delete file referred. It
+   * returns null if it is a data file.
+   */
+  default Long minDataSequenceNumber() {
+    return null;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DeleteFile.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFile.java
@@ -23,6 +23,12 @@ import java.util.List;
 /** Interface for delete files listed in a table delete manifest. */
 public interface DeleteFile extends ContentFile<DeleteFile> {
   /**
+   * A value that indicates that the data sequence number of referenced data files should be
+   * computed lazily.
+   */
+  Long LAZY_MIN_DATA_SEQUENCE_NUMBER = -2L;
+
+  /**
    * @return List of recommended split locations, if applicable, null otherwise. When available,
    *     this information is used for planning scan tasks whose boundaries are determined by these
    *     offsets. The returned list must be sorted in ascending order.

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -75,6 +75,8 @@ abstract class BaseFile<F>
   private int[] equalityIds = null;
   private byte[] keyMetadata = null;
   private Integer sortOrderId;
+  private Long dataSequenceNumber = null;
+  private Long minDataSequenceNumber = null;
 
   // cached schema
   private transient Schema avroSchema = null;
@@ -208,6 +210,8 @@ abstract class BaseFile<F>
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
     this.sortOrderId = toCopy.sortOrderId;
+    this.dataSequenceNumber = toCopy.dataSequenceNumber;
+    this.minDataSequenceNumber = toCopy.minDataSequenceNumber;
   }
 
   /** Constructor for Java serialization. */
@@ -220,6 +224,24 @@ abstract class BaseFile<F>
 
   void setSpecId(int specId) {
     this.partitionSpecId = specId;
+  }
+
+  @Override
+  public Long dataSequenceNumber() {
+    return dataSequenceNumber;
+  }
+
+  void setDataSequenceNumber(Long seq) {
+    this.dataSequenceNumber = seq;
+  }
+
+  @Override
+  public Long minDataSequenceNumber() {
+    return minDataSequenceNumber;
+  }
+
+  void setMinDataSequenceNumber(Long seq) {
+    this.minDataSequenceNumber = seq;
   }
 
   protected abstract Schema getAvroSchema(Types.StructType partitionStruct);
@@ -478,6 +500,10 @@ abstract class BaseFile<F>
         .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
         .add("equality_ids", equalityIds == null ? "null" : equalityFieldIds())
         .add("sort_order_id", sortOrderId)
+        .add("data_sequence_number", dataSequenceNumber == null ? "null" : dataSequenceNumber)
+        .add(
+            "min_data_sequence_number",
+            minDataSequenceNumber == null ? "null" : minDataSequenceNumber)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -162,6 +162,11 @@ class DeleteFileIndex {
   }
 
   private static boolean canContainPosDeletesForFile(DataFile dataFile, DeleteFile deleteFile) {
+    if (deleteFile.minDataSequenceNumber() != null
+        && deleteFile.minDataSequenceNumber() > dataFile.dataSequenceNumber()) {
+      return false;
+    }
+
     // check that the delete file can contain the data file's file_path
     Map<Integer, ByteBuffer> lowers = deleteFile.lowerBounds();
     Map<Integer, ByteBuffer> uppers = deleteFile.upperBounds();

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -56,6 +56,7 @@ public class FileMetadata {
     private Map<Integer, ByteBuffer> upperBounds = null;
     private ByteBuffer keyMetadata = null;
     private Integer sortOrderId = null;
+    private Long minDataSequenceNumber = null;
 
     Builder(PartitionSpec spec) {
       this.spec = spec;
@@ -206,6 +207,11 @@ public class FileMetadata {
       return this;
     }
 
+    public Builder withMinDataSequenceNumber(Long newMinDataSequenceNumber) {
+      this.minDataSequenceNumber = newMinDataSequenceNumber;
+      return this;
+    }
+
     public DeleteFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -247,7 +253,8 @@ public class FileMetadata {
               upperBounds),
           equalityFieldIds,
           sortOrderId,
-          keyMetadata);
+          keyMetadata,
+          minDataSequenceNumber);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -61,6 +61,39 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
         keyMetadata);
   }
 
+  GenericDeleteFile(
+      int specId,
+      FileContent content,
+      String filePath,
+      FileFormat format,
+      PartitionData partition,
+      long fileSizeInBytes,
+      Metrics metrics,
+      int[] equalityFieldIds,
+      Integer sortOrderId,
+      ByteBuffer keyMetadata,
+      Long minDataSequenceNumber) {
+    super(
+        specId,
+        content,
+        filePath,
+        format,
+        partition,
+        fileSizeInBytes,
+        metrics.recordCount(),
+        metrics.columnSizes(),
+        metrics.valueCounts(),
+        metrics.nullValueCounts(),
+        metrics.nanValueCounts(),
+        metrics.lowerBounds(),
+        metrics.upperBounds(),
+        null,
+        equalityFieldIds,
+        sortOrderId,
+        keyMetadata);
+    setMinDataSequenceNumber(minDataSequenceNumber);
+  }
+
   /**
    * Copy constructor.
    *

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -47,8 +47,14 @@ interface ManifestEntry<F extends ContentFile<F>> {
   Types.NestedField SEQUENCE_NUMBER = optional(3, "sequence_number", Types.LongType.get());
   Types.NestedField FILE_SEQUENCE_NUMBER =
       optional(4, "file_sequence_number", Types.LongType.get());
+  Types.NestedField MIN_DATA_SEQUENCE_NUMBER =
+      optional(
+          5,
+          "min_data_sequence_number",
+          Types.LongType.get(),
+          "Lowest data sequence number of data files that the delete file is referenced");
   int DATA_FILE_ID = 2;
-  // next ID to assign: 5
+  // next ID to assign: 6
 
   static Schema getSchema(StructType partitionType) {
     return wrapFileSchema(DataFile.getType(partitionType));
@@ -60,6 +66,7 @@ interface ManifestEntry<F extends ContentFile<F>> {
         SNAPSHOT_ID,
         SEQUENCE_NUMBER,
         FILE_SEQUENCE_NUMBER,
+        MIN_DATA_SEQUENCE_NUMBER,
         required(DATA_FILE_ID, "data_file", fileType));
   }
 
@@ -137,6 +144,12 @@ interface ManifestEntry<F extends ContentFile<F>> {
    * status EXISTING or DELETED (older Iceberg versions).
    */
   Long fileSequenceNumber();
+
+  /**
+   * Returns the minimum data sequence number of the data files that the delete file referenced. It
+   * returns null when the manifest entry is data file.
+   */
+  Long minDataSequenceNumber();
 
   /**
    * Sets the file sequence number for this manifest entry.

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -439,7 +439,13 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       if (ignoreEqualityDeletes) {
         ValidationException.check(
             Arrays.stream(deleteFiles)
-                .noneMatch(deleteFile -> deleteFile.content() == FileContent.POSITION_DELETES),
+                .noneMatch(
+                    deleteFile ->
+                        (deleteFile.content() == FileContent.POSITION_DELETES
+                                && deleteFile.minDataSequenceNumber() == null)
+                            || (deleteFile.content() == FileContent.POSITION_DELETES
+                                && deleteFile.minDataSequenceNumber() != null
+                                && deleteFile.minDataSequenceNumber() <= startingSequenceNumber)),
             "Cannot commit, found new position delete for replaced data file: %s",
             dataFile);
       } else {

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -311,6 +311,11 @@ class V1Metadata {
     }
 
     @Override
+    public Long minDataSequenceNumber() {
+      return null;
+    }
+
+    @Override
     public void setFileSequenceNumber(long fileSequenceNumber) {
       wrapped.setFileSequenceNumber(fileSequenceNumber);
     }

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -251,6 +251,7 @@ class V2Metadata {
         ManifestEntry.SNAPSHOT_ID,
         ManifestEntry.SEQUENCE_NUMBER,
         ManifestEntry.FILE_SEQUENCE_NUMBER,
+        ManifestEntry.MIN_DATA_SEQUENCE_NUMBER,
         required(ManifestEntry.DATA_FILE_ID, "data_file", fileSchema));
   }
 
@@ -332,6 +333,8 @@ class V2Metadata {
         case 3:
           return wrapped.fileSequenceNumber();
         case 4:
+          return wrapped.minDataSequenceNumber();
+        case 5:
           return fileWrapper.wrap(wrapped.file());
         default:
           throw new UnsupportedOperationException("Unknown field ordinal: " + i);
@@ -376,6 +379,11 @@ class V2Metadata {
     @Override
     public Long fileSequenceNumber() {
       return wrapped.fileSequenceNumber();
+    }
+
+    @Override
+    public Long minDataSequenceNumber() {
+      return wrapped.minDataSequenceNumber();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -41,6 +41,7 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
   private final ByteBuffer keyMetadata;
   private final CharSequenceSet referencedDataFiles;
   private DeleteFile deleteFile = null;
+  private Long minDataSequenceNumber = null;
 
   public PositionDeleteWriter(
       FileAppender<StructLike> appender,
@@ -82,12 +83,17 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
               .withEncryptionKeyMetadata(keyMetadata)
               .withFileSizeInBytes(appender.length())
               .withMetrics(appender.metrics())
+              .withMinDataSequenceNumber(minDataSequenceNumber)
               .build();
     }
   }
 
   public CharSequenceSet referencedDataFiles() {
     return referencedDataFiles;
+  }
+
+  public void setMinDataSequenceNumber(Long minDataSequenceNumber) {
+    this.minDataSequenceNumber = minDataSequenceNumber;
   }
 
   public DeleteFile toDeleteFile() {

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -341,14 +341,14 @@ public class TableTestBase {
     switch (status) {
       case ADDED:
         if (dataSequenceNumber != null && dataSequenceNumber != 0) {
-          return entry.wrapAppend(snapshotId, dataSequenceNumber, file);
+          return entry.wrapAppend(snapshotId, dataSequenceNumber, null, file);
         } else {
           return entry.wrapAppend(snapshotId, file);
         }
       case EXISTING:
-        return entry.wrapExisting(snapshotId, dataSequenceNumber, fileSequenceNumber, file);
+        return entry.wrapExisting(snapshotId, dataSequenceNumber, fileSequenceNumber, null, file);
       case DELETED:
-        return entry.wrapDelete(snapshotId, dataSequenceNumber, fileSequenceNumber, file);
+        return entry.wrapDelete(snapshotId, dataSequenceNumber, fileSequenceNumber, null, file);
       default:
         throw new IllegalArgumentException("Unexpected entry status: " + status);
     }
@@ -617,6 +617,18 @@ public class TableTestBase {
         .withFileSizeInBytes(10)
         .withPartitionPath(partitionPath)
         .withRecordCount(1)
+        .build();
+  }
+
+  protected DeleteFile newDeleteFile(int specId, String partitionPath, Long minSequenceNumber) {
+    PartitionSpec spec = table.specs().get(specId);
+    return FileMetadata.deleteFileBuilder(spec)
+        .ofPositionDeletes()
+        .withPath("/path/to/delete-" + UUID.randomUUID() + ".parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath(partitionPath)
+        .withRecordCount(1)
+        .withMinDataSequenceNumber(minSequenceNumber)
         .build();
   }
 


### PR DESCRIPTION
This adds a new field `min-data-sequence-number` to the manifest entry to denote the minimum sequence number of the referred data files of the delete file. The `min-data-sequence-number` can filter out deletes in planning where we apply the min/max filter. Furthermore, it can help reduce commit conflict when performing rewrite action on streaming upsert jobs.

In order for simplicity, this PR doesn't include the changes for the writer side to produce the `min-data-sequence-number`. For the flink upsert writer, it should write lazy value since the writer doesn't know the data sequence number of data files when committing. For the spark writer, it can compute the value from the referenced data files.
 