### PR TITLE
AWS: Add socket connection timeout for Apache Http Builder

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -371,7 +371,7 @@ public class AwsProperties implements Serializable {
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
    */
   public static final String APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS =
-      "client.apache-http.connection-timeout-ms";
+      "http-client.apache.connection-timeout-ms";
 
   /**
    * Used to configure the socket timeout in milliseconds for {@link
@@ -382,7 +382,7 @@ public class AwsProperties implements Serializable {
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
    */
   public static final String APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS =
-      "client.apache-http.socket-timeout-ms";
+      "http-client.apache.socket-timeout-ms";
 
   /**
    * Used by {@link S3FileIO} to tag objects when writing. To set, we can pass a catalog property.
@@ -1025,7 +1025,7 @@ public class AwsProperties implements Serializable {
   }
 
   @VisibleForTesting
-  protected <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
+  <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
     boolean setConnectionTimeout = apacheHttpClientConnectionTimeout != null;
     boolean setSocketTimeout = apacheHttpClientSocketTimeout != null;
     if (setConnectionTimeout && setSocketTimeout) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -374,15 +374,6 @@ public class AwsProperties implements Serializable {
       "client.apache-http.connection-timeout-ms";
 
   /**
-   * Default Apache Http Client connection timeout value indicates that we do not set the connection
-   * timeout value manually for {@link software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}.
-   *
-   * <p>For more details, see
-   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
-   */
-  public static final long APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT = -1;
-
-  /**
    * Used to configure the socket timeout in milliseconds for {@link
    * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
    * #HTTP_CLIENT_TYPE} is set to {@link #HTTP_CLIENT_TYPE_APACHE}
@@ -392,15 +383,6 @@ public class AwsProperties implements Serializable {
    */
   public static final String APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS =
       "client.apache-http.socket-timeout-ms";
-
-  /**
-   * Default Apache Http Client socket timeout value indicates that we do not set the socket timeout
-   * value manually for {@link software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}.
-   *
-   * <p>For more details, see
-   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
-   */
-  public static final long APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS_DEFAULT = -1;
 
   /**
    * Used by {@link S3FileIO} to tag objects when writing. To set, we can pass a catalog property.
@@ -492,8 +474,8 @@ public class AwsProperties implements Serializable {
   public static final String LAKE_FORMATION_DB_NAME = "lakeformation.db-name";
 
   private String httpClientType;
-  private long apacheHttpClientConnectionTimeout;
-  private long apacheHttpClientSocketTimeout;
+  private Long apacheHttpClientConnectionTimeout;
+  private Long apacheHttpClientSocketTimeout;
   private final Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags;
 
   private String clientAssumeRoleArn;
@@ -538,8 +520,8 @@ public class AwsProperties implements Serializable {
 
   public AwsProperties() {
     this.httpClientType = HTTP_CLIENT_TYPE_DEFAULT;
-    this.apacheHttpClientConnectionTimeout = APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT;
-    this.apacheHttpClientSocketTimeout = APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS_DEFAULT;
+    this.apacheHttpClientConnectionTimeout = null;
+    this.apacheHttpClientSocketTimeout = null;
     this.stsClientAssumeRoleTags = Sets.newHashSet();
 
     this.clientAssumeRoleArn = null;
@@ -592,15 +574,9 @@ public class AwsProperties implements Serializable {
     this.httpClientType =
         PropertyUtil.propertyAsString(properties, HTTP_CLIENT_TYPE, HTTP_CLIENT_TYPE_DEFAULT);
     this.apacheHttpClientConnectionTimeout =
-        PropertyUtil.propertyAsLong(
-            properties,
-            APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS,
-            APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT);
+        PropertyUtil.propertyAsLong(properties, APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS, null);
     this.apacheHttpClientSocketTimeout =
-        PropertyUtil.propertyAsLong(
-            properties,
-            APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS,
-            APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS_DEFAULT);
+        PropertyUtil.propertyAsLong(properties, APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS, null);
     this.stsClientAssumeRoleTags = toStsTags(properties, CLIENT_ASSUME_ROLE_TAGS_PREFIX);
 
     this.clientAssumeRoleArn = properties.get(CLIENT_ASSUME_ROLE_ARN);
@@ -1050,10 +1026,8 @@ public class AwsProperties implements Serializable {
 
   @VisibleForTesting
   protected <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
-    boolean setConnectionTimeout =
-        apacheHttpClientConnectionTimeout != APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS_DEFAULT;
-    boolean setSocketTimeout =
-        apacheHttpClientSocketTimeout != APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS_DEFAULT;
+    boolean setConnectionTimeout = apacheHttpClientConnectionTimeout != null;
+    boolean setSocketTimeout = apacheHttpClientSocketTimeout != null;
     if (setConnectionTimeout && setSocketTimeout) {
       builder
           .socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeout))

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -574,9 +574,9 @@ public class AwsProperties implements Serializable {
     this.httpClientType =
         PropertyUtil.propertyAsString(properties, HTTP_CLIENT_TYPE, HTTP_CLIENT_TYPE_DEFAULT);
     this.apacheHttpClientConnectionTimeout =
-        PropertyUtil.propertyAsLong(properties, APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS, null);
+        PropertyUtil.propertyAsNullableLong(properties, APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS);
     this.apacheHttpClientSocketTimeout =
-        PropertyUtil.propertyAsLong(properties, APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS, null);
+        PropertyUtil.propertyAsNullableLong(properties, APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS);
     this.stsClientAssumeRoleTags = toStsTags(properties, CLIENT_ASSUME_ROLE_TAGS_PREFIX);
 
     this.clientAssumeRoleArn = properties.get(CLIENT_ASSUME_ROLE_ARN);

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -474,8 +474,8 @@ public class AwsProperties implements Serializable {
   public static final String LAKE_FORMATION_DB_NAME = "lakeformation.db-name";
 
   private String httpClientType;
-  private Long apacheHttpClientConnectionTimeoutMs;
-  private Long apacheHttpClientSocketTimeoutMs;
+  private Long httpClientApacheConnectionTimeoutMs;
+  private Long httpClientApacheSocketTimeoutMs;
   private final Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags;
 
   private String clientAssumeRoleArn;
@@ -520,8 +520,8 @@ public class AwsProperties implements Serializable {
 
   public AwsProperties() {
     this.httpClientType = HTTP_CLIENT_TYPE_DEFAULT;
-    this.apacheHttpClientConnectionTimeoutMs = null;
-    this.apacheHttpClientSocketTimeoutMs = null;
+    this.httpClientApacheConnectionTimeoutMs = null;
+    this.httpClientApacheSocketTimeoutMs = null;
     this.stsClientAssumeRoleTags = Sets.newHashSet();
 
     this.clientAssumeRoleArn = null;
@@ -573,9 +573,9 @@ public class AwsProperties implements Serializable {
   public AwsProperties(Map<String, String> properties) {
     this.httpClientType =
         PropertyUtil.propertyAsString(properties, HTTP_CLIENT_TYPE, HTTP_CLIENT_TYPE_DEFAULT);
-    this.apacheHttpClientConnectionTimeoutMs =
+    this.httpClientApacheConnectionTimeoutMs =
         PropertyUtil.propertyAsNullableLong(properties, HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS);
-    this.apacheHttpClientSocketTimeoutMs =
+    this.httpClientApacheSocketTimeoutMs =
         PropertyUtil.propertyAsNullableLong(properties, HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS);
     this.stsClientAssumeRoleTags = toStsTags(properties, CLIENT_ASSUME_ROLE_TAGS_PREFIX);
 
@@ -1026,11 +1026,11 @@ public class AwsProperties implements Serializable {
 
   @VisibleForTesting
   <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
-    if (apacheHttpClientConnectionTimeoutMs != null) {
-      builder.connectionTimeout(Duration.ofMillis(apacheHttpClientConnectionTimeoutMs));
+    if (httpClientApacheConnectionTimeoutMs != null) {
+      builder.connectionTimeout(Duration.ofMillis(httpClientApacheConnectionTimeoutMs));
     }
-    if (apacheHttpClientSocketTimeoutMs != null) {
-      builder.socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeoutMs));
+    if (httpClientApacheSocketTimeoutMs != null) {
+      builder.socketTimeout(Duration.ofMillis(httpClientApacheSocketTimeoutMs));
     }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -370,7 +370,7 @@ public class AwsProperties implements Serializable {
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
    */
-  public static final String APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS =
+  public static final String HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS =
       "http-client.apache.connection-timeout-ms";
 
   /**
@@ -381,7 +381,7 @@ public class AwsProperties implements Serializable {
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
    */
-  public static final String APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS =
+  public static final String HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS =
       "http-client.apache.socket-timeout-ms";
 
   /**
@@ -474,8 +474,8 @@ public class AwsProperties implements Serializable {
   public static final String LAKE_FORMATION_DB_NAME = "lakeformation.db-name";
 
   private String httpClientType;
-  private Long apacheHttpClientConnectionTimeout;
-  private Long apacheHttpClientSocketTimeout;
+  private Long apacheHttpClientConnectionTimeoutMs;
+  private Long apacheHttpClientSocketTimeoutMs;
   private final Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags;
 
   private String clientAssumeRoleArn;
@@ -520,8 +520,8 @@ public class AwsProperties implements Serializable {
 
   public AwsProperties() {
     this.httpClientType = HTTP_CLIENT_TYPE_DEFAULT;
-    this.apacheHttpClientConnectionTimeout = null;
-    this.apacheHttpClientSocketTimeout = null;
+    this.apacheHttpClientConnectionTimeoutMs = null;
+    this.apacheHttpClientSocketTimeoutMs = null;
     this.stsClientAssumeRoleTags = Sets.newHashSet();
 
     this.clientAssumeRoleArn = null;
@@ -573,10 +573,10 @@ public class AwsProperties implements Serializable {
   public AwsProperties(Map<String, String> properties) {
     this.httpClientType =
         PropertyUtil.propertyAsString(properties, HTTP_CLIENT_TYPE, HTTP_CLIENT_TYPE_DEFAULT);
-    this.apacheHttpClientConnectionTimeout =
-        PropertyUtil.propertyAsNullableLong(properties, APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS);
-    this.apacheHttpClientSocketTimeout =
-        PropertyUtil.propertyAsNullableLong(properties, APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS);
+    this.apacheHttpClientConnectionTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(properties, HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS);
+    this.apacheHttpClientSocketTimeoutMs =
+        PropertyUtil.propertyAsNullableLong(properties, HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS);
     this.stsClientAssumeRoleTags = toStsTags(properties, CLIENT_ASSUME_ROLE_TAGS_PREFIX);
 
     this.clientAssumeRoleArn = properties.get(CLIENT_ASSUME_ROLE_ARN);
@@ -1026,11 +1026,11 @@ public class AwsProperties implements Serializable {
 
   @VisibleForTesting
   <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
-    if (apacheHttpClientConnectionTimeout != null) {
-      builder.connectionTimeout(Duration.ofMillis(apacheHttpClientConnectionTimeout));
+    if (apacheHttpClientConnectionTimeoutMs != null) {
+      builder.connectionTimeout(Duration.ofMillis(apacheHttpClientConnectionTimeoutMs));
     }
-    if (apacheHttpClientSocketTimeout != null) {
-      builder.socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeout));
+    if (apacheHttpClientSocketTimeoutMs != null) {
+      builder.socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeoutMs));
     }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -1026,15 +1026,10 @@ public class AwsProperties implements Serializable {
 
   @VisibleForTesting
   <T extends ApacheHttpClient.Builder> void configureApacheHttpClientBuilder(T builder) {
-    boolean setConnectionTimeout = apacheHttpClientConnectionTimeout != null;
-    boolean setSocketTimeout = apacheHttpClientSocketTimeout != null;
-    if (setConnectionTimeout && setSocketTimeout) {
-      builder
-          .socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeout))
-          .connectionTimeout(Duration.ofMillis(apacheHttpClientConnectionTimeout));
-    } else if (setConnectionTimeout) {
+    if (apacheHttpClientConnectionTimeout != null) {
       builder.connectionTimeout(Duration.ofMillis(apacheHttpClientConnectionTimeout));
-    } else if (setSocketTimeout) {
+    }
+    if (apacheHttpClientSocketTimeout != null) {
       builder.socketTimeout(Duration.ofMillis(apacheHttpClientSocketTimeout));
     }
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -231,8 +231,6 @@ public class TestAwsProperties {
   public void testApacheHttpClientConfiguration() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(AwsProperties.HTTP_CLIENT_TYPE, "apache");
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS, "100");
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS, "200");
     AwsProperties awsProperties = new AwsProperties(properties);
     S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
     ArgumentCaptor<SdkHttpClient.Builder> httpClientBuilderCaptor =

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -338,6 +338,7 @@ public class TestAwsProperties {
     ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
     ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
 
+    awsProperties.configureApacheHttpClientBuilder(spyApacheHttpClientBuilder);
     Mockito.verify(spyApacheHttpClientBuilder, Mockito.never())
         .connectionTimeout(connectionTimeoutCaptor.capture());
     Mockito.verify(spyApacheHttpClientBuilder, Mockito.never())

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -262,8 +262,8 @@ public class TestAwsProperties {
   @Test
   public void testApacheConnectionSocketTimeoutConfiguration() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS, "100");
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(AwsProperties.HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS, "100");
+    properties.put(AwsProperties.HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS, "200");
     AwsProperties awsProperties = new AwsProperties(properties);
     ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
     ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
@@ -288,7 +288,7 @@ public class TestAwsProperties {
   @Test
   public void testApacheConnectionTimeoutConfiguration() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_CONNECTION_TIMEOUT_MS, "200");
+    properties.put(AwsProperties.HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS, "200");
     AwsProperties awsProperties = new AwsProperties(properties);
     ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
     ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);
@@ -311,7 +311,7 @@ public class TestAwsProperties {
   @Test
   public void testApacheSocketTimeoutConfiguration() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(AwsProperties.APACHE_HTTP_CLIENT_SOCKET_TIMEOUT_MS, "100");
+    properties.put(AwsProperties.HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS, "100");
     AwsProperties awsProperties = new AwsProperties(properties);
     ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
     ApacheHttpClient.Builder spyApacheHttpClientBuilder = Mockito.spy(apacheHttpClientBuilder);

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -66,6 +66,14 @@ public class PropertyUtil {
     return defaultValue;
   }
 
+  public static Long propertyAsLong(Map<String, String> properties, String property, Long defaultValue) {
+    String value = properties.get(property);
+    if (value != null) {
+      return Long.parseLong(value);
+    }
+    return defaultValue;
+  }
+
   public static String propertyAsString(
       Map<String, String> properties, String property, String defaultValue) {
     String value = properties.get(property);

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -66,7 +66,8 @@ public class PropertyUtil {
     return defaultValue;
   }
 
-  public static Long propertyAsLong(Map<String, String> properties, String property, Long defaultValue) {
+  public static Long propertyAsLong(
+      Map<String, String> properties, String property, Long defaultValue) {
     String value = properties.get(property);
     if (value != null) {
       return Long.parseLong(value);

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -66,13 +66,12 @@ public class PropertyUtil {
     return defaultValue;
   }
 
-  public static Long propertyAsLong(
-      Map<String, String> properties, String property, Long defaultValue) {
+  public static Long propertyAsNullableLong(Map<String, String> properties, String property) {
     String value = properties.get(property);
     if (value != null) {
       return Long.parseLong(value);
     }
-    return defaultValue;
+    return null;
   }
 
   public static String propertyAsString(


### PR DESCRIPTION
User can use `apache.socket-timeout-ms` and `apache.connection-timeout-ms` tags to configure the connection and socket timeout for the `ApacheHttpClient`.

Add unit test to check the if the correct HTTP client type is configured