### PR TITLE
Core: Reuse PositionDelete

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -39,7 +39,6 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
   private final PartitionSpec spec;
   private final StructLike partition;
   private final ByteBuffer keyMetadata;
-  private final PositionDelete<T> delete;
   private final CharSequenceSet referencedDataFiles;
   private DeleteFile deleteFile = null;
 
@@ -56,7 +55,6 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
     this.spec = spec;
     this.partition = partition;
     this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
-    this.delete = PositionDelete.create();
     this.referencedDataFiles = CharSequenceSet.empty();
   }
 

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -154,6 +154,7 @@ class SortedPosDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWr
 
     PositionDeleteWriter<T> writer =
         appenderFactory.newPosDeleteWriter(outputFile, format, partition);
+    PositionDelete<T> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<T> closeableWriter = writer) {
       // Sort all the paths.
       List<CharSequence> paths = Lists.newArrayListWithCapacity(posDeletes.keySet().size());
@@ -167,7 +168,6 @@ class SortedPosDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWr
         List<PosRow<T>> positions = posDeletes.get(wrapper.set(path));
         positions.sort(Comparator.comparingLong(PosRow::pos));
 
-        PositionDelete<T> posDelete = PositionDelete.create();
         positions.forEach(
             posRow -> closeableWriter.write(posDelete.set(path, posRow.pos(), posRow.row())));
       }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
@@ -127,10 +127,10 @@ public class TestAvroDeleteWriters {
             .withSpec(PartitionSpec.unpartitioned())
             .buildPositionWriter();
 
+    PositionDelete<Record> positionDelete = PositionDelete.create();
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        PositionDelete<Record> positionDelete = PositionDelete.create();
         writer.write(positionDelete.set(deletePath, pos, records.get(i)));
         expectedDeleteRecords.add(
             posDelete.copy(
@@ -179,10 +179,10 @@ public class TestAvroDeleteWriters {
             .withSpec(PartitionSpec.unpartitioned())
             .buildPositionWriter();
 
+    PositionDelete<Void> positionDelete = PositionDelete.create();
     try (PositionDeleteWriter<Void> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        PositionDelete<Void> positionDelete = PositionDelete.create();
         writer.write(positionDelete.set(deletePath, pos, null));
         expectedDeleteRecords.add(
             posDelete.copy(ImmutableMap.of("file_path", deletePath, "pos", (long) pos)));

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -62,9 +62,9 @@ public class FileHelpers {
 
     PositionDeleteWriter<Record> writer =
         factory.newPosDeleteWriter(encrypt(out), format, partition);
+    PositionDelete<Record> posDelete = PositionDelete.create();
     try (Closeable toClose = writer) {
       for (Pair<CharSequence, Long> delete : deletes) {
-        PositionDelete<Record> posDelete = PositionDelete.create();
         writer.write(posDelete.set(delete.first(), delete.second(), null));
       }
     }

--- a/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
@@ -227,9 +227,9 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
     EncryptedOutputFile out = createEncryptedOutputFile();
     PositionDeleteWriter<T> eqDeleteWriter =
         appenderFactory.newPosDeleteWriter(out, format, partition);
+    PositionDelete<T> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<T> closeableWriter = eqDeleteWriter) {
       for (Pair<CharSequence, Long> delete : deletes) {
-        PositionDelete<T> posDelete = PositionDelete.create();
         closeableWriter.write(posDelete.set(delete.first(), delete.second(), null));
       }
     }
@@ -275,9 +275,9 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
     EncryptedOutputFile out = createEncryptedOutputFile();
     PositionDeleteWriter<T> eqDeleteWriter =
         appenderFactory.newPosDeleteWriter(out, format, partition);
+    PositionDelete<T> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<T> closeableWriter = eqDeleteWriter) {
       for (PositionDelete<T> delete : deletes) {
-        PositionDelete<T> posDelete = PositionDelete.create();
         closeableWriter.write(posDelete.set(delete.path(), delete.pos(), delete.row()));
       }
     }

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -347,9 +347,9 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     PositionDeleteWriter<T> writer =
         writerFactory.newPositionDeleteWriter(file, spec, partitionKey);
 
+    PositionDelete<T> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<T> closableWriter = writer) {
       for (PositionDelete<T> delete : deletes) {
-        PositionDelete<T> posDelete = PositionDelete.create();
         closableWriter.write(posDelete.set(delete.path(), delete.pos(), delete.row()));
       }
     }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -182,9 +182,9 @@ public class SimpleDataUtil {
 
     PositionDeleteWriter<RowData> posWriter =
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
+    PositionDelete<RowData> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        PositionDelete<RowData> posDelete = PositionDelete.create();
         writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -183,9 +183,9 @@ public class SimpleDataUtil {
 
     PositionDeleteWriter<RowData> posWriter =
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
+    PositionDelete<RowData> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        PositionDelete<RowData> posDelete = PositionDelete.create();
         writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -185,9 +185,9 @@ public class SimpleDataUtil {
 
     PositionDeleteWriter<RowData> posWriter =
         appenderFactory.newPosDeleteWriter(outputFile, format, null);
+    PositionDelete<RowData> posDelete = PositionDelete.create();
     try (PositionDeleteWriter<RowData> writer = posWriter) {
       for (Pair<CharSequence, Long> p : positions) {
-        PositionDelete<RowData> posDelete = PositionDelete.create();
         writer.write(posDelete.set(p.first(), p.second(), null));
       }
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
@@ -134,10 +134,10 @@ public class TestParquetDeleteWriters {
             .withSpec(PartitionSpec.unpartitioned())
             .buildPositionWriter();
 
+    PositionDelete<Record> positionDelete = PositionDelete.create();
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        PositionDelete<Record> positionDelete = PositionDelete.create();
         writer.write(positionDelete.set(deletePath, pos, records.get(i)));
         expectedDeleteRecords.add(
             posDelete.copy(
@@ -191,10 +191,10 @@ public class TestParquetDeleteWriters {
                 })
             .buildPositionWriter();
 
+    PositionDelete<Void> positionDelete = PositionDelete.create();
     try (PositionDeleteWriter<Void> writer = deleteWriter) {
       for (int i = 0; i < records.size(); i += 1) {
         int pos = i * 3 + 2;
-        PositionDelete<Void> positionDelete = PositionDelete.create();
         writer.write(positionDelete.set(deletePath, pos, null));
         expectedDeleteRecords.add(
             posDelete.copy(ImmutableMap.of("file_path", deletePath, "pos", (long) pos)));


### PR DESCRIPTION
This is a follow-up from #5771 to restore the old behavior where a `PositionDelete` was reused for a `PositionDeleteWriter`