### PR TITLE
Python: Add schema projection

### DIFF
--- a/python/pyiceberg/avro/resolver.py
+++ b/python/pyiceberg/avro/resolver.py
@@ -32,25 +32,15 @@ from pyiceberg.avro.reader import (
     StructReader,
     primitive_reader,
 )
-from pyiceberg.schema import Schema, visit
+from pyiceberg.exceptions import ValidationError
+from pyiceberg.schema import Schema, promote, visit
 from pyiceberg.types import (
-    BinaryType,
-    DecimalType,
-    DoubleType,
-    FloatType,
     IcebergType,
-    IntegerType,
     ListType,
-    LongType,
     MapType,
     PrimitiveType,
-    StringType,
     StructType,
 )
-
-
-class ResolveException(Exception):
-    pass
 
 
 @singledispatch
@@ -60,7 +50,7 @@ def resolve(file_schema: Union[Schema, IcebergType], read_schema: Union[Schema, 
     The function traverses the schema in post-order fashion
 
      Args:
-         file_schema (Schema | IcebergType): The schema of the Avro file
+         file_schema (Schema | IcebergType): The schema of the file
          read_schema (Schema | IcebergType): The requested read schema which is equal, subset or superset of the file schema
 
      Raises:
@@ -80,7 +70,7 @@ def _(file_struct: StructType, read_struct: IcebergType) -> Reader:
     """Iterates over the file schema, and checks if the field is in the read schema"""
 
     if not isinstance(read_struct, StructType):
-        raise ResolveException(f"File/read schema are not aligned for {file_struct}, got {read_struct}")
+        raise ValidationError(f"File/read schema are not aligned for {file_struct}, got {read_struct}")
 
     results: List[Tuple[Optional[int], Reader]] = []
     read_fields = {field.field_id: (pos, field) for pos, field in enumerate(read_struct.fields)}
@@ -99,7 +89,7 @@ def _(file_struct: StructType, read_struct: IcebergType) -> Reader:
     for pos, read_field in enumerate(read_struct.fields):
         if read_field.field_id not in file_fields:
             if read_field.required:
-                raise ResolveException(f"{read_field} is non-optional, and not part of the file schema")
+                raise ValidationError(f"{read_field} is non-optional, and not part of the file schema")
             # Just set the new field to None
             results.append((pos, NoneReader()))
 
@@ -109,7 +99,7 @@ def _(file_struct: StructType, read_struct: IcebergType) -> Reader:
 @resolve.register(ListType)
 def _(file_list: ListType, read_list: IcebergType) -> Reader:
     if not isinstance(read_list, ListType):
-        raise ResolveException(f"File/read schema are not aligned for {file_list}, got {read_list}")
+        raise ValidationError(f"File/read schema are not aligned for {file_list}, got {read_list}")
     element_reader = resolve(file_list.element_type, read_list.element_type)
     return ListReader(element_reader)
 
@@ -117,7 +107,7 @@ def _(file_list: ListType, read_list: IcebergType) -> Reader:
 @resolve.register(MapType)
 def _(file_map: MapType, read_map: IcebergType) -> Reader:
     if not isinstance(read_map, MapType):
-        raise ResolveException(f"File/read schema are not aligned for {file_map}, got {read_map}")
+        raise ValidationError(f"File/read schema are not aligned for {file_map}, got {read_map}")
     key_reader = resolve(file_map.key_type, read_map.key_type)
     value_reader = resolve(file_map.value_type, read_map.value_type)
 
@@ -128,68 +118,9 @@ def _(file_map: MapType, read_map: IcebergType) -> Reader:
 def _(file_type: PrimitiveType, read_type: IcebergType) -> Reader:
     """Converting the primitive type into an actual reader that will decode the physical data"""
     if not isinstance(read_type, PrimitiveType):
-        raise ResolveException(f"Cannot promote {file_type} to {read_type}")
+        raise ValidationError(f"Cannot promote {file_type} to {read_type}")
 
-    # In the case of a promotion, we want to check if it is valid
     if file_type != read_type:
-        return promote(file_type, read_type)
-    return primitive_reader(read_type)
-
-
-@singledispatch
-def promote(file_type: IcebergType, read_type: IcebergType) -> Reader:
-    """Promotes reading a file type to a read type
-
-    Args:
-        file_type (IcebergType): The type of the Avro file
-        read_type (IcebergType): The requested read type
-
-    Raises:
-        ResolveException: If attempting to resolve an unrecognized object type
-    """
-    raise ResolveException(f"Cannot promote {file_type} to {read_type}")
-
-
-@promote.register(IntegerType)
-def _(file_type: IntegerType, read_type: IcebergType) -> Reader:
-    if isinstance(read_type, LongType):
-        # Ints/Longs are binary compatible in Avro, so this is okay
-        return primitive_reader(read_type)
-    else:
-        raise ResolveException(f"Cannot promote an int to {read_type}")
-
-
-@promote.register(FloatType)
-def _(file_type: FloatType, read_type: IcebergType) -> Reader:
-    if isinstance(read_type, DoubleType):
-        # We should just read the float, and return it, since it both returns a float
-        return primitive_reader(file_type)
-    else:
-        raise ResolveException(f"Cannot promote an float to {read_type}")
-
-
-@promote.register(StringType)
-def _(file_type: StringType, read_type: IcebergType) -> Reader:
-    if isinstance(read_type, BinaryType):
-        return primitive_reader(read_type)
-    else:
-        raise ResolveException(f"Cannot promote an string to {read_type}")
-
-
-@promote.register(BinaryType)
-def _(file_type: BinaryType, read_type: IcebergType) -> Reader:
-    if isinstance(read_type, StringType):
-        return primitive_reader(read_type)
-    else:
-        raise ResolveException(f"Cannot promote an binary to {read_type}")
-
-
-@promote.register(DecimalType)
-def _(file_type: DecimalType, read_type: IcebergType) -> Reader:
-    if isinstance(read_type, DecimalType):
-        if file_type.precision <= read_type.precision and file_type.scale == file_type.scale:
-            return primitive_reader(read_type)
-        else:
-            raise ResolveException(f"Cannot reduce precision from {file_type} to {read_type}")
-    else:
-        raise ResolveException(f"Cannot promote an decimal to {read_type}")
+        # In the case of a promotion, we want to check if it is valid
+        promote(file_type, read_type)
+    return primitive_reader(file_type)

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -14,8 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-
 from typing import Dict, List, Optional
 
 from pydantic import Field

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -21,7 +21,7 @@ from io import SEEK_SET
 import pytest
 
 from pyiceberg.avro.decoder import BinaryDecoder
-from pyiceberg.avro.resolver import promote
+from pyiceberg.avro.resolver import resolve
 from pyiceberg.io import InputStream
 from pyiceberg.io.memory import MemoryInputStream
 from pyiceberg.types import DoubleType, FloatType
@@ -217,6 +217,7 @@ def test_skip_utf8():
 def test_read_int_as_float():
     mis = MemoryInputStream(b"\x00\x00\x9A\x41")
     decoder = BinaryDecoder(mis)
-    reader = promote(FloatType(), DoubleType())
+
+    reader = resolve(FloatType(), DoubleType())
 
     assert reader.read(decoder) == 19.25


### PR DESCRIPTION
This PR adds schema projection which will be used in the QueryPlanning for doing column projection. Moved the promotion from the Avro package, to the schema module. Removed the ResolveException and merged that into the ValidationError.