### PR TITLE
AWS: Fix issue that GlueTableOperations fails to initialize FileIO when GlueCatalog is not initialized with catalogProperties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -228,13 +228,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     }
 
     return new GlueTableOperations(
-        glue,
-        lockManager,
-        catalogName,
-        awsProperties,
-        properties(),
-        hadoopConf,
-        tableIdentifier);
+        glue, lockManager, catalogName, awsProperties, properties(), hadoopConf, tableIdentifier);
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -232,7 +232,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
         lockManager,
         catalogName,
         awsProperties,
-        catalogProperties,
+        properties(),
         hadoopConf,
         tableIdentifier);
   }


### PR DESCRIPTION
When the user initialize `GlueCatalog` without providing a `catalogProperties`, the corresponding `GlueTableOperations` will face a `NullPointerException` when initializing FileIO using `initializeFileIO`. This bug causes several tests in the AWS Integration test fail.

##  before this fix:

![Screenshot from 2022-09-17 18-40-19](https://user-images.githubusercontent.com/55990951/191060642-82a2de23-fd7a-4b33-a2f4-d2a05395d35b.png)

## after this fix:
![Screen Shot 2022-09-19 at 11 25 31](https://user-images.githubusercontent.com/55990951/191060798-c743c26b-284f-40c4-ab78-ea349a087bb9.png)

The remaining test errors are either due to the test itself or outdated environment settings. Since they are not related to `GlueCatalog`, they will be addressed in another PR: #5784 
