### PR TITLE
push down min/max/count to iceberg 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+public abstract class Aggregate<T, C extends Term> implements Expression {
+  private final Operation op;
+  private final C term;
+
+  Aggregate(Operation op, C term) {
+    this.op = op;
+    this.term = term;
+  }
+
+  @Override
+  public Operation op() {
+    return op;
+  }
+
+  public C term() {
+    return term;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/Binder.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Binder.java
@@ -158,6 +158,16 @@ public class Binder {
     public <T> Expression predicate(UnboundPredicate<T> pred) {
       return pred.bind(struct, caseSensitive);
     }
+
+    @Override
+    public <T> Expression aggregate(UnboundAggregate<T> agg) {
+      return agg.bind(struct, caseSensitive);
+    }
+
+    @Override
+    public <T> Expression aggregate(BoundAggregate<T> agg) {
+      throw new IllegalStateException("Found already bound aggregate: " + agg);
+    }
   }
 
   private static class ReferenceVisitor extends ExpressionVisitor<Set<Integer>> {

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundAggregate.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.StructLike;
+
+public class BoundAggregate<T> extends Aggregate<T, BoundTerm<T>> implements Bound<T> {
+  protected BoundAggregate(Operation op, BoundTerm<T> term) {
+    super(op, term);
+  }
+
+  @Override
+  public T eval(StructLike struct) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement eval");
+  }
+
+  @Override
+  public BoundReference<?> ref() {
+    return term().ref();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -41,7 +41,11 @@ public interface Expression extends Serializable {
     AND,
     OR,
     STARTS_WITH,
-    NOT_STARTS_WITH;
+    NOT_STARTS_WITH,
+    COUNT,
+    COUNTSTAR,
+    MAX,
+    MIN;
 
     /** Returns the operation used when this is negated. */
     public Operation negate() {

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -55,6 +55,14 @@ public class ExpressionVisitors {
     public <T> R predicate(UnboundPredicate<T> pred) {
       return null;
     }
+
+    public <T> R aggregate(BoundAggregate<T> agg) {
+      return null;
+    }
+
+    public <T> R aggregate(UnboundAggregate<T> agg) {
+      return null;
+    }
   }
 
   public abstract static class BoundExpressionVisitor<R> extends ExpressionVisitor<R> {
@@ -337,6 +345,12 @@ public class ExpressionVisitors {
         return visitor.predicate((BoundPredicate<?>) expr);
       } else {
         return visitor.predicate((UnboundPredicate<?>) expr);
+      }
+    } else if (expr instanceof Aggregate) {
+      if (expr instanceof BoundAggregate) {
+        return visitor.aggregate((BoundAggregate<?>) expr);
+      } else {
+        return visitor.aggregate((UnboundAggregate<?>) expr);
       }
     } else {
       switch (expr.op()) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -280,6 +280,22 @@ public class Expressions {
     return False.INSTANCE;
   }
 
+  public static UnboundAggregate<String> count(String name) {
+    return new UnboundAggregate<>(Operation.COUNT, ref(name));
+  }
+
+  public static UnboundAggregate<String> countStar() {
+    return new UnboundAggregate<>(Operation.COUNTSTAR, null);
+  }
+
+  public static UnboundAggregate<String> max(String name) {
+    return new UnboundAggregate<>(Operation.MAX, ref(name));
+  }
+
+  public static UnboundAggregate<String> min(String name) {
+    return new UnboundAggregate<>(Operation.MIN, ref(name));
+  }
+
   public static Expression rewriteNot(Expression expr) {
     return ExpressionVisitors.visit(expr, RewriteNot.get());
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.types.Types;
+
+public class UnboundAggregate<T> extends Aggregate<T, UnboundTerm<T>>
+    implements Unbound<T, Expression> {
+
+  UnboundAggregate(Operation op, UnboundTerm<T> term) {
+    super(op, term);
+  }
+
+  @Override
+  public NamedReference<?> ref() {
+    return term().ref();
+  }
+
+  /**
+   * Bind this UnboundAggregate.
+   *
+   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @param caseSensitive A boolean flag to control whether the bind should enforce case
+   *     sensitivity.
+   * @return an {@link Expression}
+   * @throws ValidationException if literals do not match bound references, or if comparison on
+   *     expression is invalid
+   */
+  @Override
+  public Expression bind(Types.StructType struct, boolean caseSensitive) {
+    if (term() != null) {
+      BoundTerm<T> bound = term().bind(struct, caseSensitive);
+      return new BoundAggregate<>(op(), bound);
+    } else {
+      return new BoundAggregate<>(op(), null); // Count (*)
+    }
+  }
+
+  @Override
+  public String toString() {
+    switch (op()) {
+      case COUNT:
+        return "count(" + term() + ")";
+      case COUNTSTAR:
+        return "count(*)";
+      case MAX:
+        return "max(" + term() + ")";
+      case MIN:
+        return "min(" + term() + ")";
+      default:
+        return "Invalid pushed down aggregate: operation = " + op();
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -349,4 +349,7 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String AGGREGATE_PUSHDOWN_ENABLED = "aggregate.pushdown.enabled";
+  public static final String AGGREGATE_PUSHDOWN_ENABLED_DEFAULT = "false";
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 # checksum was taken from https://gradle.org/release-checksums
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+# distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 # checksum was taken from https://gradle.org/release-checksums
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-# distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
+distributionSha256Sum=f6b8596b10cce501591e92f229816aa4046424f3b24d771751b06779d58c8ec4
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkAggregates.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkAggregates.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expression.Operation;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
+import org.apache.spark.sql.connector.expressions.aggregate.Count;
+import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
+import org.apache.spark.sql.connector.expressions.aggregate.Max;
+import org.apache.spark.sql.connector.expressions.aggregate.Min;
+
+public class SparkAggregates {
+
+  private static final Pattern BACKTICKS_PATTERN = Pattern.compile("([`])(.|$)");
+
+  private SparkAggregates() {}
+
+  private static final Map<Class<? extends AggregateFunc>, Operation> AGGREGATES =
+      ImmutableMap.<Class<? extends AggregateFunc>, Operation>builder()
+          .put(Count.class, Operation.COUNT)
+          .put(CountStar.class, Operation.COUNTSTAR)
+          .put(Max.class, Operation.MAX)
+          .put(Min.class, Operation.MIN)
+          .build();
+
+  public static Expression convert(AggregateFunc aggregate) {
+    Operation op = AGGREGATES.get(aggregate.getClass());
+    if (op != null) {
+      switch (op) {
+        case COUNT:
+          Count countAgg = (Count) aggregate;
+          return Expressions.count(unquote(countAgg.column().describe()));
+        case COUNTSTAR:
+          return Expressions.countStar();
+        case MAX:
+          Max maxAgg = (Max) aggregate;
+          return Expressions.max(unquote(maxAgg.column().describe()));
+        case MIN:
+          Min minAgg = (Min) aggregate;
+          return Expressions.min(unquote(minAgg.column().describe()));
+      }
+    }
+
+    return null;
+  }
+
+  private static String unquote(String attributeName) {
+    Matcher matcher = BACKTICKS_PATTERN.matcher(attributeName);
+    return matcher.replaceAll("$2");
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkLocalScan.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.read.LocalScan;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import scala.collection.JavaConverters;
+
+class SparkLocalScan implements LocalScan {
+
+  private final SparkSession spark;
+  private final Table table;
+  private final List<Expression> aggregateExpressions;
+  private final boolean caseSensitive;
+  private final StructType aggregateSchema;
+
+  SparkLocalScan(
+      SparkSession spark,
+      Table table,
+      SparkReadConf readConf,
+      List<Expression> aggregates,
+      StructType aggregateSchema) {
+    this.spark = spark;
+    this.table = table;
+    this.caseSensitive = readConf.caseSensitive();
+    this.aggregateExpressions = aggregates != null ? aggregates : Collections.emptyList();
+    this.aggregateSchema = aggregateSchema;
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @Override
+  public InternalRow[] rows() {
+    // get the statistics info from DATA_FILES, calculate the aggregate values (min/max/count)
+    // and use these value to build an internalRow.
+    Dataset<Row> metadataRows =
+        SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.DATA_FILES);
+
+    Row[] lowerBounds = null;
+    Row[] upperBounds = null;
+    Row[] recordCount = null;
+    Row[] nullValueCount = null;
+
+    StructField[] fields = aggregateSchema.fields();
+    List<Object> valuesInSparkInternalRow = Lists.newArrayList();
+    InternalRow[] rows = new InternalRow[1];
+
+    for (int i = 0; i < fields.length; i++) {
+      if (fields[i].name().contains("MIN")) {
+        if (lowerBounds == null) {
+          lowerBounds = (Row[]) metadataRows.selectExpr("lower_bounds").collect();
+        }
+        int index = indexInTableSchema(fields[i]);
+        Object min = getMinOrMax(lowerBounds, index + 1, fields[i], true);
+        valuesInSparkInternalRow.add(min);
+      } else if (fields[i].name().contains("MAX")) {
+        if (upperBounds == null) {
+          upperBounds = (Row[]) metadataRows.selectExpr("upper_bounds").collect();
+        }
+        int index = indexInTableSchema(fields[i]);
+        Object max = getMinOrMax(upperBounds, index + 1, fields[i], false);
+        valuesInSparkInternalRow.add(max);
+      } else if (fields[i].name().contains("COUNT(*)")) {
+        if (recordCount == null) {
+          recordCount = (Row[]) metadataRows.selectExpr("record_count").collect();
+        }
+        long count = 0;
+        for (int j = 0; j < recordCount.length; j++) {
+          count += recordCount[j].getLong(0);
+        }
+        valuesInSparkInternalRow.add(count);
+      } else if (fields[i].name().contains("COUNT")) {
+        if (recordCount == null) {
+          recordCount = (Row[]) metadataRows.selectExpr("record_count").collect();
+        }
+        if (nullValueCount == null) {
+          nullValueCount = (Row[]) metadataRows.selectExpr("null_value_counts").collect();
+        }
+        long count = 0;
+        for (int j = 0; j < recordCount.length; j++) {
+          count += recordCount[j].getLong(0);
+        }
+        int index = indexInTableSchema(fields[i]);
+        long numOfNulls = getNullValueCount(nullValueCount, index + 1);
+        valuesInSparkInternalRow.add(count - numOfNulls);
+      }
+    }
+    rows[0] = InternalRow.fromSeq(JavaConverters.asScalaBuffer(valuesInSparkInternalRow).toSeq());
+
+    return rows;
+  }
+
+  private int indexInTableSchema(StructField field) {
+    StructField[] sparkTableFields = SparkSchemaUtil.convert(table.schema()).fields();
+    for (int i = 0; i < sparkTableFields.length; i++) {
+      if (caseSensitive) {
+        if (field.name().contains(sparkTableFields[i].name())) {
+          return i;
+        }
+      } else {
+        if (field
+            .name()
+            .toLowerCase(Locale.ROOT)
+            .contains(sparkTableFields[i].name().toLowerCase(Locale.ROOT))) {
+          return i;
+        }
+      }
+    }
+    throw new RuntimeException(
+        "push down aggregate failed, can't find this aggregate col in table schema.");
+  }
+
+  private long getNullValueCount(Row[] nullValueCount, int index) {
+    long numOfNlls = 0L;
+    for (int i = 0; i < nullValueCount.length; i++) {
+      Map<Integer, Long> map = nullValueCount[i].getJavaMap(0);
+      Long value = map.get(index);
+      numOfNlls += value;
+    }
+    return numOfNlls;
+  }
+
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "MethodLength"})
+  private Object getMinOrMax(Row[] rows, int index, StructField field, boolean isMin) {
+    Object result = null;
+    boolean isString = false;
+    boolean isBinary = false;
+    boolean isDecimal = false;
+
+    for (int i = 0; i < rows.length; i++) {
+      Map<Integer, byte[]> map = rows[i].getJavaMap(0);
+      byte[] valueInBytes = map.get(index);
+      if (valueInBytes != null) {
+        Type type = SparkSchemaUtil.convert(field.dataType());
+        switch (type.typeId()) {
+          case BOOLEAN:
+            boolean booleanValue =
+                Conversions.fromByteBuffer(
+                    Types.BooleanType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || Literal.of(booleanValue).comparator().compare(booleanValue, (boolean) result) < 0) {
+                result = booleanValue;
+              }
+            } else {
+              if (result == null
+                  || Literal.of(booleanValue).comparator().compare(booleanValue, (boolean) result) > 0) {
+                result = booleanValue;
+              }
+            }
+            break;
+          case INTEGER:
+          case DATE:
+            int intValue =
+                Conversions.fromByteBuffer(
+                    Types.IntegerType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(intValue)).comparator().compare(intValue, (int) result) < 0) {
+                result = intValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(intValue)).comparator().compare(intValue, (int) result) > 0) {
+                result = intValue;
+              }
+            }
+            break;
+          case LONG:
+          case TIME:
+          case TIMESTAMP:
+            long longValue =
+                Conversions.fromByteBuffer(Types.LongType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(longValue)).comparator().compare(longValue, (Long) result) < 0) {
+                result = longValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(longValue)).comparator().compare(longValue, (Long) result) > 0) {
+                result = longValue;
+              }
+            }
+            break;
+          case FLOAT:
+            float fValue =
+                Conversions.fromByteBuffer(Types.FloatType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(fValue)).comparator().compare(fValue, (float) result) < 0) {
+                result = fValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(fValue)).comparator().compare(fValue, (float) result) > 0) {
+                result = fValue;
+              }
+            }
+            break;
+          case DOUBLE:
+            double doubleValue =
+                Conversions.fromByteBuffer(Types.DoubleType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(doubleValue)).comparator().compare(doubleValue, (double) result) < 0) {
+                result = doubleValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(doubleValue)).comparator().compare(doubleValue, (double) result) > 0) {
+                result = doubleValue;
+              }
+            }
+            break;
+          case STRING:
+            String stringValue =
+                Conversions.fromByteBuffer(Types.StringType.get(), ByteBuffer.wrap(map.get(index)))
+                    .toString();
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(stringValue)).comparator().compare(stringValue, (String) result) < 0) {
+                result = stringValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(stringValue)).comparator().compare(stringValue, (String) result) > 0) {
+                result = stringValue;
+              }
+            }
+            isString = true;
+            break;
+          case FIXED:
+          case BINARY:
+            ByteBuffer binaryValue =
+                Conversions.fromByteBuffer(Types.BinaryType.get(), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(binaryValue))
+                          .comparator()
+                          .compare(binaryValue, (ByteBuffer) result)
+                      < 0) {
+                result = binaryValue;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(binaryValue))
+                          .comparator()
+                          .compare(binaryValue, (ByteBuffer) result)
+                      > 0) {
+                result = binaryValue;
+              }
+            }
+            isBinary = true;
+            break;
+          case DECIMAL:
+            int precision = ((DecimalType) field.dataType()).precision();
+            int scale = ((DecimalType) field.dataType()).scale();
+            BigDecimal decimal =
+                Conversions.fromByteBuffer(
+                    Types.DecimalType.of(precision, scale), ByteBuffer.wrap(map.get(index)));
+            if (isMin) {
+              if (result == null
+                  || (Literal.of(decimal)).comparator().compare(decimal, (BigDecimal) result) < 0) {
+                result = decimal;
+              }
+            } else {
+              if (result == null
+                  || (Literal.of(decimal)).comparator().compare(decimal, (BigDecimal) result) > 0) {
+                result = decimal;
+              }
+            }
+            isDecimal = true;
+            break;
+          default:
+            throw new RuntimeException("Data type is not supported in push down min()");
+        }
+      }
+    }
+    if (isString) {
+      return org.apache.spark.unsafe.types.UTF8String.fromString(result.toString());
+    }
+    if (isBinary) {
+      byte[] arr = new byte[((ByteBuffer) result).remaining()];
+      ((ByteBuffer) result).get(arr);
+      return arr;
+    }
+    if (isDecimal) {
+      return Decimal.apply(new scala.math.BigDecimal((BigDecimal) result));
+    }
+    return result;
+  }
+
+  @Override
+  public StructType readSchema() {
+    return aggregateSchema;
+  }
+
+  @Override
+  public String description() {
+    String aggregates =
+        aggregateExpressions.stream().map(Spark3Util::describe).collect(Collectors.joining(", "));
+    return String.format("%s [filters=%s]", table, aggregates);
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestAggregatePushDown extends SparkCatalogTestBase {
+
+  public TestAggregatePushDown(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testDifferentDataTypesAggregatePushDownInPartitionedTable() {
+    testDifferentDataTypesAggregatePushDown(true);
+  }
+
+  @Test
+  public void testDifferentDataTypesAggregatePushDownInNonPartitionedTable() {
+    testDifferentDataTypesAggregatePushDown(false);
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  private void testDifferentDataTypesAggregatePushDown(boolean hasPartitionCol) {
+    String createTable;
+    if (hasPartitionCol) {
+      createTable =
+          "CREATE TABLE %s (id LONG, intData INT, booleanData BOOLEAN, floatData FLOAT, doubleData DOUBLE, stringData STRING, "
+              + "decimalData DECIMAL(14, 2), binaryData binary) USING iceberg PARTITIONED BY (id)";
+    } else {
+      createTable =
+          "CREATE TABLE %s (id LONG, intData INT, booleanData BOOLEAN, floatData FLOAT, doubleData DOUBLE, stringData STRING, "
+              + "decimalData DECIMAL(14, 2), binaryData binary) USING iceberg";
+    }
+    sql(createTable, tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, null, false, null, null, 'gggg', 11.11, X'1111'),"
+            + " (1, null, true, 2.222, 2.222222, null, 22.22, X'2222'),"
+            + " (2, 33, false, 3.333, 3.333333, 'iiii', 33.33, X'3333'),"
+            + " (2, 44, true, null, 4.444444, 'dddd', 44.44, X'4444'),"
+            + " (3, 55, false, 5.555, 5.555555, 'eeee', 55.55, X'5555'),"
+            + " (3, null, true, null, 6.666666, null, 66.66, null) ",
+        tableName);
+
+    String select =
+        "SELECT count(*), max(id), min(id), count(id), "
+            + "max(stringData), min(stringData), count(stringData), "
+            + "max(intData), min(intData), count(intData), "
+            + "max(booleanData), min(booleanData), count(booleanData), "
+            + "max(floatData), min(floatData), count(floatData), "
+            + "max(doubleData), min(doubleData), count(doubleData), "
+            + "max(decimalData), min(decimalData), count(decimalData), "
+            + "max(binaryData), min(binaryData), count(binaryData) FROM %s";
+
+    List<Object[]> expected = sql(select, tableName);
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("COUNT(*)")
+        && explainString.contains("MAX(id)")
+        && explainString.contains("MIN(id)")
+        && explainString.contains("COUNT(id)")
+        && explainString.contains("MAX(stringData)")
+        && explainString.contains("MIN(stringData)")
+        && explainString.contains("COUNT(stringData)")
+        && explainString.contains("MAX(intData)")
+        && explainString.contains("MIN(intData)")
+        && explainString.contains("COUNT(intData)")
+        && explainString.contains("MAX(booleanData)")
+        && explainString.contains("MIN(booleanData)")
+        && explainString.contains("COUNT(booleanData)")
+        && explainString.contains("MAX(floatData)")
+        && explainString.contains("MIN(floatData)")
+        && explainString.contains("COUNT(floatData)")
+        && explainString.contains("MAX(doubleData)")
+        && explainString.contains("MIN(doubleData)")
+        && explainString.contains("COUNT(doubleData)")
+        && explainString.contains("MAX(decimalData)")
+        && explainString.contains("MIN(decimalData)")
+        && explainString.contains("COUNT(decimalData)")
+        && explainString.contains("MAX(binaryData)")
+        && explainString.contains("MIN(binaryData)")
+        && explainString.contains("COUNT(binaryData)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertTrue(
+        "explain should contain the pushed down aggregates", explainContainsPushDownAggregates);
+
+    List<Object[]> actual = sql(select, tableName);
+    assertEquals("min/max/count push down", expected, actual);
+  }
+
+  @Test
+  public void testDateAndTimestampWithPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string, d date, ts timestamp) USING iceberg PARTITIONED BY (id)",
+        tableName);
+    sql(
+        "INSERT INTO %s VALUES (1, '1', date('2021-11-10'), null),"
+            + "(1, '2', date('2021-11-11'), timestamp('2021-11-11 22:22:22')), "
+            + "(2, '3', date('2021-11-12'), timestamp('2021-11-12 22:22:22')), "
+            + "(2, '4', date('2021-11-13'), timestamp('2021-11-13 22:22:22')), "
+            + "(3, '5', null, timestamp('2021-11-14 22:22:22')), "
+            + "(3, '6', date('2021-11-14'), null)",
+        tableName);
+    String select = "SELECT max(d), min(d), count(d), max(ts), min(ts), count(ts) FROM %s";
+
+    List<Object[]> expected = sql(select, tableName);
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("MAX(d)")
+        && explainString.contains("MIN(d)")
+        && explainString.contains("COUNT(d)")
+        && explainString.contains("MAX(ts)")
+        && explainString.contains("MIN(ts)")
+        && explainString.contains("COUNT(ts)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertTrue(
+        "explain should contain the pushed down aggregates", explainContainsPushDownAggregates);
+
+    List<Object[]> actual = sql(select, tableName);
+    assertEquals("min/max/count push down", expected, actual);
+  }
+
+  @Test
+  public void testAggregateNotPushDownIfOneCantPushDown() {
+    sql("CREATE TABLE %s (id LONG, data DOUBLE) USING iceberg", tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ",
+        tableName);
+    String select = "SELECT COUNT(data), SUM(data) FROM %s";
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("COUNT(data)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertFalse(
+        "explain should contain the pushed down aggregates", explainContainsPushDownAggregates);
+  }
+
+  @Test
+  public void testAggregateWithComplexTypeNotPushDown() {
+    sql("CREATE TABLE %s (id INT, complex STRUCT<c1:INT,c2:STRING>) USING iceberg", tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\")),"
+            + "(2, named_struct(\"c1\", 2, \"c2\", \"v2\"))",
+        tableName);
+    String select = "SELECT max(complex), min(complex), count(complex) FROM %s";
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("MAX(complex)")
+        || explainString.contains("MIN(complex)")
+        || explainString.contains("COUNT(complex)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertFalse(
+        "min/max/count not pushed down for complex types", explainContainsPushDownAggregates);
+  }
+
+  @Test
+  public void testAggregratePushDownInDeleteCopyOnWrite() {
+    sql("CREATE TABLE %s (id LONG, data INT) USING iceberg", tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ",
+        tableName);
+    sql("DELETE FROM %s WHERE data = 1111", tableName);
+    String select = "SELECT max(data), min(data), count(data) FROM %s";
+
+    List<Object[]> expected = sql(select, tableName);
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("MAX(data)")
+        && explainString.contains("MIN(data)")
+        && explainString.contains("COUNT(data)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertTrue(
+        "min/max/count not pushed down for deleted", explainContainsPushDownAggregates);
+
+    List<Object[]> actual = sql(select, tableName);
+    assertEquals("min/max/count push down", expected, actual);
+  }
+
+  @Test
+  public void testAggregrateWithGroupByNotPushDown() {
+    sql("CREATE TABLE %s (id LONG, data INT) USING iceberg PARTITIONED BY (id)", tableName);
+    sql(
+        "INSERT INTO TABLE %s VALUES (1, 1111), (1, 2222), (2, 3333), (2, 4444), (3, 5555), (3, 6666) ",
+        tableName);
+    String select = "SELECT max(data), min(data) FROM %s GROUP BY id";
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, TableProperties.AGGREGATE_PUSHDOWN_ENABLED, "true");
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString();
+    boolean explainContainsPushDownAggregates = false;
+    if (explainString.contains("MAX(data)") || explainString.contains("MIN(data)")) {
+      explainContainsPushDownAggregates = true;
+    }
+    Assert.assertFalse("min/max not pushed down", explainContainsPushDownAggregates);
+  }
+}


### PR DESCRIPTION
This PR pushes down min/max/count to iceberg.

For `SELECT MIN(col), MAX(col), COUNT(col), COUNT(*) FROM table`, without this PR, iceberg will do `SELECT col FROM table`, and Spark will calculate MIN(col), MAX(col), COUNT(col), COUNT(*). With this PR, iceberg will do `SELECT MIN(col), MAX(col), COUNT(col), COUNT(*) FROM table`. MIN, MAX, COUNT will be calculated on iceberg side using the statistics info in the manifest file.

I have the following changes:

1. Add a table property `AGGREGATE_PUSHDOWN_ENABLED`. The default is false.
2. Make `SparkScanBuilder` implement `SupportsPushDownAggregates`, so MIN/MAX/COUNT can be pushed down to iceberg, and then iceberg will read the statistics information (upper_bound, lower_bound, record_count) from manifest file, calculate the MIN/MAX/COUNT, build a Spark InternalRow and pass the InternalRow to Spark. 
3. Add a `SparkLocalScan`.  It is a special Scan which will happen on Spark driver locally instead of executors. If MIN/MAX/COUNT are pushed down, iceberg will create a `SparkLocalScan`, and then iceberg doesn't need to plan files, create FileScanTasks, and send the tasks to executors. Instead, iceberg can just do a local scan on the Spark driver.
4. SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.DATA_FILES) is used to get the statistics info(upper_bound, lower_bound, record_count), and then max, min or count are calculated from the statistics info, and an InternalRow will be built and returned to Spark.


In the tests, I look the explain result of the physical plan to check if MIN/MAX/COUNT are pushed down

For example, `SELECT max(data), min(data) FROM table`
If MIN/MAX/COUNT are not pushed down
```
== Optimized Logical Plan ==
Aggregate [max(data#146) AS max(data)#150, min(data#146) AS min(data)#151, count(data#146) AS count(data)#152L]
+- RelationV2[data#146] spark_catalog.default.table

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortAggregate(key=[], functions=[max(data#146), min(data#146), count(data#146)], output=[max(data)#150, min(data)#151, count(data)#152L])
   +- SortAggregate(key=[], functions=[partial_max(data#146), partial_min(data#146), partial_count(data#146)], output=[max#165, min#166, count#167L])
      +- BatchScan[data#146] spark_catalog.default.table [filters=] RuntimeFilters: []
```
If MIN/MAX/COUNT are pushed down
```
== Optimized Logical Plan ==
Aggregate [max(MAX(data)#440) AS max(data)#429, min(MIN(data)#441) AS min(data)#430, sum(COUNT(data)#442L) AS count(data)#431L]
+- RelationV2[MAX(data)#440, MIN(data)#441, COUNT(data)#442L] spark_catalog.default.table

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- SortAggregate(key=[], functions=[max(MAX(data)#440), min(MIN(data)#441), sum(COUNT(data)#442L)], output=[max(data)#429, min(data)#430, count(data)#431L])
   +- Exchange SinglePartition, ENSURE_REQUIREMENTS, [id=#297]
      +- SortAggregate(key=[], functions=[partial_max(MAX(data)#440), partial_min(MIN(data)#441), partial_sum(COUNT(data)#442L)], output=[max#446, min#447, sum#448L])
         +- LocalTableScan [MAX(data)#440, MIN(data)#441, COUNT(data)#442L]
```
I check the physical plan to see if it contains MAX(data)/MIN(data)/COUNT(data).