### PR TITLE
Core, Hive-metastore: Table owner can be incorrect in HMS

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -352,4 +352,6 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String HMS_TABLE_OWNER = "hms_table_owner";
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -88,12 +88,15 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Rule public TemporaryFolder temp = new TemporaryFolder();
 
+  private Schema getTestSchema() {
+    return new Schema(
+        required(1, "id", Types.IntegerType.get(), "unique ID"),
+        required(2, "data", Types.StringType.get()));
+  }
+
   @Test
   public void testCreateTableBuilder() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
@@ -120,10 +123,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testCreateTableWithCaching() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
@@ -176,10 +176,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testCreateTableTxnBuilder() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
 
@@ -199,10 +196,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testReplaceTxnBuilder() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
@@ -248,11 +242,30 @@ public class TestHiveCatalog extends HiveMetastoreTest {
   }
 
   @Test
+  public void testCreateTableWithOwner() throws Exception {
+    Schema schema = getTestSchema();
+    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
+    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    String location = temp.newFolder("tbl").toString();
+    String owner = "some_owner";
+    ImmutableMap<String, String> properties =
+        ImmutableMap.of(TableProperties.HMS_TABLE_OWNER, owner);
+
+    try {
+      Table table = catalog.createTable(tableIdent, schema, spec, location, properties);
+      org.apache.hadoop.hive.metastore.api.Table hmsTable =
+          metastoreClient.getTable(DB_NAME, "tbl");
+      Assert.assertEquals(owner, hmsTable.getOwner());
+      Map<String, String> hmsTableParams = hmsTable.getParameters();
+      Assert.assertFalse(hmsTableParams.containsKey(TableProperties.HMS_TABLE_OWNER));
+    } finally {
+      catalog.dropTable(tableIdent);
+    }
+  }
+
+  @Test
   public void testCreateTableDefaultSortOrder() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
 
@@ -271,10 +284,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testCreateTableCustomSortOrder() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     SortOrder order = SortOrder.builderFor(schema).asc("id", NULLS_FIRST).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
@@ -430,8 +440,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
   public void testDropNamespace() throws TException {
     Namespace namespace = Namespace.of("dbname_drop");
     TableIdentifier identifier = TableIdentifier.of(namespace, "table");
-    Schema schema =
-        new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
+    Schema schema = getTestSchema();
 
     catalog.createNamespace(namespace, meta);
     catalog.createTable(identifier, schema);
@@ -464,8 +473,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
   @Test
   public void testDropTableWithoutMetadataFile() {
     TableIdentifier identifier = TableIdentifier.of(DB_NAME, "tbl");
-    Schema tableSchema =
-        new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
+    Schema tableSchema = getTestSchema();
     catalog.createTable(identifier, tableSchema);
     String metadataFileLocation = catalog.newTableOps(identifier).current().metadataFileLocation();
     TableOperations ops = catalog.newTableOps(identifier);
@@ -478,10 +486,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testTableName() {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("data", 16).build();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
 
@@ -508,10 +513,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testUUIDinTableProperties() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdentifier = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
 
@@ -526,10 +528,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testSnapshotStatsTableProperties() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdentifier = TableIdentifier.of(DB_NAME, "tbl");
     String location = temp.newFolder("tbl").toString();
 
@@ -637,10 +636,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testSetDefaultPartitionSpec() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
 
     try {
@@ -660,10 +656,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testSetCurrentSchema() throws Exception {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.IntegerType.get(), "unique ID"),
-            required(2, "data", Types.StringType.get()));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
 
     try {
@@ -706,7 +699,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
   @Test
   public void testTablePropsDefinedAtCatalogLevel() {
-    Schema schema = new Schema(required(1, "id", Types.IntegerType.get(), "unique ID"));
+    Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
 
     ImmutableMap<String, String> catalogProps =


### PR DESCRIPTION
When HiveCatalog is used for creating a table the table owner property is taken from a system property of the process running Iceberg. However, in some clients (e.g. Apache Impala) it's not the owner of the process who runs the create table operation and as a result not the desired owner gets written to HMS.
For instance, in Impala's case the owner of Catalogd (the process that makes the Iceberg API calls) was set as the table owner and not the user who ran the CREATE TABLE statement.

I changed HiveCatalog to accept an owner parameter from the clients. Note, other Catalog implementations aren't affected because the issue is related to HMS only.