### PR TITLE
Core: Reduce duplicated code in JSON Parsers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Locale;
 import java.util.Map;
@@ -134,19 +133,7 @@ public class MetadataUpdateParser {
   }
 
   public static String toJson(MetadataUpdate metadataUpdate, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(metadataUpdate, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException(
-          String.format("Failed to write metadata update json for: %s", metadataUpdate), e);
-    }
+    return JsonUtil.generate(gen -> toJson(metadataUpdate, gen), pretty);
   }
 
   public static void toJson(MetadataUpdate metadataUpdate, JsonGenerator generator)

--- a/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionSpecParser.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Iterator;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -66,19 +65,7 @@ public class PartitionSpecParser {
   }
 
   public static String toJson(UnboundPartitionSpec spec, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(spec, generator);
-      generator.flush();
-      return writer.toString();
-
-    } catch (IOException e) {
-      throw new RuntimeIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(spec, gen), pretty);
   }
 
   public static PartitionSpec fromJson(Schema schema, JsonNode json) {
@@ -126,16 +113,7 @@ public class PartitionSpecParser {
   }
 
   static String toJsonFields(PartitionSpec spec) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      toJsonFields(spec, generator);
-      generator.flush();
-      return writer.toString();
-
-    } catch (IOException e) {
-      throw new RuntimeIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJsonFields(spec, gen), false);
   }
 
   static PartitionSpec fromJsonFields(Schema schema, int specId, JsonNode json) {

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -165,19 +164,9 @@ public class SchemaParser {
   }
 
   public static String toJson(Schema schema, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(schema.asStruct(), schema.schemaId(), schema.identifierFieldIds(), generator);
-      generator.flush();
-      return writer.toString();
-
-    } catch (IOException e) {
-      throw new RuntimeIOException(e);
-    }
+    return JsonUtil.generate(
+        gen -> toJson(schema.asStruct(), schema.schemaId(), schema.identifierFieldIds(), gen),
+        pretty);
   }
 
   private static Type typeFromJson(JsonNode json) {

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
@@ -240,18 +239,7 @@ public class SingleValueParser {
   }
 
   public static String toJson(Type type, Object defaultValue, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(type, defaultValue, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(type, defaultValue, gen), pretty);
   }
 
   @SuppressWarnings("checkstyle:MethodLength")

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -100,18 +99,7 @@ public class SnapshotParser {
   }
 
   public static String toJson(Snapshot snapshot, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(snapshot, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to write json for: %s", snapshot);
-    }
+    return JsonUtil.generate(gen -> toJson(snapshot, gen), pretty);
   }
 
   static Snapshot fromJson(FileIO io, JsonNode node) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -42,19 +41,7 @@ public class SnapshotRefParser {
   }
 
   public static String toJson(SnapshotRef ref, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-
-      toJson(ref, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(ref, gen), pretty);
   }
 
   public static void toJson(SnapshotRef ref, JsonGenerator generator) throws IOException {

--- a/core/src/main/java/org/apache/iceberg/StatisticsFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/StatisticsFileParser.java
@@ -21,8 +21,6 @@ package org.apache.iceberg;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -49,19 +47,7 @@ public class StatisticsFileParser {
   }
 
   public static String toJson(StatisticsFile statisticsFile, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-
-      toJson(statisticsFile, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    return JsonUtil.generate(gen -> toJson(statisticsFile, gen), pretty);
   }
 
   public static void toJson(StatisticsFile statisticsFile, JsonGenerator generator)

--- a/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.catalog;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -54,18 +53,7 @@ public class TableIdentifierParser {
   }
 
   public static String toJson(TableIdentifier identifier, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(identifier, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException(String.format("Failed to write json for: %s", identifier), e);
-    }
+    return JsonUtil.generate(gen -> toJson(identifier, gen), pretty);
   }
 
   public static void toJson(TableIdentifier identifier, JsonGenerator generator)

--- a/core/src/main/java/org/apache/iceberg/mapping/NameMappingParser.java
+++ b/core/src/main/java/org/apache/iceberg/mapping/NameMappingParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.mapping;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -51,16 +50,7 @@ public class NameMappingParser {
   private static final String FIELDS = "fields";
 
   public static String toJson(NameMapping mapping) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      generator.useDefaultPrettyPrinter();
-      toJson(mapping, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to write json for: %s", mapping);
-    }
+    return JsonUtil.generate(gen -> toJson(mapping, gen), true);
   }
 
   static void toJson(NameMapping nameMapping, JsonGenerator generator) throws IOException {

--- a/core/src/main/java/org/apache/iceberg/puffin/FileMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/FileMetadataParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.puffin;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
@@ -46,18 +45,7 @@ public final class FileMetadataParser {
   private static final String COMPRESSION_CODEC = "compression-codec";
 
   public static String toJson(FileMetadata fileMetadata, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(fileMetadata, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to write json for: " + fileMetadata, e);
-    }
+    return JsonUtil.generate(gen -> toJson(fileMetadata, gen), pretty);
   }
 
   public static FileMetadata fromJson(String json) {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -25,7 +25,6 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -252,15 +251,7 @@ public class OAuth2Util {
   }
 
   public static String tokenResponseToJson(OAuthTokenResponse response) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      tokenResponseToJson(response, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new RuntimeIOException(e);
-    }
+    return JsonUtil.generate(gen -> tokenResponseToJson(response, gen), false);
   }
 
   public static void tokenResponseToJson(OAuthTokenResponse response, JsonGenerator gen)

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.rest.requests;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.UncheckedIOException;
 import java.util.Locale;
 import java.util.Map;
@@ -87,19 +86,7 @@ public class UpdateRequirementParser {
   }
 
   public static String toJson(UpdateRequirement updateRequirement, boolean pretty) {
-    try {
-      StringWriter writer = new StringWriter();
-      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
-      if (pretty) {
-        generator.useDefaultPrettyPrinter();
-      }
-      toJson(updateRequirement, generator);
-      generator.flush();
-      return writer.toString();
-    } catch (IOException e) {
-      throw new UncheckedIOException(
-          String.format("Failed to write update requirement json for: %s", updateRequirement), e);
-    }
+    return JsonUtil.generate(gen -> toJson(updateRequirement, gen), pretty);
   }
 
   public static void toJson(UpdateRequirement updateRequirement, JsonGenerator generator)


### PR DESCRIPTION
While reviewing https://github.com/apache/iceberg/pull/5799 and the `StatisticsFileParser` I noticed that there are a bunch of places with duplicated code in the JSON Parsers. This PR aims at cleaning those up and reusing `JsonUtil.generate` where applicable