### PR TITLE
Python: Add license checker to the source distribution

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -19,6 +19,9 @@ install:
 	pip install poetry
 	poetry install -E pyarrow -E hive -E s3fs
 
+check-license:
+	./dev/check-license
+
 lint:
 	poetry run pre-commit run --all-files
 

--- a/python/dev/check-license
+++ b/python/dev/check-license
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+acquire_rat_jar () {
+
+  URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+
+  JAR="$rat_jar"
+
+  # Download rat launch jar if it hasn't been downloaded yet
+  if [ ! -f "$JAR" ]; then
+    # Download
+    printf "Attempting to fetch rat\n"
+    JAR_DL="${JAR}.part"
+    if [ $(command -v curl) ]; then
+      curl -L --silent "${URL}" > "$JAR_DL" && mv "$JAR_DL" "$JAR"
+    elif [ $(command -v wget) ]; then
+      wget --quiet ${URL} -O "$JAR_DL" && mv "$JAR_DL" "$JAR"
+    else
+      printf "You do not have curl or wget installed, please install rat manually.\n"
+      exit -1
+    fi
+  fi
+
+  unzip -tq "$JAR" &> /dev/null
+  if [ $? -ne 0 ]; then
+    # We failed to download
+    rm "$JAR"
+    printf "Our attempt to download rat locally to ${JAR} failed. Please install rat manually.\n"
+    exit -1
+  fi
+}
+
+# Go to the Spark project root directory
+FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
+cd "$FWDIR"
+
+if test -x "$JAVA_HOME/bin/java"; then
+    declare java_cmd="$JAVA_HOME/bin/java"
+else
+    declare java_cmd=java
+fi
+
+export RAT_VERSION=0.12
+export rat_jar="$FWDIR"/lib/apache-rat-${RAT_VERSION}.jar
+mkdir -p "$FWDIR"/lib
+
+[[ -f "$rat_jar" ]] || acquire_rat_jar || {
+    echo "Download failed. Obtain the rat jar manually and place it at $rat_jar"
+    exit 1
+}
+
+mkdir -p build
+$java_cmd -jar "$rat_jar" -d "$FWDIR"
+
+if [ $? -ne 0 ]; then
+   echo "RAT exited abnormally"
+   exit 1
+fi

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,7 +38,7 @@ packages = [
     { from = "vendor", include = "fb303" },
     { from = "vendor", include = "hive_metastore" },
     { include = "tests", format = "sdist" },
-    { include = "dev/check-license", format = "sdist" }
+    { include = "dev/check-license", format = "sdist" },
     { include = "Makefile", format = "sdist" },
     { include = "NOTICE", format = ["sdist", "wheel"] }
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,7 @@ packages = [
     { from = "vendor", include = "fb303" },
     { from = "vendor", include = "hive_metastore" },
     { include = "tests", format = "sdist" },
+    { include = "dev/check-license", format = "sdist" }
 ]
 
 


### PR DESCRIPTION
This adds a light version of the `check-license` script (without the exclusions), and a command in the makefile to easily run it