### PR TITLE
Core: Make testEnvironmentSubstitution effective when USER is not set

### DIFF
--- a/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestEnvironmentUtil.java
@@ -19,28 +19,24 @@
 package org.apache.iceberg.util;
 
 import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 class TestEnvironmentUtil {
   @Test
   public void testEnvironmentSubstitution() {
-    String userFromEnv = System.getenv().get("USER");
+    Optional<Map.Entry<String, String>> envEntry = System.getenv().entrySet().stream().findFirst();
+    Assumptions.assumeTrue(
+        envEntry.isPresent(), "Expecting at least one env. variable to be present");
     Map<String, String> resolvedProps =
-        EnvironmentUtil.resolveAll(ImmutableMap.of("user-test", "env:USER"));
-    if (userFromEnv == null) {
-      // some build env may not have the USER env variable set
-      Assertions.assertEquals(
-          ImmutableMap.of(),
-          resolvedProps,
-          "Resolved properties should be empty if not exist from environment variables");
-    } else {
-      Assertions.assertEquals(
-          ImmutableMap.of("user-test", userFromEnv),
-          resolvedProps,
-          "Should get the user from the environment");
-    }
+        EnvironmentUtil.resolveAll(ImmutableMap.of("env-test", "env:" + envEntry.get().getKey()));
+    Assertions.assertEquals(
+        ImmutableMap.of("env-test", envEntry.get().getValue()),
+        resolvedProps,
+        "Should get the user from the environment");
   }
 
   @Test


### PR DESCRIPTION
Make testEnvironmentSubstitution exercise the code under test even when the USER env. var. is not set by choosing some other available env. var.

When no env. variables are available (highly unlikely) the test is ignored.

PR #5353 allowed testEnvironmentSubstitution to pass when the USER env. var. was not set in the build environment. However, in that situation the test's logic would be equivalent to another existing test case: testEnvironmentSubstitutionWithMissingVar, and, more importantly, it would not validate that the code under test was using the right environment map (i.e. `System.getenv()`).

While the single parameter `resolveAll` method is trivial, this change allows it to be validated even when USER is not set.