### PR TITLE
Python: Catch ValidationError on invalid REST response

### DIFF
--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -26,7 +26,7 @@ from typing import (
 )
 
 import requests
-from pydantic import Field
+from pydantic import Field, ValidationError
 from requests import HTTPError
 
 from pyiceberg import __version__
@@ -300,6 +300,11 @@ class RestCatalog(Catalog):
         except JSONDecodeError:
             # In the case we don't have a proper response
             response = f"RESTError {exc.response.status_code}: Could not decode json payload: {exc.response.text}"
+        except ValidationError as e:
+            # In the case we don't have a proper response
+            response = (
+                f"RESTError {exc.response.status_code}: Received unexpected JSON Payload: {exc.response.text}, errors: {e.errors}"
+            )
 
         raise exception(response) from exc
 

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -302,8 +302,9 @@ class RestCatalog(Catalog):
             response = f"RESTError {exc.response.status_code}: Could not decode json payload: {exc.response.text}"
         except ValidationError as e:
             # In the case we don't have a proper response
+            errs = ", ".join(err["msg"] for err in e.errors())
             response = (
-                f"RESTError {exc.response.status_code}: Received unexpected JSON Payload: {exc.response.text}, errors: {e.errors}"
+                f"RESTError {exc.response.status_code}: Received unexpected JSON Payload: {exc.response.text}, errors: {errs}"
             )
 
         raise exception(response) from exc

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -28,6 +28,7 @@ from pyiceberg.exceptions import (
     NoSuchNamespaceError,
     NoSuchTableError,
     OAuthError,
+    RESTError,
     TableAlreadyExistsError,
 )
 from pyiceberg.schema import Schema
@@ -109,6 +110,20 @@ def test_token_401(rest_mock: Mocker):
     )
 
     with pytest.raises(BadCredentialsError) as e:
+        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS)
+    assert message in str(e.value)
+
+
+def test_token_401_oauth_error(rest_mock: Mocker):
+    """This test returns a OAuth error instead of an OpenAPI error"""
+    message = """RESTError 401: Received unexpected JSON Payload: {"error": "invalid_client", "error_description": "Invalid credentials"}, errors: <bound method ValidationError.errors of ValidationError(model='ErrorResponse', errors=[{'loc': ('error',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}])>"""
+    rest_mock.post(
+        f"{TEST_URI}v1/oauth/tokens",
+        json={"error": "invalid_client", "error_description": "Invalid credentials"},
+        status_code=401,
+    )
+
+    with pytest.raises(RESTError) as e:
         RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS)
     assert message in str(e.value)
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -116,7 +116,7 @@ def test_token_401(rest_mock: Mocker):
 
 def test_token_401_oauth_error(rest_mock: Mocker):
     """This test returns a OAuth error instead of an OpenAPI error"""
-    message = """RESTError 401: Received unexpected JSON Payload: {"error": "invalid_client", "error_description": "Invalid credentials"}, errors: <bound method ValidationError.errors of ValidationError(model='ErrorResponse', errors=[{'loc': ('error',), 'msg': 'value is not a valid dict', 'type': 'type_error.dict'}])>"""
+    message = """RESTError 401: Received unexpected JSON Payload: {"error": "invalid_client", "error_description": "Invalid credentials"}, errors: value is not a valid dict"""
     rest_mock.post(
         f"{TEST_URI}v1/oauth/tokens",
         json={"error": "invalid_client", "error_description": "Invalid credentials"},


### PR DESCRIPTION
If an implementation of the rest catalog returns something different than we expect, we just propagate the ValidationError, which subclasses the ValueError. When using the CLI, it will tell you that the URI is not set, but actually it is, it is just invalid.

This will return the json to the user, and also tell what's wrong with the response. Hopefully users won't see this ever :)