### PR TITLE
Spark: Fix MERGE INTO query with NOT MATCHED operator failure on tables with non-nullable columns

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -269,16 +269,25 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
 
     val matchedConditions = matchedActions.map(actionCondition)
     val matchedOutputs = matchedActions.map(deltaActionOutput(_, deleteRowValues, metadataReadAttrs))
+    val matchedActionsIgnoringDeletes = matchedActions.filter(filterDeleteAction)
+    val matchedOutputsIgnoringDeletes = matchedActionsIgnoringDeletes.
+      map(deltaActionOutput(_, deleteRowValues, metadataReadAttrs))
 
     val notMatchedConditions = notMatchedActions.map(actionCondition)
     val notMatchedOutputs = notMatchedActions.map(deltaActionOutput(_, deleteRowValues, metadataReadAttrs))
+    val notMatchedActionsIgnoringDeletes = notMatchedActions.filter(filterDeleteAction)
+    val notMatchedOutputsIgnoringDeletes = notMatchedActionsIgnoringDeletes.
+      map(deltaActionOutput(_, deleteRowValues, metadataReadAttrs))
 
     val operationTypeAttr = AttributeReference(OPERATION_COLUMN, IntegerType, nullable = false)()
     val rowFromSourceAttr = resolveAttrRef(ROW_FROM_SOURCE_REF, joinPlan)
     val rowFromTargetAttr = resolveAttrRef(ROW_FROM_TARGET_REF, joinPlan)
 
     // merged rows must contain values for the operation type and all read attrs
-    val mergeRowsOutput = buildMergeRowsOutput(matchedOutputs, notMatchedOutputs, operationTypeAttr +: readAttrs)
+    val mergeRowsOutput = buildMergeRowsOutput(
+      matchedOutputsIgnoringDeletes,
+      notMatchedOutputsIgnoringDeletes,
+      operationTypeAttr +: readAttrs)
 
     val mergeRows = MergeRows(
       isSourceRowPresent = IsNotNull(rowFromSourceAttr),
@@ -303,6 +312,13 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
 
   private def actionCondition(action: MergeAction): Expression = {
     action.condition.getOrElse(TrueLiteral)
+  }
+
+  private def filterDeleteAction(action: MergeAction) = {
+    action match {
+      case _: DeleteAction => false
+      case _ => true
+    }
   }
 
   private def actionOutput(
@@ -360,7 +376,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
     }.toMap
 
     attrs.zipWithIndex.map { case (attr, index) =>
-      attr.withNullability(nullabilityMap(index))
+      AttributeReference(attr.name, attr.dataType, nullabilityMap(index), attr.metadata)
     }
   }
 

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -376,7 +376,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
     }.toMap
 
     attrs.zipWithIndex.map { case (attr, index) =>
-      AttributeReference(attr.name, attr.dataType, nullabilityMap(index), attr.metadata)
+      AttributeReference(attr.name, attr.dataType, nullabilityMap(index), attr.metadata)()
     }
   }
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -2200,33 +2200,33 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
   @Test
   public void testMergeWithNonNullableColumnWithNotMatchedActions() {
     createAndInitTable(
-            "id INT NOT NULL, dep STRING",
-            "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+        "id INT NOT NULL, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
 
     createOrReplaceView(
-            "source",
-            "id INT NOT NULL, dep STRING",
-            "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
-                    + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
-                    + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+        "source",
+        "id INT NOT NULL, dep STRING",
+        "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
+            + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
+            + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
 
     sql(
-            "MERGE INTO %s AS t USING source AS s "
-                    + "ON t.id == s.id "
-                    + "WHEN MATCHED AND t.id = 1 THEN "
-                    + "  UPDATE SET * "
-                    + "WHEN MATCHED AND t.id = 6 THEN "
-                    + "  DELETE "
-                    + "WHEN NOT MATCHED AND s.id = 2 THEN "
-                    + "  INSERT *",
-            tableName);
+        "MERGE INTO %s AS t USING source AS s "
+            + "ON t.id == s.id "
+            + "WHEN MATCHED AND t.id = 1 THEN "
+            + "  UPDATE SET * "
+            + "WHEN MATCHED AND t.id = 6 THEN "
+            + "  DELETE "
+            + "WHEN NOT MATCHED AND s.id = 2 THEN "
+            + "  INSERT *",
+        tableName);
 
     ImmutableList<Object[]> expectedRows =
-            ImmutableList.of(
-                    row(1, "emp-id-1"), // updated
-                    row(2, "emp-id-2") // new
+        ImmutableList.of(
+            row(1, "emp-id-1"), // updated
+            row(2, "emp-id-2") // new
             );
     assertEquals(
-            "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
+        "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -2196,4 +2196,37 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     List<Object[]> result = sql("SELECT * FROM %s ORDER BY id", tableName);
     assertEquals("Should correctly add the non-matching rows", expectedRows, result);
   }
+
+  @Test
+  public void testMergeWithNonNullableColumnWithNotMatchedActions() {
+    createAndInitTable(
+            "id INT NOT NULL, dep STRING",
+            "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    createOrReplaceView(
+            "source",
+            "id INT NOT NULL, dep STRING",
+            "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
+                    + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
+                    + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    sql(
+            "MERGE INTO %s AS t USING source AS s "
+                    + "ON t.id == s.id "
+                    + "WHEN MATCHED AND t.id = 1 THEN "
+                    + "  UPDATE SET * "
+                    + "WHEN MATCHED AND t.id = 6 THEN "
+                    + "  DELETE "
+                    + "WHEN NOT MATCHED AND s.id = 2 THEN "
+                    + "  INSERT *",
+            tableName);
+
+    ImmutableList<Object[]> expectedRows =
+            ImmutableList.of(
+                    row(1, "emp-id-1"), // updated
+                    row(2, "emp-id-2") // new
+            );
+    assertEquals(
+            "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -2200,33 +2200,33 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
   @Test
   public void testMergeWithNonNullableColumnWithNotMatchedActions() {
     createAndInitTable(
-            "id INT NOT NULL, dep STRING",
-            "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+        "id INT NOT NULL, dep STRING",
+        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
 
     createOrReplaceView(
-            "source",
-            "id INT NOT NULL, dep STRING",
-            "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
-                    + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
-                    + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+        "source",
+        "id INT NOT NULL, dep STRING",
+        "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
+            + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
+            + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
 
     sql(
-            "MERGE INTO %s AS t USING source AS s "
-                    + "ON t.id == s.id "
-                    + "WHEN MATCHED AND t.id = 1 THEN "
-                    + "  UPDATE SET * "
-                    + "WHEN MATCHED AND t.id = 6 THEN "
-                    + "  DELETE "
-                    + "WHEN NOT MATCHED AND s.id = 2 THEN "
-                    + "  INSERT *",
-            tableName);
+        "MERGE INTO %s AS t USING source AS s "
+            + "ON t.id == s.id "
+            + "WHEN MATCHED AND t.id = 1 THEN "
+            + "  UPDATE SET * "
+            + "WHEN MATCHED AND t.id = 6 THEN "
+            + "  DELETE "
+            + "WHEN NOT MATCHED AND s.id = 2 THEN "
+            + "  INSERT *",
+        tableName);
 
     ImmutableList<Object[]> expectedRows =
-            ImmutableList.of(
-                    row(1, "emp-id-1"), // updated
-                    row(2, "emp-id-2") // new
+        ImmutableList.of(
+            row(1, "emp-id-1"), // updated
+            row(2, "emp-id-2") // new
             );
     assertEquals(
-            "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
+        "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -2196,4 +2196,37 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     List<Object[]> result = sql("SELECT * FROM %s ORDER BY id", tableName);
     assertEquals("Should correctly add the non-matching rows", expectedRows, result);
   }
+
+  @Test
+  public void testMergeWithNonNullableColumnWithNotMatchedActions() {
+    createAndInitTable(
+            "id INT NOT NULL, dep STRING",
+            "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    createOrReplaceView(
+            "source",
+            "id INT NOT NULL, dep STRING",
+            "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
+                    + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
+                    + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
+
+    sql(
+            "MERGE INTO %s AS t USING source AS s "
+                    + "ON t.id == s.id "
+                    + "WHEN MATCHED AND t.id = 1 THEN "
+                    + "  UPDATE SET * "
+                    + "WHEN MATCHED AND t.id = 6 THEN "
+                    + "  DELETE "
+                    + "WHEN NOT MATCHED AND s.id = 2 THEN "
+                    + "  INSERT *",
+            tableName);
+
+    ImmutableList<Object[]> expectedRows =
+            ImmutableList.of(
+                    row(1, "emp-id-1"), // updated
+                    row(2, "emp-id-2") // new
+            );
+    assertEquals(
+            "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
 }


### PR DESCRIPTION
**About the change :**
Presently the MERGE INTO query with WHEN NOT MATCHED operation on table with non-nullable columns fails. https://github.com/apache/iceberg/issues/5739

The actual error is caused while resolving updateAttributeNullability spark rule, which recursively resolves null-ability of output columns of an operator based on null-ability of input columns(children operators output).

- We decide on Join type (FULL-OUTER/LEFT-OUTER/INNER) in MERGE INTO query based on the presence of NOT MATCHED operator in the query.
- The type of JOIN will affect the null-ability of output columns of the JOIN operator, if the JOIN operator output column null-ability doesn't match with target table null-able constraints, we will get UNRESOLVED error.
- Addition of NEW Expression Id for MergeRows output will decouple the null-ability of MergeRows operator output columns from null-ability of JOIN operator output columns.

The PR https://github.com/apache/iceberg/pull/5679 addressed the fix for CoW write-mode, With MoR write-mode the fix works unless there is DELETE statement in the MERGE INTO query.

Current PR is built on top of PR https://github.com/apache/iceberg/pull/5679 to address the MoR write-mode with DELETE statement.

- In MoR mode the delete action output is causing all the table fields in MergeRows operator output columns to be nullable.
- In this PR we are filtering Delete Actions from both matched actions and not matched actions to compute the MergeRows operator output column null-ability.
