### PR TITLE
cherry-pick AWS: Fix PUT retry failures by opening new data file streams (#5282)

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -55,7 +55,9 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFact
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.ContentStreamProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
@@ -343,7 +345,7 @@ class S3OutputStream extends PositionOutputStream {
   private void completeUploads() {
     if (multipartUploadId == null) {
       long contentLength = stagingFiles.stream().map(FileAndDigest::file).mapToLong(File::length).sum();
-      InputStream contentStream = new BufferedInputStream(stagingFiles.stream()
+      ContentStreamProvider contentProvider = () -> new BufferedInputStream(stagingFiles.stream()
           .map(FileAndDigest::file)
           .map(S3OutputStream::uncheckedInputStream)
           .reduce(SequenceInputStream::new)
@@ -360,7 +362,9 @@ class S3OutputStream extends PositionOutputStream {
       S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
       S3RequestUtil.configurePermission(awsProperties, requestBuilder);
 
-      s3.putObject(requestBuilder.build(), RequestBody.fromInputStream(contentStream, contentLength));
+      s3.putObject(
+          requestBuilder.build(),
+          RequestBody.fromContentProvider(contentProvider, contentLength, Mimetype.MIMETYPE_OCTET_STREAM));
     } else {
       uploadParts();
       completeMultiPartUpload();


### PR DESCRIPTION
cherry-pick https://github.com/apache/iceberg/pull/5282