### PR TITLE
Core: Avoid extra getFileStatus call in HadoopInputFile

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -160,6 +160,8 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
     if (stat == null) {
       try {
         this.stat = fs.getFileStatus(path);
+      } catch (FileNotFoundException e) {
+        throw new NotFoundException(e, "Path does not exist: %s", path);
       } catch (IOException e) {
         throw new RuntimeIOException(e, "Failed to get status for file: %s", path);
       }
@@ -224,9 +226,9 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
   @Override
   public boolean exists() {
     try {
-      return fs.exists(path);
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to check existence for file: %s", path);
+      return lazyStat() != null;
+    } catch (NotFoundException e) {
+      return false;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopInputFile.java
@@ -161,7 +161,7 @@ public class HadoopInputFile implements InputFile, NativelyEncryptedFile {
       try {
         this.stat = fs.getFileStatus(path);
       } catch (FileNotFoundException e) {
-        throw new NotFoundException(e, "Path does not exist: %s", path);
+        throw new NotFoundException(e, "File does not exist: %s", path);
       } catch (IOException e) {
         throw new RuntimeIOException(e, "Failed to get status for file: %s", path);
       }

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -76,6 +77,19 @@ public class HadoopFileIOTest {
     long totalFiles = scaleSizes.stream().mapToLong(Integer::longValue).sum();
     assertEquals(
         totalFiles, Streams.stream(hadoopFileIO.listPrefix(parent.toUri().toString())).count());
+  }
+
+  @Test
+  public void testFileExists() throws IOException {
+    Path parent = new Path(tempDir.toURI());
+    Path randomFilePath = new Path(parent, "random-file-" + UUID.randomUUID().toString());
+    fs.createNewFile(randomFilePath);
+
+    // check existence of the created file
+    Assert.assertTrue(hadoopFileIO.newInputFile(randomFilePath.toUri().toString()).exists());
+
+    fs.delete(randomFilePath, false);
+    Assert.assertFalse(hadoopFileIO.newInputFile(randomFilePath.toUri().toString()).exists());
   }
 
   @Test


### PR DESCRIPTION
### About the change

In case we call both exists() & getLength() we make a redundant call to `getFileStatus` as `fs.exists(path)` internally checks 
```java
  /** Check if exists.
   * @param f source file
   */
  public boolean exists(Path f) throws IOException {
    try {
      return getFileStatus(f) != null;
    } catch (FileNotFoundException e) {
      return false;
    }
  }
```

So we could getFileStatus directly and cache it via lazyStat() in `stat` prop and in `getLength` & subsequent calls directly return it.

Note : This similar opt exists in S3InputFile as well as we cache the results in `getObjectMetadata` call https://github.com/apache/iceberg/blob/b9bbcfb0e4d8f2605d3c6fb2543cefdd5d09524d/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java#L70


----

### Testing Done 

Existing UT's

