### PR TITLE
Python: Include the tests in source distribution

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,6 +37,7 @@ packages = [
     { include = "pyiceberg" },
     { from = "vendor", include = "fb303" },
     { from = "vendor", include = "hive_metastore" },
+    { include = "tests", format = "sdist" },
 ]
 
 


### PR DESCRIPTION
Adds the tests to the source distribution so we can run them when validating a release.