### PR TITLE
API/Core: Make ScanReport and its related classes Immutable

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -383,6 +383,11 @@
             <property name="format" value="@Test\(.*expected.*\)"/>
             <property name="message" value="Prefer using Assertions.assertThatThrownBy(...).isInstanceOf(...) instead."/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="ignoreComments" value="true"/>
+            <property name="format" value="@Json(S|Des)erialize"/>
+            <property name="message" value="Avoid using Jackson-related ser-de annotations"/>
+        </module>
         <module name="SimplifyBooleanExpression"/> <!-- Java Coding Guidelines: Keep Boolean expressions simple -->
         <module name="SimplifyBooleanReturn"/> <!-- Java Coding Guidelines: Keep Boolean expressions simple -->
         <module name="StaticVariableName"/> <!-- Java Style Guide: Naming -->

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -57,8 +57,8 @@ subprojects {
   pluginManager.withPlugin('com.palantir.baseline-error-prone') {
     tasks.withType(JavaCompile).configureEach {
       options.errorprone.errorproneArgs.addAll (
-          // error-prone is slow, don't run on tests and generated src
-          '-XepExcludedPaths:.*/(test|generated-src)/.*',
+          // error-prone is slow, don't run on tests/generated-src/generated
+          '-XepExcludedPaths:.*/(test|generated-src|generated)/.*',
           // specific to Palantir
           '-Xep:ConsistentLoggerName:OFF',  // Uses name `log` but we use name `LOG`
           '-Xep:FinalClass:OFF',

--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,8 @@ project(':iceberg-api') {
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly "com.google.errorprone:error_prone_annotations"
+    annotationProcessor "org.immutables:value"
+    compileOnly "org.immutables:value"
     testImplementation "org.apache.avro:avro"
     testImplementation "com.esotericsoftware:kryo"
   }
@@ -259,6 +261,8 @@ project(':iceberg-core') {
     api project(':iceberg-api')
     implementation project(':iceberg-common')
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    annotationProcessor "org.immutables:value"
+    compileOnly "org.immutables:value"
 
     implementation("org.apache.avro:avro") {
       exclude group: 'org.tukaani' // xz compression is not supported

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -24,7 +24,9 @@ import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ImmutableScanReport;
 import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.ScanReport.ScanMetricsResult;
 import org.apache.iceberg.metrics.Timer;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -61,7 +63,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
 
   protected ScanReport.ScanMetrics scanMetrics() {
     if (scanMetrics == null) {
-      this.scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+      this.scanMetrics = ScanReport.ScanMetrics.of(new DefaultMetricsContext());
     }
 
     return scanMetrics;
@@ -121,12 +123,12 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
           () -> {
             scanDuration.stop();
             ScanReport scanReport =
-                ScanReport.builder()
-                    .withProjection(schema())
-                    .withTableName(table().name())
-                    .withSnapshotId(snapshot.snapshotId())
-                    .withFilter(ExpressionUtil.sanitize(filter()))
-                    .fromScanMetrics(scanMetrics())
+                ImmutableScanReport.builder()
+                    .projection(schema())
+                    .tableName(table().name())
+                    .snapshotId(snapshot.snapshotId())
+                    .filter(ExpressionUtil.sanitize(filter()))
+                    .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                     .build();
             context().scanReporter().reportScan(scanReport);
           });

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -364,7 +364,7 @@ class DeleteFileIndex {
     private PartitionSet partitionSet = null;
     private boolean caseSensitive = true;
     private ExecutorService executorService = null;
-    private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.NOOP;
+    private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.noop();
 
     Builder(FileIO io, Set<ManifestFile> deleteManifests) {
       this.io = io;

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -85,7 +85,7 @@ class ManifestGroup {
     this.caseSensitive = true;
     this.manifestPredicate = m -> true;
     this.manifestEntryPredicate = e -> true;
-    this.scanMetrics = ScanReport.ScanMetrics.NOOP;
+    this.scanMetrics = ScanReport.ScanMetrics.noop();
   }
 
   ManifestGroup specsById(Map<Integer, PartitionSpec> newSpecsById) {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -93,7 +93,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   private Schema fileProjection = null;
   private Collection<String> columns = null;
   private boolean caseSensitive = true;
-  private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.NOOP;
+  private ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.noop();
 
   // lazily initialized
   private Evaluator lazyEvaluator = null;

--- a/core/src/main/java/org/apache/iceberg/metrics/CounterResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/CounterResultParser.java
@@ -63,7 +63,7 @@ class CounterResultParser {
 
     String unit = JsonUtil.getString(UNIT, json);
     long value = JsonUtil.getLong(VALUE, json);
-    return new CounterResult(Unit.fromDisplayName(unit), value);
+    return CounterResult.of(Unit.fromDisplayName(unit), value);
   }
 
   /**
@@ -88,6 +88,6 @@ class CounterResultParser {
 
     String unit = JsonUtil.getString(UNIT, counter);
     long value = JsonUtil.getLong(VALUE, counter);
-    return new CounterResult(Unit.fromDisplayName(unit), value);
+    return CounterResult.of(Unit.fromDisplayName(unit), value);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
@@ -99,15 +99,22 @@ class ScanMetricsResultParser {
     Preconditions.checkArgument(
         json.isObject(), "Cannot parse scan metrics from non-object: %s", json);
 
-    return new ScanMetricsResult(
-        TimerResultParser.fromJson(ScanMetrics.TOTAL_PLANNING_DURATION, json),
-        CounterResultParser.fromJson(ScanMetrics.RESULT_DATA_FILES, json),
-        CounterResultParser.fromJson(ScanMetrics.RESULT_DELETE_FILES, json),
-        CounterResultParser.fromJson(ScanMetrics.TOTAL_DATA_MANIFESTS, json),
-        CounterResultParser.fromJson(ScanMetrics.TOTAL_DELETE_MANIFESTS, json),
-        CounterResultParser.fromJson(ScanMetrics.SCANNED_DATA_MANIFESTS, json),
-        CounterResultParser.fromJson(ScanMetrics.SKIPPED_DATA_MANIFESTS, json),
-        CounterResultParser.fromJson(ScanMetrics.TOTAL_FILE_SIZE_IN_BYTES, json),
-        CounterResultParser.fromJson(ScanMetrics.TOTAL_DELETE_FILE_SIZE_IN_BYTES, json));
+    return ImmutableScanMetricsResult.builder()
+        .totalPlanningDuration(
+            TimerResultParser.fromJson(ScanMetrics.TOTAL_PLANNING_DURATION, json))
+        .resultDataFiles(CounterResultParser.fromJson(ScanMetrics.RESULT_DATA_FILES, json))
+        .resultDeleteFiles(CounterResultParser.fromJson(ScanMetrics.RESULT_DELETE_FILES, json))
+        .totalDataManifests(CounterResultParser.fromJson(ScanMetrics.TOTAL_DATA_MANIFESTS, json))
+        .totalDeleteManifests(
+            CounterResultParser.fromJson(ScanMetrics.TOTAL_DELETE_MANIFESTS, json))
+        .scannedDataManifests(
+            CounterResultParser.fromJson(ScanMetrics.SCANNED_DATA_MANIFESTS, json))
+        .skippedDataManifests(
+            CounterResultParser.fromJson(ScanMetrics.SKIPPED_DATA_MANIFESTS, json))
+        .totalFileSizeInBytes(
+            CounterResultParser.fromJson(ScanMetrics.TOTAL_FILE_SIZE_IN_BYTES, json))
+        .totalDeleteFileSizeInBytes(
+            CounterResultParser.fromJson(ScanMetrics.TOTAL_DELETE_FILE_SIZE_IN_BYTES, json))
+        .build();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanReportParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanReportParser.java
@@ -81,12 +81,12 @@ public class ScanReportParser {
     Schema projection = SchemaParser.fromJson(JsonUtil.get(PROJECTION, json));
     ScanMetricsResult scanMetricsResult =
         ScanMetricsResultParser.fromJson(JsonUtil.get(METRICS, json));
-    return ScanReport.builder()
-        .withTableName(tableName)
-        .withSnapshotId(snapshotId)
-        .withProjection(projection)
-        .withFilter(filter)
-        .fromScanMetricsResult(scanMetricsResult)
+    return ImmutableScanReport.builder()
+        .tableName(tableName)
+        .snapshotId(snapshotId)
+        .projection(projection)
+        .filter(filter)
+        .scanMetrics(scanMetricsResult)
         .build();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
@@ -69,7 +69,7 @@ class TimerResultParser {
     long count = JsonUtil.getLong(COUNT, json);
     TimeUnit unit = TimeUnit.valueOf(JsonUtil.getString(TIME_UNIT, json).toUpperCase(Locale.ROOT));
     long duration = JsonUtil.getLong(TOTAL_DURATION, json);
-    return new TimerResult(unit, toDuration(duration, unit), count);
+    return TimerResult.of(unit, toDuration(duration, unit), count);
   }
 
   /**
@@ -98,7 +98,7 @@ class TimerResultParser {
     long count = JsonUtil.getLong(COUNT, timer);
     TimeUnit unit = TimeUnit.valueOf(JsonUtil.getString(TIME_UNIT, timer).toUpperCase(Locale.ROOT));
     long duration = JsonUtil.getLong(TOTAL_DURATION, timer);
-    return new TimerResult(unit, toDuration(duration, unit), count);
+    return TimerResult.of(unit, toDuration(duration, unit), count);
   }
 
   @VisibleForTesting

--- a/core/src/test/java/org/apache/iceberg/metrics/TestCounterResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestCounterResultParser.java
@@ -52,7 +52,7 @@ public class TestCounterResultParser {
   public void extraFields() {
     Assertions.assertThat(
             CounterResultParser.fromJson("{\"unit\":\"bytes\",\"value\":23,\"extra\": \"value\"}"))
-        .isEqualTo(new CounterResult(Unit.BYTES, 23L));
+        .isEqualTo(CounterResult.of(Unit.BYTES, 23L));
   }
 
   @Test
@@ -73,7 +73,7 @@ public class TestCounterResultParser {
 
   @Test
   public void roundTripSerde() {
-    CounterResult counter = new CounterResult(Unit.BYTES, Long.MAX_VALUE);
+    CounterResult counter = CounterResult.of(Unit.BYTES, Long.MAX_VALUE);
 
     String json = CounterResultParser.toJson(counter);
     Assertions.assertThat(CounterResultParser.fromJson(json)).isEqualTo(counter);

--- a/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestScanMetricsResultParser.java
@@ -45,67 +45,43 @@ public class TestScanMetricsResultParser {
   @Test
   public void missingFields() {
     Assertions.assertThat(ScanMetricsResultParser.fromJson("{}"))
-        .isEqualTo(new ScanMetricsResult(null, null, null, null, null, null, null, null, null));
+        .isEqualTo(ImmutableScanMetricsResult.builder().build());
 
-    TimerResult totalPlanningDuration = new TimerResult(TimeUnit.HOURS, Duration.ofHours(10), 3L);
-    CounterResult resultDataFiles = new CounterResult(Unit.COUNT, 5L);
-    CounterResult resultDeleteFiles = new CounterResult(Unit.COUNT, 5L);
-    CounterResult totalDataManifests = new CounterResult(Unit.COUNT, 5L);
-    CounterResult totalDeleteManifests = new CounterResult(Unit.COUNT, 0L);
-    CounterResult scannedDataManifests = new CounterResult(Unit.COUNT, 5L);
-    CounterResult skippedDataManifests = new CounterResult(Unit.COUNT, 5L);
-    CounterResult totalFileSizeInBytes = new CounterResult(Unit.BYTES, 1069L);
-
+    ImmutableScanMetricsResult scanMetricsResult =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(TimerResult.of(TimeUnit.HOURS, Duration.ofHours(10), 3L))
+            .build();
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration, null, null, null, null, null, null, null, null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult = scanMetricsResult.withResultDataFiles(CounterResult.of(Unit.COUNT, 5L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
                     + "\"result-data-files\":{\"unit\":\"count\",\"value\":5}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration, resultDataFiles, null, null, null, null, null, null, null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult = scanMetricsResult.withResultDeleteFiles(CounterResult.of(Unit.COUNT, 5L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
                     + "\"result-data-files\":{\"unit\":\"count\",\"value\":5},"
                     + "\"result-delete-files\":{\"unit\":\"count\",\"value\":5}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult = scanMetricsResult.withTotalDataManifests(CounterResult.of(Unit.COUNT, 5L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
                     + "\"result-data-files\":{\"unit\":\"count\",\"value\":5},"
                     + "\"result-delete-files\":{\"unit\":\"count\",\"value\":5},"
                     + "\"total-data-manifests\":{\"unit\":\"count\",\"value\":5}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                totalDataManifests,
-                null,
-                null,
-                null,
-                null,
-                null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult =
+        scanMetricsResult.withTotalDeleteManifests(CounterResult.of(Unit.COUNT, 0L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
@@ -113,18 +89,10 @@ public class TestScanMetricsResultParser {
                     + "\"result-delete-files\":{\"unit\":\"count\",\"value\":5},"
                     + "\"total-data-manifests\":{\"unit\":\"count\",\"value\":5},"
                     + "\"total-delete-manifests\":{\"unit\":\"count\",\"value\":0}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                totalDataManifests,
-                totalDeleteManifests,
-                null,
-                null,
-                null,
-                null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult =
+        scanMetricsResult.withScannedDataManifests(CounterResult.of(Unit.COUNT, 5L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
@@ -133,18 +101,10 @@ public class TestScanMetricsResultParser {
                     + "\"total-data-manifests\":{\"unit\":\"count\",\"value\":5},"
                     + "\"total-delete-manifests\":{\"unit\":\"count\",\"value\":0},"
                     + "\"scanned-data-manifests\":{\"unit\":\"count\",\"value\":5}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                totalDataManifests,
-                totalDeleteManifests,
-                scannedDataManifests,
-                null,
-                null,
-                null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult =
+        scanMetricsResult.withSkippedDataManifests(CounterResult.of(Unit.COUNT, 5L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
@@ -154,18 +114,10 @@ public class TestScanMetricsResultParser {
                     + "\"total-delete-manifests\":{\"unit\":\"count\",\"value\":0},"
                     + "\"scanned-data-manifests\":{\"unit\":\"count\",\"value\":5},"
                     + "\"skipped-data-manifests\":{\"unit\":\"count\",\"value\":5}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                totalDataManifests,
-                totalDeleteManifests,
-                scannedDataManifests,
-                skippedDataManifests,
-                null,
-                null));
+        .isEqualTo(scanMetricsResult);
 
+    scanMetricsResult =
+        scanMetricsResult.withTotalFileSizeInBytes(CounterResult.of(Unit.BYTES, 1069L));
     Assertions.assertThat(
             ScanMetricsResultParser.fromJson(
                 "{\"total-planning-duration\":{\"count\":3,\"time-unit\":\"hours\",\"total-duration\":10},"
@@ -176,22 +128,12 @@ public class TestScanMetricsResultParser {
                     + "\"scanned-data-manifests\":{\"unit\":\"count\",\"value\":5},"
                     + "\"skipped-data-manifests\":{\"unit\":\"count\",\"value\":5},"
                     + "\"total-file-size-in-bytes\":{\"unit\":\"bytes\",\"value\":1069}}"))
-        .isEqualTo(
-            new ScanMetricsResult(
-                totalPlanningDuration,
-                resultDataFiles,
-                resultDeleteFiles,
-                totalDataManifests,
-                totalDeleteManifests,
-                scannedDataManifests,
-                skippedDataManifests,
-                totalFileSizeInBytes,
-                null));
+        .isEqualTo(scanMetricsResult);
   }
 
   @Test
   public void extraFields() {
-    ScanReport.ScanMetrics scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.of(new DefaultMetricsContext());
     scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
     scanMetrics.resultDataFiles().increment(5L);
     scanMetrics.resultDeleteFiles().increment(5L);
@@ -241,7 +183,7 @@ public class TestScanMetricsResultParser {
 
   @Test
   public void roundTripSerde() {
-    ScanReport.ScanMetrics scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.of(new DefaultMetricsContext());
     scanMetrics.totalPlanningDuration().record(10, TimeUnit.DAYS);
     scanMetrics.resultDataFiles().increment(5L);
     scanMetrics.resultDeleteFiles().increment(5L);
@@ -302,13 +244,13 @@ public class TestScanMetricsResultParser {
 
   @Test
   public void roundTripSerdeNoopScanMetrics() {
-    ScanMetricsResult scanMetricsResult = ScanMetricsResult.fromScanMetrics(ScanMetrics.NOOP);
+    ScanMetricsResult scanMetricsResult = ScanMetricsResult.fromScanMetrics(ScanMetrics.noop());
     String expectedJson = "{ }";
 
     String json = ScanMetricsResultParser.toJson(scanMetricsResult, true);
     System.out.println(json);
     Assertions.assertThat(json).isEqualTo(expectedJson);
     Assertions.assertThat(ScanMetricsResultParser.fromJson(json))
-        .isEqualTo(new ScanMetricsResult(null, null, null, null, null, null, null, null, null));
+        .isEqualTo(ImmutableScanMetricsResult.builder().build());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/metrics/TestScanReportParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestScanReportParser.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.metrics.ScanReport.ScanMetrics;
+import org.apache.iceberg.metrics.ScanReport.ScanMetricsResult;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -69,7 +70,7 @@ public class TestScanReportParser {
 
   @Test
   public void extraFields() {
-    ScanReport.ScanMetrics scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.of(new DefaultMetricsContext());
     scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
     scanMetrics.resultDataFiles().increment(5L);
     scanMetrics.resultDeleteFiles().increment(5L);
@@ -84,12 +85,12 @@ public class TestScanReportParser {
     Schema projection =
         new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
     ScanReport scanReport =
-        ScanReport.builder()
-            .withTableName(tableName)
-            .withProjection(projection)
-            .withSnapshotId(23L)
-            .withFilter(Expressions.alwaysTrue())
-            .fromScanMetrics(scanMetrics)
+        ImmutableScanReport.builder()
+            .tableName(tableName)
+            .projection(projection)
+            .snapshotId(23L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics))
             .build();
 
     Assertions.assertThat(
@@ -151,7 +152,7 @@ public class TestScanReportParser {
 
   @Test
   public void roundTripSerde() {
-    ScanReport.ScanMetrics scanMetrics = new ScanReport.ScanMetrics(new DefaultMetricsContext());
+    ScanReport.ScanMetrics scanMetrics = ScanReport.ScanMetrics.of(new DefaultMetricsContext());
     scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
     scanMetrics.resultDataFiles().increment(5L);
     scanMetrics.resultDeleteFiles().increment(5L);
@@ -166,12 +167,12 @@ public class TestScanReportParser {
     Schema projection =
         new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
     ScanReport scanReport =
-        ScanReport.builder()
-            .withTableName(tableName)
-            .withProjection(projection)
-            .withSnapshotId(23L)
-            .withFilter(Expressions.alwaysTrue())
-            .fromScanMetrics(scanMetrics)
+        ImmutableScanReport.builder()
+            .tableName(tableName)
+            .projection(projection)
+            .filter(Expressions.alwaysTrue())
+            .snapshotId(23L)
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics))
             .build();
 
     String expectedJson =
@@ -245,12 +246,12 @@ public class TestScanReportParser {
     Schema projection =
         new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
     ScanReport scanReport =
-        ScanReport.builder()
-            .withTableName(tableName)
-            .withProjection(projection)
-            .withSnapshotId(23L)
-            .withFilter(Expressions.alwaysTrue())
-            .fromScanMetrics(ScanMetrics.NOOP)
+        ImmutableScanReport.builder()
+            .tableName(tableName)
+            .projection(projection)
+            .snapshotId(23L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
             .build();
 
     String expectedJson =

--- a/core/src/test/java/org/apache/iceberg/metrics/TestTimerResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestTimerResultParser.java
@@ -60,7 +60,7 @@ public class TestTimerResultParser {
     Assertions.assertThat(
             TimerResultParser.fromJson(
                 "{\"count\":44,\"time-unit\":\"hours\",\"total-duration\":24,\"extra\": \"value\"}"))
-        .isEqualTo(new TimerResult(TimeUnit.HOURS, Duration.ofHours(24), 44));
+        .isEqualTo(TimerResult.of(TimeUnit.HOURS, Duration.ofHours(24), 44));
   }
 
   @Test
@@ -95,7 +95,7 @@ public class TestTimerResultParser {
 
   @Test
   public void roundTripSerde() {
-    TimerResult timer = new TimerResult(TimeUnit.HOURS, Duration.ofHours(23), 44);
+    TimerResult timer = TimerResult.of(TimeUnit.HOURS, Duration.ofHours(23), 44);
 
     String json = TimerResultParser.toJson(timer);
     Assertions.assertThat(TimerResultParser.fromJson(json)).isEqualTo(timer);

--- a/versions.props
+++ b/versions.props
@@ -27,6 +27,7 @@ com.google.cloud:libraries-bom = 24.1.0
 org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
+org.immutables:value = 2.9.2
 
 # test deps
 org.junit.vintage:junit-vintage-engine = 5.8.2


### PR DESCRIPTION
* Use true immutable objects that are type-safe, thread-safe, null-safe
* Get builder classes for free

This is relying on https://immutables.github.io/ (Apache License 2.0), which allows generating immutable objects and builders via annotation processing.
* Immutable objects are serialization ready (including JSON and its binary forms)
* Supports lazy, derived and optional attributes
* Immutable objects are constructed once, in a consistent state, and can be safely shared
  * Will fail if mandatory attributes are missing
  * Cannot be sneakily modified when passed to other code
* Immutable objects are naturally thread-safe and can therefore be safely shared among threads
  * No excessive copying
  * No excessive synchronization
* Object definitions are pleasant to write and read
  * No boilerplate setter and getters
  * No ugly IDE-generated hashCode, equals and toString methods that end up being stored in source control.

Note that we are specifically preventing people from using Jackson-related annotations (`@JsonSerialize` & `@JsonDeserialize`) in order to avoid potential runtime library dependency issues where a clashing jackson lib would prevent jackson-related annotations to be used/processed.