### PR TITLE
Build: Apply spotless on integration modules as well 

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/AwsIntegTestUtil.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws;
 
 import java.util.List;
@@ -42,11 +41,11 @@ public class AwsIntegTestUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(AwsIntegTestUtil.class);
 
-  private AwsIntegTestUtil() {
-  }
+  private AwsIntegTestUtil() {}
 
   /**
    * Get the environment variable AWS_REGION to use for testing
+   *
    * @return region
    */
   public static String testRegion() {
@@ -55,17 +54,20 @@ public class AwsIntegTestUtil {
 
   /**
    * Get the environment variable AWS_CROSS_REGION to use for testing
+   *
    * @return region
    */
   public static String testCrossRegion() {
     String crossRegion = System.getenv("AWS_CROSS_REGION");
-    Preconditions.checkArgument(!testRegion().equals(crossRegion), "AWS_REGION should not be equal to " +
-        "AWS_CROSS_REGION");
+    Preconditions.checkArgument(
+        !testRegion().equals(crossRegion),
+        "AWS_REGION should not be equal to " + "AWS_CROSS_REGION");
     return crossRegion;
   }
 
   /**
    * Set the environment variable AWS_TEST_BUCKET for a default bucket to use for testing
+   *
    * @return bucket name
    */
   public static String testBucketName() {
@@ -73,7 +75,9 @@ public class AwsIntegTestUtil {
   }
 
   /**
-   * Set the environment variable AWS_TEST_CROSS_REGION_BUCKET for a default bucket to use for testing
+   * Set the environment variable AWS_TEST_CROSS_REGION_BUCKET for a default bucket to use for
+   * testing
+   *
    * @return bucket name
    */
   public static String testCrossRegionBucketName() {
@@ -82,6 +86,7 @@ public class AwsIntegTestUtil {
 
   /**
    * Set the environment variable AWS_TEST_ACCOUNT_ID for a default account to use for testing
+   *
    * @return account id
    */
   public static String testAccountId() {
@@ -91,15 +96,22 @@ public class AwsIntegTestUtil {
   public static void cleanS3Bucket(S3Client s3, String bucketName, String prefix) {
     boolean hasContent = true;
     while (hasContent) {
-      ListObjectsV2Response response = s3.listObjectsV2(ListObjectsV2Request.builder()
-          .bucket(bucketName).prefix(prefix).build());
+      ListObjectsV2Response response =
+          s3.listObjectsV2(
+              ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build());
       hasContent = response.hasContents();
       if (hasContent) {
-        s3.deleteObjects(DeleteObjectsRequest.builder().bucket(bucketName).delete(Delete.builder().objects(
-            response.contents().stream()
-                .map(obj -> ObjectIdentifier.builder().key(obj.key()).build())
-                .collect(Collectors.toList())
-        ).build()).build());
+        s3.deleteObjects(
+            DeleteObjectsRequest.builder()
+                .bucket(bucketName)
+                .delete(
+                    Delete.builder()
+                        .objects(
+                            response.contents().stream()
+                                .map(obj -> ObjectIdentifier.builder().key(obj.key()).build())
+                                .collect(Collectors.toList()))
+                        .build())
+                .build());
       }
     }
   }
@@ -122,15 +134,15 @@ public class AwsIntegTestUtil {
         .build();
   }
 
-  public static void createAccessPoint(S3ControlClient s3ControlClient, String accessPointName, String bucketName) {
+  public static void createAccessPoint(
+      S3ControlClient s3ControlClient, String accessPointName, String bucketName) {
     try {
-      s3ControlClient.createAccessPoint(CreateAccessPointRequest
-          .builder()
-          .name(accessPointName)
-          .bucket(bucketName)
-          .accountId(testAccountId())
-          .build()
-      );
+      s3ControlClient.createAccessPoint(
+          CreateAccessPointRequest.builder()
+              .name(accessPointName)
+              .bucket(bucketName)
+              .accountId(testAccountId())
+              .build());
     } catch (Exception e) {
       LOG.error("Cannot create access point {}", accessPointName, e);
     }
@@ -138,12 +150,11 @@ public class AwsIntegTestUtil {
 
   public static void deleteAccessPoint(S3ControlClient s3ControlClient, String accessPointName) {
     try {
-      s3ControlClient.deleteAccessPoint(DeleteAccessPointRequest
-          .builder()
-          .name(accessPointName)
-          .accountId(testAccountId())
-          .build()
-      );
+      s3ControlClient.deleteAccessPoint(
+          DeleteAccessPointRequest.builder()
+              .name(accessPointName)
+              .accountId(testAccountId())
+              .build());
     } catch (Exception e) {
       LOG.error("Cannot delete access point {}", accessPointName, e);
     }

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws;
 
 import java.util.Map;
@@ -56,24 +55,31 @@ public class TestAssumeRoleAwsClientFactory {
   @Before
   public void before() {
     roleName = UUID.randomUUID().toString();
-    iam = IamClient.builder()
-        .region(Region.AWS_GLOBAL)
-        .httpClientBuilder(UrlConnectionHttpClient.builder())
-        .build();
-    CreateRoleResponse response = iam.createRole(CreateRoleRequest.builder()
-        .roleName(roleName)
-        .assumeRolePolicyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Effect\":\"Allow\"," +
-            "\"Principal\":{" +
-            "\"AWS\":\"arn:aws:iam::" + AwsIntegTestUtil.testAccountId() + ":root\"}," +
-            "\"Action\": [\"sts:AssumeRole\"," +
-            "\"sts:TagSession\"]}]}")
-        .maxSessionDuration(3600)
-        .build());
+    iam =
+        IamClient.builder()
+            .region(Region.AWS_GLOBAL)
+            .httpClientBuilder(UrlConnectionHttpClient.builder())
+            .build();
+    CreateRoleResponse response =
+        iam.createRole(
+            CreateRoleRequest.builder()
+                .roleName(roleName)
+                .assumeRolePolicyDocument(
+                    "{"
+                        + "\"Version\":\"2012-10-17\","
+                        + "\"Statement\":[{"
+                        + "\"Effect\":\"Allow\","
+                        + "\"Principal\":{"
+                        + "\"AWS\":\"arn:aws:iam::"
+                        + AwsIntegTestUtil.testAccountId()
+                        + ":root\"},"
+                        + "\"Action\": [\"sts:AssumeRole\","
+                        + "\"sts:TagSession\"]}]}")
+                .maxSessionDuration(3600)
+                .build());
     assumeRoleProperties = Maps.newHashMap();
-    assumeRoleProperties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    assumeRoleProperties.put(
+        AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
     assumeRoleProperties.put(AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_APACHE);
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, response.role().arn());
@@ -84,34 +90,46 @@ public class TestAssumeRoleAwsClientFactory {
 
   @After
   public void after() {
-    iam.deleteRolePolicy(DeleteRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
+    iam.deleteRolePolicy(
+        DeleteRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
     iam.deleteRole(DeleteRoleRequest.builder().roleName(roleName).build());
   }
 
   @Test
   public void testAssumeRoleGlueCatalog() throws Exception {
     String glueArnPrefix = "arn:aws:glue:*:" + AwsIntegTestUtil.testAccountId();
-    iam.putRolePolicy(PutRolePolicyRequest.builder()
-        .roleName(roleName)
-        .policyName(policyName)
-        .policyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Sid\":\"policy1\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":[\"glue:CreateDatabase\",\"glue:DeleteDatabase\",\"glue:GetDatabase\",\"glue:GetTables\"]," +
-            "\"Resource\":[\"" + glueArnPrefix + ":catalog\"," +
-            "\"" + glueArnPrefix + ":database/allowed_*\"," +
-            "\"" + glueArnPrefix + ":table/allowed_*/*\"," +
-            "\"" + glueArnPrefix + ":userDefinedFunction/allowed_*/*\"]}]}")
-        .build());
+    iam.putRolePolicy(
+        PutRolePolicyRequest.builder()
+            .roleName(roleName)
+            .policyName(policyName)
+            .policyDocument(
+                "{"
+                    + "\"Version\":\"2012-10-17\","
+                    + "\"Statement\":[{"
+                    + "\"Sid\":\"policy1\","
+                    + "\"Effect\":\"Allow\","
+                    + "\"Action\":[\"glue:CreateDatabase\",\"glue:DeleteDatabase\",\"glue:GetDatabase\",\"glue:GetTables\"],"
+                    + "\"Resource\":[\""
+                    + glueArnPrefix
+                    + ":catalog\","
+                    + "\""
+                    + glueArnPrefix
+                    + ":database/allowed_*\","
+                    + "\""
+                    + glueArnPrefix
+                    + ":table/allowed_*/*\","
+                    + "\""
+                    + glueArnPrefix
+                    + ":userDefinedFunction/allowed_*/*\"]}]}")
+            .build());
     waitForIamConsistency();
 
     GlueCatalog glueCatalog = new GlueCatalog();
     assumeRoleProperties.put("warehouse", "s3://path");
     glueCatalog.initialize("test", assumeRoleProperties);
     try {
-      glueCatalog.createNamespace(Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", "")));
+      glueCatalog.createNamespace(
+          Namespace.of("denied_" + UUID.randomUUID().toString().replace("-", "")));
       Assert.fail("Access to Glue should be denied");
     } catch (GlueException e) {
       Assert.assertEquals(AccessDeniedException.class, e.getClass());
@@ -131,27 +149,34 @@ public class TestAssumeRoleAwsClientFactory {
   @Test
   public void testAssumeRoleS3FileIO() throws Exception {
     String bucketArn = "arn:aws:s3:::" + AwsIntegTestUtil.testBucketName();
-    iam.putRolePolicy(PutRolePolicyRequest.builder()
-        .roleName(roleName)
-        .policyName(policyName)
-        .policyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Sid\":\"policy1\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":\"s3:ListBucket\"," +
-            "\"Resource\":[\"" + bucketArn + "\"]," +
-            "\"Condition\":{\"StringLike\":{\"s3:prefix\":[\"allowed/*\"]}}} ,{" +
-            "\"Sid\":\"policy2\"," +
-            "\"Effect\":\"Allow\"," +
-            "\"Action\":\"s3:GetObject\"," +
-            "\"Resource\":[\"" + bucketArn + "/allowed/*\"]}]}")
-        .build());
+    iam.putRolePolicy(
+        PutRolePolicyRequest.builder()
+            .roleName(roleName)
+            .policyName(policyName)
+            .policyDocument(
+                "{"
+                    + "\"Version\":\"2012-10-17\","
+                    + "\"Statement\":[{"
+                    + "\"Sid\":\"policy1\","
+                    + "\"Effect\":\"Allow\","
+                    + "\"Action\":\"s3:ListBucket\","
+                    + "\"Resource\":[\""
+                    + bucketArn
+                    + "\"],"
+                    + "\"Condition\":{\"StringLike\":{\"s3:prefix\":[\"allowed/*\"]}}} ,{"
+                    + "\"Sid\":\"policy2\","
+                    + "\"Effect\":\"Allow\","
+                    + "\"Action\":\"s3:GetObject\","
+                    + "\"Resource\":[\""
+                    + bucketArn
+                    + "/allowed/*\"]}]}")
+            .build());
     waitForIamConsistency();
 
     S3FileIO s3FileIO = new S3FileIO();
     s3FileIO.initialize(assumeRoleProperties);
-    InputFile inputFile = s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file");
+    InputFile inputFile =
+        s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/denied/file");
     try {
       inputFile.exists();
       Assert.fail("Access to s3 should be denied");
@@ -159,7 +184,8 @@ public class TestAssumeRoleAwsClientFactory {
       Assert.assertEquals("Should see 403 error code", 403, e.statusCode());
     }
 
-    inputFile = s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/allowed/file");
+    inputFile =
+        s3FileIO.newInputFile("s3://" + AwsIntegTestUtil.testBucketName() + "/allowed/file");
     Assert.assertFalse("should be able to access file", inputFile.exists());
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws;
 
 import java.util.Map;
@@ -39,7 +38,8 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.GLUE_CATALOG_ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     GlueClient glueClient = factory.glue();
-    AssertHelpers.assertThrowsCause("Should refuse connection to unknown endpoint",
+    AssertHelpers.assertThrowsCause(
+        "Should refuse connection to unknown endpoint",
         SdkClientException.class,
         "Unable to execute HTTP request: unknown",
         () -> glueClient.getDatabase(GetDatabaseRequest.builder().name("TEST").build()));
@@ -51,7 +51,8 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.S3FILEIO_ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     S3Client s3Client = factory.s3();
-    AssertHelpers.assertThrowsCause("Should refuse connection to unknown endpoint",
+    AssertHelpers.assertThrowsCause(
+        "Should refuse connection to unknown endpoint",
         SdkClientException.class,
         "Unable to execute HTTP request: unknown",
         () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
@@ -64,7 +65,8 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY, "unknown");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     S3Client s3Client = factory.s3();
-    AssertHelpers.assertThrows("Should fail request because of bad access key",
+    AssertHelpers.assertThrows(
+        "Should fail request because of bad access key",
         S3Exception.class,
         "The AWS Access Key Id you provided does not exist in our records",
         () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
@@ -76,7 +78,8 @@ public class TestDefaultAwsClientFactory {
     properties.put(AwsProperties.DYNAMODB_ENDPOINT, "https://unknown:1234");
     AwsClientFactory factory = AwsClientFactories.from(properties);
     DynamoDbClient dynamoDbClient = factory.dynamo();
-    AssertHelpers.assertThrowsCause("Should refuse connection to unknown endpoint",
+    AssertHelpers.assertThrowsCause(
+        "Should refuse connection to unknown endpoint",
         SdkClientException.class,
         "Unable to execute HTTP request: unknown",
         dynamoDbClient::listTables);

--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/TestDynamoDbCatalog.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.dynamodb;
 
 import java.util.List;
@@ -60,7 +59,8 @@ import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 public class TestDynamoDbCatalog {
 
   private static final ForkJoinPool POOL = new ForkJoinPool(16);
-  private static final Schema SCHEMA = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
 
   private static String catalogTableName;
   private static DynamoDbClient dynamo;
@@ -76,9 +76,13 @@ public class TestDynamoDbCatalog {
     s3 = clientFactory.s3();
     catalog = new DynamoDbCatalog();
     testBucket = AwsIntegTestUtil.testBucketName();
-    catalog.initialize("test", ImmutableMap.of(
-        AwsProperties.DYNAMODB_TABLE_NAME, catalogTableName,
-        CatalogProperties.WAREHOUSE_LOCATION, "s3://" + testBucket + "/" + genRandomName()));
+    catalog.initialize(
+        "test",
+        ImmutableMap.of(
+            AwsProperties.DYNAMODB_TABLE_NAME,
+            catalogTableName,
+            CatalogProperties.WAREHOUSE_LOCATION,
+            "s3://" + testBucket + "/" + genRandomName()));
   }
 
   @AfterClass
@@ -90,15 +94,20 @@ public class TestDynamoDbCatalog {
   public void testCreateNamespace() {
     Namespace namespace = Namespace.of(genRandomName());
     catalog.createNamespace(namespace);
-    GetItemResponse response = dynamo.getItem(GetItemRequest.builder()
-        .tableName(catalogTableName)
-        .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
-        .build());
+    GetItemResponse response =
+        dynamo.getItem(
+            GetItemRequest.builder()
+                .tableName(catalogTableName)
+                .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
+                .build());
     Assert.assertTrue("namespace must exist", response.hasItem());
-    Assert.assertEquals("namespace must be stored in DynamoDB",
-        namespace.toString(), response.item().get("namespace").s());
+    Assert.assertEquals(
+        "namespace must be stored in DynamoDB",
+        namespace.toString(),
+        response.item().get("namespace").s());
 
-    AssertHelpers.assertThrows("should not create duplicated namespace",
+    AssertHelpers.assertThrows(
+        "should not create duplicated namespace",
         AlreadyExistsException.class,
         "already exists",
         () -> catalog.createNamespace(namespace));
@@ -106,12 +115,14 @@ public class TestDynamoDbCatalog {
 
   @Test
   public void testCreateNamespaceBadName() {
-    AssertHelpers.assertThrows("should not create namespace with empty level",
+    AssertHelpers.assertThrows(
+        "should not create namespace with empty level",
         ValidationException.class,
         "must not be empty",
         () -> catalog.createNamespace(Namespace.of("a", "", "b")));
 
-    AssertHelpers.assertThrows("should not create namespace with dot in level",
+    AssertHelpers.assertThrows(
+        "should not create namespace with dot in level",
         ValidationException.class,
         "must not contain dot",
         () -> catalog.createNamespace(Namespace.of("a", "b.c")));
@@ -120,9 +131,10 @@ public class TestDynamoDbCatalog {
   @Test
   public void testListSubNamespaces() {
     Namespace parent = Namespace.of(genRandomName());
-    List<Namespace> namespaceList = IntStream.range(0, 3)
-        .mapToObj(i -> Namespace.of(parent.toString(), genRandomName()))
-        .collect(Collectors.toList());
+    List<Namespace> namespaceList =
+        IntStream.range(0, 3)
+            .mapToObj(i -> Namespace.of(parent.toString(), genRandomName()))
+            .collect(Collectors.toList());
     catalog.createNamespace(parent);
     namespaceList.forEach(ns -> catalog.createNamespace(ns));
     Assert.assertEquals(4, catalog.listNamespaces(parent).size());
@@ -153,17 +165,24 @@ public class TestDynamoDbCatalog {
     catalog.createNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, genRandomName());
     catalog.createTable(tableIdentifier, SCHEMA);
-    GetItemResponse response = dynamo.getItem(GetItemRequest.builder()
-        .tableName(catalogTableName)
-        .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
-        .build());
+    GetItemResponse response =
+        dynamo.getItem(
+            GetItemRequest.builder()
+                .tableName(catalogTableName)
+                .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
+                .build());
     Assert.assertTrue("table must exist", response.hasItem());
-    Assert.assertEquals("table must be stored in DynamoDB with table identifier as partition key",
-        tableIdentifier.toString(), response.item().get("identifier").s());
-    Assert.assertEquals("table must be stored in DynamoDB with namespace as sort key",
-        namespace.toString(), response.item().get("namespace").s());
+    Assert.assertEquals(
+        "table must be stored in DynamoDB with table identifier as partition key",
+        tableIdentifier.toString(),
+        response.item().get("identifier").s());
+    Assert.assertEquals(
+        "table must be stored in DynamoDB with namespace as sort key",
+        namespace.toString(),
+        response.item().get("namespace").s());
 
-    AssertHelpers.assertThrows("should not create duplicated table",
+    AssertHelpers.assertThrows(
+        "should not create duplicated table",
         AlreadyExistsException.class,
         "already exists",
         () -> catalog.createTable(tableIdentifier, SCHEMA));
@@ -173,12 +192,14 @@ public class TestDynamoDbCatalog {
   public void testCreateTableBadName() {
     Namespace namespace = Namespace.of(genRandomName());
     catalog.createNamespace(namespace);
-    AssertHelpers.assertThrows("should not create table name with empty namespace",
+    AssertHelpers.assertThrows(
+        "should not create table name with empty namespace",
         ValidationException.class,
         "Table namespace must not be empty",
         () -> catalog.createTable(TableIdentifier.of(Namespace.empty(), "a"), SCHEMA));
 
-    AssertHelpers.assertThrows("should not create table name with dot",
+    AssertHelpers.assertThrows(
+        "should not create table name with dot",
         ValidationException.class,
         "must not contain dot",
         () -> catalog.createTable(TableIdentifier.of(namespace, "a.b"), SCHEMA));
@@ -188,9 +209,10 @@ public class TestDynamoDbCatalog {
   public void testListTable() {
     Namespace namespace = Namespace.of(genRandomName());
     catalog.createNamespace(namespace);
-    List<TableIdentifier> tableIdentifiers = IntStream.range(0, 3)
-        .mapToObj(i -> TableIdentifier.of(namespace, genRandomName()))
-        .collect(Collectors.toList());
+    List<TableIdentifier> tableIdentifiers =
+        IntStream.range(0, 3)
+            .mapToObj(i -> TableIdentifier.of(namespace, genRandomName()))
+            .collect(Collectors.toList());
     tableIdentifiers.forEach(id -> catalog.createTable(id, SCHEMA));
     Assert.assertEquals(3, catalog.listTables(namespace).size());
   }
@@ -201,22 +223,35 @@ public class TestDynamoDbCatalog {
     catalog.createNamespace(namespace);
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, genRandomName());
     catalog.createTable(tableIdentifier, SCHEMA);
-    String metadataLocation = dynamo.getItem(GetItemRequest.builder()
-        .tableName(catalogTableName)
-        .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier)).build())
-        .item().get("p.metadata_location").s();
+    String metadataLocation =
+        dynamo
+            .getItem(
+                GetItemRequest.builder()
+                    .tableName(catalogTableName)
+                    .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
+                    .build())
+            .item()
+            .get("p.metadata_location")
+            .s();
     catalog.dropTable(tableIdentifier, true);
-    Assert.assertFalse("table entry should not exist in dynamo",
-        dynamo.getItem(GetItemRequest.builder()
-            .tableName(catalogTableName)
-            .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier)).build())
+    Assert.assertFalse(
+        "table entry should not exist in dynamo",
+        dynamo
+            .getItem(
+                GetItemRequest.builder()
+                    .tableName(catalogTableName)
+                    .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
+                    .build())
             .hasItem());
-    AssertHelpers.assertThrows("metadata location should be deleted",
+    AssertHelpers.assertThrows(
+        "metadata location should be deleted",
         NoSuchKeyException.class,
-        () -> s3.headObject(HeadObjectRequest.builder()
-            .bucket(testBucket)
-            .key(metadataLocation.substring(testBucket.length() + 6)) // s3:// + end slash
-            .build()));
+        () ->
+            s3.headObject(
+                HeadObjectRequest.builder()
+                    .bucket(testBucket)
+                    .key(metadataLocation.substring(testBucket.length() + 6)) // s3:// + end slash
+                    .build()));
   }
 
   @Test
@@ -229,30 +264,46 @@ public class TestDynamoDbCatalog {
     catalog.createTable(tableIdentifier, SCHEMA);
     TableIdentifier tableIdentifier2 = TableIdentifier.of(namespace2, genRandomName());
 
-    AssertHelpers.assertThrows("should not be able to rename a table not exist",
+    AssertHelpers.assertThrows(
+        "should not be able to rename a table not exist",
         NoSuchTableException.class,
         "does not exist",
         () -> catalog.renameTable(TableIdentifier.of(namespace, "a"), tableIdentifier2));
 
-    AssertHelpers.assertThrows("should not be able to rename an existing table",
+    AssertHelpers.assertThrows(
+        "should not be able to rename an existing table",
         AlreadyExistsException.class,
         "already exists",
         () -> catalog.renameTable(tableIdentifier, tableIdentifier));
 
-    String metadataLocation = dynamo.getItem(GetItemRequest.builder()
-        .tableName(catalogTableName)
-        .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier)).build())
-        .item().get("p.metadata_location").s();
+    String metadataLocation =
+        dynamo
+            .getItem(
+                GetItemRequest.builder()
+                    .tableName(catalogTableName)
+                    .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier))
+                    .build())
+            .item()
+            .get("p.metadata_location")
+            .s();
 
     catalog.renameTable(tableIdentifier, tableIdentifier2);
 
-    String metadataLocation2 = dynamo.getItem(GetItemRequest.builder()
-        .tableName(catalogTableName)
-        .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier2)).build())
-        .item().get("p.metadata_location").s();
+    String metadataLocation2 =
+        dynamo
+            .getItem(
+                GetItemRequest.builder()
+                    .tableName(catalogTableName)
+                    .key(DynamoDbCatalog.tablePrimaryKey(tableIdentifier2))
+                    .build())
+            .item()
+            .get("p.metadata_location")
+            .s();
 
-    Assert.assertEquals("metadata location should be copied to new table entry",
-        metadataLocation, metadataLocation2);
+    Assert.assertEquals(
+        "metadata location should be copied to new table entry",
+        metadataLocation,
+        metadataLocation2);
   }
 
   @Test
@@ -274,14 +325,22 @@ public class TestDynamoDbCatalog {
     TableIdentifier tableIdentifier = TableIdentifier.of(namespace, genRandomName());
     catalog.createTable(tableIdentifier, SCHEMA);
     Table table = catalog.loadTable(tableIdentifier);
-    POOL.submit(() -> IntStream.range(0, 16).parallel()
-        .forEach(i -> {
-          try {
-            table.updateSchema().addColumn(genRandomName(), Types.StringType.get()).commit();
-          } catch (Exception e) {
-            // ignore
-          }
-        })).get();
+    POOL.submit(
+            () ->
+                IntStream.range(0, 16)
+                    .parallel()
+                    .forEach(
+                        i -> {
+                          try {
+                            table
+                                .updateSchema()
+                                .addColumn(genRandomName(), Types.StringType.get())
+                                .commit();
+                          } catch (Exception e) {
+                            // ignore
+                          }
+                        }))
+        .get();
 
     Assert.assertEquals(2, table.schema().columns().size());
   }
@@ -291,10 +350,12 @@ public class TestDynamoDbCatalog {
     Namespace namespace = Namespace.of(genRandomName());
     catalog.createNamespace(namespace);
     catalog.dropNamespace(namespace);
-    GetItemResponse response = dynamo.getItem(GetItemRequest.builder()
-            .tableName(catalogTableName)
-            .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
-            .build());
+    GetItemResponse response =
+        dynamo.getItem(
+            GetItemRequest.builder()
+                .tableName(catalogTableName)
+                .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
+                .build());
     Assert.assertFalse("namespace must not exist", response.hasItem());
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.glue;
 
 import java.util.List;
@@ -65,32 +64,45 @@ public class GlueTestBase {
   static GlueCatalog glueCatalogWithSkip;
   static GlueCatalog glueCatalogWithSkipNameValidation;
 
-  static Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
+  static Schema schema =
+      new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
   static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
   // table location properties
-  static final Map<String, String> tableLocationProperties = ImmutableMap.of(
-      TableProperties.WRITE_DATA_LOCATION, "s3://" + testBucketName + "/writeDataLoc",
-      TableProperties.WRITE_METADATA_LOCATION, "s3://" + testBucketName + "/writeMetaDataLoc",
-      TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "s3://" + testBucketName + "/writeFolderStorageLoc");
+  static final Map<String, String> tableLocationProperties =
+      ImmutableMap.of(
+          TableProperties.WRITE_DATA_LOCATION, "s3://" + testBucketName + "/writeDataLoc",
+          TableProperties.WRITE_METADATA_LOCATION, "s3://" + testBucketName + "/writeMetaDataLoc",
+          TableProperties.WRITE_FOLDER_STORAGE_LOCATION,
+              "s3://" + testBucketName + "/writeFolderStorageLoc");
 
   @BeforeClass
   public static void beforeClass() {
     String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     glueCatalog = new GlueCatalog();
-    glueCatalog.initialize(catalogName, testBucketPath, new AwsProperties(), glue,
-            LockManagers.defaultLockManager(), fileIO);
+    glueCatalog.initialize(
+        catalogName,
+        testBucketPath,
+        new AwsProperties(),
+        glue,
+        LockManagers.defaultLockManager(),
+        fileIO);
     AwsProperties properties = new AwsProperties();
     properties.setGlueCatalogSkipArchive(true);
     properties.setS3FileIoDeleteBatchSize(10);
     glueCatalogWithSkip = new GlueCatalog();
-    glueCatalogWithSkip.initialize(catalogName, testBucketPath, properties, glue,
-            LockManagers.defaultLockManager(), fileIO);
+    glueCatalogWithSkip.initialize(
+        catalogName, testBucketPath, properties, glue, LockManagers.defaultLockManager(), fileIO);
     glueCatalogWithSkipNameValidation = new GlueCatalog();
     AwsProperties propertiesSkipNameValidation = new AwsProperties();
     propertiesSkipNameValidation.setGlueCatalogSkipNameValidation(true);
-    glueCatalogWithSkipNameValidation.initialize(catalogName, testBucketPath, propertiesSkipNameValidation, glue,
-            LockManagers.defaultLockManager(), fileIO);
+    glueCatalogWithSkipNameValidation.initialize(
+        catalogName,
+        testBucketPath,
+        propertiesSkipNameValidation,
+        glue,
+        LockManagers.defaultLockManager(),
+        fileIO);
   }
 
   @AfterClass

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.glue;
 
 import java.io.File;
@@ -92,8 +91,10 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
     Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
-    Assert.assertEquals("Client could not determine outcome so new metadata file should also exist",
-        3, metadataFileCount(ops.current()));
+    Assert.assertEquals(
+        "Client could not determine outcome so new metadata file should also exist",
+        3,
+        metadataFileCount(ops.current()));
   }
 
   @Test
@@ -107,7 +108,8 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, ConcurrentModificationException.builder().build());
 
-    AssertHelpers.assertThrowsWithCause("GlueCatalog should fail on concurrent modifications",
+    AssertHelpers.assertThrowsWithCause(
+        "GlueCatalog should fail on concurrent modifications",
         CommitFailedException.class,
         "Glue detected concurrent update",
         ConcurrentModificationException.class,
@@ -134,14 +136,18 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     // Simulate a communication error after a successful commit
     commitAndThrowException(ops, spyOps);
 
-    // Shouldn't throw because the commit actually succeeds even though persistTable throws an exception
+    // Shouldn't throw because the commit actually succeeds even though persistTable throws an
+    // exception
     spyOps.commit(metadataV2, metadataV1);
 
     ops.refresh();
     Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals("Commit should have been successful and new metadata file should be made",
-        3, metadataFileCount(ops.current()));
+    Assert.assertTrue(
+        "Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals(
+        "Commit should have been successful and new metadata file should be made",
+        3,
+        metadataFileCount(ops.current()));
   }
 
   @Test
@@ -156,16 +162,21 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
 
-    AssertHelpers.assertThrows("Should throw CommitStateUnknownException since the catalog check was blocked",
-        CommitStateUnknownException.class, "Datacenter on fire",
+    AssertHelpers.assertThrows(
+        "Should throw CommitStateUnknownException since the catalog check was blocked",
+        CommitStateUnknownException.class,
+        "Datacenter on fire",
         () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
 
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals("Client could not determine outcome so new metadata file should also exist",
-        3, metadataFileCount(ops.current()));
+    Assert.assertTrue(
+        "Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals(
+        "Client could not determine outcome so new metadata file should also exist",
+        3,
+        metadataFileCount(ops.current()));
   }
 
   @Test
@@ -180,29 +191,31 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     commitAndThrowException(ops, spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
 
-    AssertHelpers.assertThrows("Should throw CommitStateUnknownException since the catalog check was blocked",
-        CommitStateUnknownException.class, "Datacenter on fire",
+    AssertHelpers.assertThrows(
+        "Should throw CommitStateUnknownException since the catalog check was blocked",
+        CommitStateUnknownException.class,
+        "Datacenter on fire",
         () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
 
     Assert.assertNotEquals("Current metadata should have changed", ops.current(), metadataV2);
-    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertTrue(
+        "Current metadata file should still exist", metadataFileExists(ops.current()));
   }
 
   /**
-   * Pretends we threw an exception while persisting, the commit succeeded, the lock expired,
-   * and a second committer placed a commit on top of ours before the first committer was able to check
-   * if their commit succeeded or not
+   * Pretends we threw an exception while persisting, the commit succeeded, the lock expired, and a
+   * second committer placed a commit on top of ours before the first committer was able to check if
+   * their commit succeeded or not
    *
-   * Timeline:
-   *   Client 1 commits which throws an exception but suceeded
-   *   Client 1's lock expires while waiting to do the recheck for commit success
-   *   Client 2 acquires a lock, commits successfully on top of client 1's commit and release lock
-   *   Client 1 check's to see if their commit was successful
+   * <p>Timeline: Client 1 commits which throws an exception but suceeded Client 1's lock expires
+   * while waiting to do the recheck for commit success Client 2 acquires a lock, commits
+   * successfully on top of client 1's commit and release lock Client 1 check's to see if their
+   * commit was successful
    *
-   * This tests to make sure a disconnected client 1 doesn't think their commit failed just because it isn't the
-   * current one during the recheck phase.
+   * <p>This tests to make sure a disconnected client 1 doesn't think their commit failed just
+   * because it isn't the current one during the recheck phase.
    */
   @Test
   public void testExceptionThrownInConcurrentCommit() {
@@ -223,31 +236,38 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
     ops.refresh();
     Assert.assertNotEquals("Current metadata should have changed", metadataV2, ops.current());
-    Assert.assertTrue("Current metadata file should still exist", metadataFileExists(ops.current()));
-    Assert.assertEquals("The column addition from the concurrent commit should have been successful",
-        2, ops.current().schema().columns().size());
+    Assert.assertTrue(
+        "Current metadata file should still exist", metadataFileExists(ops.current()));
+    Assert.assertEquals(
+        "The column addition from the concurrent commit should have been successful",
+        2,
+        ops.current().schema().columns().size());
   }
 
-  private void concurrentCommitAndThrowException(GlueTableOperations realOps, GlueTableOperations spyOperations,
-                                                 Table table) {
+  private void concurrentCommitAndThrowException(
+      GlueTableOperations realOps, GlueTableOperations spyOperations, Table table) {
     // Simulate a communication error after a successful commit
-    Mockito.doAnswer(i -> {
-      Map<String, String> mapProperties = i.getArgument(1, Map.class);
-      realOps.persistGlueTable(
-          i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
-          mapProperties,
-          i.getArgument(2, TableMetadata.class));
+    Mockito.doAnswer(
+            i -> {
+              Map<String, String> mapProperties = i.getArgument(1, Map.class);
+              realOps.persistGlueTable(
+                  i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
+                  mapProperties,
+                  i.getArgument(2, TableMetadata.class));
 
-      // new metadata location is stored in map property, and used for locking
-      String newMetadataLocation = mapProperties.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+              // new metadata location is stored in map property, and used for locking
+              String newMetadataLocation =
+                  mapProperties.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
 
-      // Simulate lock expiration or removal, use commit status null to avoid deleting data
-      realOps.cleanupMetadataAndUnlock(null, newMetadataLocation);
+              // Simulate lock expiration or removal, use commit status null to avoid deleting data
+              realOps.cleanupMetadataAndUnlock(null, newMetadataLocation);
 
-      table.refresh();
-      table.updateSchema().addColumn("newCol", Types.IntegerType.get()).commit();
-      throw new RuntimeException("Datacenter on fire");
-    }).when(spyOperations).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+              table.refresh();
+              table.updateSchema().addColumn("newCol", Types.IntegerType.get()).commit();
+              throw new RuntimeException("Datacenter on fire");
+            })
+        .when(spyOperations)
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   @Test
@@ -262,10 +282,10 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, EntityNotFoundException.builder().build());
 
     AssertHelpers.assertThrows(
-            "Should throw not found exception",
-            NotFoundException.class,
-            "because Glue cannot find the requested entity",
-            () -> spyOps.commit(metadataV2, metadataV1));
+        "Should throw not found exception",
+        NotFoundException.class,
+        "because Glue cannot find the requested entity",
+        () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -285,10 +305,10 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, AccessDeniedException.builder().build());
 
     AssertHelpers.assertThrows(
-            "Should throw forbidden exception",
-            ForbiddenException.class,
-            "because Glue cannot access the requested resources",
-            () -> spyOps.commit(metadataV2, metadataV1));
+        "Should throw forbidden exception",
+        ForbiddenException.class,
+        "because Glue cannot access the requested resources",
+        () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -308,10 +328,10 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, ValidationException.builder().build());
 
     AssertHelpers.assertThrows(
-            "Should throw validation exception",
-            org.apache.iceberg.exceptions.ValidationException.class,
-            "because Glue encountered a validation exception while accessing requested resources",
-            () -> spyOps.commit(metadataV2, metadataV1));
+        "Should throw validation exception",
+        org.apache.iceberg.exceptions.ValidationException.class,
+        "because Glue encountered a validation exception while accessing requested resources",
+        () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -331,9 +351,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, S3Exception.builder().statusCode(300).build());
 
     AssertHelpers.assertThrows(
-            null,
-            S3Exception.class,
-            () -> spyOps.commit(metadataV2, metadataV1));
+        null, S3Exception.class, () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -353,9 +371,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, GlueException.builder().statusCode(300).build());
 
     AssertHelpers.assertThrows(
-            null,
-            GlueException.class,
-            () -> spyOps.commit(metadataV2, metadataV1));
+        null, GlueException.class, () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -375,9 +391,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
     failCommitAndThrowException(spyOps, GlueException.builder().statusCode(500).build());
 
     AssertHelpers.assertThrows(
-            null,
-            CommitFailedException.class,
-            () -> spyOps.commit(metadataV2, metadataV1));
+        null, CommitFailedException.class, () -> spyOps.commit(metadataV2, metadataV1));
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -392,9 +406,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   }
 
   private TableMetadata updateTable(Table table, GlueTableOperations ops) {
-    table.updateSchema()
-        .addColumn("n", Types.IntegerType.get())
-        .commit();
+    table.updateSchema().addColumn("n", Types.IntegerType.get()).commit();
 
     ops.refresh();
 
@@ -405,13 +417,16 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   }
 
   private void commitAndThrowException(GlueTableOperations realOps, GlueTableOperations spyOps) {
-    Mockito.doAnswer(i -> {
-      realOps.persistGlueTable(
-          i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
-          i.getArgument(1, Map.class),
-          i.getArgument(2, TableMetadata.class));
-      throw new RuntimeException("Datacenter on fire");
-    }).when(spyOps).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+    Mockito.doAnswer(
+            i -> {
+              realOps.persistGlueTable(
+                  i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
+                  i.getArgument(1, Map.class),
+                  i.getArgument(2, TableMetadata.class));
+              throw new RuntimeException("Datacenter on fire");
+            })
+        .when(spyOps)
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   private void failCommitAndThrowException(GlueTableOperations spyOps) {
@@ -420,7 +435,8 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
   private void failCommitAndThrowException(GlueTableOperations spyOps, Exception exceptionToThrow) {
     Mockito.doThrow(exceptionToThrow)
-        .when(spyOps).persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+        .when(spyOps)
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
   }
 
   private void breakFallbackCatalogCommitCheck(GlueTableOperations spyOperations) {
@@ -430,10 +446,11 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
 
   private boolean metadataFileExists(TableMetadata metadata) {
     try {
-      s3.headObject(HeadObjectRequest.builder()
-          .bucket(S3TestUtil.getBucketFromUri(metadata.metadataFileLocation()))
-          .key(S3TestUtil.getKeyFromUri(metadata.metadataFileLocation()))
-          .build());
+      s3.headObject(
+          HeadObjectRequest.builder()
+              .bucket(S3TestUtil.getBucketFromUri(metadata.metadataFileLocation()))
+              .key(S3TestUtil.getKeyFromUri(metadata.metadataFileLocation()))
+              .build());
       return true;
     } catch (NoSuchKeyException e) {
       return false;
@@ -441,10 +458,17 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   }
 
   private int metadataFileCount(TableMetadata metadata) {
-    return (int) s3.listObjectsV2(ListObjectsV2Request.builder()
-        .bucket(S3TestUtil.getBucketFromUri(metadata.metadataFileLocation()))
-        .prefix(new File(S3TestUtil.getKeyFromUri(metadata.metadataFileLocation())).getParent())
-        .build())
-        .contents().stream().filter(s3Object -> s3Object.key().endsWith("metadata.json")).count();
+    return (int)
+        s3
+            .listObjectsV2(
+                ListObjectsV2Request.builder()
+                    .bucket(S3TestUtil.getBucketFromUri(metadata.metadataFileLocation()))
+                    .prefix(
+                        new File(S3TestUtil.getKeyFromUri(metadata.metadataFileLocation()))
+                            .getParent())
+                    .build())
+            .contents().stream()
+            .filter(s3Object -> s3Object.key().endsWith("metadata.json"))
+            .count();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.glue;
 
 import java.util.List;
@@ -59,8 +58,13 @@ public class TestGlueCatalogLock extends GlueTestBase {
     glueCatalog = new GlueCatalog();
     AwsProperties awsProperties = new AwsProperties();
     dynamo = clientFactory.dynamo();
-    glueCatalog.initialize(catalogName, testBucketPath, awsProperties, glue,
-        new DynamoDbLockManager(dynamo, lockTableName), fileIO);
+    glueCatalog.initialize(
+        catalogName,
+        testBucketPath,
+        awsProperties,
+        glue,
+        new DynamoDbLockManager(dynamo, lockTableName),
+        fileIO);
   }
 
   @AfterClass
@@ -76,18 +80,21 @@ public class TestGlueCatalogLock extends GlueTestBase {
     String tableName = getRandomName();
     createTable(namespace, tableName);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath("/path/to/data-a.parquet")
-        .withFileSizeInBytes(1)
-        .withRecordCount(1)
-        .build();
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(1)
+            .withRecordCount(1)
+            .build();
 
-    List<AppendFiles> pendingCommits = IntStream.range(0, nThreads)
-        .mapToObj(i -> table.newAppend().appendFile(dataFile))
-        .collect(Collectors.toList());
+    List<AppendFiles> pendingCommits =
+        IntStream.range(0, nThreads)
+            .mapToObj(i -> table.newAppend().appendFile(dataFile))
+            .collect(Collectors.toList());
 
-    ExecutorService executorService = MoreExecutors.getExitingExecutorService(
-        (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads));
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads));
 
     Tasks.range(nThreads)
         .retry(10000)
@@ -96,8 +103,11 @@ public class TestGlueCatalogLock extends GlueTestBase {
         .run(i -> pendingCommits.get(i).commit());
 
     table.refresh();
-    Assert.assertEquals("Commits should all succeed sequentially", nThreads, table.history().size());
-    Assert.assertEquals("Should have all manifests", nThreads,
+    Assert.assertEquals(
+        "Commits should all succeed sequentially", nThreads, table.history().size());
+    Assert.assertEquals(
+        "Should have all manifests",
+        nThreads,
         table.currentSnapshot().allManifests(table.io()).size());
   }
 
@@ -108,38 +118,41 @@ public class TestGlueCatalogLock extends GlueTestBase {
     createTable(namespace, tableName);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     String fileName = UUID.randomUUID().toString();
-    DataFile file = DataFiles.builder(table.spec())
-        .withPath(FileFormat.PARQUET.addExtension(fileName))
-        .withRecordCount(2)
-        .withFileSizeInBytes(0)
-        .build();
+    DataFile file =
+        DataFiles.builder(table.spec())
+            .withPath(FileFormat.PARQUET.addExtension(fileName))
+            .withRecordCount(2)
+            .withFileSizeInBytes(0)
+            .build();
 
-    ExecutorService executorService = MoreExecutors.getExitingExecutorService(
-        (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
     Tasks.range(2)
         .stopOnFailure()
         .throwFailureWhenFinished()
         .executeWith(executorService)
-        .run(index -> {
-          for (int numCommittedFiles = 0; numCommittedFiles < 10; numCommittedFiles++) {
-            while (barrier.get() < numCommittedFiles * 2) {
-              try {
-                Thread.sleep(10);
-              } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            }
+        .run(
+            index -> {
+              for (int numCommittedFiles = 0; numCommittedFiles < 10; numCommittedFiles++) {
+                while (barrier.get() < numCommittedFiles * 2) {
+                  try {
+                    Thread.sleep(10);
+                  } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                  }
+                }
 
-            table.newFastAppend().appendFile(file).commit();
-            barrier.incrementAndGet();
-          }
-        });
+                table.newFastAppend().appendFile(file).commit();
+                barrier.incrementAndGet();
+              }
+            });
 
     table.refresh();
     Assert.assertEquals("Commits should all succeed sequentially", 20, table.history().size());
-    Assert.assertEquals("should have 20 manifests", 20, table.currentSnapshot().allManifests(table.io()).size());
+    Assert.assertEquals(
+        "should have 20 manifests", 20, table.currentSnapshot().allManifests(table.io()).size());
   }
-
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.glue;
+
+import static org.apache.iceberg.expressions.Expressions.truncate;
 
 import java.util.List;
 import java.util.Locale;
@@ -61,30 +62,39 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
-import static org.apache.iceberg.expressions.Expressions.truncate;
-
 public class TestGlueCatalogTable extends GlueTestBase {
 
   @Test
   public void testCreateTable() {
     String namespace = createNamespace();
     String tableName = getRandomName();
-    glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
+    glueCatalog.createTable(
+        TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
     // verify table exists in Glue
-    GetTableResponse response = glue.getTable(GetTableRequest.builder()
-        .databaseName(namespace).name(tableName).build());
+    GetTableResponse response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
     Assert.assertEquals(namespace, response.table().databaseName());
     Assert.assertEquals(tableName, response.table().name());
-    Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH),
+    Assert.assertEquals(
+        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH),
         response.table().parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
-    Assert.assertTrue(response.table().parameters().containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP));
-    Assert.assertEquals(schema.columns().size(), response.table().storageDescriptor().columns().size());
+    Assert.assertTrue(
+        response
+            .table()
+            .parameters()
+            .containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP));
+    Assert.assertEquals(
+        schema.columns().size(), response.table().storageDescriptor().columns().size());
     Assert.assertEquals(partitionSpec.fields().size(), response.table().partitionKeys().size());
-    Assert.assertEquals("additionalLocations should match",
+    Assert.assertEquals(
+        "additionalLocations should match",
         tableLocationProperties.values().stream().sorted().collect(Collectors.toList()),
-        response.table().storageDescriptor().additionalLocations().stream().sorted().collect(Collectors.toList()));
+        response.table().storageDescriptor().additionalLocations().stream()
+            .sorted()
+            .collect(Collectors.toList()));
     // verify metadata file exists in S3
-    String metaLocation = response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+    String metaLocation =
+        response.table().parameters().get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
     String key = metaLocation.split(testBucketName, -1)[1].substring(1);
     s3.headObject(HeadObjectRequest.builder().bucket(testBucketName).key(key).build());
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
@@ -96,25 +106,32 @@ public class TestGlueCatalogTable extends GlueTestBase {
   public void testCreateTableDuplicate() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
-    AssertHelpers.assertThrows("should not create table with the same name",
+    AssertHelpers.assertThrows(
+        "should not create table with the same name",
         AlreadyExistsException.class,
         "Table already exists",
-        () -> glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec));
+        () ->
+            glueCatalog.createTable(
+                TableIdentifier.of(namespace, tableName), schema, partitionSpec));
   }
 
   @Test
   public void testCreateTableBadName() {
     String namespace = createNamespace();
-    AssertHelpers.assertThrows("should not create table with bad name",
+    AssertHelpers.assertThrows(
+        "should not create table with bad name",
         IllegalArgumentException.class,
         "Invalid table identifier",
-        () -> glueCatalog.createTable(TableIdentifier.of(namespace, "table-1"), schema, partitionSpec));
+        () ->
+            glueCatalog.createTable(
+                TableIdentifier.of(namespace, "table-1"), schema, partitionSpec));
   }
 
   @Test
   public void testListTables() {
     String namespace = createNamespace();
-    Assert.assertTrue("list namespace should have nothing before table creation",
+    Assert.assertTrue(
+        "list namespace should have nothing before table creation",
         glueCatalog.listTables(Namespace.of(namespace)).isEmpty());
     String tableName = createTable(namespace);
     List<TableIdentifier> tables = glueCatalog.listTables(Namespace.of(namespace));
@@ -146,19 +163,22 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Assert.assertTrue("initial table history should be empty", table.history().isEmpty());
     // commit new version, should create a new snapshot
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath("/path/to/data-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
     table.newAppend().appendFile(dataFile).commit();
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     Assert.assertEquals("commit should create a new table version", 1, table.history().size());
     // check table in Glue
-    GetTableResponse response = glue.getTable(GetTableRequest.builder()
-        .databaseName(namespace).name(tableName).build());
-    Assert.assertEquals("external table type is set after update", "EXTERNAL_TABLE", response.table().tableType());
-    Assert.assertEquals(schema.columns().size(), response.table().storageDescriptor().columns().size());
+    GetTableResponse response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
+    Assert.assertEquals(
+        "external table type is set after update", "EXTERNAL_TABLE", response.table().tableType());
+    Assert.assertEquals(
+        schema.columns().size(), response.table().storageDescriptor().columns().size());
     Assert.assertEquals(partitionSpec.fields().size(), response.table().partitionKeys().size());
   }
 
@@ -169,7 +189,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     // rename table
     String newTableName = tableName + "_2";
-    glueCatalog.renameTable(TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName));
+    glueCatalog.renameTable(
+        TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName));
     Table renamedTable = glueCatalog.loadTable(TableIdentifier.of(namespace, newTableName));
     Assert.assertEquals(table.location(), renamedTable.location());
     Assert.assertEquals(table.schema().toString(), renamedTable.schema().toString());
@@ -185,15 +206,19 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(id);
     // create a new table in Glue, so that rename to that table will fail
     String newTableName = tableName + "_2";
-    glue.createTable(CreateTableRequest.builder()
-        .databaseName(namespace)
-        .tableInput(TableInput.builder().name(newTableName).build())
-        .build());
-    AssertHelpers.assertThrows("should fail to rename to an existing table",
+    glue.createTable(
+        CreateTableRequest.builder()
+            .databaseName(namespace)
+            .tableInput(TableInput.builder().name(newTableName).build())
+            .build());
+    AssertHelpers.assertThrows(
+        "should fail to rename to an existing table",
         software.amazon.awssdk.services.glue.model.AlreadyExistsException.class,
         "Table already exists",
-        () -> glueCatalog.renameTable(
-            TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName)));
+        () ->
+            glueCatalog.renameTable(
+                TableIdentifier.of(namespace, tableName),
+                TableIdentifier.of(namespace, newTableName)));
     // old table can still be read with same metadata
     Table oldTable = glueCatalog.loadTable(id);
     Assert.assertEquals(table.location(), oldTable.location());
@@ -210,19 +235,26 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(id);
     // delete the old table metadata, so that drop old table will fail
     String newTableName = tableName + "_2";
-    glue.updateTable(UpdateTableRequest.builder()
-        .databaseName(namespace)
-        .tableInput(TableInput.builder().name(tableName).parameters(Maps.newHashMap()).build())
-        .build());
-    AssertHelpers.assertThrows("should fail to rename",
+    glue.updateTable(
+        UpdateTableRequest.builder()
+            .databaseName(namespace)
+            .tableInput(TableInput.builder().name(tableName).parameters(Maps.newHashMap()).build())
+            .build());
+    AssertHelpers.assertThrows(
+        "should fail to rename",
         ValidationException.class,
         "Input Glue table is not an iceberg table",
-        () -> glueCatalog.renameTable(
-            TableIdentifier.of(namespace, tableName), TableIdentifier.of(namespace, newTableName)));
-    AssertHelpers.assertThrows("renamed table should be deleted",
+        () ->
+            glueCatalog.renameTable(
+                TableIdentifier.of(namespace, tableName),
+                TableIdentifier.of(namespace, newTableName)));
+    AssertHelpers.assertThrows(
+        "renamed table should be deleted",
         EntityNotFoundException.class,
         "not found",
-        () -> glue.getTable(GetTableRequest.builder().databaseName(namespace).name(newTableName).build()));
+        () ->
+            glue.getTable(
+                GetTableRequest.builder().databaseName(namespace).name(newTableName).build()));
   }
 
   @Test
@@ -230,14 +262,20 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     glueCatalog.dropTable(TableIdentifier.of(namespace, tableName), false);
-    AssertHelpers.assertThrows("should not have table",
+    AssertHelpers.assertThrows(
+        "should not have table",
         NoSuchTableException.class,
         "Table does not exist",
         () -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)));
-    String warehouseLocation = glueCatalog.defaultWarehouseLocation(TableIdentifier.of(namespace, tableName));
+    String warehouseLocation =
+        glueCatalog.defaultWarehouseLocation(TableIdentifier.of(namespace, tableName));
     String prefix = warehouseLocation.split(testBucketName + "/", -1)[1];
-    ListObjectsV2Response response = s3.listObjectsV2(ListObjectsV2Request.builder()
-        .bucket(testBucketName).prefix(prefix + "/metadata/").build());
+    ListObjectsV2Response response =
+        s3.listObjectsV2(
+            ListObjectsV2Request.builder()
+                .bucket(testBucketName)
+                .prefix(prefix + "/metadata/")
+                .build());
     Assert.assertTrue(response.hasContents());
     boolean hasMetaFile = false;
     for (S3Object s3Object : response.contents()) {
@@ -256,18 +294,19 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
 
     DataFile testFile =
-      DataFiles.builder(PartitionSpec.unpartitioned())
-          .withPath("/path/to/data-unpartitioned-a.parquet")
-          .withFileSizeInBytes(1)
-          .withRecordCount(1)
-          .build();
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath("/path/to/data-unpartitioned-a.parquet")
+            .withFileSizeInBytes(1)
+            .withRecordCount(1)
+            .build();
     int numFilesToCreate = 31;
     int commitFrequency = 5;
     Transaction txn = table.newTransaction();
     for (int i = 1; i <= numFilesToCreate; i++) {
       AppendFiles appendFiles = txn.newFastAppend().appendFile(testFile);
       appendFiles.commit();
-      // Every "commitFrequency" appends commit the transaction and start a new one so we can have multiple manifests
+      // Every "commitFrequency" appends commit the transaction and start a new one so we can have
+      // multiple manifests
       if (i % commitFrequency == 0) {
         txn.commitTransaction();
         txn = table.newTransaction();
@@ -277,14 +316,17 @@ public class TestGlueCatalogTable extends GlueTestBase {
     txn.commitTransaction();
 
     glueCatalog.dropTable(TableIdentifier.of(namespace, tableName));
-    AssertHelpers.assertThrows("should not have table",
+    AssertHelpers.assertThrows(
+        "should not have table",
         NoSuchTableException.class,
         "Table does not exist",
         () -> glueCatalog.loadTable(TableIdentifier.of(namespace, tableName)));
-    String warehouseLocation = glueCatalog.defaultWarehouseLocation(TableIdentifier.of(namespace, tableName));
+    String warehouseLocation =
+        glueCatalog.defaultWarehouseLocation(TableIdentifier.of(namespace, tableName));
     String prefix = warehouseLocation.split(testBucketName + "/", -1)[1];
-    ListObjectsV2Response response = s3.listObjectsV2(ListObjectsV2Request.builder()
-        .bucket(testBucketName).prefix(prefix).build());
+    ListObjectsV2Response response =
+        s3.listObjectsV2(
+            ListObjectsV2Request.builder().bucket(testBucketName).prefix(prefix).build());
     if (response.hasContents()) {
       // might have directory markers left
       for (S3Object s3Object : response.contents()) {
@@ -307,22 +349,38 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String tableName = getRandomName();
     glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath("/path/to/data-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
     table.newAppend().appendFile(dataFile).commit();
-    Assert.assertEquals(2, glue.getTableVersions(GetTableVersionsRequest.builder()
-        .databaseName(namespace).tableName(tableName).build()).tableVersions().size());
+    Assert.assertEquals(
+        2,
+        glue.getTableVersions(
+                GetTableVersionsRequest.builder()
+                    .databaseName(namespace)
+                    .tableName(tableName)
+                    .build())
+            .tableVersions()
+            .size());
     // create table and commit with skip
     tableName = getRandomName();
-    glueCatalogWithSkip.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
+    glueCatalogWithSkip.createTable(
+        TableIdentifier.of(namespace, tableName), schema, partitionSpec);
     table = glueCatalogWithSkip.loadTable(TableIdentifier.of(namespace, tableName));
     table.newAppend().appendFile(dataFile).commit();
-    Assert.assertEquals("skipArchive should not create new version",
-        1, glue.getTableVersions(GetTableVersionsRequest.builder()
-            .databaseName(namespace).tableName(tableName).build()).tableVersions().size());
+    Assert.assertEquals(
+        "skipArchive should not create new version",
+        1,
+        glue.getTableVersions(
+                GetTableVersionsRequest.builder()
+                    .databaseName(namespace)
+                    .tableName(tableName)
+                    .build())
+            .tableVersions()
+            .size());
   }
 
   @Test
@@ -332,9 +390,9 @@ public class TestGlueCatalogTable extends GlueTestBase {
     glueCatalogWithSkipNameValidation.createNamespace(Namespace.of(namespace));
     String tableName = "cc-cc";
     glueCatalogWithSkipNameValidation.createTable(
-            TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
-    GetTableResponse response = glue.getTable(GetTableRequest.builder()
-            .databaseName(namespace).name(tableName).build());
+        TableIdentifier.of(namespace, tableName), schema, partitionSpec, tableLocationProperties);
+    GetTableResponse response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
     Assert.assertEquals(namespace, response.table().databaseName());
     Assert.assertEquals(tableName, response.table().name());
   }
@@ -344,70 +402,70 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
-    table.updateSchema()
-        .addColumn("c2",
-            Types.StructType.of(Types.NestedField.required(3, "z", Types.IntegerType.get())), "c2")
+    table
+        .updateSchema()
+        .addColumn(
+            "c2",
+            Types.StructType.of(Types.NestedField.required(3, "z", Types.IntegerType.get())),
+            "c2")
         .addColumn("c3", Types.StringType.get())
         .addColumn("c4", Types.StringType.get())
         .commit();
     table.updateSpec().addField(truncate("c1", 8)).commit();
-    table.updateSchema()
-        .deleteColumn("c3")
-        .renameColumn("c4", "c5")
-        .commit();
-    GetTableResponse response = glue.getTable(GetTableRequest.builder()
-        .databaseName(namespace).name(tableName).build());
+    table.updateSchema().deleteColumn("c3").renameColumn("c4", "c5").commit();
+    GetTableResponse response =
+        glue.getTable(GetTableRequest.builder().databaseName(namespace).name(tableName).build());
     List<Column> actualColumns = response.table().storageDescriptor().columns();
 
-    List<Column> expectedColumns = ImmutableList.of(
-        Column.builder()
-            .name("c1")
-            .type("string")
-            .comment("c1")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
-            ))
-            .build(),
-        Column.builder()
-            .name("c2")
-            .type("struct<z:int>")
-            .comment("c2")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
-                IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
-            ))
-            .build(),
-        Column.builder()
-            .name("c5")
-            .type("string")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "5",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
-                IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
-            ))
-            .build(),
-        Column.builder()
-            .name("c3")
-            .type("string")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "4",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
-                IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "false"
-            ))
-            .build(),
-        Column.builder()
-            .name("c4")
-            .type("string")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "5",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
-                IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "false"
-            ))
-            .build()
-    );
+    List<Column> expectedColumns =
+        ImmutableList.of(
+            Column.builder()
+                .name("c1")
+                .type("string")
+                .comment("c1")
+                .parameters(
+                    ImmutableMap.of(
+                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"))
+                .build(),
+            Column.builder()
+                .name("c2")
+                .type("struct<z:int>")
+                .comment("c2")
+                .parameters(
+                    ImmutableMap.of(
+                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"))
+                .build(),
+            Column.builder()
+                .name("c5")
+                .type("string")
+                .parameters(
+                    ImmutableMap.of(
+                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "5",
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"))
+                .build(),
+            Column.builder()
+                .name("c3")
+                .type("string")
+                .parameters(
+                    ImmutableMap.of(
+                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "4",
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "false"))
+                .build(),
+            Column.builder()
+                .name("c4")
+                .type("string")
+                .parameters(
+                    ImmutableMap.of(
+                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "5",
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "false"))
+                .build());
     Assert.assertEquals("Columns do not match", expectedColumns, actualColumns);
   }
 
@@ -416,26 +474,29 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = getRandomName();
     TableIdentifier tableIdent = TableIdentifier.of(namespace, tableName);
-    ImmutableMap<String, String> catalogProps = ImmutableMap.of(
-        "table-default.key1", "catalog-default-key1",
-        "table-default.key2", "catalog-default-key2",
-        "table-default.key3", "catalog-default-key3",
-        "table-override.key3", "catalog-override-key3",
-        "table-override.key4", "catalog-override-key4",
-        "warehouse", "s3://" + testBucketName + "/" + testPathPrefix);
+    ImmutableMap<String, String> catalogProps =
+        ImmutableMap.of(
+            "table-default.key1", "catalog-default-key1",
+            "table-default.key2", "catalog-default-key2",
+            "table-default.key3", "catalog-default-key3",
+            "table-override.key3", "catalog-override-key3",
+            "table-override.key4", "catalog-override-key4",
+            "warehouse", "s3://" + testBucketName + "/" + testPathPrefix);
 
     glueCatalog.initialize("glue", catalogProps);
 
-    Schema schema = new Schema(
-        NestedField.required(3, "id", Types.IntegerType.get(), "unique ID"),
-        NestedField.required(4, "data", Types.StringType.get())
-    );
+    Schema schema =
+        new Schema(
+            NestedField.required(3, "id", Types.IntegerType.get(), "unique ID"),
+            NestedField.required(4, "data", Types.StringType.get()));
 
-    Table table = glueCatalog.buildTable(tableIdent, schema)
-        .withProperty("key2", "table-key2")
-        .withProperty("key3", "table-key3")
-        .withProperty("key5", "table-key5")
-        .create();
+    Table table =
+        glueCatalog
+            .buildTable(tableIdent, schema)
+            .withProperty("key2", "table-key2")
+            .withProperty("key3", "table-key3")
+            .withProperty("key5", "table-key5")
+            .create();
 
     Assert.assertEquals(
         "Table defaults set for the catalog must be added to the table properties.",
@@ -446,8 +507,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
         "table-key2",
         table.properties().get("key2"));
     Assert.assertEquals(
-        "Table property override set at catalog level must override table default" +
-            " properties set at catalog level and table property specified.",
+        "Table property override set at catalog level must override table default"
+            + " properties set at catalog level and table property specified.",
         "catalog-override-key3",
         table.properties().get("key3"));
     Assert.assertEquals(
@@ -455,8 +516,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
         "catalog-override-key4",
         table.properties().get("key4"));
     Assert.assertEquals(
-        "Table properties without any catalog level default or override should be added to table" +
-            " properties.",
+        "Table properties without any catalog level default or override should be added to table"
+            + " properties.",
         "table-key5",
         table.properties().get("key5"));
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/LakeFormationTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/LakeFormationTestBase.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.lakeformation;
 
 import java.io.UnsupportedEncodingException;
@@ -109,8 +108,10 @@ public class LakeFormationTestBase {
   static String lfRegisterPathRoleIamPolicyName;
   static String lfPrivilegedRolePolicyName;
   static DataLakePrincipal principalUnderTest;
-  static String testBucketPath = "s3://" + AwsIntegTestUtil.testBucketName() + "/" + TEST_PATH_PREFIX;
-  static Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
+  static String testBucketPath =
+      "s3://" + AwsIntegTestUtil.testBucketName() + "/" + TEST_PATH_PREFIX;
+  static Schema schema =
+      new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
   static PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
 
   static GlueCatalog glueCatalogRegisterPathRole;
@@ -123,92 +124,125 @@ public class LakeFormationTestBase {
   public static void beforeClass() throws Exception {
     lfRegisterPathRoleName = LF_REGISTER_PATH_ROLE_PREFIX + UUID.randomUUID().toString();
     lfPrivilegedRoleName = LF_PRIVILEGED_ROLE_PREFIX + UUID.randomUUID().toString();
-    lfRegisterPathRoleS3PolicyName = LF_REGISTER_PATH_ROLE_S3_POLICY_PREFIX + UUID.randomUUID().toString();
-    lfRegisterPathRoleLfPolicyName = LF_REGISTER_PATH_ROLE_LF_POLICY_PREFIX + UUID.randomUUID().toString();
-    lfRegisterPathRoleIamPolicyName = LF_REGISTER_PATH_ROLE_IAM_POLICY_PREFIX + UUID.randomUUID().toString();
+    lfRegisterPathRoleS3PolicyName =
+        LF_REGISTER_PATH_ROLE_S3_POLICY_PREFIX + UUID.randomUUID().toString();
+    lfRegisterPathRoleLfPolicyName =
+        LF_REGISTER_PATH_ROLE_LF_POLICY_PREFIX + UUID.randomUUID().toString();
+    lfRegisterPathRoleIamPolicyName =
+        LF_REGISTER_PATH_ROLE_IAM_POLICY_PREFIX + UUID.randomUUID().toString();
     lfPrivilegedRolePolicyName = LF_PRIVILEGED_ROLE_POLICY_PREFIX + UUID.randomUUID().toString();
 
-    iam = IamClient.builder()
-        .region(Region.AWS_GLOBAL)
-        .httpClientBuilder(UrlConnectionHttpClient.builder())
-        .build();
+    iam =
+        IamClient.builder()
+            .region(Region.AWS_GLOBAL)
+            .httpClientBuilder(UrlConnectionHttpClient.builder())
+            .build();
 
-    CreateRoleResponse response = iam.createRole(CreateRoleRequest.builder()
-        .roleName(lfRegisterPathRoleName)
-        .assumeRolePolicyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Effect\":\"Allow\"," +
-            "\"Principal\":{" +
-            "\"Service\":[\"glue.amazonaws.com\"," +
-            "\"lakeformation.amazonaws.com\"]," +
-            "\"AWS\":\"arn:aws:iam::" + AwsIntegTestUtil.testAccountId() + ":root\"}," +
-            "\"Action\": [\"sts:AssumeRole\"]}]}")
-        .maxSessionDuration(ASSUME_ROLE_SESSION_DURATION)
-        .build());
+    CreateRoleResponse response =
+        iam.createRole(
+            CreateRoleRequest.builder()
+                .roleName(lfRegisterPathRoleName)
+                .assumeRolePolicyDocument(
+                    "{"
+                        + "\"Version\":\"2012-10-17\","
+                        + "\"Statement\":[{"
+                        + "\"Effect\":\"Allow\","
+                        + "\"Principal\":{"
+                        + "\"Service\":[\"glue.amazonaws.com\","
+                        + "\"lakeformation.amazonaws.com\"],"
+                        + "\"AWS\":\"arn:aws:iam::"
+                        + AwsIntegTestUtil.testAccountId()
+                        + ":root\"},"
+                        + "\"Action\": [\"sts:AssumeRole\"]}]}")
+                .maxSessionDuration(ASSUME_ROLE_SESSION_DURATION)
+                .build());
     lfRegisterPathRoleArn = response.role().arn();
 
     // create and attach test policy to lfRegisterPathRole
-    createAndAttachRolePolicy(createPolicyArn(lfRegisterPathRoleS3PolicyName),
-        lfRegisterPathRoleS3PolicyName, lfRegisterPathRolePolicyDocForS3(), lfRegisterPathRoleName);
-    createAndAttachRolePolicy(createPolicyArn(lfRegisterPathRoleLfPolicyName),
-        lfRegisterPathRoleLfPolicyName, lfRegisterPathRolePolicyDocForLakeFormation(), lfRegisterPathRoleName);
-    createAndAttachRolePolicy(createPolicyArn(lfRegisterPathRoleIamPolicyName),
+    createAndAttachRolePolicy(
+        createPolicyArn(lfRegisterPathRoleS3PolicyName),
+        lfRegisterPathRoleS3PolicyName,
+        lfRegisterPathRolePolicyDocForS3(),
+        lfRegisterPathRoleName);
+    createAndAttachRolePolicy(
+        createPolicyArn(lfRegisterPathRoleLfPolicyName),
+        lfRegisterPathRoleLfPolicyName,
+        lfRegisterPathRolePolicyDocForLakeFormation(),
+        lfRegisterPathRoleName);
+    createAndAttachRolePolicy(
+        createPolicyArn(lfRegisterPathRoleIamPolicyName),
         lfRegisterPathRoleIamPolicyName,
-        lfRegisterPathRolePolicyDocForIam(lfRegisterPathRoleArn), lfRegisterPathRoleName);
+        lfRegisterPathRolePolicyDocForIam(lfRegisterPathRoleArn),
+        lfRegisterPathRoleName);
     waitForIamConsistency();
 
     // create lfPrivilegedRole
-    response = iam.createRole(CreateRoleRequest.builder()
-        .roleName(lfPrivilegedRoleName)
-        .assumeRolePolicyDocument("{" +
-            "\"Version\":\"2012-10-17\"," +
-            "\"Statement\":[{" +
-            "\"Effect\":\"Allow\"," +
-            "\"Principal\":{" +
-            "\"AWS\":\"arn:aws:iam::" + AwsIntegTestUtil.testAccountId() + ":root\"}," +
-            "\"Action\": [\"sts:AssumeRole\"," +
-            "\"sts:TagSession\"]}]}")
-        .maxSessionDuration(ASSUME_ROLE_SESSION_DURATION)
-        .build());
+    response =
+        iam.createRole(
+            CreateRoleRequest.builder()
+                .roleName(lfPrivilegedRoleName)
+                .assumeRolePolicyDocument(
+                    "{"
+                        + "\"Version\":\"2012-10-17\","
+                        + "\"Statement\":[{"
+                        + "\"Effect\":\"Allow\","
+                        + "\"Principal\":{"
+                        + "\"AWS\":\"arn:aws:iam::"
+                        + AwsIntegTestUtil.testAccountId()
+                        + ":root\"},"
+                        + "\"Action\": [\"sts:AssumeRole\","
+                        + "\"sts:TagSession\"]}]}")
+                .maxSessionDuration(ASSUME_ROLE_SESSION_DURATION)
+                .build());
     lfPrivilegedRoleArn = response.role().arn();
-    principalUnderTest = DataLakePrincipal.builder().dataLakePrincipalIdentifier(lfPrivilegedRoleArn).build();
+    principalUnderTest =
+        DataLakePrincipal.builder().dataLakePrincipalIdentifier(lfPrivilegedRoleArn).build();
 
     // create and attach test policy to lfPrivilegedRole
-    createAndAttachRolePolicy(createPolicyArn(lfPrivilegedRolePolicyName),
-        lfPrivilegedRolePolicyName, lfPrivilegedRolePolicyDoc(), lfPrivilegedRoleName);
+    createAndAttachRolePolicy(
+        createPolicyArn(lfPrivilegedRolePolicyName),
+        lfPrivilegedRolePolicyName,
+        lfPrivilegedRolePolicyDoc(),
+        lfPrivilegedRoleName);
     waitForIamConsistency();
 
     // build lf and glue client with lfRegisterPathRole
-    lakeformation = buildLakeFormationClient(lfRegisterPathRoleArn, "test_lf", AwsIntegTestUtil.testRegion());
+    lakeformation =
+        buildLakeFormationClient(lfRegisterPathRoleArn, "test_lf", AwsIntegTestUtil.testRegion());
     glue = buildGlueClient(lfRegisterPathRoleArn, "test_lf", AwsIntegTestUtil.testRegion());
 
     // put lf data lake settings
     GetDataLakeSettingsResponse getDataLakeSettingsResponse =
         lakeformation.getDataLakeSettings(GetDataLakeSettingsRequest.builder().build());
-    PutDataLakeSettingsResponse putDataLakeSettingsResponse
-        = lakeformation.putDataLakeSettings(putDataLakeSettingsRequest(lfRegisterPathRoleArn,
-        getDataLakeSettingsResponse.dataLakeSettings(), true));
+    PutDataLakeSettingsResponse putDataLakeSettingsResponse =
+        lakeformation.putDataLakeSettings(
+            putDataLakeSettingsRequest(
+                lfRegisterPathRoleArn, getDataLakeSettingsResponse.dataLakeSettings(), true));
 
     // Build test glueCatalog with lfPrivilegedRole
     glueCatalogPrivilegedRole = new GlueCatalog();
     assumeRoleProperties = Maps.newHashMap();
     assumeRoleProperties.put("warehouse", "s3://path");
-    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, AwsIntegTestUtil.testRegion());
+    assumeRoleProperties.put(
+        AwsProperties.CLIENT_ASSUME_ROLE_REGION, AwsIntegTestUtil.testRegion());
     assumeRoleProperties.put(AwsProperties.GLUE_LAKEFORMATION_ENABLED, "true");
     assumeRoleProperties.put(AwsProperties.GLUE_ACCOUNT_ID, AwsIntegTestUtil.testAccountId());
     assumeRoleProperties.put(AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_APACHE);
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, lfPrivilegedRoleArn);
-    assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX +
-        LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER, LF_AUTHORIZED_CALLER_VALUE);
+    assumeRoleProperties.put(
+        AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX
+            + LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER,
+        LF_AUTHORIZED_CALLER_VALUE);
     glueCatalogPrivilegedRole.initialize("test_registered", assumeRoleProperties);
 
     // Build test glueCatalog with lfRegisterPathRole
     assumeRoleProperties.put(AwsProperties.GLUE_LAKEFORMATION_ENABLED, "false");
     assumeRoleProperties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, lfRegisterPathRoleArn);
-    assumeRoleProperties.remove(AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX +
-        LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER);
-    assumeRoleProperties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    assumeRoleProperties.remove(
+        AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX
+            + LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER);
+    assumeRoleProperties.put(
+        AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
     glueCatalogRegisterPathRole = new GlueCatalog();
     glueCatalogRegisterPathRole.initialize("test_privileged", assumeRoleProperties);
     // register S3 test bucket path
@@ -221,11 +255,15 @@ public class LakeFormationTestBase {
   public static void afterClass() {
     GetDataLakeSettingsResponse getDataLakeSettingsResponse =
         lakeformation.getDataLakeSettings(GetDataLakeSettingsRequest.builder().build());
-    lakeformation.putDataLakeSettings(putDataLakeSettingsRequest(lfRegisterPathRoleArn,
-        getDataLakeSettingsResponse.dataLakeSettings(), false));
-    detachAndDeleteRolePolicy(createPolicyArn(lfRegisterPathRoleS3PolicyName), lfRegisterPathRoleName);
-    detachAndDeleteRolePolicy(createPolicyArn(lfRegisterPathRoleLfPolicyName), lfRegisterPathRoleName);
-    detachAndDeleteRolePolicy(createPolicyArn(lfRegisterPathRoleIamPolicyName), lfRegisterPathRoleName);
+    lakeformation.putDataLakeSettings(
+        putDataLakeSettingsRequest(
+            lfRegisterPathRoleArn, getDataLakeSettingsResponse.dataLakeSettings(), false));
+    detachAndDeleteRolePolicy(
+        createPolicyArn(lfRegisterPathRoleS3PolicyName), lfRegisterPathRoleName);
+    detachAndDeleteRolePolicy(
+        createPolicyArn(lfRegisterPathRoleLfPolicyName), lfRegisterPathRoleName);
+    detachAndDeleteRolePolicy(
+        createPolicyArn(lfRegisterPathRoleIamPolicyName), lfRegisterPathRoleName);
     iam.deleteRole(DeleteRoleRequest.builder().roleName(lfRegisterPathRoleName).build());
     detachAndDeleteRolePolicy(createPolicyArn(lfPrivilegedRolePolicyName), lfPrivilegedRoleName);
     iam.deleteRole(DeleteRoleRequest.builder().roleName(lfPrivilegedRoleName).build());
@@ -233,21 +271,30 @@ public class LakeFormationTestBase {
   }
 
   void grantDatabasePrivileges(String dbName, Permission... permissions) {
-    Resource dbResource = Resource.builder().database(DatabaseResource.builder().name(dbName).build()).build();
-    lakeformation.grantPermissions(GrantPermissionsRequest.builder()
-        .principal(principalUnderTest)
-        .resource(dbResource)
-        .permissions(permissions).build());
+    Resource dbResource =
+        Resource.builder().database(DatabaseResource.builder().name(dbName).build()).build();
+    lakeformation.grantPermissions(
+        GrantPermissionsRequest.builder()
+            .principal(principalUnderTest)
+            .resource(dbResource)
+            .permissions(permissions)
+            .build());
   }
 
   void grantDataPathPrivileges(String resourceLocation) {
-    Resource dataLocationResource = Resource.builder()
-        .dataLocation(DataLocationResource.builder()
-            .resourceArn(getArnForS3Location(resourceLocation)).build()).build();
-    lakeformation.grantPermissions(GrantPermissionsRequest.builder()
-        .principal(principalUnderTest)
-        .resource(dataLocationResource)
-        .permissions(Permission.DATA_LOCATION_ACCESS).build());
+    Resource dataLocationResource =
+        Resource.builder()
+            .dataLocation(
+                DataLocationResource.builder()
+                    .resourceArn(getArnForS3Location(resourceLocation))
+                    .build())
+            .build();
+    lakeformation.grantPermissions(
+        GrantPermissionsRequest.builder()
+            .principal(principalUnderTest)
+            .resource(dataLocationResource)
+            .permissions(Permission.DATA_LOCATION_ACCESS)
+            .build());
   }
 
   void lfRegisterPathRoleCreateDb(String dbName) {
@@ -259,12 +306,17 @@ public class LakeFormationTestBase {
   }
 
   void lfRegisterPathRoleCreateTable(String dbName, String tableName) {
-    glueCatalogRegisterPathRole.createTable(TableIdentifier.of(Namespace.of(dbName), tableName),
-        schema, partitionSpec, getTableLocation(tableName), null);
+    glueCatalogRegisterPathRole.createTable(
+        TableIdentifier.of(Namespace.of(dbName), tableName),
+        schema,
+        partitionSpec,
+        getTableLocation(tableName),
+        null);
   }
 
   void lfRegisterPathRoleDeleteTable(String dbName, String tableName) {
-    glueCatalogRegisterPathRole.dropTable(TableIdentifier.of(Namespace.of(dbName), tableName), false);
+    glueCatalogRegisterPathRole.dropTable(
+        TableIdentifier.of(Namespace.of(dbName), tableName), false);
   }
 
   String getTableLocation(String tableName) {
@@ -272,20 +324,26 @@ public class LakeFormationTestBase {
   }
 
   void grantCreateDbPermission() {
-    lakeformation.grantPermissions(GrantPermissionsRequest.builder()
-        .principal(principalUnderTest)
-        .permissions(Permission.CREATE_DATABASE)
-        .resource(Resource.builder().catalog(CatalogResource.builder().build()).build()).build());
+    lakeformation.grantPermissions(
+        GrantPermissionsRequest.builder()
+            .principal(principalUnderTest)
+            .permissions(Permission.CREATE_DATABASE)
+            .resource(Resource.builder().catalog(CatalogResource.builder().build()).build())
+            .build());
   }
 
   void grantTablePrivileges(String dbName, String tableName, Permission... tableDdlPrivileges) {
-    Resource tableResource = Resource.builder()
-        .table(TableResource.builder().databaseName(dbName).name(tableName).build()).build();
-    GrantPermissionsRequest grantDataLakePrivilegesRequest = GrantPermissionsRequest.builder()
-        .principal(principalUnderTest)
-        .resource(tableResource)
-        .permissionsWithGrantOption(tableDdlPrivileges)
-        .permissions(tableDdlPrivileges).build();
+    Resource tableResource =
+        Resource.builder()
+            .table(TableResource.builder().databaseName(dbName).name(tableName).build())
+            .build();
+    GrantPermissionsRequest grantDataLakePrivilegesRequest =
+        GrantPermissionsRequest.builder()
+            .principal(principalUnderTest)
+            .resource(tableResource)
+            .permissionsWithGrantOption(tableDdlPrivileges)
+            .permissions(tableDdlPrivileges)
+            .build();
     lakeformation.grantPermissions(grantDataLakePrivilegesRequest);
   }
 
@@ -294,25 +352,28 @@ public class LakeFormationTestBase {
   }
 
   String getRandomTableName() {
-    return LF_TEST_TABLE_PREFIX  + UUID.randomUUID().toString().replace("-", "");
+    return LF_TEST_TABLE_PREFIX + UUID.randomUUID().toString().replace("-", "");
   }
 
   private static void waitForIamConsistency() throws Exception {
     Thread.sleep(IAM_PROPAGATION_DELAY); // sleep to make sure IAM up to date
   }
 
-  private static LakeFormationClient buildLakeFormationClient(String roleArn, String sessionName, String region) {
-    AssumeRoleRequest request = AssumeRoleRequest.builder()
-        .roleArn(roleArn)
-        .roleSessionName(sessionName)
-        .durationSeconds(ASSUME_ROLE_SESSION_DURATION)
-        .build();
+  private static LakeFormationClient buildLakeFormationClient(
+      String roleArn, String sessionName, String region) {
+    AssumeRoleRequest request =
+        AssumeRoleRequest.builder()
+            .roleArn(roleArn)
+            .roleSessionName(sessionName)
+            .durationSeconds(ASSUME_ROLE_SESSION_DURATION)
+            .build();
 
     LakeFormationClientBuilder clientBuilder = LakeFormationClient.builder();
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
+            .stsClient(
+                StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
             .refreshRequest(request)
             .build());
 
@@ -322,17 +383,19 @@ public class LakeFormationTestBase {
   }
 
   private static GlueClient buildGlueClient(String roleArn, String sessionName, String region) {
-    AssumeRoleRequest request = AssumeRoleRequest.builder()
-        .roleArn(roleArn)
-        .roleSessionName(sessionName)
-        .durationSeconds(ASSUME_ROLE_SESSION_DURATION)
-        .build();
+    AssumeRoleRequest request =
+        AssumeRoleRequest.builder()
+            .roleArn(roleArn)
+            .roleSessionName(sessionName)
+            .durationSeconds(ASSUME_ROLE_SESSION_DURATION)
+            .build();
 
     GlueClientBuilder clientBuilder = GlueClient.builder();
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
+            .stsClient(
+                StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
             .refreshRequest(request)
             .build());
 
@@ -344,11 +407,14 @@ public class LakeFormationTestBase {
   private static void registerResource(String s3Location) {
     String arn = getArnForS3Location(s3Location);
     try {
-      lakeformation.registerResource(RegisterResourceRequest.builder()
-          .resourceArn(arn)
-          .roleArn(lfRegisterPathRoleArn)
-          .useServiceLinkedRole(false).build());
-      // when a resource is registered, LF will update SLR with necessary permissions which has a propagation delay
+      lakeformation.registerResource(
+          RegisterResourceRequest.builder()
+              .resourceArn(arn)
+              .roleArn(lfRegisterPathRoleArn)
+              .useServiceLinkedRole(false)
+              .build());
+      // when a resource is registered, LF will update SLR with necessary permissions which has a
+      // propagation delay
       waitForIamConsistency();
     } catch (AlreadyExistsException e) {
       LOG.warn("Resource {} already registered. Error: {}", arn, e);
@@ -360,46 +426,61 @@ public class LakeFormationTestBase {
   private static void deregisterResource(String s3Location) {
     String arn = getArnForS3Location(s3Location);
     try {
-      lakeformation.deregisterResource(DeregisterResourceRequest.builder().resourceArn(arn).build());
+      lakeformation.deregisterResource(
+          DeregisterResourceRequest.builder().resourceArn(arn).build());
     } catch (EntityNotFoundException e) {
       LOG.info("Resource {} not found. Error: {}", arn, e);
     }
   }
 
   private static String createPolicyArn(String policyName) {
-    return String.format("arn:%s:iam::%s:policy/%s",
+    return String.format(
+        "arn:%s:iam::%s:policy/%s",
         PartitionMetadata.of(Region.of(AwsIntegTestUtil.testRegion())).id(),
         AwsIntegTestUtil.testAccountId(),
         policyName);
   }
 
-  private static void createAndAttachRolePolicy(String policyArn, String policyName,
-      String policyDocument, String roleName) {
+  private static void createAndAttachRolePolicy(
+      String policyArn, String policyName, String policyDocument, String roleName) {
     createOrReplacePolicy(policyArn, policyName, policyDocument, roleName);
     attachRolePolicyIfNotExists(policyArn, policyName, roleName);
   }
 
-  private static void attachRolePolicyIfNotExists(String policyArn, String policyName, String roleName) {
+  private static void attachRolePolicyIfNotExists(
+      String policyArn, String policyName, String roleName) {
     try {
-      iam.getRolePolicy(GetRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
+      iam.getRolePolicy(
+          GetRolePolicyRequest.builder().roleName(roleName).policyName(policyName).build());
       LOG.info("Policy {} already attached to role {}", policyName, roleName);
     } catch (NoSuchEntityException e) {
       LOG.info("Attaching policy {} to role {} {}", policyName, roleName, e);
-      iam.attachRolePolicy(AttachRolePolicyRequest.builder().roleName(roleName).policyArn(policyArn).build());
+      iam.attachRolePolicy(
+          AttachRolePolicyRequest.builder().roleName(roleName).policyArn(policyArn).build());
     }
   }
 
-  private static void createOrReplacePolicy(String policyArn, String policyName,
-      String policyDocument, String roleName) {
+  private static void createOrReplacePolicy(
+      String policyArn, String policyName, String policyDocument, String roleName) {
     try {
-      PolicyVersion existingPolicy = iam.getPolicyVersion(GetPolicyVersionRequest.builder()
-          .policyArn(policyArn).versionId(DEFAULT_IAM_POLICY_VERSION).build()).policyVersion();
-      String currentDocument = URLDecoder.decode(existingPolicy.document(), StandardCharsets.UTF_8.name());
+      PolicyVersion existingPolicy =
+          iam.getPolicyVersion(
+                  GetPolicyVersionRequest.builder()
+                      .policyArn(policyArn)
+                      .versionId(DEFAULT_IAM_POLICY_VERSION)
+                      .build())
+              .policyVersion();
+      String currentDocument =
+          URLDecoder.decode(existingPolicy.document(), StandardCharsets.UTF_8.name());
       if (Objects.equals(currentDocument, policyDocument)) {
-        LOG.info("Policy {} already exists and policy content did not change. Nothing to do.", policyArn);
+        LOG.info(
+            "Policy {} already exists and policy content did not change. Nothing to do.",
+            policyArn);
       } else {
-        LOG.info("Role policy exists but has different policy content. Existing content: {}, new content: {}",
-            currentDocument, policyDocument);
+        LOG.info(
+            "Role policy exists but has different policy content. Existing content: {}, new content: {}",
+            currentDocument,
+            policyDocument);
         detachAndDeleteRolePolicy(policyArn, roleName);
         createPolicy(policyName, policyDocument);
       }
@@ -412,13 +493,18 @@ public class LakeFormationTestBase {
 
   private static void createPolicy(String policyName, String policyDocument) {
     LOG.info("Creating policy {} with version v1", policyName);
-    iam.createPolicy(CreatePolicyRequest.builder().policyName(policyName).policyDocument(policyDocument).build());
+    iam.createPolicy(
+        CreatePolicyRequest.builder()
+            .policyName(policyName)
+            .policyDocument(policyDocument)
+            .build());
   }
 
   private static void detachAndDeleteRolePolicy(String policyArn, String roleName) {
     LOG.info("Detaching role policy {} if attached", policyArn);
     try {
-      iam.detachRolePolicy(DetachRolePolicyRequest.builder().policyArn(policyArn).roleName(roleName).build());
+      iam.detachRolePolicy(
+          DetachRolePolicyRequest.builder().policyArn(policyArn).roleName(roleName).build());
     } catch (NoSuchEntityException ex) {
       // nothing to do if it doesn't exist
     }
@@ -432,73 +518,78 @@ public class LakeFormationTestBase {
   }
 
   private static String lfRegisterPathRolePolicyDocForS3() {
-    return "{" +
-        "\"Version\":\"2012-10-17\"," +
-        "\"Statement\":[{" +
-        "\"Effect\":\"Allow\"," +
-        "\"Action\": [\"s3:*\"]," +
-        "\"Resource\": [\"*\"]}]}";
+    return "{"
+        + "\"Version\":\"2012-10-17\","
+        + "\"Statement\":[{"
+        + "\"Effect\":\"Allow\","
+        + "\"Action\": [\"s3:*\"],"
+        + "\"Resource\": [\"*\"]}]}";
   }
 
   private static String lfRegisterPathRolePolicyDocForLakeFormation() {
-    return "{" +
-        "\"Version\":\"2012-10-17\"," +
-        "\"Statement\":[{" +
-        "\"Sid\":\"policy1\"," +
-        "\"Effect\":\"Allow\"," +
-        "\"Action\":[\"lakeformation:GetDataLakeSettings\"," +
-        "\"lakeformation:PutDataLakeSettings\"," +
-        "\"lakeformation:GrantPermissions\"," +
-        "\"lakeformation:RevokePermissions\"," +
-        "\"lakeformation:RegisterResource\"," +
-        "\"lakeformation:DeregisterResource\"," +
-        "\"lakeformation:GetDataAccess\"," +
-        "\"glue:CreateDatabase\",\"glue:DeleteDatabase\"," +
-        "\"glue:Get*\", \"glue:CreateTable\", \"glue:DeleteTable\", \"glue:UpdateTable\"]," +
-        "\"Resource\":[\"*\"]}]}";
+    return "{"
+        + "\"Version\":\"2012-10-17\","
+        + "\"Statement\":[{"
+        + "\"Sid\":\"policy1\","
+        + "\"Effect\":\"Allow\","
+        + "\"Action\":[\"lakeformation:GetDataLakeSettings\","
+        + "\"lakeformation:PutDataLakeSettings\","
+        + "\"lakeformation:GrantPermissions\","
+        + "\"lakeformation:RevokePermissions\","
+        + "\"lakeformation:RegisterResource\","
+        + "\"lakeformation:DeregisterResource\","
+        + "\"lakeformation:GetDataAccess\","
+        + "\"glue:CreateDatabase\",\"glue:DeleteDatabase\","
+        + "\"glue:Get*\", \"glue:CreateTable\", \"glue:DeleteTable\", \"glue:UpdateTable\"],"
+        + "\"Resource\":[\"*\"]}]}";
   }
 
   private static String lfRegisterPathRolePolicyDocForIam(String roleArn) {
-    return "{\n" +
-        "\"Version\":\"2012-10-17\"," +
-        "\"Statement\":{" +
-        "\"Effect\":\"Allow\"," +
-        "\"Action\": [" +
-        "\"iam:PassRole\"," +
-        "\"iam:GetRole\"" +
-        "]," +
-        "\"Resource\": [" +
-        "\"" + roleArn + "\"" +
-        "]}}";
+    return "{\n"
+        + "\"Version\":\"2012-10-17\","
+        + "\"Statement\":{"
+        + "\"Effect\":\"Allow\","
+        + "\"Action\": ["
+        + "\"iam:PassRole\","
+        + "\"iam:GetRole\""
+        + "],"
+        + "\"Resource\": ["
+        + "\""
+        + roleArn
+        + "\""
+        + "]}}";
   }
 
   private static String lfPrivilegedRolePolicyDoc() {
-    return "{" +
-        "\"Version\":\"2012-10-17\"," +
-        "\"Statement\":[{" +
-        "\"Sid\":\"policy1\"," +
-        "\"Effect\":\"Allow\"," +
-        "\"Action\":[\"glue:CreateDatabase\", \"glue:DeleteDatabase\"," +
-        "\"glue:Get*\", \"glue:UpdateTable\", \"glue:DeleteTable\", \"glue:CreateTable\"," +
-        "\"lakeformation:GetDataAccess\"]," +
-        "\"Resource\":[\"*\"]}]}";
+    return "{"
+        + "\"Version\":\"2012-10-17\","
+        + "\"Statement\":[{"
+        + "\"Sid\":\"policy1\","
+        + "\"Effect\":\"Allow\","
+        + "\"Action\":[\"glue:CreateDatabase\", \"glue:DeleteDatabase\","
+        + "\"glue:Get*\", \"glue:UpdateTable\", \"glue:DeleteTable\", \"glue:CreateTable\","
+        + "\"lakeformation:GetDataAccess\"],"
+        + "\"Resource\":[\"*\"]}]}";
   }
 
-  private static PutDataLakeSettingsRequest putDataLakeSettingsRequest(String adminArn,
-      DataLakeSettings dataLakeSettings, boolean add) {
-    List<DataLakePrincipal> dataLakeAdmins =  Lists.newArrayList(dataLakeSettings.dataLakeAdmins());
+  private static PutDataLakeSettingsRequest putDataLakeSettingsRequest(
+      String adminArn, DataLakeSettings dataLakeSettings, boolean add) {
+    List<DataLakePrincipal> dataLakeAdmins = Lists.newArrayList(dataLakeSettings.dataLakeAdmins());
     if (add) {
       dataLakeAdmins.add(DataLakePrincipal.builder().dataLakePrincipalIdentifier(adminArn).build());
     } else {
       dataLakeAdmins.removeIf(p -> p.dataLakePrincipalIdentifier().equals(adminArn));
     }
-    DataLakeSettings newDataLakeSettings = DataLakeSettings.builder()
-        .dataLakeAdmins(dataLakeAdmins)
-        .allowExternalDataFiltering(true)
-        .externalDataFilteringAllowList(DataLakePrincipal.builder()
-            .dataLakePrincipalIdentifier(AwsIntegTestUtil.testAccountId()).build())
-        .authorizedSessionTagValueList(LF_AUTHORIZED_CALLER_VALUE)
-        .build();
+    DataLakeSettings newDataLakeSettings =
+        DataLakeSettings.builder()
+            .dataLakeAdmins(dataLakeAdmins)
+            .allowExternalDataFiltering(true)
+            .externalDataFilteringAllowList(
+                DataLakePrincipal.builder()
+                    .dataLakePrincipalIdentifier(AwsIntegTestUtil.testAccountId())
+                    .build())
+            .authorizedSessionTagValueList(LF_AUTHORIZED_CALLER_VALUE)
+            .build();
 
     return PutDataLakeSettingsRequest.builder().dataLakeSettings(newDataLakeSettings).build();
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationDataOperations.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationDataOperations.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.lakeformation;
 
 import org.apache.iceberg.AssertHelpers;
@@ -33,8 +32,7 @@ import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.lakeformation.model.Permission;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
-public class TestLakeFormationDataOperations
-    extends LakeFormationTestBase {
+public class TestLakeFormationDataOperations extends LakeFormationTestBase {
 
   private static String testDbName;
   private static String testTableName;
@@ -55,28 +53,36 @@ public class TestLakeFormationDataOperations
 
   @Test
   public void testLoadTableWithNoTableAccess() {
-    AssertHelpers.assertThrows("attempt to load a table without SELECT permission should fail",
+    AssertHelpers.assertThrows(
+        "attempt to load a table without SELECT permission should fail",
         AccessDeniedException.class,
         "Insufficient Lake Formation permission(s)",
-        () -> glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName)));
+        () ->
+            glueCatalogPrivilegedRole.loadTable(
+                TableIdentifier.of(Namespace.of(testDbName), testTableName)));
   }
 
   @Test
   public void testLoadTableSuccess() {
     grantTablePrivileges(testDbName, testTableName, Permission.SELECT);
-    glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
+    glueCatalogPrivilegedRole.loadTable(
+        TableIdentifier.of(Namespace.of(testDbName), testTableName));
   }
 
   @Test
   public void testUpdateTableWithNoInsertAccess() {
     grantTablePrivileges(testDbName, testTableName, Permission.SELECT);
-    Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
-    AssertHelpers.assertThrows("attempt to insert to a table without INSERT permission should fail",
+    Table table =
+        glueCatalogPrivilegedRole.loadTable(
+            TableIdentifier.of(Namespace.of(testDbName), testTableName));
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    AssertHelpers.assertThrows(
+        "attempt to insert to a table without INSERT permission should fail",
         S3Exception.class,
         "Access Denied",
         () -> table.newAppend().appendFile(dataFile).commit());
@@ -84,27 +90,36 @@ public class TestLakeFormationDataOperations
 
   @Test
   public void testUpdateTableSuccess() {
-    grantTablePrivileges(testDbName, testTableName, Permission.SELECT, Permission.ALTER, Permission.INSERT);
+    grantTablePrivileges(
+        testDbName, testTableName, Permission.SELECT, Permission.ALTER, Permission.INSERT);
     grantDataPathPrivileges(getTableLocation(testTableName));
-    Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
+    Table table =
+        glueCatalogPrivilegedRole.loadTable(
+            TableIdentifier.of(Namespace.of(testDbName), testTableName));
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
     table.newAppend().appendFile(dataFile).commit();
   }
 
   @Test
   public void testDeleteWithNoDataPathAccess() {
-    grantTablePrivileges(testDbName, testTableName, Permission.SELECT, Permission.INSERT, Permission.ALTER);
-    Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath(getTableLocation(testTableName) + "/path/to/delete-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
-    AssertHelpers.assertThrows("attempt to delete without DATA_LOCATION_ACCESS permission should fail",
+    grantTablePrivileges(
+        testDbName, testTableName, Permission.SELECT, Permission.INSERT, Permission.ALTER);
+    Table table =
+        glueCatalogPrivilegedRole.loadTable(
+            TableIdentifier.of(Namespace.of(testDbName), testTableName));
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath(getTableLocation(testTableName) + "/path/to/delete-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    AssertHelpers.assertThrows(
+        "attempt to delete without DATA_LOCATION_ACCESS permission should fail",
         ForbiddenException.class,
         "Glue cannot access the requested resources",
         () -> table.newDelete().deleteFile(dataFile).commit());
@@ -112,14 +127,18 @@ public class TestLakeFormationDataOperations
 
   @Test
   public void testDeleteSuccess() {
-    grantTablePrivileges(testDbName, testTableName, Permission.SELECT, Permission.ALTER, Permission.INSERT);
+    grantTablePrivileges(
+        testDbName, testTableName, Permission.SELECT, Permission.ALTER, Permission.INSERT);
     grantDataPathPrivileges(getTableLocation(testTableName));
-    Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
-    DataFile dataFile = DataFiles.builder(partitionSpec)
-        .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
-        .withFileSizeInBytes(10)
-        .withRecordCount(1)
-        .build();
+    Table table =
+        glueCatalogPrivilegedRole.loadTable(
+            TableIdentifier.of(Namespace.of(testDbName), testTableName));
+    DataFile dataFile =
+        DataFiles.builder(partitionSpec)
+            .withPath(getTableLocation(testTableName) + "/path/to/data-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
     table.newDelete().deleteFile(dataFile).commit();
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationMetadataOperations.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.lakeformation;
 
 import java.util.List;
@@ -34,8 +33,7 @@ import org.junit.Test;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.lakeformation.model.Permission;
 
-public class TestLakeFormationMetadataOperations
-    extends LakeFormationTestBase {
+public class TestLakeFormationMetadataOperations extends LakeFormationTestBase {
   @Test
   public void testCreateAndDropDatabaseSuccessful() {
     String testDbName = getRandomDbName();
@@ -50,7 +48,8 @@ public class TestLakeFormationMetadataOperations
   @Test
   public void testCreateDatabaseNoPrivileges() {
     String testDbName = getRandomDbName();
-    AssertHelpers.assertThrows("attempt to create a database without CREATE_DATABASE permission should fail",
+    AssertHelpers.assertThrows(
+        "attempt to create a database without CREATE_DATABASE permission should fail",
         AccessDeniedException.class,
         "Insufficient Lake Formation permission(s)",
         () -> glueCatalogPrivilegedRole.createNamespace(Namespace.of(testDbName)));
@@ -61,7 +60,8 @@ public class TestLakeFormationMetadataOperations
     String testDbName = getRandomDbName();
     lfRegisterPathRoleCreateDb(testDbName);
     try {
-      AssertHelpers.assertThrows("attempt to drop a database without DROP permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to drop a database without DROP permission should fail",
           AccessDeniedException.class,
           "Insufficient Lake Formation permission(s)",
           () -> glueCatalogPrivilegedRole.dropNamespace(Namespace.of(testDbName)));
@@ -92,11 +92,17 @@ public class TestLakeFormationMetadataOperations
     String tableLocation = getTableLocation(testTableName);
     grantDataPathPrivileges(tableLocation);
     try {
-      AssertHelpers.assertThrows("attempt to create a table without CREATE_TABLE permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to create a table without CREATE_TABLE permission should fail",
           AccessDeniedException.class,
           "Insufficient Lake Formation permission(s)",
-          () -> glueCatalogPrivilegedRole.createTable(
-              TableIdentifier.of(testDbName, testTableName), schema, partitionSpec, tableLocation, null));
+          () ->
+              glueCatalogPrivilegedRole.createTable(
+                  TableIdentifier.of(testDbName, testTableName),
+                  schema,
+                  partitionSpec,
+                  tableLocation,
+                  null));
     } finally {
       lfRegisterPathRoleDeleteDb(testDbName);
     }
@@ -111,7 +117,8 @@ public class TestLakeFormationMetadataOperations
     grantTablePrivileges(testDbName, testTableName, Permission.ALTER);
     try {
       List<TableIdentifier> tables = glueCatalogPrivilegedRole.listTables(Namespace.of(testDbName));
-      Assert.assertTrue(tables.contains(TableIdentifier.of(Namespace.of(testDbName), testTableName)));
+      Assert.assertTrue(
+          tables.contains(TableIdentifier.of(Namespace.of(testDbName), testTableName)));
     } finally {
       lfRegisterPathRoleDeleteTable(testDbName, testTableName);
       lfRegisterPathRoleDeleteDb(testDbName);
@@ -125,7 +132,8 @@ public class TestLakeFormationMetadataOperations
     lfRegisterPathRoleCreateDb(testDbName);
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     try {
-      AssertHelpers.assertThrows("attempt to show tables without any permissions should fail",
+      AssertHelpers.assertThrows(
+          "attempt to show tables without any permissions should fail",
           AccessDeniedException.class,
           "Insufficient Lake Formation permission(s)",
           () -> glueCatalogPrivilegedRole.listTables(Namespace.of(testDbName)));
@@ -142,11 +150,17 @@ public class TestLakeFormationMetadataOperations
     lfRegisterPathRoleCreateDb(testDbName);
     grantDatabasePrivileges(testDbName, Permission.CREATE_TABLE);
     try {
-      AssertHelpers.assertThrows("attempt to create a table without DATA_LOCATION_ACCESS permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to create a table without DATA_LOCATION_ACCESS permission should fail",
           ForbiddenException.class,
           "Glue cannot access the requested resources",
-          () -> glueCatalogPrivilegedRole.createTable(TableIdentifier.of(testDbName, testTableName),
-              schema, partitionSpec, getTableLocation(testTableName), null));
+          () ->
+              glueCatalogPrivilegedRole.createTable(
+                  TableIdentifier.of(testDbName, testTableName),
+                  schema,
+                  partitionSpec,
+                  getTableLocation(testTableName),
+                  null));
     } finally {
       lfRegisterPathRoleDeleteDb(testDbName);
     }
@@ -161,8 +175,12 @@ public class TestLakeFormationMetadataOperations
     grantDataPathPrivileges(tableLocation);
     grantDatabasePrivileges(testDbName, Permission.CREATE_TABLE);
     try {
-      glueCatalogPrivilegedRole.createTable(TableIdentifier.of(testDbName, testTableName),
-          schema, partitionSpec, tableLocation, null);
+      glueCatalogPrivilegedRole.createTable(
+          TableIdentifier.of(testDbName, testTableName),
+          schema,
+          partitionSpec,
+          tableLocation,
+          null);
     } finally {
       grantTablePrivileges(testDbName, testTableName, Permission.DELETE, Permission.DROP);
       glueCatalogPrivilegedRole.dropTable(TableIdentifier.of(testDbName, testTableName), false);
@@ -192,10 +210,13 @@ public class TestLakeFormationMetadataOperations
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     grantTablePrivileges(testDbName, testTableName, Permission.SELECT);
     try {
-      AssertHelpers.assertThrows("attempt to drop a table without DROP permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to drop a table without DROP permission should fail",
           AccessDeniedException.class,
           "Insufficient Lake Formation permission(s)",
-          () -> glueCatalogPrivilegedRole.dropTable(TableIdentifier.of(testDbName, testTableName), false));
+          () ->
+              glueCatalogPrivilegedRole.dropTable(
+                  TableIdentifier.of(testDbName, testTableName), false));
     } finally {
       lfRegisterPathRoleDeleteTable(testDbName, testTableName);
       lfRegisterPathRoleDeleteDb(testDbName);
@@ -212,9 +233,12 @@ public class TestLakeFormationMetadataOperations
     grantTablePrivileges(testDbName, testTableName, Permission.ALTER, Permission.INSERT);
     grantDataPathPrivileges(getTableLocation(testTableName));
     try {
-      Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
+      Table table =
+          glueCatalogPrivilegedRole.loadTable(
+              TableIdentifier.of(Namespace.of(testDbName), testTableName));
       properties.putAll(table.properties());
-      properties.put(TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+      properties.put(
+          TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
       UpdateProperties updateProperties = table.updateProperties();
       properties.forEach(updateProperties::set);
       updateProperties.commit();
@@ -233,12 +257,16 @@ public class TestLakeFormationMetadataOperations
     Map<String, String> properties = Maps.newHashMap();
     grantTablePrivileges(testDbName, testTableName, Permission.ALTER, Permission.INSERT);
     try {
-      Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
+      Table table =
+          glueCatalogPrivilegedRole.loadTable(
+              TableIdentifier.of(Namespace.of(testDbName), testTableName));
       properties.putAll(table.properties());
-      properties.put(TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+      properties.put(
+          TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
       UpdateProperties updateProperties = table.updateProperties();
       properties.forEach(updateProperties::set);
-      AssertHelpers.assertThrows("attempt to alter a table without ALTER permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to alter a table without ALTER permission should fail",
           ForbiddenException.class,
           "Glue cannot access the requested resources",
           updateProperties::commit);
@@ -256,10 +284,13 @@ public class TestLakeFormationMetadataOperations
     lfRegisterPathRoleCreateTable(testDbName, testTableName);
     grantDataPathPrivileges(getTableLocation(testTableName));
     try {
-      AssertHelpers.assertThrows("attempt to alter a table without ALTER permission should fail",
+      AssertHelpers.assertThrows(
+          "attempt to alter a table without ALTER permission should fail",
           AccessDeniedException.class,
           "Insufficient Lake Formation permission(s)",
-          () -> glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName)));
+          () ->
+              glueCatalogPrivilegedRole.loadTable(
+                  TableIdentifier.of(Namespace.of(testDbName), testTableName)));
     } finally {
       lfRegisterPathRoleDeleteTable(testDbName, testTableName);
       lfRegisterPathRoleDeleteDb(testDbName);
@@ -275,12 +306,16 @@ public class TestLakeFormationMetadataOperations
     Map<String, String> properties = Maps.newHashMap();
     grantTablePrivileges(testDbName, testTableName, Permission.SELECT, Permission.INSERT);
     try {
-      Table table = glueCatalogPrivilegedRole.loadTable(TableIdentifier.of(Namespace.of(testDbName), testTableName));
+      Table table =
+          glueCatalogPrivilegedRole.loadTable(
+              TableIdentifier.of(Namespace.of(testDbName), testTableName));
       properties.putAll(table.properties());
-      properties.put(TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+      properties.put(
+          TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
       UpdateProperties updateProperties = table.updateProperties();
       properties.forEach(updateProperties::set);
-      AssertHelpers.assertThrows("attempt to alter a table without ALTER privileges should fail",
+      AssertHelpers.assertThrows(
+          "attempt to alter a table without ALTER privileges should fail",
           ForbiddenException.class,
           "Glue cannot access the requested resources",
           updateProperties::commit);

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3TestUtil.java
@@ -16,13 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.s3;
 
 public class S3TestUtil {
 
-  private S3TestUtil() {
-  }
+  private S3TestUtil() {}
 
   public static String getBucketFromUri(String s3Uri) {
     return new S3URI(s3Uri).bucket();

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.s3;
+
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -68,8 +69,6 @@ import software.amazon.awssdk.services.s3control.S3ControlClient;
 import software.amazon.awssdk.utils.ImmutableMap;
 import software.amazon.awssdk.utils.IoUtils;
 
-import static org.junit.Assert.assertEquals;
-
 public class TestS3FileIOIntegration {
 
   private final Random random = new Random(1);
@@ -96,7 +95,8 @@ public class TestS3FileIOIntegration {
     s3 = clientFactory.s3();
     kms = clientFactory.kms();
     s3Control = AwsIntegTestUtil.createS3ControlClient(AwsIntegTestUtil.testRegion());
-    crossRegionS3Control = AwsIntegTestUtil.createS3ControlClient(AwsIntegTestUtil.testCrossRegion());
+    crossRegionS3Control =
+        AwsIntegTestUtil.createS3ControlClient(AwsIntegTestUtil.testCrossRegion());
     bucketName = AwsIntegTestUtil.testBucketName();
     crossRegionBucketName = AwsIntegTestUtil.testCrossRegionBucketName();
     accessPointName = UUID.randomUUID().toString();
@@ -108,7 +108,8 @@ public class TestS3FileIOIntegration {
     kmsKeyArn = kms.createKey().keyMetadata().arn();
 
     AwsIntegTestUtil.createAccessPoint(s3Control, accessPointName, bucketName);
-    AwsIntegTestUtil.createAccessPoint(crossRegionS3Control, crossRegionAccessPointName, crossRegionBucketName);
+    AwsIntegTestUtil.createAccessPoint(
+        crossRegionS3Control, crossRegionAccessPointName, crossRegionBucketName);
   }
 
   @AfterClass
@@ -116,7 +117,8 @@ public class TestS3FileIOIntegration {
     AwsIntegTestUtil.cleanS3Bucket(s3, bucketName, prefix);
     AwsIntegTestUtil.deleteAccessPoint(s3Control, accessPointName);
     AwsIntegTestUtil.deleteAccessPoint(crossRegionS3Control, crossRegionAccessPointName);
-    kms.scheduleKeyDeletion(ScheduleKeyDeletionRequest.builder().keyId(kmsKeyArn).pendingWindowInDays(7).build());
+    kms.scheduleKeyDeletion(
+        ScheduleKeyDeletionRequest.builder().keyId(kmsKeyArn).pendingWindowInDays(7).build());
   }
 
   @Before
@@ -132,7 +134,8 @@ public class TestS3FileIOIntegration {
 
   @Test
   public void testNewInputStream() throws Exception {
-    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+    s3.putObject(
+        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
     validateRead(s3FileIO);
@@ -140,11 +143,14 @@ public class TestS3FileIOIntegration {
 
   @Test
   public void testNewInputStreamWithAccessPoint() throws Exception {
-    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+    s3.putObject(
+        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
     validateRead(s3FileIO);
   }
 
@@ -152,16 +158,22 @@ public class TestS3FileIOIntegration {
   public void testNewInputStreamWithCrossRegionAccessPoint() throws Exception {
     clientFactory.initialize(ImmutableMap.of(AwsProperties.S3_USE_ARN_REGION_ENABLED, "true"));
     S3Client s3Client = clientFactory.s3();
-    s3Client.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+    s3Client.putObject(
+        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     // make a copy in cross-region bucket
-    s3Client.putObject(PutObjectRequest.builder()
-        .bucket(testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName))
-            .key(objectKey).build(),
+    s3Client.putObject(
+        PutObjectRequest.builder()
+            .bucket(
+                testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName))
+            .key(objectKey)
+            .build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
     validateRead(s3FileIO);
   }
 
@@ -169,7 +181,8 @@ public class TestS3FileIOIntegration {
   public void testNewOutputStream() throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
     write(s3FileIO);
-    InputStream stream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
+    InputStream stream =
+        s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
     Assert.assertEquals(content, result);
@@ -178,10 +191,13 @@ public class TestS3FileIOIntegration {
   @Test
   public void testNewOutputStreamWithAccessPoint() throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
     write(s3FileIO);
-    InputStream stream = s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
+    InputStream stream =
+        s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
     Assert.assertEquals(content, result);
@@ -192,12 +208,19 @@ public class TestS3FileIOIntegration {
     clientFactory.initialize(ImmutableMap.of(AwsProperties.S3_USE_ARN_REGION_ENABLED, "true"));
     S3Client s3Client = clientFactory.s3();
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
     write(s3FileIO);
-    InputStream stream = s3Client.getObject(GetObjectRequest.builder()
-        .bucket(testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName))
-        .key(objectKey).build());
+    InputStream stream =
+        s3Client.getObject(
+            GetObjectRequest.builder()
+                .bucket(
+                    testAccessPointARN(
+                        AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName))
+                .key(objectKey)
+                .build());
     String result = IoUtils.toUtf8String(stream);
     stream.close();
     Assert.assertEquals(content, result);
@@ -210,8 +233,9 @@ public class TestS3FileIOIntegration {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
     write(s3FileIO);
     validateRead(s3FileIO);
-    GetObjectResponse response = s3.getObject(
-        GetObjectRequest.builder().bucket(bucketName).key(objectKey).build()).response();
+    GetObjectResponse response =
+        s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
+            .response();
     Assert.assertEquals(ServerSideEncryption.AES256, response.serverSideEncryption());
   }
 
@@ -223,8 +247,9 @@ public class TestS3FileIOIntegration {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
     write(s3FileIO);
     validateRead(s3FileIO);
-    GetObjectResponse response = s3.getObject(
-        GetObjectRequest.builder().bucket(bucketName).key(objectKey).build()).response();
+    GetObjectResponse response =
+        s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
+            .response();
     Assert.assertEquals(ServerSideEncryption.AWS_KMS, response.serverSideEncryption());
     Assert.assertEquals(response.ssekmsKeyId(), kmsKeyArn);
   }
@@ -236,11 +261,12 @@ public class TestS3FileIOIntegration {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
     write(s3FileIO);
     validateRead(s3FileIO);
-    GetObjectResponse response = s3.getObject(
-        GetObjectRequest.builder().bucket(bucketName).key(objectKey).build()).response();
+    GetObjectResponse response =
+        s3.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build())
+            .response();
     Assert.assertEquals(ServerSideEncryption.AWS_KMS, response.serverSideEncryption());
-    ListAliasesResponse listAliasesResponse = kms.listAliases(
-        ListAliasesRequest.builder().keyId(response.ssekmsKeyId()).build());
+    ListAliasesResponse listAliasesResponse =
+        kms.listAliases(ListAliasesRequest.builder().keyId(response.ssekmsKeyId()).build());
     Assert.assertTrue(listAliasesResponse.hasAliases());
     Assert.assertEquals(1, listAliasesResponse.aliases().size());
     Assert.assertEquals("alias/aws/s3", listAliasesResponse.aliases().get(0).aliasName());
@@ -256,7 +282,8 @@ public class TestS3FileIOIntegration {
     String encodedKey = new String(encoder.encode(secretKey.getEncoded()), StandardCharsets.UTF_8);
     // generate md5
     MessageDigest digest = MessageDigest.getInstance("MD5");
-    String md5 = new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
+    String md5 =
+        new String(encoder.encode(digest.digest(secretKey.getEncoded())), StandardCharsets.UTF_8);
 
     AwsProperties properties = new AwsProperties();
     properties.setS3FileIoSseType(AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM);
@@ -265,12 +292,16 @@ public class TestS3FileIOIntegration {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
     write(s3FileIO);
     validateRead(s3FileIO);
-    GetObjectResponse response = s3.getObject(
-        GetObjectRequest.builder().bucket(bucketName).key(objectKey)
-            .sseCustomerAlgorithm(ServerSideEncryption.AES256.name())
-            .sseCustomerKey(encodedKey)
-            .sseCustomerKeyMD5(md5)
-            .build()).response();
+    GetObjectResponse response =
+        s3.getObject(
+                GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .sseCustomerAlgorithm(ServerSideEncryption.AES256.name())
+                    .sseCustomerKey(encodedKey)
+                    .sseCustomerKeyMD5(md5)
+                    .build())
+            .response();
     Assert.assertNull(response.serverSideEncryption());
     Assert.assertEquals(ServerSideEncryption.AES256.name(), response.sseCustomerAlgorithm());
     Assert.assertEquals(md5, response.sseCustomerKeyMD5());
@@ -283,8 +314,8 @@ public class TestS3FileIOIntegration {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, properties);
     write(s3FileIO);
     validateRead(s3FileIO);
-    GetObjectAclResponse response = s3.getObjectAcl(
-        GetObjectAclRequest.builder().bucket(bucketName).key(objectKey).build());
+    GetObjectAclResponse response =
+        s3.getObjectAcl(GetObjectAclRequest.builder().bucket(bucketName).key(objectKey).build());
     Assert.assertTrue(response.hasGrants());
     Assert.assertEquals(1, response.grants().size());
     Assert.assertEquals(Permission.FULL_CONTROL, response.grants().get(0).permission());
@@ -294,7 +325,7 @@ public class TestS3FileIOIntegration {
   public void testClientFactorySerialization() throws Exception {
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     write(fileIO);
-    byte [] data = SerializationUtils.serialize(fileIO);
+    byte[] data = SerializationUtils.serialize(fileIO);
     S3FileIO fileIO2 = SerializationUtils.deserialize(data);
     validateRead(fileIO2);
   }
@@ -308,8 +339,10 @@ public class TestS3FileIOIntegration {
   @Test
   public void testDeleteFilesMultipleBatchesWithAccessPoints() throws Exception {
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, getDeletionTestProperties());
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testRegion(), accessPointName)));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
@@ -317,8 +350,10 @@ public class TestS3FileIOIntegration {
   public void testDeleteFilesMultipleBatchesWithCrossRegionAccessPoints() throws Exception {
     clientFactory.initialize(ImmutableMap.of(AwsProperties.S3_USE_ARN_REGION_ENABLED, "true"));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3, getDeletionTestProperties());
-    s3FileIO.initialize(ImmutableMap.of(AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
-        testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
+    s3FileIO.initialize(
+        ImmutableMap.of(
+            AwsProperties.S3_ACCESS_POINTS_PREFIX + bucketName,
+            testAccessPointARN(AwsIntegTestUtil.testCrossRegion(), crossRegionAccessPointName)));
     testDeleteFiles(deletionBatchSize * 2, s3FileIO);
   }
 
@@ -341,11 +376,14 @@ public class TestS3FileIOIntegration {
     List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
     String listPrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-list-test");
 
-    scaleSizes.parallelStream().forEach(scale -> {
-      String scalePrefix = String.format("%s/%s/", listPrefix, scale);
-      createRandomObjects(scalePrefix, scale);
-      assertEquals((long) scale, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
-    });
+    scaleSizes
+        .parallelStream()
+        .forEach(
+            scale -> {
+              String scalePrefix = String.format("%s/%s/", listPrefix, scale);
+              createRandomObjects(scalePrefix, scale);
+              assertEquals((long) scale, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+            });
 
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
     Assertions.assertEquals(totalFiles, Streams.stream(s3FileIO.listPrefix(listPrefix)).count());
@@ -360,12 +398,15 @@ public class TestS3FileIOIntegration {
     String deletePrefix = String.format("s3://%s/%s/%s", bucketName, prefix, "prefix-delete-test");
 
     List<Integer> scaleSizes = Lists.newArrayList(0, 5, 1000, 2500);
-    scaleSizes.parallelStream().forEach(scale -> {
-      String scalePrefix = String.format("%s/%s/", deletePrefix, scale);
-      createRandomObjects(scalePrefix, scale);
-      s3FileIO.deletePrefix(scalePrefix);
-      assertEquals(0L, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
-    });
+    scaleSizes
+        .parallelStream()
+        .forEach(
+            scale -> {
+              String scalePrefix = String.format("%s/%s/", deletePrefix, scale);
+              createRandomObjects(scalePrefix, scale);
+              s3FileIO.deletePrefix(scalePrefix);
+              assertEquals(0L, Streams.stream(s3FileIO.listPrefix(scalePrefix)).count());
+            });
   }
 
   private AwsProperties getDeletionTestProperties() {
@@ -409,14 +450,23 @@ public class TestS3FileIOIntegration {
 
   private String testAccessPointARN(String region, String accessPoint) {
     // format: arn:aws:s3:region:account-id:accesspoint/resource
-    return String.format("arn:%s:s3:%s:%s:accesspoint/%s",
-        PartitionMetadata.of(Region.of(region)).id(), region, AwsIntegTestUtil.testAccountId(), accessPoint);
+    return String.format(
+        "arn:%s:s3:%s:%s:accesspoint/%s",
+        PartitionMetadata.of(Region.of(region)).id(),
+        region,
+        AwsIntegTestUtil.testAccountId(),
+        accessPoint);
   }
 
   private void createRandomObjects(String objectPrefix, int count) {
     S3URI s3URI = new S3URI(objectPrefix);
-    random.ints(count).parallel().forEach(i ->
-        s3.putObject(builder -> builder.bucket(s3URI.bucket()).key(s3URI.key() + i).build(), RequestBody.empty())
-    );
+    random
+        .ints(count)
+        .parallel()
+        .forEach(
+            i ->
+                s3.putObject(
+                    builder -> builder.bucket(s3URI.bucket()).key(s3URI.key() + i).build(),
+                    RequestBody.empty()));
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3MultipartUpload.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3MultipartUpload.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
@@ -36,9 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
-/**
- * Long-running tests to ensure multipart upload logic is resilient
- */
+/** Long-running tests to ensure multipart upload logic is resilient */
 public class TestS3MultipartUpload {
 
   private final Random random = new Random(1);
@@ -75,7 +72,8 @@ public class TestS3MultipartUpload {
   public void testManyPartsWriteWithInt() throws IOException {
     int parts = 200;
     writeInts(objectUri, parts, random::nextInt);
-    Assert.assertEquals(parts * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
+    Assert.assertEquals(
+        parts * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
         io.newInputFile(objectUri).getLength());
   }
 
@@ -83,11 +81,15 @@ public class TestS3MultipartUpload {
   public void testManyPartsWriteWithBytes() throws IOException {
     int parts = 200;
     byte[] bytes = new byte[AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN];
-    writeBytes(objectUri, parts, () -> {
-      random.nextBytes(bytes);
-      return bytes;
-    });
-    Assert.assertEquals(parts * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
+    writeBytes(
+        objectUri,
+        parts,
+        () -> {
+          random.nextBytes(bytes);
+          return bytes;
+        });
+    Assert.assertEquals(
+        parts * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
         io.newInputFile(objectUri).getLength());
   }
 
@@ -117,8 +119,7 @@ public class TestS3MultipartUpload {
   @Test
   public void testParallelUpload() throws IOException {
     int threads = 16;
-    IntStream.range(0, threads).parallel()
-        .forEach(d -> writeInts(objectUri + d, 3, () -> d));
+    IntStream.range(0, threads).parallel().forEach(d -> writeInts(objectUri + d, 3, () -> d));
 
     for (int i = 0; i < threads; i++) {
       final int d = i;

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -45,7 +45,7 @@ subprojects {
   pluginManager.withPlugin('com.diffplug.spotless') {
     spotless {
       java {
-        target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/jmh/java/**/*.java'
+        target 'src/main/java/**/*.java', 'src/test/java/**/*.java', 'src/jmh/java/**/*.java', 'src/integration/java/**/*.java'
         // we use an older version of google-java-format that is compatible with JDK 8
         googleJavaFormat("1.7")
         removeUnusedImports()

--- a/spark/v3.0/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.0/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
@@ -41,7 +40,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this test suite to run
+  // TODO Update doc example so that it can actually be run, modifications were required for this
+  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -49,45 +49,58 @@ public class SmokeTest extends SparkExtensionsTestBase {
 
     // Writing
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
-    Assert.assertEquals("Should have inserted 3 rows",
-        3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Should have inserted 3 rows", 3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS source");
-    sql("CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO source VALUES (10, 'd'), (11, 'ee')");
 
     sql("INSERT INTO %s SELECT id, data FROM source WHERE length(data) = 1", tableName);
-    Assert.assertEquals("Table should now have 4 rows",
-        4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Table should now have 4 rows", 4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS updates");
-    sql("CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
 
-    sql("MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n" +
-        "WHEN MATCHED THEN UPDATE SET t.data = u.data\n" +
-        "WHEN NOT MATCHED THEN INSERT *", tableName);
-    Assert.assertEquals("Table should now have 5 rows",
-        5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
-    Assert.assertEquals("Record 1 should now have data x",
-        "x", scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
+            + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+    Assert.assertEquals(
+        "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Record 1 should now have data x",
+        "x",
+        scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
 
     // Reading
-    Assert.assertEquals("There should be 2 records with data x",
-        2L, scalarSql(
-            "SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+    Assert.assertEquals(
+        "There should be 2 records with data x",
+        2L,
+        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {
-      Assert.assertEquals("There should be 3 snapshots",
-          3L, scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
+      Assert.assertEquals(
+          "There should be 3 snapshots",
+          3L,
+          scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
     }
   }
 
   // From Spark DDL Docs section
   @Test
   public void testAlterTable() throws NoSuchTableException {
-    sql("CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg",
+        tableName);
     Table table = getTable();
     // Add examples
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id)", tableName);
@@ -106,7 +119,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
     table = getTable();
     Assert.assertEquals("Table should have 4 partition fields", 4, table.spec().fields().size());
     // VoidTransform is package private so we can't reach it here, just checking name
-    Assert.assertTrue("All transforms should be void",
+    Assert.assertTrue(
+        "All transforms should be void",
         table.spec().fields().stream().allMatch(pf -> pf.transform().toString().equals("void")));
 
     // Sort order examples
@@ -123,28 +137,34 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName("second"));
     sql("DROP TABLE IF EXISTS %s", tableName("third"));
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint COMMENT 'unique id',\n" +
-        "    data string)\n" +
-        "USING iceberg", tableName("first"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint COMMENT 'unique id',\n"
+            + "    data string)\n"
+            + "USING iceberg",
+        tableName("first"));
     getTable("first"); // Table should exist
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (category)", tableName("second"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (category)",
+        tableName("second"));
     Table second = getTable("second");
     Assert.assertEquals("Should be partitioned on 1 column", 1, second.spec().fields().size());
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string,\n" +
-        "    ts timestamp)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (bucket(16, id), days(ts), category)", tableName("third"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string,\n"
+            + "    ts timestamp)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (bucket(16, id), days(ts), category)",
+        tableName("third"));
     Table third = getTable("third");
     Assert.assertEquals("Should be partitioned on 3 columns", 3, third.spec().fields().size());
   }
@@ -156,5 +176,4 @@ public class SmokeTest extends SparkExtensionsTestBase {
   private Table getTable() {
     return validationCatalog.loadTable(tableIdent);
   }
-
 }

--- a/spark/v3.1/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.1/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
@@ -41,7 +40,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this test suite to run
+  // TODO Update doc example so that it can actually be run, modifications were required for this
+  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -49,45 +49,58 @@ public class SmokeTest extends SparkExtensionsTestBase {
 
     // Writing
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
-    Assert.assertEquals("Should have inserted 3 rows",
-        3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Should have inserted 3 rows", 3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS source");
-    sql("CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO source VALUES (10, 'd'), (11, 'ee')");
 
     sql("INSERT INTO %s SELECT id, data FROM source WHERE length(data) = 1", tableName);
-    Assert.assertEquals("Table should now have 4 rows",
-        4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Table should now have 4 rows", 4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS updates");
-    sql("CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
 
-    sql("MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n" +
-        "WHEN MATCHED THEN UPDATE SET t.data = u.data\n" +
-        "WHEN NOT MATCHED THEN INSERT *", tableName);
-    Assert.assertEquals("Table should now have 5 rows",
-        5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
-    Assert.assertEquals("Record 1 should now have data x",
-        "x", scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
+            + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+    Assert.assertEquals(
+        "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Record 1 should now have data x",
+        "x",
+        scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
 
     // Reading
-    Assert.assertEquals("There should be 2 records with data x",
-        2L, scalarSql(
-            "SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+    Assert.assertEquals(
+        "There should be 2 records with data x",
+        2L,
+        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {
-      Assert.assertEquals("There should be 3 snapshots",
-          3L, scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
+      Assert.assertEquals(
+          "There should be 3 snapshots",
+          3L,
+          scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
     }
   }
 
   // From Spark DDL Docs section
   @Test
   public void testAlterTable() throws NoSuchTableException {
-    sql("CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg",
+        tableName);
     Table table = getTable();
     // Add examples
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id)", tableName);
@@ -106,7 +119,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
     table = getTable();
     Assert.assertEquals("Table should have 4 partition fields", 4, table.spec().fields().size());
     // VoidTransform is package private so we can't reach it here, just checking name
-    Assert.assertTrue("All transforms should be void",
+    Assert.assertTrue(
+        "All transforms should be void",
         table.spec().fields().stream().allMatch(pf -> pf.transform().toString().equals("void")));
 
     // Sort order examples
@@ -123,28 +137,34 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName("second"));
     sql("DROP TABLE IF EXISTS %s", tableName("third"));
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint COMMENT 'unique id',\n" +
-        "    data string)\n" +
-        "USING iceberg", tableName("first"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint COMMENT 'unique id',\n"
+            + "    data string)\n"
+            + "USING iceberg",
+        tableName("first"));
     getTable("first"); // Table should exist
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (category)", tableName("second"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (category)",
+        tableName("second"));
     Table second = getTable("second");
     Assert.assertEquals("Should be partitioned on 1 column", 1, second.spec().fields().size());
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string,\n" +
-        "    ts timestamp)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (bucket(16, id), days(ts), category)", tableName("third"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string,\n"
+            + "    ts timestamp)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (bucket(16, id), days(ts), category)",
+        tableName("third"));
     Table third = getTable("third");
     Assert.assertEquals("Should be partitioned on 3 columns", 3, third.spec().fields().size());
   }
@@ -156,5 +176,4 @@ public class SmokeTest extends SparkExtensionsTestBase {
   private Table getTable() {
     return validationCatalog.loadTable(tableIdent);
   }
-
 }

--- a/spark/v3.2/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.2/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
@@ -41,7 +40,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this test suite to run
+  // TODO Update doc example so that it can actually be run, modifications were required for this
+  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -49,45 +49,58 @@ public class SmokeTest extends SparkExtensionsTestBase {
 
     // Writing
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
-    Assert.assertEquals("Should have inserted 3 rows",
-        3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Should have inserted 3 rows", 3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS source");
-    sql("CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO source VALUES (10, 'd'), (11, 'ee')");
 
     sql("INSERT INTO %s SELECT id, data FROM source WHERE length(data) = 1", tableName);
-    Assert.assertEquals("Table should now have 4 rows",
-        4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Table should now have 4 rows", 4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS updates");
-    sql("CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
 
-    sql("MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n" +
-        "WHEN MATCHED THEN UPDATE SET t.data = u.data\n" +
-        "WHEN NOT MATCHED THEN INSERT *", tableName);
-    Assert.assertEquals("Table should now have 5 rows",
-        5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
-    Assert.assertEquals("Record 1 should now have data x",
-        "x", scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
+            + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+    Assert.assertEquals(
+        "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Record 1 should now have data x",
+        "x",
+        scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
 
     // Reading
-    Assert.assertEquals("There should be 2 records with data x",
-        2L, scalarSql(
-            "SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+    Assert.assertEquals(
+        "There should be 2 records with data x",
+        2L,
+        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {
-      Assert.assertEquals("There should be 3 snapshots",
-          3L, scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
+      Assert.assertEquals(
+          "There should be 3 snapshots",
+          3L,
+          scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
     }
   }
 
   // From Spark DDL Docs section
   @Test
   public void testAlterTable() throws NoSuchTableException {
-    sql("CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg",
+        tableName);
     Table table = getTable();
     // Add examples
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id)", tableName);
@@ -106,7 +119,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
     table = getTable();
     Assert.assertEquals("Table should have 4 partition fields", 4, table.spec().fields().size());
     // VoidTransform is package private so we can't reach it here, just checking name
-    Assert.assertTrue("All transforms should be void",
+    Assert.assertTrue(
+        "All transforms should be void",
         table.spec().fields().stream().allMatch(pf -> pf.transform().toString().equals("void")));
 
     // Sort order examples
@@ -123,28 +137,34 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName("second"));
     sql("DROP TABLE IF EXISTS %s", tableName("third"));
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint COMMENT 'unique id',\n" +
-        "    data string)\n" +
-        "USING iceberg", tableName("first"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint COMMENT 'unique id',\n"
+            + "    data string)\n"
+            + "USING iceberg",
+        tableName("first"));
     getTable("first"); // Table should exist
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (category)", tableName("second"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (category)",
+        tableName("second"));
     Table second = getTable("second");
     Assert.assertEquals("Should be partitioned on 1 column", 1, second.spec().fields().size());
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string,\n" +
-        "    ts timestamp)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (bucket(16, id), days(ts), category)", tableName("third"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string,\n"
+            + "    ts timestamp)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (bucket(16, id), days(ts), category)",
+        tableName("third"));
     Table third = getTable("third");
     Assert.assertEquals("Should be partitioned on 3 columns", 3, third.spec().fields().size());
   }
@@ -156,5 +176,4 @@ public class SmokeTest extends SparkExtensionsTestBase {
   private Table getTable() {
     return validationCatalog.loadTable(tableIdent);
   }
-
 }

--- a/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.3/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg.spark;
 
 import java.io.IOException;
@@ -41,7 +40,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   // Run through our Doc's Getting Started Example
-  // TODO Update doc example so that it can actually be run, modifications were required for this test suite to run
+  // TODO Update doc example so that it can actually be run, modifications were required for this
+  // test suite to run
   @Test
   public void testGettingStarted() throws IOException {
     // Creating a table
@@ -49,45 +49,58 @@ public class SmokeTest extends SparkExtensionsTestBase {
 
     // Writing
     sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
-    Assert.assertEquals("Should have inserted 3 rows",
-        3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Should have inserted 3 rows", 3L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS source");
-    sql("CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE source (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO source VALUES (10, 'd'), (11, 'ee')");
 
     sql("INSERT INTO %s SELECT id, data FROM source WHERE length(data) = 1", tableName);
-    Assert.assertEquals("Table should now have 4 rows",
-        4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Table should now have 4 rows", 4L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
 
     sql("DROP TABLE IF EXISTS updates");
-    sql("CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'", temp.newFolder());
+    sql(
+        "CREATE TABLE updates (id bigint, data string) USING parquet LOCATION '%s'",
+        temp.newFolder());
     sql("INSERT INTO updates VALUES (1, 'x'), (2, 'x'), (4, 'z')");
 
-    sql("MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n" +
-        "WHEN MATCHED THEN UPDATE SET t.data = u.data\n" +
-        "WHEN NOT MATCHED THEN INSERT *", tableName);
-    Assert.assertEquals("Table should now have 5 rows",
-        5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
-    Assert.assertEquals("Record 1 should now have data x",
-        "x", scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
+    sql(
+        "MERGE INTO %s t USING (SELECT * FROM updates) u ON t.id = u.id\n"
+            + "WHEN MATCHED THEN UPDATE SET t.data = u.data\n"
+            + "WHEN NOT MATCHED THEN INSERT *",
+        tableName);
+    Assert.assertEquals(
+        "Table should now have 5 rows", 5L, scalarSql("SELECT COUNT(*) FROM %s", tableName));
+    Assert.assertEquals(
+        "Record 1 should now have data x",
+        "x",
+        scalarSql("SELECT data FROM %s WHERE id = 1", tableName));
 
     // Reading
-    Assert.assertEquals("There should be 2 records with data x",
-        2L, scalarSql(
-            "SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
+    Assert.assertEquals(
+        "There should be 2 records with data x",
+        2L,
+        scalarSql("SELECT count(1) as count FROM %s WHERE data = 'x' GROUP BY data ", tableName));
 
     // Not supported because of Spark limitation
     if (!catalogName.equals("spark_catalog")) {
-      Assert.assertEquals("There should be 3 snapshots",
-          3L, scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
+      Assert.assertEquals(
+          "There should be 3 snapshots",
+          3L,
+          scalarSql("SELECT COUNT(*) FROM %s.snapshots", tableName));
     }
   }
 
   // From Spark DDL Docs section
   @Test
   public void testAlterTable() throws NoSuchTableException {
-    sql("CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg", tableName);
+    sql(
+        "CREATE TABLE %s (category int, id bigint, data string, ts timestamp) USING iceberg",
+        tableName);
     Table table = getTable();
     // Add examples
     sql("ALTER TABLE %s ADD PARTITION FIELD bucket(16, id)", tableName);
@@ -106,7 +119,8 @@ public class SmokeTest extends SparkExtensionsTestBase {
     table = getTable();
     Assert.assertEquals("Table should have 4 partition fields", 4, table.spec().fields().size());
     // VoidTransform is package private so we can't reach it here, just checking name
-    Assert.assertTrue("All transforms should be void",
+    Assert.assertTrue(
+        "All transforms should be void",
         table.spec().fields().stream().allMatch(pf -> pf.transform().toString().equals("void")));
 
     // Sort order examples
@@ -123,28 +137,34 @@ public class SmokeTest extends SparkExtensionsTestBase {
     sql("DROP TABLE IF EXISTS %s", tableName("second"));
     sql("DROP TABLE IF EXISTS %s", tableName("third"));
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint COMMENT 'unique id',\n" +
-        "    data string)\n" +
-        "USING iceberg", tableName("first"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint COMMENT 'unique id',\n"
+            + "    data string)\n"
+            + "USING iceberg",
+        tableName("first"));
     getTable("first"); // Table should exist
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (category)", tableName("second"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (category)",
+        tableName("second"));
     Table second = getTable("second");
     Assert.assertEquals("Should be partitioned on 1 column", 1, second.spec().fields().size());
 
-    sql("CREATE TABLE %s (\n" +
-        "    id bigint,\n" +
-        "    data string,\n" +
-        "    category string,\n" +
-        "    ts timestamp)\n" +
-        "USING iceberg\n" +
-        "PARTITIONED BY (bucket(16, id), days(ts), category)", tableName("third"));
+    sql(
+        "CREATE TABLE %s (\n"
+            + "    id bigint,\n"
+            + "    data string,\n"
+            + "    category string,\n"
+            + "    ts timestamp)\n"
+            + "USING iceberg\n"
+            + "PARTITIONED BY (bucket(16, id), days(ts), category)",
+        tableName("third"));
     Table third = getTable("third");
     Assert.assertEquals("Should be partitioned on 3 columns", 3, third.spec().fields().size());
   }
@@ -156,5 +176,4 @@ public class SmokeTest extends SparkExtensionsTestBase {
   private Table getTable() {
     return validationCatalog.loadTable(tableIdent);
   }
-
 }


### PR DESCRIPTION
This was unintentionally forgotten and usually spotless is able to infer
all java files from the source sets. However, the way we defined the
source sets doesn't seem working with spotless and so
we were defining relevant modules via `target`.

Additional details:

Spotless requires all source sets to be part of the current module being
evaluated, which isn't the case for the hive module:
```
> Spotless error! All target files must be within the project dir.
    project dir: /home/nastra/Development/workspace/iceberg/hive3
         target: /home/nastra/Development/workspace/iceberg/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
```

And this is how the sourceSets are defined in `iceberg-hive3` which
cause issues:

```
project(':iceberg-hive3') {

  // run the tests in iceberg-mr with Hive3 dependencies
  sourceSets {
    test {
      java.srcDirs = ['../mr/src/test/java', 'src/test/java']
      resources.srcDirs = ['../mr/src/test/resources', 'src/test/resources']
    }
  }
...
}
```
