### PR TITLE
Doc: Update  output of expire_snapshots procedure

### DIFF
--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -214,6 +214,8 @@ If `older_than` and `retain_last` are omitted, the table's [expiration propertie
 | Output Name | Type | Description |
 | ------------|------|-------------|
 | `deleted_data_files_count` | long | Number of data files deleted by this operation |
+| `deleted_position_delete_files_count` | long | Number of position delete data files deleted by this operation |
+| `deleted_equality_delete_files_count` | long | Number of equality delete data files deleted by this operation |
 | `deleted_manifest_files_count` | long | Number of manifest files deleted by this operation |
 | `deleted_manifest_lists_count` | long | Number of manifest List files deleted by this operation |
 

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -214,7 +214,7 @@ If `older_than` and `retain_last` are omitted, the table's [expiration propertie
 | Output Name | Type | Description |
 | ------------|------|-------------|
 | `deleted_data_files_count` | long | Number of data files deleted by this operation |
-| `deleted_position_delete_files_count` | long | Number of position delete data files deleted by this operation |
+| `deleted_position_delete_files_count` | long | Number of position delete files deleted by this operation |
 | `deleted_equality_delete_files_count` | long | Number of equality delete data files deleted by this operation |
 | `deleted_manifest_files_count` | long | Number of manifest files deleted by this operation |
 | `deleted_manifest_lists_count` | long | Number of manifest List files deleted by this operation |

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -215,7 +215,7 @@ If `older_than` and `retain_last` are omitted, the table's [expiration propertie
 | ------------|------|-------------|
 | `deleted_data_files_count` | long | Number of data files deleted by this operation |
 | `deleted_position_delete_files_count` | long | Number of position delete files deleted by this operation |
-| `deleted_equality_delete_files_count` | long | Number of equality delete data files deleted by this operation |
+| `deleted_equality_delete_files_count` | long | Number of equality delete files deleted by this operation |
 | `deleted_manifest_files_count` | long | Number of manifest files deleted by this operation |
 | `deleted_manifest_lists_count` | long | Number of manifest List files deleted by this operation |
 


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/4629 is already merged, but the the document hasn't been updated.
The execution output is inconsistent with the [documentation](https://iceberg.apache.org/docs/latest/spark-procedures/#output-4), which will lead to confuse, this pr will fix it.

```
CALL spark_catalog.system.expire_snapshots('test_table');
0       0       0       0       1
Time taken: 7.254 seconds, Fetched 1 row(s)
22/09/27 17:32:43 INFO SparkSQLCLIDriver: Time taken: 7.254 seconds, Fetched 1 row(s)
```