### PR TITLE
AWS: Add socket connection timeout for UrlConnectionHttpClient

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -363,8 +363,27 @@ public class AwsProperties implements Serializable {
 
   public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_URLCONNECTION;
 
-  public static final String HTTP_CLIENT_URL_CONNECTION_TIMEOUT_MS = "http-client.url.connection-timeout-ms";
-  public static final String HTTP_CLIENT_URL_SOCKET_TIMEOUT_MS = "http-client.url.socket-timeout-ms";
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * UrlConnectionHttpClient.Builder}. This flag only works when {@link #HTTP_CLIENT_TYPE} is set to
+   * {@link #HTTP_CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS =
+      "http-client.urlconnection.connection-timeout-ms";
+
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * UrlConnectionHttpClient.Builder}. This flag only works when {@link #HTTP_CLIENT_TYPE} is set to
+   * {@link #HTTP_CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS =
+      "http-client.urlconnection.socket-timeout-ms";
 
   /**
    * Used to configure the connection timeout in milliseconds for {@link

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -540,7 +540,7 @@ public class AwsProperties implements Serializable {
 
   private String httpClientType;
   private Long httpClientUrlConnectionConnectionTimeoutMs;
-  private Long httpClientUrlConnectionSocketTimeoutMS;
+  private Long httpClientUrlConnectionSocketTimeoutMs;
   private Long httpClientApacheConnectionTimeoutMs;
   private Long httpClientApacheSocketTimeoutMs;
   private final Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags;
@@ -590,7 +590,7 @@ public class AwsProperties implements Serializable {
   public AwsProperties() {
     this.httpClientType = HTTP_CLIENT_TYPE_DEFAULT;
     this.httpClientUrlConnectionConnectionTimeoutMs = null;
-    this.httpClientUrlConnectionSocketTimeoutMS = null;
+    this.httpClientUrlConnectionSocketTimeoutMs = null;
     this.httpClientApacheConnectionTimeoutMs = null;
     this.httpClientApacheSocketTimeoutMs = null;
     this.stsClientAssumeRoleTags = Sets.newHashSet();
@@ -649,7 +649,7 @@ public class AwsProperties implements Serializable {
     this.httpClientUrlConnectionConnectionTimeoutMs =
         PropertyUtil.propertyAsNullableLong(
             properties, HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS);
-    this.httpClientUrlConnectionSocketTimeoutMS =
+    this.httpClientUrlConnectionSocketTimeoutMs =
         PropertyUtil.propertyAsNullableLong(
             properties, HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS);
     this.httpClientApacheConnectionTimeoutMs =
@@ -1134,8 +1134,8 @@ public class AwsProperties implements Serializable {
       builder.connectionTimeout(Duration.ofMillis(httpClientUrlConnectionConnectionTimeoutMs));
     }
 
-    if (httpClientUrlConnectionSocketTimeoutMS != null) {
-      builder.socketTimeout(Duration.ofMillis(httpClientUrlConnectionSocketTimeoutMS));
+    if (httpClientUrlConnectionSocketTimeoutMs != null) {
+      builder.socketTimeout(Duration.ofMillis(httpClientUrlConnectionSocketTimeoutMs));
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -363,6 +363,9 @@ public class AwsProperties implements Serializable {
 
   public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_URLCONNECTION;
 
+  public static final String HTTP_CLIENT_URL_CONNECTION_TIMEOUT_MS = "http-client.url.connection-timeout-ms";
+  public static final String HTTP_CLIENT_URL_SOCKET_TIMEOUT_MS = "http-client.url.socket-timeout-ms";
+
   /**
    * Used to configure the connection timeout in milliseconds for {@link
    * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -265,10 +265,10 @@ public class TestAwsProperties {
     properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS, "90");
     properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS, "80");
     AwsProperties awsProperties = new AwsProperties(properties);
-    UrlConnectionHttpClient.Builder UrlConnectionHttpClientBuilder =
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
         UrlConnectionHttpClient.builder();
     UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
-        Mockito.spy(UrlConnectionHttpClientBuilder);
+        Mockito.spy(urlConnectionHttpClientBuilder);
     ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
     ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
 

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -260,6 +260,102 @@ public class TestAwsProperties {
   }
 
   @Test
+  public void testUrlConnectionConnectionSocketTimeoutConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS, "90");
+    properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS, "80");
+    AwsProperties awsProperties = new AwsProperties(properties);
+    UrlConnectionHttpClient.Builder UrlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(UrlConnectionHttpClientBuilder);
+    ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+    ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+
+    awsProperties.configureUrlConnectionHttpClientBuilder(spyUrlConnectionHttpClientBuilder);
+    Mockito.verify(spyUrlConnectionHttpClientBuilder).socketTimeout(socketTimeoutCaptor.capture());
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .connectionTimeout(connectionTimeoutCaptor.capture());
+
+    Duration capturedSocketTimeout = socketTimeoutCaptor.getValue();
+    Duration capturedConnectionTimeout = connectionTimeoutCaptor.getValue();
+
+    Assert.assertEquals(
+        "The configured socket timeout should be 90 ms", 90, capturedSocketTimeout.toMillis());
+    Assert.assertEquals(
+        "The configured connection timeout should be 80 ms",
+        80,
+        capturedConnectionTimeout.toMillis());
+  }
+
+  @Test
+  public void testUrlConnectionConnectionTimeoutConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS, "80");
+    AwsProperties awsProperties = new AwsProperties(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+    ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+    ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+
+    awsProperties.configureUrlConnectionHttpClientBuilder(spyUrlConnectionHttpClientBuilder);
+    Mockito.verify(spyUrlConnectionHttpClientBuilder)
+        .connectionTimeout(connectionTimeoutCaptor.capture());
+    Mockito.verify(spyUrlConnectionHttpClientBuilder, Mockito.never())
+        .socketTimeout(socketTimeoutCaptor.capture());
+
+    Duration capturedConnectionTimeout = connectionTimeoutCaptor.getValue();
+
+    Assert.assertEquals(
+        "The configured connection timeout should be 80 ms",
+        80,
+        capturedConnectionTimeout.toMillis());
+  }
+
+  @Test
+  public void testUrlConnectionSocketTimeoutConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS, "90");
+    AwsProperties awsProperties = new AwsProperties(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+    ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+    ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+
+    awsProperties.configureUrlConnectionHttpClientBuilder(spyUrlConnectionHttpClientBuilder);
+    Mockito.verify(spyUrlConnectionHttpClientBuilder, Mockito.never())
+        .connectionTimeout(connectionTimeoutCaptor.capture());
+    Mockito.verify(spyUrlConnectionHttpClientBuilder).socketTimeout(socketTimeoutCaptor.capture());
+
+    Duration capturedSocketTimeout = socketTimeoutCaptor.getValue();
+
+    Assert.assertEquals(
+        "The configured socket timeout should be 90 ms", 90, capturedSocketTimeout.toMillis());
+  }
+
+  @Test
+  public void testUrlConnectionDefaultConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    AwsProperties awsProperties = new AwsProperties(properties);
+    UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder =
+        UrlConnectionHttpClient.builder();
+    UrlConnectionHttpClient.Builder spyUrlConnectionHttpClientBuilder =
+        Mockito.spy(urlConnectionHttpClientBuilder);
+    ArgumentCaptor<Duration> connectionTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+    ArgumentCaptor<Duration> socketTimeoutCaptor = ArgumentCaptor.forClass(Duration.class);
+
+    awsProperties.configureUrlConnectionHttpClientBuilder(spyUrlConnectionHttpClientBuilder);
+    Mockito.verify(spyUrlConnectionHttpClientBuilder, Mockito.never())
+        .connectionTimeout(connectionTimeoutCaptor.capture());
+    Mockito.verify(spyUrlConnectionHttpClientBuilder, Mockito.never())
+        .socketTimeout(socketTimeoutCaptor.capture());
+  }
+
+  @Test
   public void testApacheConnectionSocketTimeoutConfiguration() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(AwsProperties.HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS, "100");


### PR DESCRIPTION
User can use `http-client.urlconnection.socket-timeout-ms` and `http-client.urlconnection.connection-timeout-ms` tags to configure the connection and socket timeout for the `UrlConnectionHttpClient`.

Add unit test to check the timeout setting.