### PR TITLE
Python: Remove duplicate dispatch types

### DIFF
--- a/python/pyiceberg/expressions/base.py
+++ b/python/pyiceberg/expressions/base.py
@@ -599,26 +599,26 @@ def visit(obj, visitor: BooleanExpressionVisitor[T]) -> T:
     raise NotImplementedError(f"Cannot visit unsupported expression: {obj}")
 
 
-@visit.register(AlwaysTrue)
-def _(obj: AlwaysTrue, visitor: BooleanExpressionVisitor[T]) -> T:
+@visit.register
+def _(_: AlwaysTrue, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an AlwaysTrue boolean expression with a concrete BooleanExpressionVisitor"""
     return visitor.visit_true()
 
 
-@visit.register(AlwaysFalse)
-def _(obj: AlwaysFalse, visitor: BooleanExpressionVisitor[T]) -> T:
+@visit.register
+def _(_: AlwaysFalse, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an AlwaysFalse boolean expression with a concrete BooleanExpressionVisitor"""
     return visitor.visit_false()
 
 
-@visit.register(Not)
+@visit.register
 def _(obj: Not, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit a Not boolean expression with a concrete BooleanExpressionVisitor"""
     child_result: T = visit(obj.child, visitor=visitor)
     return visitor.visit_not(child_result=child_result)
 
 
-@visit.register(And)
+@visit.register
 def _(obj: And, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an And boolean expression with a concrete BooleanExpressionVisitor"""
     left_result: T = visit(obj.left, visitor=visitor)
@@ -626,13 +626,13 @@ def _(obj: And, visitor: BooleanExpressionVisitor[T]) -> T:
     return visitor.visit_and(left_result=left_result, right_result=right_result)
 
 
-@visit.register(UnboundPredicate)
+@visit.register
 def _(obj: UnboundPredicate, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an In boolean expression with a concrete BooleanExpressionVisitor"""
     return visitor.visit_unbound_predicate(predicate=obj)
 
 
-@visit.register(Or)
+@visit.register
 def _(obj: Or, visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an Or boolean expression with a concrete BooleanExpressionVisitor"""
     left_result: T = visit(obj.left, visitor=visitor)


### PR DESCRIPTION
Prefer to just use the first argument of the method. This makes it easier to read (less visual noise)