### PR TITLE
Spark: Fix QueryFailure when running RewriteManifestProcedure on Date partitioned table

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -32,29 +32,11 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
-
-  private static final StructField[] dateStruct = {
-    new StructField("id", DataTypes.IntegerType, true, Metadata.empty()),
-    new StructField("name", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("dept", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("ts", DataTypes.DateType, true, Metadata.empty())
-  };
-
-  private static final StructField[] timeStampStruct = {
-    new StructField("id", DataTypes.IntegerType, true, Metadata.empty()),
-    new StructField("name", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("dept", DataTypes.StringType, true, Metadata.empty()),
-    new StructField("ts", DataTypes.TimestampType, true, Metadata.empty())
-  };
 
   public TestRewriteManifestsProcedure(
       String catalogName, String implementation, Map<String, String> config) {
@@ -132,8 +114,7 @@ public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
                                 "Will Doe",
                                 "facilities",
                                 partitionColumn(partitionColType, "2021-01-04"))),
-                        new StructType(
-                            ("DATE".equals(partitionColType) ? dateStruct : timeStampStruct)))
+                        spark.table(tableName).schema())
                     .writeTo(tableName)
                     .append();
               } catch (NoSuchTableException e) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -19,8 +19,6 @@
 package org.apache.iceberg.spark;
 
 import java.nio.ByteBuffer;
-import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
@@ -70,9 +68,13 @@ public class SparkValueConverter {
         return convertedMap;
 
       case DATE:
-        return DateTimeUtils.fromJavaDate((Date) object);
+        // if spark.sql.datetime.java8API.enabled is set to true, java.time.LocalDate
+        // for Spark SQL DATE type otherwise java.sql.Date is returned.
+        return DateTimeUtils.anyToDays(object);
       case TIMESTAMP:
-        return DateTimeUtils.fromJavaTimestamp((Timestamp) object);
+        // if spark.sql.datetime.java8API.enabled is set to true, java.time.Instant
+        // for Spark SQL TIMESTAMP type is returned otherwise java.sql.Timestamp is returned.
+        return DateTimeUtils.anyToMicros(object);
       case BINARY:
         return ByteBuffer.wrap((byte[]) object);
       case INTEGER:


### PR DESCRIPTION
### About the change

Solves https://github.com/apache/iceberg/issues/5104

Presently when `spark.sql.datetime.java8API.enabled` is set to true, 

- java.time.LocalDate is returned for Spark SQL DATE type
- java.time.Instant is returned for Spark SQL TIMESTAMP type

so always casting date type to java.sql.Date or timestamp to java.sql.Timestamp is not correct and can lead to class cast exception. This change attempts to use appropriate api's from DateTimeUtils class which take these scenarios into consideration and calls the relevant api's as per the object type.

```scala
  /**
   * Converts an Java object to days.
   *
   * @param obj Either an object of `java.sql.Date` or `java.time.LocalDate`.
   * @return The number of days since 1970-01-01.
   */
  def anyToDays(obj: Any): Int = obj match {
    case d: Date => fromJavaDate(d)
    case ld: LocalDate => localDateToDays(ld)
  }


  /**
   * Converts an Java object to microseconds.
   *
   * @param obj Either an object of `java.sql.Timestamp` or `java.time.Instant`.
   * @return The number of micros since the epoch.
   */
  def anyToMicros(obj: Any): Long = obj match {
    case t: Timestamp => fromJavaTimestamp(t)
    case i: Instant => instantToMicros(i)
  }
```

----

### Testing Done 

Added an UT which would fail without this change.

cc @rdblue @aokolnychyi 

