### PR TITLE
API,Core: Introduce metrics for data files by file format

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -455,6 +455,9 @@ acceptedBreaks:
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.TableProperties.HMS_TABLE_OWNER"
       justification: "Removing deprecations for 1.3.0"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.metrics.MultiDimensionCounterResult org.apache.iceberg.metrics.ScanMetricsResult::resultDataFilesByFormat()"
+      justification: "Introduced MultiDimensionCounter API"
     - code: "java.method.parameterTypeChanged"
       old: "parameter void org.apache.iceberg.actions.RewriteDataFilesCommitManager.CommitService::offer(===org.apache.iceberg.actions.RewriteFileGroup===)"
       new: "parameter void org.apache.iceberg.actions.BaseCommitService<T>::offer(===T===)\

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricTag.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricTag.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+public class DefaultMetricTag implements MetricTag {
+  private final String key;
+  private final int numDimensions;
+
+  public DefaultMetricTag(String... keys) {
+    key = String.join("-", keys);
+    this.numDimensions = keys.length;
+  }
+
+  @Override
+  public String get() {
+    return key;
+  }
+
+  @Override
+  public int numDimensions() {
+    return numDimensions;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMetricsContext.java
@@ -53,6 +53,16 @@ public class DefaultMetricsContext implements MetricsContext {
   }
 
   @Override
+  public MultiDimensionCounter multiCounter(String name, Unit unit) {
+    return new DefaultMultiDimensionCounter(name, unit, this);
+  }
+
+  @Override
+  public MultiDimensionCounter multiCounter(String name, Unit unit, int numDimensions) {
+    return new DefaultMultiDimensionCounter(name, unit, this, numDimensions);
+  }
+
+  @Override
   public Histogram histogram(String name) {
     return new FixedReservoirHistogram(DEFAULT_HISTOGRAM_RESERVOIR_SIZE);
   }

--- a/api/src/main/java/org/apache/iceberg/metrics/DefaultMultiDimensionCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/DefaultMultiDimensionCounter.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class DefaultMultiDimensionCounter implements MultiDimensionCounter {
+  public static final DefaultMultiDimensionCounter NOOP =
+      new DefaultMultiDimensionCounter("NOOP-MultiDimensionCounter", Unit.UNDEFINED, null) {
+        @Override
+        public String toString() {
+          return "NOOP multi-dimension counter";
+        }
+
+        @Override
+        public void increment(MetricTag tag) {}
+
+        @Override
+        public void increment(MetricTag tag, long amount) {}
+
+        @Override
+        public String name() {
+          throw new UnsupportedOperationException("NOOP multi-dimension counter has no name");
+        }
+
+        @Override
+        public Set<String> metricTags() {
+          throw new UnsupportedOperationException(
+              "NOOP multi-dimension counter does not have keys");
+        }
+
+        @Override
+        public Unit unit() {
+          return Unit.UNDEFINED;
+        }
+
+        @Override
+        public long value(MetricTag tag) {
+          throw new UnsupportedOperationException("NOOP multi-dimension counter has no value");
+        }
+
+        @Override
+        public boolean isNoop() {
+          return true;
+        }
+      };
+
+  private Map<String, Counter> counters = Maps.newConcurrentMap();
+  private final String name;
+  private final MetricsContext metricsContext;
+  private final Unit unit;
+  private final int numDimensions;
+
+  public DefaultMultiDimensionCounter(String name, Unit unit, MetricsContext metricsContext) {
+    this(name, unit, metricsContext, 1);
+  }
+
+  public DefaultMultiDimensionCounter(
+      String name, Unit unit, MetricsContext metricsContext, int numDimensions) {
+    Preconditions.checkArgument(null != name, "Invalid name: null");
+    Preconditions.checkArgument(null != unit, "Invalid count unit: null");
+
+    this.name = name;
+    this.metricsContext = metricsContext;
+    this.unit = unit;
+    this.numDimensions = numDimensions;
+  }
+
+  @Override
+  public void increment(MetricTag tag) {
+    increment(tag, 1);
+  }
+
+  @Override
+  public void increment(MetricTag tag, long amount) {
+    Preconditions.checkArgument(null != tag, "Invalid key: null");
+    validateNumOfDimensions(tag);
+    counters
+        .computeIfAbsent(
+            tag.get(),
+            s -> {
+              return metricsContext.counter(counterId(s));
+            })
+        .increment(amount);
+  }
+
+  private String counterId(String key) {
+    return name + "-" + key;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Set<String> metricTags() {
+    return counters.keySet();
+  }
+
+  @Override
+  public Unit unit() {
+    return unit;
+  }
+
+  @Override
+  public long value(MetricTag tag) {
+    validateNumOfDimensions(tag);
+    if (!counters.containsKey(tag.get())) {
+      return 0;
+    }
+    return counters.get(tag.get()).value();
+  }
+
+  private void validateNumOfDimensions(MetricTag tag) {
+    if (tag.numDimensions() != numDimensions) {
+      throw new RuntimeException(
+          String.format(
+              "Number of dimensions mismatch between the provided tag and %s. %s vs %s",
+              name, tag.numDimensions(), numDimensions));
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricTag.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricTag.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+/** Serves as a key for multi-dimension counters. */
+public interface MetricTag {
+  String get();
+
+  int numDimensions();
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -139,6 +139,29 @@ public interface MetricsContext extends Serializable {
   }
 
   /**
+   * Get a named multi-dimension counter
+   *
+   * @param name The name of the counter
+   * @param unit The unit designation of the counter
+   * @return a {@link MultiDimensionCounter} implementation
+   */
+  default MultiDimensionCounter multiCounter(String name, Unit unit) {
+    throw new UnsupportedOperationException("MultiDimensionCounter is not supported.");
+  }
+
+  /**
+   * Get a named multi-dimension counter
+   *
+   * @param name The name of the counter
+   * @param unit The unit designation of the counter
+   * @param numDimensions The number of dimensions in the multi-dimension counter
+   * @return a {@link MultiDimensionCounter} implementation
+   */
+  default MultiDimensionCounter multiCounter(String name, Unit unit, int numDimensions) {
+    throw new UnsupportedOperationException("MultiDimensionCounter is not supported.");
+  }
+
+  /**
    * Get a named timer.
    *
    * @param name name of the metric
@@ -186,6 +209,11 @@ public interface MetricsContext extends Serializable {
       @Override
       public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
         return org.apache.iceberg.metrics.DefaultCounter.NOOP;
+      }
+
+      @Override
+      public MultiDimensionCounter multiCounter(String name, Unit unit) {
+        return DefaultMultiDimensionCounter.NOOP;
       }
     };
   }

--- a/api/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounter.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Set;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+
+/** Generalized multi-dimension Counter interface. */
+public interface MultiDimensionCounter {
+
+  /** Increment the counter under a given key by 1. */
+  void increment(MetricTag tag);
+
+  /** Increment the counter under a given key by the provided amount. */
+  void increment(MetricTag tag, long amount);
+
+  /**
+   * The name of the multi-dimension counter.
+   *
+   * @return The name of the multi-dimension counter.
+   */
+  String name();
+
+  /**
+   * The keys used by this multi-dimension counter.
+   *
+   * @return The tags used by this multi-dimension counter.
+   */
+  Set<String> metricTags();
+
+  /**
+   * The unit of the counter.
+   *
+   * @return The unit of the counter.
+   */
+  Unit unit();
+
+  /**
+   * Reports the current count associated by the given key.
+   *
+   * @return The current count associated by the given key.
+   */
+  long value(MetricTag tag);
+
+  /**
+   * Determines whether this counter is a NOOP counter.
+   *
+   * @return Whether this counter is a NOOP counter.
+   */
+  default boolean isNoop() {
+    return false;
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMultiDimensionCounter.java
+++ b/api/src/test/java/org/apache/iceberg/metrics/TestDefaultMultiDimensionCounter.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestDefaultMultiDimensionCounter {
+  static final String COUNTER_NAME1 = "counter-name1";
+  static final String COUNTER_NAME2 = "counter-name2";
+  static final DefaultMetricTag KEY1 = new DefaultMetricTag("key1");
+  static final DefaultMetricTag KEY1_UPPER = new DefaultMetricTag("KEY1");
+
+  @Test
+  public void nullCheck() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    Assertions.assertThatThrownBy(() -> metricsContext.multiCounter(null, Unit.COUNT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid name: null");
+
+    Assertions.assertThatThrownBy(() -> new DefaultMetricsContext().multiCounter("test", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid count unit: null");
+  }
+
+  @Test
+  public void noop() {
+    Assertions.assertThat(DefaultMultiDimensionCounter.NOOP.unit()).isEqualTo(Unit.UNDEFINED);
+    Assertions.assertThat(DefaultMultiDimensionCounter.NOOP.isNoop()).isTrue();
+    Assertions.assertThatThrownBy(
+            () -> DefaultMultiDimensionCounter.NOOP.value(new DefaultMetricTag("key")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("NOOP multi-dimension counter has no value");
+    Assertions.assertThatThrownBy(DefaultMultiDimensionCounter.NOOP::name)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("NOOP multi-dimension counter has no name");
+    Assertions.assertThatThrownBy(DefaultMultiDimensionCounter.NOOP::metricTags)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("NOOP multi-dimension counter does not have keys");
+  }
+
+  @Test
+  public void countWithSingleDimension() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MultiDimensionCounter counter1 =
+        new DefaultMultiDimensionCounter(COUNTER_NAME1, Unit.BYTES, metricsContext);
+    Assertions.assertThat(counter1.name()).isEqualTo(COUNTER_NAME1);
+    Assertions.assertThat(counter1.unit()).isEqualTo(MetricsContext.Unit.BYTES);
+    Assertions.assertThat(counter1.isNoop()).isFalse();
+
+    counter1.increment(KEY1);
+    counter1.increment(KEY1, 2L);
+    Assertions.assertThat(counter1.value(KEY1)).isEqualTo(3L);
+
+    counter1.increment(KEY1_UPPER, 10L);
+    Assertions.assertThat(counter1.value(KEY1)).isEqualTo(3L);
+    Assertions.assertThat(counter1.value(KEY1_UPPER)).isEqualTo(10L);
+
+    // Test counter with different name but using same keys
+    MultiDimensionCounter counter2 =
+        new DefaultMultiDimensionCounter(COUNTER_NAME2, Unit.BYTES, metricsContext);
+    Assertions.assertThat(counter2.name()).isEqualTo(COUNTER_NAME2);
+    counter2.increment(KEY1, 100L);
+    Assertions.assertThat(counter2.value(KEY1)).isEqualTo(100L);
+    Assertions.assertThat(counter1.value(KEY1)).isEqualTo(3L);
+
+    // Test counter with same name and same keys
+    MultiDimensionCounter counter3 =
+        new DefaultMultiDimensionCounter(COUNTER_NAME1, Unit.BYTES, metricsContext);
+    Assertions.assertThat(counter3.name()).isEqualTo(COUNTER_NAME1);
+    counter3.increment(KEY1, 1000L);
+    Assertions.assertThat(counter3.value(KEY1)).isEqualTo(1000L);
+    Assertions.assertThat(counter1.value(KEY1)).isEqualTo(3L);
+
+    Assertions.assertThatThrownBy(() -> counter1.increment(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid key: null");
+  }
+
+  @Test
+  public void countWithMultiDimensions() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MultiDimensionCounter counter = metricsContext.multiCounter(COUNTER_NAME1, Unit.COUNT, 3);
+    final MetricTag key3D = new DefaultMetricTag("1d_key", "2d_key", "3d_key");
+
+    counter.increment(key3D);
+    Assertions.assertThat(counter.value(key3D)).isEqualTo(1);
+
+    counter.increment(key3D, 10L);
+    Assertions.assertThat(counter.value(key3D)).isEqualTo(11L);
+
+    // The order of dimensions matter
+    final MetricTag key3DMixed = new DefaultMetricTag("2d_key", "3d_key", "1d_key");
+    counter.increment(key3DMixed, 100L);
+    Assertions.assertThat(counter.value(key3DMixed)).isEqualTo(100L);
+    Assertions.assertThat(counter.value(key3D)).isEqualTo(11L);
+  }
+
+  @Test
+  public void dimensionMismatch() {
+    MetricsContext metricsContext = new DefaultMetricsContext();
+    MultiDimensionCounter counter1 = metricsContext.multiCounter(COUNTER_NAME1, Unit.COUNT);
+
+    Assertions.assertThatThrownBy(() -> counter1.increment(new DefaultMetricTag("key1", "key2")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "Number of dimensions mismatch between the provided tag and counter-name1. 2 vs 1");
+
+    Assertions.assertThatThrownBy(() -> counter1.increment(new DefaultMetricTag("key1", "key2"), 5))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "Number of dimensions mismatch between the provided tag and counter-name1. 2 vs 1");
+
+    Assertions.assertThatThrownBy(() -> counter1.value(new DefaultMetricTag("key1", "key2")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "Number of dimensions mismatch between the provided tag and counter-name1. 2 vs 1");
+
+    MultiDimensionCounter counter2 = metricsContext.multiCounter(COUNTER_NAME1, Unit.COUNT, 3);
+    Assertions.assertThatThrownBy(() -> counter2.increment(new DefaultMetricTag("key1")))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "Number of dimensions mismatch between the provided tag and counter-name1. 1 vs 3");
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -370,6 +370,7 @@ project(':iceberg-core') {
     testImplementation libs.esotericsoftware.kryo
     testImplementation libs.guava.testlib
     testImplementation libs.awaitility
+    testImplementation "org.skyscreamer:jsonassert:1.5.1"
   }
 }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounterResult.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounterResult.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Map;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public abstract class MultiDimensionCounterResult {
+  public abstract Map<String, Long> counterResults();
+
+  public abstract String name();
+
+  public abstract Unit unit();
+
+  @Value.Derived
+  public long value(String key) {
+    return counterResults().getOrDefault(key, 0L);
+  }
+
+  @Value.Derived
+  public long totalValue() {
+    return counterResults().values().stream().reduce(0L, Long::sum);
+  }
+
+  static MultiDimensionCounterResult fromCounter(MultiDimensionCounter multiCounter) {
+    Preconditions.checkArgument(null != multiCounter, "Invalid counter: null");
+    if (multiCounter.isNoop()) {
+      return null;
+    }
+
+    Map<String, Long> result = Maps.newHashMap();
+    for (String counterKey : multiCounter.metricTags()) {
+      result.put(counterKey, multiCounter.value(new DefaultMetricTag(counterKey)));
+    }
+    return ImmutableMultiDimensionCounterResult.builder()
+        .name(multiCounter.name())
+        .unit(multiCounter.unit())
+        .counterResults(result)
+        .build();
+  }
+
+  static MultiDimensionCounterResult of(String name, Unit unit, Map<String, Long> counterResults) {
+    return ImmutableMultiDimensionCounterResult.builder()
+        .name(name)
+        .unit(unit)
+        .counterResults(counterResults)
+        .build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounterResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MultiDimensionCounterResultParser.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.JsonUtil;
+
+public class MultiDimensionCounterResultParser {
+  private static final String MISSING_FIELD_ERROR_MSG =
+      "Cannot parse counter from '%s': Missing field '%s'";
+  private static final String UNIT = "unit";
+  private static final String VALUE = "value";
+  private static final String COUNTER_ID = "counter-id";
+  private static final String COUNTERS = "counters";
+
+  private MultiDimensionCounterResultParser() {}
+
+  static void toJson(String name, MultiDimensionCounterResult multiCounter, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != multiCounter, "Invalid counter: null");
+
+    gen.writeFieldName(name);
+    gen.writeStartObject();
+    gen.writeStringField(UNIT, multiCounter.unit().displayName());
+    gen.writeArrayFieldStart(COUNTERS);
+    for (Map.Entry<String, Long> counterResult : multiCounter.counterResults().entrySet()) {
+      gen.writeStartObject();
+      gen.writeStringField(COUNTER_ID, counterResult.getKey());
+      gen.writeNumberField(VALUE, counterResult.getValue());
+      gen.writeEndObject();
+    }
+    gen.writeEndArray();
+    gen.writeEndObject();
+  }
+
+  static MultiDimensionCounterResult fromJson(String multiCounterName, JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse counter from null object");
+    Preconditions.checkArgument(json.isObject(), "Cannot parse counter from non-object: %s", json);
+
+    if (!json.has(multiCounterName)) {
+      return null;
+    }
+
+    JsonNode multiCounter = json.get(multiCounterName);
+    Preconditions.checkArgument(
+        multiCounter.has(UNIT), MISSING_FIELD_ERROR_MSG, multiCounterName, UNIT);
+    Preconditions.checkArgument(
+        multiCounter.has(COUNTERS), MISSING_FIELD_ERROR_MSG, multiCounterName, COUNTERS);
+
+    String multiCounterUnit = JsonUtil.getString(UNIT, multiCounter);
+    JsonNode counters = multiCounter.get(COUNTERS);
+    Preconditions.checkArgument(
+        counters.isArray(), "'%s' should be an array in '%s'", COUNTERS, multiCounterName);
+    ArrayNode countersArray = (ArrayNode) counters;
+
+    Map<String, Long> counterResults = Maps.newHashMap();
+    Iterator<JsonNode> it = countersArray.elements();
+    while (it.hasNext()) {
+      JsonNode item = it.next();
+      Preconditions.checkArgument(
+          item.has(COUNTER_ID), MISSING_FIELD_ERROR_MSG, COUNTERS, COUNTER_ID);
+      Preconditions.checkArgument(item.has(VALUE), MISSING_FIELD_ERROR_MSG, COUNTERS, VALUE);
+      String counterId = JsonUtil.getString(COUNTER_ID, item);
+      long value = JsonUtil.getLong(VALUE, item);
+
+      counterResults.put(counterId, value);
+    }
+
+    return MultiDimensionCounterResult.of(
+        multiCounterName, MetricsContext.Unit.fromDisplayName(multiCounterUnit), counterResults);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.metrics;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
 import org.immutables.value.Value;
 
 /** Carries all metrics for a particular scan */
@@ -26,6 +27,7 @@ import org.immutables.value.Value;
 public abstract class ScanMetrics {
   public static final String TOTAL_PLANNING_DURATION = "total-planning-duration";
   public static final String RESULT_DATA_FILES = "result-data-files";
+  public static final String RESULT_DATA_FILES_BY_FORMAT = "result-data-files-by-format";
   public static final String RESULT_DELETE_FILES = "result-delete-files";
   public static final String SCANNED_DATA_MANIFESTS = "scanned-data-manifests";
   public static final String SCANNED_DELETE_MANIFESTS = "scanned-delete-manifests";
@@ -55,6 +57,11 @@ public abstract class ScanMetrics {
   @Value.Derived
   public Counter resultDataFiles() {
     return metricsContext().counter(RESULT_DATA_FILES);
+  }
+
+  @Value.Derived
+  public MultiDimensionCounter resultDataFilesByFormat() {
+    return metricsContext().multiCounter(RESULT_DATA_FILES_BY_FORMAT, Unit.COUNT);
   }
 
   @Value.Derived

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResult.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResult.java
@@ -73,11 +73,16 @@ public interface ScanMetricsResult {
   @Nullable
   CounterResult positionalDeleteFiles();
 
+  @Nullable
+  MultiDimensionCounterResult resultDataFilesByFormat();
+
   static ScanMetricsResult fromScanMetrics(ScanMetrics scanMetrics) {
     Preconditions.checkArgument(null != scanMetrics, "Invalid scan metrics: null");
     return ImmutableScanMetricsResult.builder()
         .totalPlanningDuration(TimerResult.fromTimer(scanMetrics.totalPlanningDuration()))
         .resultDataFiles(CounterResult.fromCounter(scanMetrics.resultDataFiles()))
+        .resultDataFilesByFormat(
+            MultiDimensionCounterResult.fromCounter(scanMetrics.resultDataFilesByFormat()))
         .resultDeleteFiles(CounterResult.fromCounter(scanMetrics.resultDeleteFiles()))
         .totalDataManifests(CounterResult.fromCounter(scanMetrics.totalDataManifests()))
         .totalDeleteManifests(CounterResult.fromCounter(scanMetrics.totalDeleteManifests()))

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsResultParser.java
@@ -51,6 +51,11 @@ class ScanMetricsResultParser {
       CounterResultParser.toJson(metrics.resultDataFiles(), gen);
     }
 
+    if (null != metrics.resultDataFilesByFormat()) {
+      MultiDimensionCounterResultParser.toJson(
+          ScanMetrics.RESULT_DATA_FILES_BY_FORMAT, metrics.resultDataFilesByFormat(), gen);
+    }
+
     if (null != metrics.resultDeleteFiles()) {
       gen.writeFieldName(ScanMetrics.RESULT_DELETE_FILES);
       CounterResultParser.toJson(metrics.resultDeleteFiles(), gen);
@@ -137,6 +142,9 @@ class ScanMetricsResultParser {
         .totalPlanningDuration(
             TimerResultParser.fromJson(ScanMetrics.TOTAL_PLANNING_DURATION, json))
         .resultDataFiles(CounterResultParser.fromJson(ScanMetrics.RESULT_DATA_FILES, json))
+        .resultDataFilesByFormat(
+            MultiDimensionCounterResultParser.fromJson(
+                ScanMetrics.RESULT_DATA_FILES_BY_FORMAT, json))
         .resultDeleteFiles(CounterResultParser.fromJson(ScanMetrics.RESULT_DELETE_FILES, json))
         .totalDataManifests(CounterResultParser.fromJson(ScanMetrics.TOTAL_DATA_MANIFESTS, json))
         .totalDeleteManifests(

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsUtil.java
@@ -47,5 +47,7 @@ public class ScanMetricsUtil {
     }
 
     metrics.totalDeleteFileSizeInBytes().increment(deletesSizeInBytes);
+
+    metrics.resultDataFilesByFormat().increment(new DefaultMetricTag(dataFile.format().toString()));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TestBase.java
@@ -163,6 +163,20 @@ public class TestBase {
                   ))
           .withFileSizeInBytes(350)
           .build();
+  static final DataFile FILE_AVRO =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-a.avro")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_ORC =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-a.orc")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
 
   static final FileIO FILE_IO = new TestTables.LocalFileIO();
 


### PR DESCRIPTION
There is an existing metric to hold the total number of non-skipped data files during a planFiles() call. This patch adds new metrics to break that number up by file format (Avro, ORC, Parquet). These new metrics could come handy for profiling queries on mixed file format tables.