### PR TITLE
INFRA: Avoid running engine tests on ISSUE_TEMPLATE update

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -27,6 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
+    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/hive-ci.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -27,6 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
+    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/flink-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -27,6 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
+    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/flink-ci.yml'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -27,6 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
+    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'


### PR DESCRIPTION
Presently on updating ISSUE_TEMPLATE we trigger complete engine suite. Like Licence / Notice / readme we can also ignore running suite when we update the ISSUE_TEMPLATE. 