### PR TITLE
AWS: update AWS Integration Test to fix false positives

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -75,7 +75,7 @@ public class TestAssumeRoleAwsClientFactory {
     assumeRoleProperties = Maps.newHashMap();
     assumeRoleProperties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
     assumeRoleProperties.put(AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_APACHE);
-    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, AwsIntegTestUtil.testRegion());
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, response.role().arn());
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX + "key1", "value1");
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX + "key2", "value2");

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -67,7 +67,7 @@ public class TestDefaultAwsClientFactory {
     AssertHelpers.assertThrows("Should fail request because of bad access key",
         S3Exception.class,
         "The AWS Access Key Id you provided does not exist in our records",
-        () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
+        () -> s3Client.getObject(GetObjectRequest.builder().bucket(AwsIntegTestUtil.testBucketName()).key("key").build()));
   }
 
   @Test


### PR DESCRIPTION
The AWS Integration Test gives false positive errors if users use buckets in regions other than `us-east-1`. This PR updates the tests to accommodate the different region setting and eliminate false positive errors