### PR TITLE
Core: Serialize statistics files in TableMetadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -154,6 +154,7 @@ public class TableMetadataParser {
     }
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static void toJson(TableMetadata metadata, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
 
@@ -222,6 +223,12 @@ public class TableMetadataParser {
     generator.writeArrayFieldStart(SNAPSHOTS);
     for (Snapshot snapshot : metadata.snapshots()) {
       SnapshotParser.toJson(snapshot, generator);
+    }
+    generator.writeEndArray();
+
+    generator.writeArrayFieldStart(STATISTICS);
+    for (StatisticsFile statisticsFile : metadata.statisticsFiles()) {
+      StatisticsFileParser.toJson(statisticsFile, generator);
     }
     generator.writeEndArray();
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -133,6 +133,17 @@ public class TestTableMetadata {
             "previous", SnapshotRef.tagBuilder(previousSnapshotId).build(),
             "test", SnapshotRef.branchBuilder(previousSnapshotId).build());
 
+    List<StatisticsFile> statisticsFiles =
+        ImmutableList.of(
+            new GenericStatisticsFile(
+                11L,
+                "/some/stats/file.puffin",
+                100,
+                42,
+                ImmutableList.of(
+                    new GenericBlobMetadata(
+                        "some-stats", 11L, 2, ImmutableList.of(4), ImmutableMap.of()))));
+
     TableMetadata expected =
         new TableMetadata(
             null,
@@ -155,7 +166,7 @@ public class TestTableMetadata {
             snapshotLog,
             ImmutableList.of(),
             refs,
-            ImmutableList.of(),
+            statisticsFiles,
             ImmutableList.of());
 
     String asJson = TableMetadataParser.toJson(expected);
@@ -220,6 +231,8 @@ public class TestTableMetadata {
     Assert.assertNull(
         "Previous snapshot's schema ID should be null",
         metadata.snapshot(previousSnapshotId).schemaId());
+    Assert.assertEquals(
+        "Statistics files should match", statisticsFiles, metadata.statisticsFiles());
     Assert.assertEquals("Refs map should match", refs, metadata.refs());
   }
 


### PR DESCRIPTION
`TableMetadataParser.toJson` now serializes table statistics. This
completes the read path from JSON.

Extracted from https://github.com/apache/iceberg/pull/4741 / https://github.com/apache/iceberg/pull/5794