### PR TITLE
Build: Fix & Run spark integration tests on CI

### DIFF
--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -269,6 +269,7 @@ project(':iceberg-spark:iceberg-spark-runtime-3.0_2.12') {
     inputs.file(shadowJar.archiveFile.get().asFile.path)
   }
   integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -269,6 +269,7 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
     inputs.file(shadowJar.archiveFile.get().asFile.path)
   }
   integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -219,6 +219,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
+    integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}"
     integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}"
     integrationImplementation 'org.junit.vintage:junit-vintage-engine'
     integrationImplementation 'org.slf4j:slf4j-simple'
@@ -274,6 +275,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     inputs.file(shadowJar.archiveFile.get().asFile.path)
   }
   integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -208,6 +208,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
 
+    integrationImplementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}"
     integrationImplementation "org.apache.spark:spark-hive_${scalaVersion}:${sparkVersion}"
     integrationImplementation 'org.junit.vintage:junit-vintage-engine'
     integrationImplementation 'org.slf4j:slf4j-simple'
@@ -263,6 +264,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     inputs.file(shadowJar.archiveFile.get().asFile.path)
   }
   integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false


### PR DESCRIPTION
While looking at https://github.com/apache/iceberg/issues/5791 I noticed that the Spark integration tests (`integrationTest` task) was never part of CI. On CI we're running the `check` task (which basically runs `test`) and this PR makes sure that `integrationTest` is part of the `check` task.

fixes #5791 