### PR TITLE
Ensure the default value of hive.in.test to avoid overwriting

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -268,7 +268,7 @@ public class TestHiveMetastore {
     conf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     conf.set("iceberg.hive.client-pool-size", "2");
     // Setting this to avoid thrift exception during running Iceberg tests outside Iceberg.
-    conf.set(HiveConf.ConfVars.HIVE_IN_TEST.varname, "false");
+    conf.set(HiveConf.ConfVars.HIVE_IN_TEST.varname, HiveConf.ConfVars.HIVE_IN_TEST.getDefaultValue());
   }
 
   private static void setupMetastoreDB(String dbURL) throws SQLException, IOException {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -267,6 +267,8 @@ public class TestHiveMetastore {
     conf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
     conf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     conf.set("iceberg.hive.client-pool-size", "2");
+    // Setting this to avoid thrift exception during running Iceberg tests outside Iceberg.
+    conf.set(HiveConf.ConfVars.HIVE_IN_TEST.varname, "false");
   }
 
   private static void setupMetastoreDB(String dbURL) throws SQLException, IOException {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -268,7 +268,8 @@ public class TestHiveMetastore {
     conf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     conf.set("iceberg.hive.client-pool-size", "2");
     // Setting this to avoid thrift exception during running Iceberg tests outside Iceberg.
-    conf.set(HiveConf.ConfVars.HIVE_IN_TEST.varname, HiveConf.ConfVars.HIVE_IN_TEST.getDefaultValue());
+    conf.set(
+        HiveConf.ConfVars.HIVE_IN_TEST.varname, HiveConf.ConfVars.HIVE_IN_TEST.getDefaultValue());
   }
 
   private static void setupMetastoreDB(String dbURL) throws SQLException, IOException {


### PR DESCRIPTION
We have tried to run some Iceberg unit tests through test-jars in Spark.

Although Iceberg Spark v3.2 unit tests are okay to run, we got a lot errors on Hive metastore unit tests:

```
org.apache.thrift.ProcessFunction: Internal error processing lock
```

After setting hive.in.test as false in Iceberg `TestHiveMetastore.java`, the locking issue seems disappeared. 

The config seems to let Hive throw an exception when thrift version doesn't match under test.

Setting this to false to allow others to run Iceberg unit test through test-jars.
