### PR TITLE
Build: Update Spark to 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ allprojects {
   group = "org.apache.iceberg"
   version = projectVersion
   repositories {
+    maven { url "https://repository.apache.org/content/repositories/orgapachespark-1430/" }
     mavenCentral()
     mavenLocal()
   }

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,6 @@ allprojects {
   group = "org.apache.iceberg"
   version = projectVersion
   repositories {
-    maven { url "https://repository.apache.org/content/repositories/orgapachespark-1430/" }
     mavenCentral()
     mavenLocal()
   }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -31,7 +31,7 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
+        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4'
       }
     }
   }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-String sparkVersion = '3.3.0'
+String sparkVersion = '3.3.1'
 String sparkMajorVersion = '3.3'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -31,6 +31,7 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
         force 'com.fasterxml.jackson.module:jackson-databind:2.13.4'
         force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
       }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -31,7 +31,7 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4',
+        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4'
         force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
       }
     }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -31,7 +31,8 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4'
+        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4',
+        force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
       }
     }
   }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -32,8 +32,6 @@ configure(sparkProjects) {
     all {
       resolutionStrategy {
         force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
-        force 'com.fasterxml.jackson.module:jackson-databind:2.13.4'
-        force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
       }
     }
   }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -31,7 +31,7 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
       }
     }
   }

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -27,6 +27,16 @@ def sparkProjects = [
     project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersion}"),
 ]
 
+configure(sparkProjects) {
+  configurations {
+    all {
+      resolutionStrategy {
+        force 'com.fasterxml.jackson.module:jackson-bom:2.13.4'
+      }
+    }
+  }
+}
+
 project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
   apply plugin: 'scala'
   apply plugin: 'com.github.alisiikh.scalastyle'


### PR DESCRIPTION
This PR update Spark to 3.3.1.

Spark 3.3.1 release notes:
https://spark.apache.org/releases/spark-release-3-3-1.html