### PR TITLE
Doc: Update the default value of table property `read.parquet.vectorization.enabled`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,9 +39,9 @@ Iceberg tables support table properties to configure table behavior, like the de
 | read.split.metadata-target-size   | 33554432 (32 MB)   | Target size when combining metadata input splits       |
 | read.split.planning-lookback      | 10                 | Number of bins to consider when combining input splits |
 | read.split.open-file-cost         | 4194304 (4 MB)     | The estimated cost to open a file, used as a minimum weight when combining splits. |
-| read.parquet.vectorization.enabled| false              | Enables parquet vectorized reads                       |
+| read.parquet.vectorization.enabled| true               | Controls whether Parquet vectorized reads are used     |
 | read.parquet.vectorization.batch-size| 5000            | The batch size for parquet vectorized reads            |
-| read.orc.vectorization.enabled    | false              | Enables orc vectorized reads                           |
+| read.orc.vectorization.enabled    | false              | Controls whether orc vectorized reads are used         |
 | read.orc.vectorization.batch-size | 5000               | The batch size for orc vectorized reads                |
 
 ### Write properties


### PR DESCRIPTION
Vectorized read for parquet was enabled by default since [commit ec2f1ad7](https://github.com/apache/iceberg/commit/ec2f1ad76d2152d6aa08b185be4a2447319db642), this patch updates the doc accordingly.