### PR TITLE
Python: Add code conventions for Python

### DIFF
--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -94,3 +94,31 @@ make test PYTEST_ARGS="--pdb"
 ```
 
 To see all available pytest arguments, run `make test PYTEST_ARGS="--help"`.
+
+# Code standards
+
+Below are the formalized conventions that we adhere to in the PyIceberg project. The goal of this is to have a common agreement on how to evolve the codebase, but also using it as guidelines for newcomers to the project.
+
+## API Compatibility
+
+We try to keep the Python public API compatible across versions. The Python official [PEP-8](https://peps.python.org/pep-0008/) defines Public methods as: _Public attributes should have no leading underscores_. This means not removing any methods without any notice, or removing or renaming any existing parameters. Adding new optional parameters is okay.
+
+If you want to remove a method, please add a deprecation notice by annotating the function using `@deprecated`:
+
+```python
+from pyiceberg.utils.deprecated import deprecated
+
+@deprecated(deprecated_in="0.1.0", removed_in="0.2.0")
+def load_something():
+    pass
+```
+
+Which will return:
+
+```
+DeprecationWarning: Call to deprecated function load_something, deprecated in 0.1.0, will be removed in 0.2.0.
+```
+
+## Third party libraries
+
+Since we expect PyIceberg to be integrated into the Python ecosystem, we want to be hesitant with the use of third party packages. Adding a lot of packages makes the library heavyweight, and causes incompatibilities with other projects if they use a different version of the library. Also, big libraries such as `s3fs`, `pyarrow`, `thrift` should be optional to avoid downloading everything, while not being sure if is actually being used.

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -108,15 +108,20 @@ If you want to remove a method, please add a deprecation notice by annotating th
 ```python
 from pyiceberg.utils.deprecated import deprecated
 
-@deprecated(deprecated_in="0.1.0", removed_in="0.2.0")
+
+@deprecated(
+    deprecated_in="0.1.0",
+    removed_in="0.2.0",
+    help_message="Please use load_something_else() instead",
+)
 def load_something():
     pass
 ```
 
-Which will return:
+Which will warn:
 
 ```
-DeprecationWarning: Call to deprecated function load_something, deprecated in 0.1.0, will be removed in 0.2.0.
+Call to load_something, deprecated in 0.1.0, will be removed in 0.2.0. Please use load_something_else() instead.
 ```
 
 ## Third party libraries

--- a/python/pyiceberg/utils/deprecated.py
+++ b/python/pyiceberg/utils/deprecated.py
@@ -1,0 +1,38 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+import warnings
+import functools
+from typing import Callable
+
+
+def deprecated(deprecated_in: str, removed_in: str):
+    """This is a decorator which can be used to mark functions
+    as deprecated. It will result in a warning being emitted
+    when the function is used."""
+
+    def decorator(func: Callable):
+        @functools.wraps(func)
+        def new_func(*args, **kwargs):
+            warnings.simplefilter('always', DeprecationWarning)  # turn off filter
+            warnings.warn(f"Call to deprecated function {func.__name__}, deprecated in {deprecated_in}, will be removed in {removed_in}.",
+                          category=DeprecationWarning,
+                          stacklevel=2)
+            warnings.simplefilter('default', DeprecationWarning)  # reset filter
+            return func(*args, **kwargs)
+        return new_func
+
+    return decorator

--- a/python/pyiceberg/utils/deprecated.py
+++ b/python/pyiceberg/utils/deprecated.py
@@ -14,25 +14,32 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-import warnings
 import functools
-from typing import Callable
+import warnings
+from typing import Callable, Optional
 
 
-def deprecated(deprecated_in: str, removed_in: str):
+def deprecated(deprecated_in: str, removed_in: str, help_message: Optional[str] = None):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
     when the function is used."""
 
+    if help_message is not None:
+        help_message = f" {help_message}."
+
     def decorator(func: Callable):
         @functools.wraps(func)
         def new_func(*args, **kwargs):
-            warnings.simplefilter('always', DeprecationWarning)  # turn off filter
-            warnings.warn(f"Call to deprecated function {func.__name__}, deprecated in {deprecated_in}, will be removed in {removed_in}.",
-                          category=DeprecationWarning,
-                          stacklevel=2)
-            warnings.simplefilter('default', DeprecationWarning)  # reset filter
+            warnings.simplefilter("always", DeprecationWarning)  # turn off filter
+
+            warnings.warn(
+                f"Call to {func.__name__}, deprecated in {deprecated_in}, will be removed in {removed_in}.{help_message}",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
+            warnings.simplefilter("default", DeprecationWarning)  # reset filter
             return func(*args, **kwargs)
+
         return new_func
 
     return decorator


### PR DESCRIPTION
Since we're approaching the first version of the PyIceberg library, I think it would be good to formalize the code conventions a bit. Would love to hear what you think of this.