### PR TITLE
Python: Test if version is PEP440 compliant

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -68,6 +68,7 @@ pre-commit = "^2.0.0"
 fastavro = "^1.6.1"
 coverage = { version = "^6.4.4", extras = ["toml"] }
 requests-mock = "^1.9.3"
+packaging = "^21.3"
 
 [tool.poetry.scripts]
 pyiceberg = "pyiceberg.cli.console:run"
@@ -162,6 +163,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "s3fs.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "packaging.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -14,16 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import re
+
+from packaging.version import Version
 
 from pyiceberg import __version__
 
-VERSION_REGEX = re.compile(r"^\d+.\d+.\d+(.(dev|rc)\d+)?$")
-
 
 def test_version_format():
-    # should be in the format of 0.14.0 or 0.14.0.dev0
-    assert VERSION_REGEX.search(__version__)
-
-    # RCs should work as well
-    assert VERSION_REGEX.search("0.1.0.rc0")
+    # We should be able to parse the version
+    assert Version(__version__)


### PR DESCRIPTION
Turned out that my regex isn't PEP440 compatible.

RCs are represented as 0.1.0rc1 and dev versions are with a dot: 0.1.0.dev1 And, they can be combined: 0.1.0rc1.dev1.

Instead of figuring out the regex myself, we can just use the one from packaging.

This package is already installed because it is also a dependency of pytest.