### PR TITLE
Python: Remove version modifier

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [tool.poetry]
 name = "pyiceberg"
-version = "0.1.0.dev0"
+version = "0.1.0"
 readme = "README.md"
 homepage = "https://iceberg.apache.org/"
 repository = "https://github.com/apache/iceberg/"


### PR DESCRIPTION
This way we can just use the code as is when releasing, and we don't have to remove the modifier afterward.