### PR TITLE
API: Make COUNT default unit when creating a Counter

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -60,7 +60,7 @@ class OSSInputStream extends SeekableInputStream {
     this.createStack = Thread.currentThread().getStackTrace();
 
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Unit.COUNT);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
   }
 
   @Override

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
@@ -67,7 +67,7 @@ public class OSSOutputStream extends PositionOutputStream {
     this.currentStagingFile = newStagingFile(aliyunProperties.ossStagingDirectory());
     this.stream = newStream(currentStagingFile);
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Unit.BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Unit.COUNT);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS);
   }
 
   private static File newStagingFile(String ossStagingDirectory) {

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -123,6 +123,16 @@ public interface MetricsContext extends Serializable {
   }
 
   /**
+   * Get a named counter using {@link Unit#COUNT}
+   *
+   * @param name The name of the counter
+   * @return a {@link org.apache.iceberg.metrics.Counter} implementation
+   */
+  default org.apache.iceberg.metrics.Counter counter(String name) {
+    return counter(name, Unit.COUNT);
+  }
+
+  /**
    * Get a named timer.
    *
    * @param name name of the metric

--- a/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/ScanReport.java
@@ -203,27 +203,27 @@ public interface ScanReport extends MetricsReport {
 
     @Value.Derived
     public Counter resultDataFiles() {
-      return metricsContext().counter(RESULT_DATA_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(RESULT_DATA_FILES);
     }
 
     @Value.Derived
     public Counter resultDeleteFiles() {
-      return metricsContext().counter(RESULT_DELETE_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(RESULT_DELETE_FILES);
     }
 
     @Value.Derived
     public Counter scannedDataManifests() {
-      return metricsContext().counter(SCANNED_DATA_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SCANNED_DATA_MANIFESTS);
     }
 
     @Value.Derived
     public Counter totalDataManifests() {
-      return metricsContext().counter(TOTAL_DATA_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(TOTAL_DATA_MANIFESTS);
     }
 
     @Value.Derived
     public Counter totalDeleteManifests() {
-      return metricsContext().counter(TOTAL_DELETE_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(TOTAL_DELETE_MANIFESTS);
     }
 
     @Value.Derived
@@ -238,42 +238,42 @@ public interface ScanReport extends MetricsReport {
 
     @Value.Derived
     public Counter skippedDataManifests() {
-      return metricsContext().counter(SKIPPED_DATA_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SKIPPED_DATA_MANIFESTS);
     }
 
     @Value.Derived
     public Counter skippedDataFiles() {
-      return metricsContext().counter(SKIPPED_DATA_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SKIPPED_DATA_FILES);
     }
 
     @Value.Derived
     public Counter skippedDeleteFiles() {
-      return metricsContext().counter(SKIPPED_DELETE_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SKIPPED_DELETE_FILES);
     }
 
     @Value.Derived
     public Counter scannedDeleteManifests() {
-      return metricsContext().counter(SCANNED_DELETE_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SCANNED_DELETE_MANIFESTS);
     }
 
     @Value.Derived
     public Counter skippedDeleteManifests() {
-      return metricsContext().counter(SKIPPED_DELETE_MANIFESTS, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(SKIPPED_DELETE_MANIFESTS);
     }
 
     @Value.Derived
     public Counter indexedDeleteFiles() {
-      return metricsContext().counter(INDEXED_DELETE_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(INDEXED_DELETE_FILES);
     }
 
     @Value.Derived
     public Counter equalityDeleteFiles() {
-      return metricsContext().counter(EQUALITY_DELETE_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(EQUALITY_DELETE_FILES);
     }
 
     @Value.Derived
     public Counter positionalDeleteFiles() {
-      return metricsContext().counter(POSITIONAL_DELETE_FILES, MetricsContext.Unit.COUNT);
+      return metricsContext().counter(POSITIONAL_DELETE_FILES);
     }
 
     public static ScanMetrics of(MetricsContext metricsContext) {

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -29,7 +29,6 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.io.TestableCloseableIterable.TestableCloseableIterator;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
-import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
@@ -204,7 +203,7 @@ public class TestCloseableIterable {
 
   @Test
   public void count() {
-    Counter counter = new DefaultMetricsContext().counter("x", MetricsContext.Unit.COUNT);
+    Counter counter = new DefaultMetricsContext().counter("x");
     CloseableIterable<Integer> items =
         CloseableIterable.count(
             counter, CloseableIterable.withNoopClose(Arrays.asList(1, 2, 3, 4, 5)));
@@ -215,7 +214,7 @@ public class TestCloseableIterable {
 
   @Test
   public void countSkipped() {
-    Counter counter = new DefaultMetricsContext().counter("x", MetricsContext.Unit.COUNT);
+    Counter counter = new DefaultMetricsContext().counter("x");
     CloseableIterable<Integer> items =
         CloseableIterable.filter(
             counter,
@@ -232,7 +231,7 @@ public class TestCloseableIterable {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid counter: null");
 
-    Counter counter = new DefaultMetricsContext().counter("x", MetricsContext.Unit.COUNT);
+    Counter counter = new DefaultMetricsContext().counter("x");
     Assertions.assertThatThrownBy(() -> CloseableIterable.count(counter, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid iterable: null");
@@ -246,7 +245,7 @@ public class TestCloseableIterable {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid counter: null");
 
-    Counter counter = new DefaultMetricsContext().counter("x", MetricsContext.Unit.COUNT);
+    Counter counter = new DefaultMetricsContext().counter("x");
     Assertions.assertThatThrownBy(
             () -> CloseableIterable.filter(counter, null, Predicate.isEqual(true)))
         .isInstanceOf(IllegalArgumentException.class)

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -68,7 +68,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     this.awsProperties = awsProperties;
 
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Unit.COUNT);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
 
     this.createStack = Thread.currentThread().getStackTrace();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -146,7 +146,7 @@ class S3OutputStream extends PositionOutputStream {
     }
 
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Unit.BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Unit.COUNT);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS);
 
     newStream();
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsAppendOutputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsAppendOutputStream.java
@@ -57,7 +57,7 @@ class EcsAppendOutputStream extends PositionOutputStream {
     this.uri = uri;
     this.localCache = ByteBuffer.wrap(localCache);
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Unit.BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Unit.COUNT);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS);
   }
 
   /** Use built-in 1 KiB byte buffer */

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -58,7 +58,7 @@ class EcsSeekableInputStream extends SeekableInputStream {
     this.client = client;
     this.uri = uri;
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Unit.COUNT);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
   }
 
   @Override

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -67,7 +67,7 @@ class GCSInputStream extends SeekableInputStream {
     this.gcpProperties = gcpProperties;
 
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Unit.BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Unit.COUNT);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS);
 
     createStack = Thread.currentThread().getStackTrace();
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
@@ -69,7 +69,7 @@ class GCSOutputStream extends PositionOutputStream {
     createStack = Thread.currentThread().getStackTrace();
 
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Unit.BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Unit.COUNT);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS);
 
     openStream();
   }


### PR DESCRIPTION
This is a follow-up from https://github.com/apache/iceberg/pull/5792#discussion_r984024379. `COUNT` is usually the unit that will be used in most places, so it makes sense to have `default org.apache.iceberg.metrics.Counter counter(String name)` that defaults to it