### PR TITLE
Core: Deprecate functions in DeleteWriters

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -67,26 +67,6 @@ public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult>
     appender.add(row);
   }
 
-  /**
-   * Writes equality deletes.
-   *
-   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(Iterable)} instead.
-   */
-  @Deprecated
-  public void deleteAll(Iterable<T> rows) {
-    appender.addAll(rows);
-  }
-
-  /**
-   * Writes an equality delete.
-   *
-   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(Object)} instead.
-   */
-  @Deprecated
-  public void delete(T row) {
-    appender.add(row);
-  }
-
   @Override
   public long length() {
     return appender.length();

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -66,29 +66,6 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
     appender.add(positionDelete);
   }
 
-  /**
-   * Writes a position delete.
-   *
-   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(PositionDelete)}
-   *     instead.
-   */
-  @Deprecated
-  public void delete(CharSequence path, long pos) {
-    delete(path, pos, null);
-  }
-
-  /**
-   * Writes a position delete and persists the deleted row.
-   *
-   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(PositionDelete)}
-   *     instead.
-   */
-  @Deprecated
-  public void delete(CharSequence path, long pos, T row) {
-    referencedDataFiles.add(path);
-    appender.add(delete.set(path, pos, row));
-  }
-
   @Override
   public long length() {
     return appender.length();

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -385,7 +385,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
 
     @Override
     void write(EqualityDeleteWriter<T> writer, T record) {
-      writer.delete(record);
+      writer.write(record);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -167,7 +167,9 @@ class SortedPosDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWr
         List<PosRow<T>> positions = posDeletes.get(wrapper.set(path));
         positions.sort(Comparator.comparingLong(PosRow::pos));
 
-        positions.forEach(posRow -> closeableWriter.delete(path, posRow.pos(), posRow.row()));
+        PositionDelete<T> posDelete = PositionDelete.create();
+        positions.forEach(
+            posRow -> closeableWriter.write(posDelete.set(path, posRow.pos(), posRow.row())));
       }
     } catch (IOException e) {
       setFailure(e);

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.avro.DataReader;
 import org.apache.iceberg.data.avro.DataWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.io.InMemoryOutputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -84,7 +85,7 @@ public class TestAvroDeleteWriters {
             .buildEqualityWriter();
 
     try (EqualityDeleteWriter<Record> writer = deleteWriter) {
-      writer.deleteAll(records);
+      writer.write(records);
     }
 
     DeleteFile metadata = deleteWriter.toDeleteFile();
@@ -129,7 +130,8 @@ public class TestAvroDeleteWriters {
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        writer.delete(deletePath, pos, records.get(i));
+        PositionDelete<Record> positionDelete = PositionDelete.create();
+        writer.write(positionDelete.set(deletePath, pos, records.get(i)));
         expectedDeleteRecords.add(
             posDelete.copy(
                 ImmutableMap.of(
@@ -180,7 +182,8 @@ public class TestAvroDeleteWriters {
     try (PositionDeleteWriter<Void> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        writer.delete(deletePath, pos, null);
+        PositionDelete<Void> positionDelete = PositionDelete.create();
+        writer.write(positionDelete.set(deletePath, pos, null));
         expectedDeleteRecords.add(
             posDelete.copy(ImmutableMap.of("file_path", deletePath, "pos", (long) pos)));
       }

--- a/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
@@ -192,7 +192,7 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
     EqualityDeleteWriter<T> eqDeleteWriter =
         appenderFactory.newEqDeleteWriter(out, format, partition);
     try (EqualityDeleteWriter<T> closeableWriter = eqDeleteWriter) {
-      closeableWriter.deleteAll(deletes);
+      closeableWriter.write(deletes);
     }
 
     // Check that the delete equality file has the expected equality deletes.
@@ -229,7 +229,8 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
         appenderFactory.newPosDeleteWriter(out, format, partition);
     try (PositionDeleteWriter<T> closeableWriter = eqDeleteWriter) {
       for (Pair<CharSequence, Long> delete : deletes) {
-        closeableWriter.delete(delete.first(), delete.second());
+        PositionDelete<T> posDelete = PositionDelete.create();
+        closeableWriter.write(posDelete.set(delete.first(), delete.second(), null));
       }
     }
 
@@ -276,7 +277,8 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
         appenderFactory.newPosDeleteWriter(out, format, partition);
     try (PositionDeleteWriter<T> closeableWriter = eqDeleteWriter) {
       for (PositionDelete<T> delete : deletes) {
-        closeableWriter.delete(delete.path(), delete.pos(), delete.row());
+        PositionDelete<T> posDelete = PositionDelete.create();
+        closeableWriter.write(posDelete.set(delete.path(), delete.pos(), delete.row()));
       }
     }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -330,7 +330,7 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
         writerFactory.newEqualityDeleteWriter(file, spec, partitionKey);
 
     try (EqualityDeleteWriter<T> closableWriter = writer) {
-      closableWriter.deleteAll(deletes);
+      closableWriter.write(deletes);
     }
 
     return writer.toDeleteFile();
@@ -349,7 +349,8 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
 
     try (PositionDeleteWriter<T> closableWriter = writer) {
       for (PositionDelete<T> delete : deletes) {
-        closableWriter.delete(delete.path(), delete.pos(), delete.row());
+        PositionDelete<T> posDelete = PositionDelete.create();
+        closableWriter.write(posDelete.set(delete.path(), delete.pos(), delete.row()));
       }
     }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.sink.FlinkAppenderFactory;
@@ -163,7 +164,7 @@ public class SimpleDataUtil {
     EqualityDeleteWriter<RowData> eqWriter =
         appenderFactory.newEqDeleteWriter(outputFile, format, null);
     try (EqualityDeleteWriter<RowData> writer = eqWriter) {
-      writer.deleteAll(deletes);
+      writer.write(deletes);
     }
     return eqWriter.toDeleteFile();
   }
@@ -183,7 +184,8 @@ public class SimpleDataUtil {
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        writer.delete(p.first(), p.second());
+        PositionDelete<RowData> posDelete = PositionDelete.create();
+        writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }
     return posWriter.toDeleteFile();

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.sink.FlinkAppenderFactory;
@@ -164,7 +165,7 @@ public class SimpleDataUtil {
     EqualityDeleteWriter<RowData> eqWriter =
         appenderFactory.newEqDeleteWriter(outputFile, format, null);
     try (EqualityDeleteWriter<RowData> writer = eqWriter) {
-      writer.deleteAll(deletes);
+      writer.write(deletes);
     }
     return eqWriter.toDeleteFile();
   }
@@ -184,7 +185,8 @@ public class SimpleDataUtil {
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        writer.delete(p.first(), p.second());
+        PositionDelete<RowData> posDelete = PositionDelete.create();
+        writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }
     return posWriter.toDeleteFile();

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.flink.sink.FlinkAppenderFactory;
@@ -165,7 +166,7 @@ public class SimpleDataUtil {
     EqualityDeleteWriter<RowData> eqWriter =
         appenderFactory.newEqDeleteWriter(outputFile, format, null);
     try (EqualityDeleteWriter<RowData> writer = eqWriter) {
-      writer.deleteAll(deletes);
+      writer.write(deletes);
     }
     return eqWriter.toDeleteFile();
   }
@@ -186,7 +187,8 @@ public class SimpleDataUtil {
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        writer.delete(p.first(), p.second());
+        PositionDelete<RowData> posDelete = PositionDelete.create();
+        writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }
     return posWriter.toDeleteFile();

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDeleteWriters.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDeleteWriters.java
@@ -86,7 +86,7 @@ public class TestOrcDeleteWriters {
             .buildEqualityWriter();
 
     try (EqualityDeleteWriter<Record> writer = deleteWriter) {
-      writer.deleteAll(records);
+      writer.write(records);
     }
 
     DeleteFile metadata = deleteWriter.toDeleteFile();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
@@ -86,7 +87,7 @@ public class TestParquetDeleteWriters {
             .buildEqualityWriter();
 
     try (EqualityDeleteWriter<Record> writer = deleteWriter) {
-      writer.deleteAll(records);
+      writer.write(records);
     }
 
     DeleteFile metadata = deleteWriter.toDeleteFile();
@@ -136,7 +137,8 @@ public class TestParquetDeleteWriters {
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        writer.delete(deletePath, pos, records.get(i));
+        PositionDelete<Record> positionDelete = PositionDelete.create();
+        writer.write(positionDelete.set(deletePath, pos, records.get(i)));
         expectedDeleteRecords.add(
             posDelete.copy(
                 ImmutableMap.of(
@@ -192,7 +194,8 @@ public class TestParquetDeleteWriters {
     try (PositionDeleteWriter<Void> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        writer.delete(deletePath, pos, null);
+        PositionDelete<Void> positionDelete = PositionDelete.create();
+        writer.write(positionDelete.set(deletePath, pos, null));
         expectedDeleteRecords.add(
             posDelete.copy(ImmutableMap.of("file_path", deletePath, "pos", (long) pos)));
       }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SortStrategy;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1449,7 +1450,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
               .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
               .newPosDeleteWriter(encryptedOutputFile, FileFormat.PARQUET, partition);
 
-      posDeleteWriter.delete(path, rowPosition);
+      PositionDelete<Record> posDelete = PositionDelete.create();
+      posDeleteWriter.write(posDelete.set(path, rowPosition, null));
       try {
         posDeleteWriter.close();
       } catch (IOException e) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -66,6 +66,7 @@ import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SortStrategy;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1449,7 +1450,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
               .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
               .newPosDeleteWriter(encryptedOutputFile, FileFormat.PARQUET, partition);
 
-      posDeleteWriter.delete(path, rowPosition);
+      PositionDelete<Record> posDelete = PositionDelete.create();
+      posDeleteWriter.write(posDelete.set(path, rowPosition, null));
       try {
         posDeleteWriter.close();
       } catch (IOException e) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SortStrategy;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1598,7 +1599,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
               .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
               .newPosDeleteWriter(encryptedOutputFile, FileFormat.PARQUET, partition);
 
-      posDeleteWriter.delete(path, rowPosition);
+      PositionDelete<Record> posDelete = PositionDelete.create();
+      posDeleteWriter.write(posDelete.set(path, rowPosition, null));
       try {
         posDeleteWriter.close();
       } catch (IOException e) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SortStrategy;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1598,7 +1599,8 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
               .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
               .newPosDeleteWriter(encryptedOutputFile, FileFormat.PARQUET, partition);
 
-      posDeleteWriter.delete(path, rowPosition);
+      PositionDelete<Record> posDelete = PositionDelete.create();
+      posDeleteWriter.write(posDelete.set(path, rowPosition, null));
       try {
         posDeleteWriter.close();
       } catch (IOException e) {


### PR DESCRIPTION
There are some functions marked to be deprecated in 0.14. As we passed that release already and getting close to 1.0.0 this might be the time to drop them.
This patch takes care of the functions in EqualityDeleteWriter and PositionDeleteWriter classes in the core/ folder.