### PR TITLE
[1.0.x] Spark: Exclude Scala library files from JAR (#5754)

### DIFF
--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -199,6 +199,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'org.glassfish'
       exclude group: 'org.abego.treelayout'
       exclude group: 'org.antlr'
+      exclude group: 'org.scala-lang'
+      exclude group: 'org.scala-lang.modules'
     }
   }
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -188,6 +188,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       exclude group: 'org.glassfish'
       exclude group: 'org.abego.treelayout'
       exclude group: 'org.antlr'
+      exclude group: 'org.scala-lang'
+      exclude group: 'org.scala-lang.modules'
     }
   }
 


### PR DESCRIPTION
This backports #5754 to 1.0.x