### PR TITLE
[1.0.x] Spark: Bump Spark version for vulnerability (#5292)

### DIFF
--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -25,7 +25,7 @@ def sparkProjects = [
 
 configure(sparkProjects) {
   project.ext {
-    sparkVersion = '3.1.2'
+    sparkVersion = '3.1.3'
   }
 
   configurations {

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-String sparkVersion = '3.2.1'
+String sparkVersion = '3.2.2'
 String sparkMajorVersion = '3.2'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 


### PR DESCRIPTION
This backports #5292 to 1.0.x