### PR TITLE
Python: Add the Makefile to the source distribution

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,7 @@ packages = [
     { from = "vendor", include = "fb303" },
     { from = "vendor", include = "hive_metastore" },
     { include = "tests", format = "sdist" },
+    { include = "Makefile", format = "sdist" }
 ]
 
 


### PR DESCRIPTION
This makes it easier for testing.

```
➜  python git:(fd-add-makefile-to-sdist) ✗ poetry build
Building pyiceberg (0.1.0.dev0)
  - Building sdist
  - Built pyiceberg-0.1.0.dev0.tar.gz
  - Building wheel
  - Built pyiceberg-0.1.0.dev0-py3-none-any.whl
➜  python git:(fd-add-makefile-to-sdist) ✗ cd dist
➜  dist git:(fd-add-makefile-to-sdist) ✗ tar -xf pyiceberg-0.1.0.dev0.tar.gz
➜  dist git:(fd-add-makefile-to-sdist) ✗ cd pyiceberg-0.1.0.dev0
➜  pyiceberg-0.1.0.dev0 git:(fd-add-makefile-to-sdist) ✗ find . | grep Makefile
./Makefile
➜  pyiceberg-0.1.0.dev0 git:(fd-add-makefile-to-sdist) ✗ head Makefile
```