### PR TITLE
Refactor commit lock mechanism from HiveTableOperations

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/CommitStateUnknownException.java
@@ -36,7 +36,7 @@ public class CommitStateUnknownException extends RuntimeException {
     super(cause.getMessage() + "\n" + COMMON_INFO, cause);
   }
 
-  public CommitStateUnknownException(String message, Throwable cause) {
-    super(message + "\n" + cause.getMessage() + "\n" + COMMON_INFO, cause);
+  public CommitStateUnknownException(String message) {
+    super(message + "\n" + COMMON_INFO);
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -40,7 +40,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
   private final int clientPoolSize;
   private final long evictionInterval;
 
-  CachedClientPool(Configuration conf, Map<String, String> properties) {
+  public CachedClientPool(Configuration conf, Map<String, String> properties) {
     this.conf = conf;
     this.metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
     this.clientPoolSize =

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCommitLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCommitLock.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hive;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.LockComponent;
+import org.apache.hadoop.hive.metastore.api.LockLevel;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.hadoop.hive.metastore.api.LockType;
+import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.util.Tasks;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HiveCommitLock {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveCommitLock.class);
+
+  private static final String HIVE_ACQUIRE_LOCK_TIMEOUT_MS = "iceberg.hive.lock-timeout-ms";
+  private static final String HIVE_LOCK_CHECK_MIN_WAIT_MS = "iceberg.hive.lock-check-min-wait-ms";
+  private static final String HIVE_LOCK_CHECK_MAX_WAIT_MS = "iceberg.hive.lock-check-max-wait-ms";
+  private static final String HIVE_LOCK_HEARTBEAT_INTERVAL_MS =
+      "iceberg.hive.lock-heartbeat-interval-ms";
+  private static final String HIVE_TABLE_LEVEL_LOCK_EVICT_MS =
+      "iceberg.hive.table-level-lock-evict-ms";
+
+  private static final long HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT = 3 * 60 * 1000; // 3 minutes
+  private static final long HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT = 50; // 50 milliseconds
+  private static final long HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT = 5 * 1000; // 5 seconds
+  private static final long HIVE_LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT = 4 * 60 * 1000; // 4 minutes
+  private static final long HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT = TimeUnit.MINUTES.toMillis(10);
+  private static Cache<String, ReentrantLock> commitLockCache;
+
+  private static synchronized void initTableLevelLockCache(long evictionTimeout) {
+    if (commitLockCache == null) {
+      commitLockCache =
+          Caffeine.newBuilder().expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS).build();
+    }
+  }
+
+  private static class WaitingForLockException extends RuntimeException {
+    WaitingForLockException(String message) {
+      super(message);
+    }
+  }
+
+  private final String fullName;
+  private final String databaseName;
+  private final String tableName;
+  private final long lockAcquireTimeout;
+  private final long lockCheckMinWaitTime;
+  private final long lockCheckMaxWaitTime;
+  private final long lockHeartbeatIntervalTime;
+
+  private final ClientPool<IMetaStoreClient, TException> metaClients;
+  private final ScheduledExecutorService exitingScheduledExecutorService;
+
+  private Optional<Long> hmsLockId = Optional.empty();
+  private Optional<ReentrantLock> jvmLock = Optional.empty();
+  private HiveLockHeartbeat hiveLockHeartbeat = null;
+
+  public HiveCommitLock(
+      Configuration conf,
+      ClientPool<IMetaStoreClient, TException> metaClients,
+      String catalogName,
+      String databaseName,
+      String tableName) {
+    this.metaClients = metaClients;
+    this.fullName = catalogName + "." + databaseName + "." + tableName;
+    this.databaseName = databaseName;
+    this.tableName = tableName;
+    this.lockAcquireTimeout =
+        conf.getLong(HIVE_ACQUIRE_LOCK_TIMEOUT_MS, HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT);
+    this.lockCheckMinWaitTime =
+        conf.getLong(HIVE_LOCK_CHECK_MIN_WAIT_MS, HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT);
+    this.lockCheckMaxWaitTime =
+        conf.getLong(HIVE_LOCK_CHECK_MAX_WAIT_MS, HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT);
+    this.lockHeartbeatIntervalTime =
+        conf.getLong(HIVE_LOCK_HEARTBEAT_INTERVAL_MS, HIVE_LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT);
+    long tableLevelLockCacheEvictionTimeout =
+        conf.getLong(HIVE_TABLE_LEVEL_LOCK_EVICT_MS, HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT);
+    this.exitingScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("iceberg-hive-lock-heartbeat-%d")
+                .build());
+    initTableLevelLockCache(tableLevelLockCacheEvictionTimeout);
+  }
+
+  public void acquire() throws UnknownHostException, TException, InterruptedException {
+    // getting a process-level lock per table to avoid concurrent commit attempts to the same table
+    // from the same JVM process, which would result in unnecessary and costly HMS lock acquisition
+    // requests
+    acquireJvmLock();
+    acquireLockFromHms();
+  }
+
+  public void release() {
+    releaseHmsLock();
+    releaseJvmLock();
+  }
+
+  public boolean isHeartbeatInProgress() {
+    return hiveLockHeartbeat != null
+        && hiveLockHeartbeat.future != null
+        && !hiveLockHeartbeat.future.isCancelled()
+        && hiveLockHeartbeat.encounteredException == null;
+  }
+
+  private void acquireLockFromHms() throws UnknownHostException, TException, InterruptedException {
+    if (hmsLockId.isPresent()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "HMS lock ID=%s already acquired for table %s.%s",
+              hmsLockId.get(), databaseName, tableName));
+    }
+    final LockComponent lockComponent =
+        new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, databaseName);
+    lockComponent.setTablename(tableName);
+    final LockRequest lockRequest =
+        new LockRequest(
+            Lists.newArrayList(lockComponent),
+            System.getProperty("user.name"),
+            InetAddress.getLocalHost().getHostName());
+    LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
+    AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
+    long lockId = lockResponse.getLockid();
+    this.hmsLockId = Optional.of(lockId);
+
+    final long start = System.currentTimeMillis();
+    long duration = 0;
+    boolean timeout = false;
+
+    try {
+      if (state.get().equals(LockState.WAITING)) {
+        // Retry count is the typical "upper bound of retries" for Tasks.run() function. In fact,
+        // the maximum number of
+        // attempts the Tasks.run() would try is `retries + 1`. Here, for checking locks, we use
+        // timeout as the
+        // upper bound of retries. So it is just reasonable to set a large retry count. However, if
+        // we set
+        // Integer.MAX_VALUE, the above logic of `retries + 1` would overflow into
+        // Integer.MIN_VALUE. Hence,
+        // the retry is set conservatively as `Integer.MAX_VALUE - 100` so it doesn't hit any
+        // boundary issues.
+        Tasks.foreach(lockId)
+            .retry(Integer.MAX_VALUE - 100)
+            .exponentialBackoff(lockCheckMinWaitTime, lockCheckMaxWaitTime, lockAcquireTimeout, 1.5)
+            .throwFailureWhenFinished()
+            .onlyRetryOn(WaitingForLockException.class)
+            .run(
+                id -> {
+                  try {
+                    LockResponse response = metaClients.run(client -> client.checkLock(id));
+                    LockState newState = response.getState();
+                    state.set(newState);
+                    if (newState.equals(LockState.WAITING)) {
+                      throw new WaitingForLockException(
+                          String.format(
+                              "Waiting for lock on table %s.%s", databaseName, tableName));
+                    }
+                  } catch (InterruptedException e) {
+                    Thread.interrupted(); // Clear the interrupt status flag
+                    LOG.warn(
+                        "Interrupted while waiting for lock on table {}.{}",
+                        databaseName,
+                        tableName,
+                        e);
+                  }
+                },
+                TException.class);
+      }
+    } catch (WaitingForLockException waitingForLockException) {
+      timeout = true;
+      duration = System.currentTimeMillis() - start;
+    } finally {
+      if (!state.get().equals(LockState.ACQUIRED)) {
+        releaseHmsLock();
+      }
+    }
+
+    // timeout and do not have lock acquired
+    if (timeout && !state.get().equals(LockState.ACQUIRED)) {
+      throw new CommitFailedException(
+          "Timed out after %s ms waiting for lock on %s.%s", duration, databaseName, tableName);
+    }
+
+    if (!state.get().equals(LockState.ACQUIRED)) {
+      throw new CommitFailedException(
+          "Could not acquire the lock on %s.%s, " + "lock request ended in state %s",
+          databaseName, tableName, state);
+    }
+
+    hiveLockHeartbeat = new HiveLockHeartbeat(metaClients, lockId, lockHeartbeatIntervalTime);
+    hiveLockHeartbeat.schedule(exitingScheduledExecutorService);
+  }
+
+  private void releaseHmsLock() {
+    if (hmsLockId.isPresent()) {
+      try {
+        metaClients.run(
+            client -> {
+              client.unlock(hmsLockId.get());
+              return null;
+            });
+        hmsLockId = Optional.empty();
+      } catch (Exception e) {
+        LOG.warn("Failed to unlock {}.{}", databaseName, tableName, e);
+      }
+    }
+    if (hiveLockHeartbeat != null) {
+      hiveLockHeartbeat.cancel();
+    }
+  }
+
+  private void acquireJvmLock() {
+    if (jvmLock.isPresent()) {
+      throw new IllegalStateException(
+          String.format("JVM lock already acquired for table %s", fullName));
+    }
+    jvmLock = Optional.of(commitLockCache.get(fullName, t -> new ReentrantLock(true)));
+    jvmLock.get().lock();
+  }
+
+  private void releaseJvmLock() {
+    if (jvmLock.isPresent()) {
+      jvmLock.get().unlock();
+      jvmLock = Optional.empty();
+    }
+  }
+
+  private static class HiveLockHeartbeat implements Runnable {
+    private final ClientPool<IMetaStoreClient, TException> hmsClients;
+    private final long lockId;
+    private final long intervalMs;
+    private ScheduledFuture<?> future;
+    private volatile Exception encounteredException = null;
+
+    HiveLockHeartbeat(
+        ClientPool<IMetaStoreClient, TException> hmsClients, long lockId, long intervalMs) {
+      this.hmsClients = hmsClients;
+      this.lockId = lockId;
+      this.intervalMs = intervalMs;
+      this.future = null;
+    }
+
+    @Override
+    public void run() {
+      try {
+        hmsClients.run(
+            client -> {
+              client.heartbeat(0, lockId);
+              return null;
+            });
+      } catch (TException | InterruptedException e) {
+        this.encounteredException = e;
+        throw new CommitFailedException(e, "Failed to heartbeat for lock: %d", lockId);
+      }
+    }
+
+    public void schedule(ScheduledExecutorService scheduler) {
+      future =
+          scheduler.scheduleAtFixedRate(this, intervalMs / 2, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    public void cancel() {
+      if (future != null) {
+        future.cancel(false);
+      }
+    }
+  }
+}

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -21,9 +21,6 @@ package org.apache.iceberg.hive;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Locale;
@@ -31,24 +28,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
-import org.apache.hadoop.hive.metastore.api.LockComponent;
-import org.apache.hadoop.hive.metastore.api.LockLevel;
-import org.apache.hadoop.hive.metastore.api.LockRequest;
-import org.apache.hadoop.hive.metastore.api.LockResponse;
-import org.apache.hadoop.hive.metastore.api.LockState;
-import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -75,11 +60,8 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.collect.BiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.util.JsonUtil;
-import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,16 +72,8 @@ import org.slf4j.LoggerFactory;
  */
 public class HiveTableOperations extends BaseMetastoreTableOperations {
   private static final Logger LOG = LoggerFactory.getLogger(HiveTableOperations.class);
-
-  private static final String HIVE_ACQUIRE_LOCK_TIMEOUT_MS = "iceberg.hive.lock-timeout-ms";
-  private static final String HIVE_LOCK_CHECK_MIN_WAIT_MS = "iceberg.hive.lock-check-min-wait-ms";
-  private static final String HIVE_LOCK_CHECK_MAX_WAIT_MS = "iceberg.hive.lock-check-max-wait-ms";
-  private static final String HIVE_LOCK_HEARTBEAT_INTERVAL_MS =
-      "iceberg.hive.lock-heartbeat-interval-ms";
   private static final String HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES =
       "iceberg.hive.metadata-refresh-max-retries";
-  private static final String HIVE_TABLE_LEVEL_LOCK_EVICT_MS =
-      "iceberg.hive.table-level-lock-evict-ms";
 
   // the max size is based on HMS backend database. For Hive versions below 2.3, the max table
   // parameter size is 4000
@@ -107,26 +81,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   // set to 0 to not expose Iceberg metadata in HMS Table properties.
   private static final String HIVE_TABLE_PROPERTY_MAX_SIZE = "iceberg.hive.table-property-max-size";
   private static final long HIVE_TABLE_PROPERTY_MAX_SIZE_DEFAULT = 32672;
-  private static final long HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT = 3 * 60 * 1000; // 3 minutes
-  private static final long HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT = 50; // 50 milliseconds
-  private static final long HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT = 5 * 1000; // 5 seconds
-  private static final long HIVE_LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT = 4 * 60 * 1000; // 4 minutes
   private static final int HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES_DEFAULT = 2;
-  private static final long HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT = TimeUnit.MINUTES.toMillis(10);
+
   private static final BiMap<String, String> ICEBERG_TO_HMS_TRANSLATION =
       ImmutableBiMap.of(
           // gc.enabled in Iceberg and external.table.purge in Hive are meant to do the same things
           // but with different names
           GC_ENABLED, "external.table.purge");
-
-  private static Cache<String, ReentrantLock> commitLockCache;
-
-  private static synchronized void initTableLevelLockCache(long evictionTimeout) {
-    if (commitLockCache == null) {
-      commitLockCache =
-          Caffeine.newBuilder().expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS).build();
-    }
-  }
 
   /**
    * Provides key translation where necessary between Iceberg and HMS props. This translation is
@@ -147,25 +108,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return ICEBERG_TO_HMS_TRANSLATION.inverse().getOrDefault(hmsProp, hmsProp);
   }
 
-  private static class WaitingForLockException extends RuntimeException {
-    WaitingForLockException(String message) {
-      super(message);
-    }
-  }
-
   private final String fullName;
+  private final String catalogName;
   private final String database;
   private final String tableName;
   private final Configuration conf;
-  private final long lockAcquireTimeout;
-  private final long lockCheckMinWaitTime;
-  private final long lockCheckMaxWaitTime;
-  private final long lockHeartbeatIntervalTime;
   private final long maxHiveTablePropertySize;
   private final int metadataRefreshMaxRetries;
   private final FileIO fileIO;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
-  private final ScheduledExecutorService exitingScheduledExecutorService;
 
   protected HiveTableOperations(
       Configuration conf,
@@ -178,31 +129,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     this.metaClients = metaClients;
     this.fileIO = fileIO;
     this.fullName = catalogName + "." + database + "." + table;
+    this.catalogName = catalogName;
     this.database = database;
     this.tableName = table;
-    this.lockAcquireTimeout =
-        conf.getLong(HIVE_ACQUIRE_LOCK_TIMEOUT_MS, HIVE_ACQUIRE_LOCK_TIMEOUT_MS_DEFAULT);
-    this.lockCheckMinWaitTime =
-        conf.getLong(HIVE_LOCK_CHECK_MIN_WAIT_MS, HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT);
-    this.lockCheckMaxWaitTime =
-        conf.getLong(HIVE_LOCK_CHECK_MAX_WAIT_MS, HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT);
-    this.lockHeartbeatIntervalTime =
-        conf.getLong(HIVE_LOCK_HEARTBEAT_INTERVAL_MS, HIVE_LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT);
     this.metadataRefreshMaxRetries =
         conf.getInt(
             HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES,
             HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES_DEFAULT);
     this.maxHiveTablePropertySize =
         conf.getLong(HIVE_TABLE_PROPERTY_MAX_SIZE, HIVE_TABLE_PROPERTY_MAX_SIZE_DEFAULT);
-    long tableLevelLockCacheEvictionTimeout =
-        conf.getLong(HIVE_TABLE_LEVEL_LOCK_EVICT_MS, HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT);
-    this.exitingScheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat("iceberg-hive-lock-heartbeat-%d")
-                .build());
-    initTableLevelLockCache(tableLevelLockCacheEvictionTimeout);
   }
 
   @Override
@@ -254,18 +189,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
     CommitStatus commitStatus = CommitStatus.FAILURE;
     boolean updateHiveTable = false;
-    Optional<Long> lockId = Optional.empty();
-    // getting a process-level lock per table to avoid concurrent commit attempts to the same table
-    // from the same
-    // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
-    ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
-    tableLevelMutex.lock();
-    HiveLockHeartbeat hiveLockHeartbeat = null;
+    HiveCommitLock commitLock = null;
     try {
-      lockId = Optional.of(acquireLock());
-      hiveLockHeartbeat =
-          new HiveLockHeartbeat(metaClients, lockId.get(), lockHeartbeatIntervalTime);
-      hiveLockHeartbeat.schedule(exitingScheduledExecutorService);
+      commitLock = createLock();
+      commitLock.acquire();
 
       Table tbl = loadHmsTable();
 
@@ -316,22 +243,16 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       }
 
       try {
-        if (hiveLockHeartbeat.future.isCancelled()
-            || hiveLockHeartbeat.encounteredException != null) {
-          throw new CommitFailedException(
-              "Failed to heartbeat for hive lock. %s",
-              hiveLockHeartbeat.encounteredException.getMessage());
+        if (!commitLock.isHeartbeatInProgress()) {
+          throw new CommitFailedException("Failed to heartbeat for hive lock.");
         }
-
         persistTable(tbl, updateHiveTable);
-        if (hiveLockHeartbeat.future.isCancelled()
-            || hiveLockHeartbeat.encounteredException != null) {
+        if (!commitLock.isHeartbeatInProgress()) {
           throw new CommitStateUnknownException(
               "Failed to heartbeat for hive lock while "
                   + "committing changes. This can lead to a concurrent commit attempt be able to overwrite this commit. "
                   + "Please check the commit history. If you are running into this issue, try reducing "
-                  + "iceberg.hive.lock-heartbeat-interval-ms.",
-              hiveLockHeartbeat.encounteredException);
+                  + "iceberg.hive.lock-heartbeat-interval-ms.");
         }
 
         commitStatus = CommitStatus.SUCCESS;
@@ -378,11 +299,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       throw new RuntimeException("Interrupted during commit", e);
 
     } finally {
-      if (hiveLockHeartbeat != null) {
-        hiveLockHeartbeat.cancel();
-      }
-
-      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
+      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, commitLock);
     }
 
     LOG.info(
@@ -605,89 +522,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
   @SuppressWarnings("ReverseDnsLookup")
   @VisibleForTesting
-  long acquireLock() throws UnknownHostException, TException, InterruptedException {
-    final LockComponent lockComponent =
-        new LockComponent(LockType.EXCLUSIVE, LockLevel.TABLE, database);
-    lockComponent.setTablename(tableName);
-    final LockRequest lockRequest =
-        new LockRequest(
-            Lists.newArrayList(lockComponent),
-            System.getProperty("user.name"),
-            InetAddress.getLocalHost().getHostName());
-    LockResponse lockResponse = metaClients.run(client -> client.lock(lockRequest));
-    AtomicReference<LockState> state = new AtomicReference<>(lockResponse.getState());
-    long lockId = lockResponse.getLockid();
-
-    final long start = System.currentTimeMillis();
-    long duration = 0;
-    boolean timeout = false;
-
-    try {
-      if (state.get().equals(LockState.WAITING)) {
-        // Retry count is the typical "upper bound of retries" for Tasks.run() function. In fact,
-        // the maximum number of
-        // attempts the Tasks.run() would try is `retries + 1`. Here, for checking locks, we use
-        // timeout as the
-        // upper bound of retries. So it is just reasonable to set a large retry count. However, if
-        // we set
-        // Integer.MAX_VALUE, the above logic of `retries + 1` would overflow into
-        // Integer.MIN_VALUE. Hence,
-        // the retry is set conservatively as `Integer.MAX_VALUE - 100` so it doesn't hit any
-        // boundary issues.
-        Tasks.foreach(lockId)
-            .retry(Integer.MAX_VALUE - 100)
-            .exponentialBackoff(lockCheckMinWaitTime, lockCheckMaxWaitTime, lockAcquireTimeout, 1.5)
-            .throwFailureWhenFinished()
-            .onlyRetryOn(WaitingForLockException.class)
-            .run(
-                id -> {
-                  try {
-                    LockResponse response = metaClients.run(client -> client.checkLock(id));
-                    LockState newState = response.getState();
-                    state.set(newState);
-                    if (newState.equals(LockState.WAITING)) {
-                      throw new WaitingForLockException(
-                          String.format("Waiting for lock on table %s.%s", database, tableName));
-                    }
-                  } catch (InterruptedException e) {
-                    Thread.interrupted(); // Clear the interrupt status flag
-                    LOG.warn(
-                        "Interrupted while waiting for lock on table {}.{}",
-                        database,
-                        tableName,
-                        e);
-                  }
-                },
-                TException.class);
-      }
-    } catch (WaitingForLockException waitingForLockException) {
-      timeout = true;
-      duration = System.currentTimeMillis() - start;
-    } finally {
-      if (!state.get().equals(LockState.ACQUIRED)) {
-        unlock(Optional.of(lockId));
-      }
-    }
-
-    // timeout and do not have lock acquired
-    if (timeout && !state.get().equals(LockState.ACQUIRED)) {
-      throw new CommitFailedException(
-          "Timed out after %s ms waiting for lock on %s.%s", duration, database, tableName);
-    }
-
-    if (!state.get().equals(LockState.ACQUIRED)) {
-      throw new CommitFailedException(
-          "Could not acquire the lock on %s.%s, " + "lock request ended in state %s",
-          database, tableName, state);
-    }
-    return lockId;
+  HiveCommitLock createLock() throws UnknownHostException, TException, InterruptedException {
+    return new HiveCommitLock(conf, metaClients, catalogName, database, tableName);
   }
 
   private void cleanupMetadataAndUnlock(
-      CommitStatus commitStatus,
-      String metadataLocation,
-      Optional<Long> lockId,
-      ReentrantLock tableLevelMutex) {
+      CommitStatus commitStatus, String metadataLocation, HiveCommitLock lock) {
     try {
       if (commitStatus == CommitStatus.FAILURE) {
         // If we are sure the commit failed, clean up the uncommitted metadata file
@@ -696,28 +536,19 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     } catch (RuntimeException e) {
       LOG.error("Failed to cleanup metadata file at {}", metadataLocation, e);
     } finally {
-      unlock(lockId);
-      tableLevelMutex.unlock();
-    }
-  }
-
-  private void unlock(Optional<Long> lockId) {
-    if (lockId.isPresent()) {
-      try {
-        doUnlock(lockId.get());
-      } catch (Exception e) {
-        LOG.warn("Failed to unlock {}.{}", database, tableName, e);
-      }
+      doUnlock(lock);
     }
   }
 
   @VisibleForTesting
-  void doUnlock(long lockId) throws TException, InterruptedException {
-    metaClients.run(
-        client -> {
-          client.unlock(lockId);
-          return null;
-        });
+  void doUnlock(HiveCommitLock lock) {
+    if (lock != null) {
+      try {
+        lock.release();
+      } catch (Exception e) {
+        LOG.warn("Failed to unlock {}.{}", database, tableName, e);
+      }
+    }
   }
 
   static void validateTableIsIceberg(Table table, String fullName) {
@@ -754,46 +585,5 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
     return conf.getBoolean(
         ConfigProperties.ENGINE_HIVE_ENABLED, TableProperties.ENGINE_HIVE_ENABLED_DEFAULT);
-  }
-
-  private static class HiveLockHeartbeat implements Runnable {
-    private final ClientPool<IMetaStoreClient, TException> hmsClients;
-    private final long lockId;
-    private final long intervalMs;
-    private ScheduledFuture<?> future;
-    private volatile Exception encounteredException = null;
-
-    HiveLockHeartbeat(
-        ClientPool<IMetaStoreClient, TException> hmsClients, long lockId, long intervalMs) {
-      this.hmsClients = hmsClients;
-      this.lockId = lockId;
-      this.intervalMs = intervalMs;
-      this.future = null;
-    }
-
-    @Override
-    public void run() {
-      try {
-        hmsClients.run(
-            client -> {
-              client.heartbeat(0, lockId);
-              return null;
-            });
-      } catch (TException | InterruptedException e) {
-        this.encounteredException = e;
-        throw new CommitFailedException(e, "Failed to heartbeat for lock: %d", lockId);
-      }
-    }
-
-    public void schedule(ScheduledExecutorService scheduler) {
-      future =
-          scheduler.scheduleAtFixedRate(this, intervalMs / 2, intervalMs, TimeUnit.MILLISECONDS);
-    }
-
-    public void cancel() {
-      if (future != null) {
-        future.cancel(false);
-      }
-    }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -151,7 +151,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
   @Test
   public void testLockAcquisitionAtFirstTime() throws TException, InterruptedException {
     doReturn(acquiredLockResponse).when(spyClient).lock(any());
-    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+    doNothing().when(spyClient).unlock(eq(dummyLockId));
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
@@ -170,7 +170,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .doReturn(acquiredLockResponse)
         .when(spyClient)
         .checkLock(eq(dummyLockId));
-    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+    doNothing().when(spyClient).unlock(eq(dummyLockId));
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
     spyOps.doCommit(metadataV2, metadataV1);
@@ -311,7 +311,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
     AssertHelpers.assertThrows(
         "Expected commit failure due to failure in heartbeat.",
         CommitFailedException.class,
-        "Failed to heartbeat for hive lock. Failed to heart beat.",
+        "Failed to heartbeat for hive lock.",
         () -> spyOps.doCommit(metadataV2, metadataV1));
   }
 }


### PR DESCRIPTION
`HiveTableOperations` has grown to a substantial size and got pretty complex.
A large portion of the logic is the implementation of the locking mechanism which I think could be separated out to reduce this complexity.

Let me know what you think @pvary @szehon-ho 