### PR TITLE
Core: Add dataSequenceNumber to ManifestEntry

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -126,7 +126,7 @@ public interface ManifestFile {
   /** Returns the sequence number of the commit that added the manifest file. */
   long sequenceNumber();
 
-  /** Returns the lowest sequence number of any data file in the manifest. */
+  /** Returns the lowest data sequence number of any live file in the manifest. */
   long minSequenceNumber();
 
   /** Returns iD of the snapshot that added the manifest file to table metadata. */

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -119,7 +119,7 @@ class DeleteFileIndex {
   }
 
   DeleteFile[] forEntry(ManifestEntry<DataFile> entry) {
-    return forDataFile(entry.sequenceNumber(), entry.file());
+    return forDataFile(entry.dataSequenceNumber(), entry.file());
   }
 
   DeleteFile[] forDataFile(long sequenceNumber, DataFile file) {
@@ -423,7 +423,7 @@ class DeleteFileIndex {
               deleteFile -> {
                 try (CloseableIterable<ManifestEntry<DeleteFile>> reader = deleteFile) {
                   for (ManifestEntry<DeleteFile> entry : reader) {
-                    if (entry.sequenceNumber() > minSequenceNumber) {
+                    if (entry.dataSequenceNumber() > minSequenceNumber) {
                       // copy with stats for better filtering against data file stats
                       deleteEntries.add(entry.copy());
                     }
@@ -467,7 +467,7 @@ class DeleteFileIndex {
                   .map(
                       entry ->
                           // a delete file is indexed by the sequence number it should be applied to
-                          Pair.of(entry.sequenceNumber() - 1, entry.file()))
+                          Pair.of(entry.dataSequenceNumber() - 1, entry.file()))
                   .sorted(Comparator.comparingLong(Pair::first))
                   .collect(Collectors.toList());
 
@@ -477,7 +477,7 @@ class DeleteFileIndex {
           List<Pair<Long, DeleteFile>> posFilesSortedBySeq =
               deleteFilesByPartition.get(partition).stream()
                   .filter(entry -> entry.file().content() == FileContent.POSITION_DELETES)
-                  .map(entry -> Pair.of(entry.sequenceNumber(), entry.file()))
+                  .map(entry -> Pair.of(entry.dataSequenceNumber(), entry.file()))
                   .sorted(Comparator.comparingLong(Pair::first))
                   .collect(Collectors.toList());
 
@@ -494,7 +494,7 @@ class DeleteFileIndex {
                       entry -> {
                         // a delete file is indexed by the sequence number it should be applied to
                         long applySeq =
-                            entry.sequenceNumber()
+                            entry.dataSequenceNumber()
                                 - (entry.file().content() == FileContent.EQUALITY_DELETES ? 1 : 0);
                         return Pair.of(applySeq, entry.file());
                       })

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -29,6 +29,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
   private final org.apache.avro.Schema schema;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;
+  private Long dataSequenceNumber = null;
   private Long sequenceNumber = null;
   private F file = null;
 
@@ -44,14 +45,16 @@ class GenericManifestEntry<F extends ContentFile<F>>
     this.schema = toCopy.schema;
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
+    this.dataSequenceNumber = toCopy.dataSequenceNumber;
     this.sequenceNumber = toCopy.sequenceNumber;
     this.file = toCopy.file().copy(fullCopy);
   }
 
-  ManifestEntry<F> wrapExisting(Long newSnapshotId, Long newSequenceNumber, F newFile) {
+  ManifestEntry<F> wrapExisting(Long newSnapshotId, Long newDataSequenceNumber, F newFile) {
     this.status = Status.EXISTING;
     this.snapshotId = newSnapshotId;
-    this.sequenceNumber = newSequenceNumber;
+    this.dataSequenceNumber = newDataSequenceNumber;
+    this.sequenceNumber = newDataSequenceNumber;
     this.file = newFile;
     return this;
   }
@@ -60,17 +63,19 @@ class GenericManifestEntry<F extends ContentFile<F>>
     return wrapAppend(newSnapshotId, null, newFile);
   }
 
-  ManifestEntry<F> wrapAppend(Long newSnapshotId, Long newSequenceNumber, F newFile) {
+  ManifestEntry<F> wrapAppend(Long newSnapshotId, Long newDataSequenceNumber, F newFile) {
     this.status = Status.ADDED;
     this.snapshotId = newSnapshotId;
-    this.sequenceNumber = newSequenceNumber;
+    this.dataSequenceNumber = newDataSequenceNumber;
+    this.sequenceNumber = newDataSequenceNumber;
     this.file = newFile;
     return this;
   }
 
-  ManifestEntry<F> wrapDelete(Long newSnapshotId, F newFile) {
+  ManifestEntry<F> wrapDelete(Long newSnapshotId, Long newDataSequenceNumber, F newFile) {
     this.status = Status.DELETED;
     this.snapshotId = newSnapshotId;
+    this.dataSequenceNumber = newDataSequenceNumber;
     this.sequenceNumber = null;
     this.file = newFile;
     return this;
@@ -88,9 +93,19 @@ class GenericManifestEntry<F extends ContentFile<F>>
     return snapshotId;
   }
 
+  /** @return the data sequence number of the file */
+  @Override
+  public Long dataSequenceNumber() {
+    return dataSequenceNumber;
+  }
+
   @Override
   public Long sequenceNumber() {
-    return sequenceNumber;
+    if (sequenceNumber != null) {
+      return sequenceNumber;
+    } else {
+      return isLive() ? dataSequenceNumber : null;
+    }
   }
 
   /** @return a file */
@@ -115,6 +130,13 @@ class GenericManifestEntry<F extends ContentFile<F>>
   }
 
   @Override
+  public void setDataSequenceNumber(long newDataSequenceNumber) {
+    // always reset sequenceNumber whenever dataSequenceNumber is changed
+    this.dataSequenceNumber = newDataSequenceNumber;
+    this.sequenceNumber = null;
+  }
+
+  @Override
   public void setSequenceNumber(long newSequenceNumber) {
     this.sequenceNumber = newSequenceNumber;
   }
@@ -130,7 +152,9 @@ class GenericManifestEntry<F extends ContentFile<F>>
         this.snapshotId = (Long) v;
         return;
       case 2:
-        this.sequenceNumber = (Long) v;
+        // always reset sequenceNumber whenever dataSequenceNumber is changed
+        this.dataSequenceNumber = (Long) v;
+        this.sequenceNumber = null;
         return;
       case 3:
         this.file = (F) v;
@@ -153,7 +177,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
       case 1:
         return snapshotId;
       case 2:
-        return sequenceNumber;
+        return dataSequenceNumber;
       case 3:
         return file;
       default:
@@ -181,7 +205,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
     return MoreObjects.toStringHelper(this)
         .add("status", status)
         .add("snapshot_id", snapshotId)
-        .add("sequence_number", sequenceNumber)
+        .add("data_sequence_number", dataSequenceNumber)
         .add("file", file)
         .toString();
   }

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -93,7 +93,6 @@ class GenericManifestEntry<F extends ContentFile<F>>
     return snapshotId;
   }
 
-  /** @return the data sequence number of the file */
   @Override
   public Long dataSequenceNumber() {
     return dataSequenceNumber;

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
@@ -59,12 +59,22 @@ class InheritableMetadataFactory {
         BaseFile<?> file = (BaseFile<?>) manifestEntry.file();
         file.setSpecId(specId);
       }
+
       if (manifestEntry.snapshotId() == null) {
         manifestEntry.setSnapshotId(snapshotId);
       }
+
+      // in v1 tables, the data sequence number is not persisted and can be safely defaulted to 0
+      // in v2 tables, the data sequence number should be inherited iff the entry status is ADDED
+      if (manifestEntry.dataSequenceNumber() == null
+          && (sequenceNumber == 0 || manifestEntry.status() == ManifestEntry.Status.ADDED)) {
+        manifestEntry.setDataSequenceNumber(sequenceNumber);
+      }
+
       if (manifestEntry.sequenceNumber() == null) {
         manifestEntry.setSequenceNumber(sequenceNumber);
       }
+
       return manifestEntry;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -60,6 +60,11 @@ interface ManifestEntry<F extends ContentFile<F>> {
   /** Returns the status of the file, whether EXISTING, ADDED, or DELETED. */
   Status status();
 
+  /** Returns whether this entry is live */
+  default boolean isLive() {
+    return status() == Status.ADDED || status() == Status.EXISTING;
+  }
+
   /** Returns id of the snapshot in which the file was added to the table. */
   Long snapshotId();
 
@@ -70,14 +75,47 @@ interface ManifestEntry<F extends ContentFile<F>> {
    */
   void setSnapshotId(long snapshotId);
 
-  /** Returns the sequence number of the snapshot in which the file was added to the table. */
+  /**
+   * Returns the data sequence number of the file.
+   *
+   * <p>Independently of the entry status, this method represents the sequence number to which the
+   * file should apply. Note the data sequence number may differ from the sequence number of the
+   * snapshot in which the underlying file was added. New snapshots can add files that belong to
+   * older sequence numbers (e.g. compaction). The data sequence number also does not change when
+   * the file is marked as deleted.
+   *
+   * <p>This method can return null if the data sequence number is not known. This may happen while
+   * reading a V2 manifest that did not persist the data sequence number for manifest entries with
+   * status DELETED (older Iceberg versions).
+   */
+  Long dataSequenceNumber();
+
+  /**
+   * Sets the data sequence number for this manifest entry.
+   *
+   * @param dataSequenceNumber a data sequence number
+   */
+  void setDataSequenceNumber(long dataSequenceNumber);
+
+  /**
+   * Returns the data sequence number of the file if the entry status is ADDED or EXISTING.
+   * Otherwise, returns the sequence number of the snapshot in which the file was removed.
+   *
+   * <p>Note that usage of this method should be avoided as it behaves inconsistently for different
+   * entry statutes. Use {@link #dataSequenceNumber()} instead.
+   *
+   * @deprecated since 1.0.0, will be removed in 1.1.0; use {@link #dataSequenceNumber()} instead.
+   */
+  @Deprecated
   Long sequenceNumber();
 
   /**
    * Set the sequence number for this manifest entry.
    *
    * @param sequenceNumber a sequence number
+   * @deprecated since 1.0.0, will be removed in 1.1.0; use the data sequence number instead.
    */
+  @Deprecated
   void setSequenceNumber(long sequenceNumber);
 
   /** Returns a file. */

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -84,8 +84,8 @@ interface ManifestEntry<F extends ContentFile<F>> {
    * older sequence numbers (e.g. compaction). The data sequence number also does not change when
    * the file is marked as deleted.
    *
-   * <p>This method can return null if the data sequence number is not known. This may happen while
-   * reading a V2 manifest that did not persist the data sequence number for manifest entries with
+   * <p>This method can return null if the data sequence number is unknown. This may happen while
+   * reading a v2 manifest that did not persist the data sequence number for manifest entries with
    * status DELETED (older Iceberg versions).
    */
   Long dataSequenceNumber();

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -357,7 +357,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
         || canContainDropBySeq;
   }
 
-  @SuppressWarnings("CollectionUndefinedEquality")
+  @SuppressWarnings({"CollectionUndefinedEquality", "checkstyle:CyclomaticComplexity"})
   private boolean manifestHasDeletedFiles(
       PartitionAndMetricsEvaluator evaluator, ManifestReader<F> reader) {
     boolean isDelete = reader.isDeleteManifestReader();
@@ -368,8 +368,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
           deletePaths.contains(file.path())
               || dropPartitions.contains(file.specId(), file.partition())
               || (isDelete
-                  && entry.sequenceNumber() > 0
-                  && entry.sequenceNumber() < minSequenceNumber);
+                  && entry.isLive()
+                  && entry.dataSequenceNumber() > 0
+                  && entry.dataSequenceNumber() < minSequenceNumber);
 
       if (markedForDelete || evaluator.rowsMightMatch(file)) {
         boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
@@ -415,8 +416,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                       deletePaths.contains(file.path())
                           || dropPartitions.contains(file.specId(), file.partition())
                           || (isDelete
-                              && entry.sequenceNumber() > 0
-                              && entry.sequenceNumber() < minSequenceNumber);
+                              && entry.isLive()
+                              && entry.dataSequenceNumber() > 0
+                              && entry.dataSequenceNumber() < minSequenceNumber);
                   if (entry.status() != ManifestEntry.Status.DELETED) {
                     if (markedForDelete || evaluator.rowsMightMatch(file)) {
                       boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -133,9 +133,12 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   /**
    * Add an existing entry for a file.
    *
+   * <p>The original data sequence number and snapshot ID, which were assigned at commit, must be
+   * preserved when adding an existing entry.
+   *
    * @param existingFile a file
    * @param fileSnapshotId snapshot ID when the data file was added to the table
-   * @param dataSequenceNumber a data sequence number for the file
+   * @param dataSequenceNumber a data sequence number of the file (assigned when the file was added)
    */
   public void existing(F existingFile, long fileSnapshotId, long dataSequenceNumber) {
     addEntry(reused.wrapExisting(fileSnapshotId, dataSequenceNumber, existingFile));
@@ -148,10 +151,26 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   /**
    * Add a delete entry for a file.
    *
-   * <p>The entry's snapshot ID will be this manifest's snapshot ID.
+   * <p>This method must not be used as the original data sequence number of the file must be
+   * preserved when the file is marked as deleted.
    *
    * @param deletedFile a file
-   * @param dataSequenceNumber a data sequence number for the file
+   * @deprecated since 1.0.0, will be removed in 1.1.0; use {@link #delete(ContentFile, long)}.
+   */
+  @Deprecated
+  public void delete(F deletedFile) {
+    throw new UnsupportedOperationException(
+        "Can't add a delete entry without a data sequence number");
+  }
+
+  /**
+   * Add a delete entry for a file.
+   *
+   * <p>The entry's snapshot ID will be this manifest's snapshot ID. However, the original data
+   * sequence number of the file must be preserved when the file is marked as deleted.
+   *
+   * @param deletedFile a file
+   * @param dataSequenceNumber a data sequence number of the file (assigned when the file was added)
    */
   public void delete(F deletedFile, long dataSequenceNumber) {
     addEntry(reused.wrapDelete(snapshotId, dataSequenceNumber, deletedFile));

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -286,6 +286,16 @@ class V1Metadata {
     }
 
     @Override
+    public Long dataSequenceNumber() {
+      return wrapped.dataSequenceNumber();
+    }
+
+    @Override
+    public void setDataSequenceNumber(long dataSequenceNumber) {
+      wrapped.setDataSequenceNumber(dataSequenceNumber);
+    }
+
+    @Override
     public Long sequenceNumber() {
       return wrapped.sequenceNumber();
     }

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -310,19 +310,24 @@ class V2Metadata {
         case 1:
           return wrapped.snapshotId();
         case 2:
-          if (wrapped.sequenceNumber() == null) {
-            // if the entry's sequence number is null, then it will inherit the sequence number of
-            // the current commit.
+          if (wrapped.dataSequenceNumber() == null) {
+            // if the entry's data sequence number is null,
+            // then it will inherit the sequence number of the current commit.
             // to validate that this is correct, check that the snapshot id is either null (will
-            // also be inherited) or
-            // that it matches the id of the current commit.
+            // also be inherited) or that it matches the id of the current commit.
             Preconditions.checkState(
                 wrapped.snapshotId() == null || wrapped.snapshotId().equals(commitSnapshotId),
                 "Found unassigned sequence number for an entry from snapshot: %s",
                 wrapped.snapshotId());
+
+            // inheritance should work only for ADDED entries
+            Preconditions.checkState(
+                wrapped.status() == Status.ADDED,
+                "Only entries with status ADDED can have null sequence number");
+
             return null;
           }
-          return wrapped.sequenceNumber();
+          return wrapped.dataSequenceNumber();
         case 3:
           return fileWrapper.wrap(wrapped.file());
         default:
@@ -343,6 +348,16 @@ class V2Metadata {
     @Override
     public void setSnapshotId(long snapshotId) {
       wrapped.setSnapshotId(snapshotId);
+    }
+
+    @Override
+    public Long dataSequenceNumber() {
+      return wrapped.dataSequenceNumber();
+    }
+
+    @Override
+    public void setDataSequenceNumber(long dataSequenceNumber) {
+      wrapped.setDataSequenceNumber(dataSequenceNumber);
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriter.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriter.java
@@ -112,6 +112,10 @@ public class TestManifestWriter extends TableTestBase {
     ManifestReader<DataFile> manifestReader = ManifestFiles.read(manifest, table.io());
     for (ManifestEntry<DataFile> entry : manifestReader.entries()) {
       Assert.assertEquals(
+          "Custom data sequence number should be used for all manifest entries",
+          1000L,
+          (long) entry.dataSequenceNumber());
+      Assert.assertEquals(
           "Custom sequence number should be used for all manifest entries",
           1000L,
           (long) entry.sequenceNumber());

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -197,6 +197,7 @@ public class TestManifestWriterVersions {
   void checkEntry(ManifestEntry<?> entry, Long expectedSequenceNumber, FileContent content) {
     Assert.assertEquals("Status", ManifestEntry.Status.ADDED, entry.status());
     Assert.assertEquals("Snapshot ID", (Long) SNAPSHOT_ID, entry.snapshotId());
+    Assert.assertEquals("Data sequence number", expectedSequenceNumber, entry.dataSequenceNumber());
     Assert.assertEquals("Sequence number", expectedSequenceNumber, entry.sequenceNumber());
     checkDataFile(entry.file(), content);
   }
@@ -205,6 +206,7 @@ public class TestManifestWriterVersions {
       ManifestEntry<DataFile> entry, Long expectedSequenceNumber, FileContent content) {
     Assert.assertEquals("Status", ManifestEntry.Status.EXISTING, entry.status());
     Assert.assertEquals("Snapshot ID", (Long) SNAPSHOT_ID, entry.snapshotId());
+    Assert.assertEquals("Data sequence number", expectedSequenceNumber, entry.dataSequenceNumber());
     Assert.assertEquals("Sequence number", expectedSequenceNumber, entry.sequenceNumber());
     checkDataFile(entry.file(), content);
   }

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -580,7 +580,7 @@ public class TestMergeAppend extends TableTestBase {
 
     validateManifest(
         deleteManifest,
-        seqs(2, 1),
+        seqs(1, 1),
         ids(deleteId, baseId),
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -290,7 +290,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     validateDeleteManifest(
         pending.allManifests(table.io()).get(2),
-        seqs(2, 1),
+        seqs(1, 1),
         ids(pendingId, baseSnapshotId),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(DELETED, EXISTING));
@@ -354,7 +354,7 @@ public class TestRewriteFiles extends TableTestBase {
       Assert.assertEquals(
           "Should have old sequence number for manifest entries",
           oldSequenceNumber,
-          (long) entry.sequenceNumber());
+          (long) entry.dataSequenceNumber());
     }
     Assert.assertEquals(
         "Should use new sequence number for the manifest file",
@@ -455,7 +455,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     validateDeleteManifest(
         pending.allManifests(table.io()).get(2),
-        seqs(2, 2),
+        seqs(1, 1),
         ids(pending.snapshotId(), pending.snapshotId()),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(DELETED, DELETED));
@@ -549,7 +549,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     validateDeleteManifest(
         manifest3,
-        seqs(2, 2),
+        seqs(1, 1),
         ids(pending.snapshotId(), pending.snapshotId()),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(DELETED, DELETED));
@@ -601,7 +601,7 @@ public class TestRewriteFiles extends TableTestBase {
         manifest2, seqs(2), ids(pending.snapshotId()), files(FILE_B_DELETES), statuses(ADDED));
 
     validateDeleteManifest(
-        manifest3, seqs(2), ids(pending.snapshotId()), files(FILE_A2_DELETES), statuses(DELETED));
+        manifest3, seqs(1), ids(pending.snapshotId()), files(FILE_A2_DELETES), statuses(DELETED));
 
     rewrite.commit();
 
@@ -644,7 +644,7 @@ public class TestRewriteFiles extends TableTestBase {
     validateManifestEntries(manifest1, ids(pending.snapshotId()), files(FILE_A), statuses(DELETED));
 
     validateDeleteManifest(
-        manifest2, seqs(2), ids(pending.snapshotId()), files(FILE_A_DELETES), statuses(DELETED));
+        manifest2, seqs(1), ids(pending.snapshotId()), files(FILE_A_DELETES), statuses(DELETED));
 
     rewrite.commit();
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -962,7 +962,7 @@ public class TestRewriteManifests extends TableTestBase {
     ManifestEntry<DataFile> appendEntry =
         manifestEntry(ManifestEntry.Status.ADDED, snapshot.snapshotId(), FILE_A);
     // update the entry's sequence number or else it will be rejected by the writer
-    appendEntry.setSequenceNumber(snapshot.sequenceNumber());
+    appendEntry.setDataSequenceNumber(snapshot.sequenceNumber());
 
     ManifestFile invalidAddedFileManifest = writeManifest("manifest-file-2.avro", appendEntry);
 
@@ -980,7 +980,7 @@ public class TestRewriteManifests extends TableTestBase {
     ManifestEntry<DataFile> deleteEntry =
         manifestEntry(ManifestEntry.Status.DELETED, snapshot.snapshotId(), FILE_A);
     // update the entry's sequence number or else it will be rejected by the writer
-    deleteEntry.setSequenceNumber(snapshot.sequenceNumber());
+    deleteEntry.setDataSequenceNumber(snapshot.sequenceNumber());
 
     ManifestFile invalidDeletedFileManifest = writeManifest("manifest-file-3.avro", deleteEntry);
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -243,7 +243,7 @@ public class TestRowDelta extends V2TableTestBase {
     // manifest with FILE_A deleted
     validateManifest(
         snap.dataManifests(table.io()).get(1),
-        seqs(2, 1),
+        seqs(1, 1),
         ids(replaceSnapshotId, appendSnapshotId),
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));
@@ -450,7 +450,7 @@ public class TestRowDelta extends V2TableTestBase {
     Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests(table.io()).size());
     validateManifest(
         snap.dataManifests(table.io()).get(0),
-        seqs(2),
+        seqs(1),
         ids(snap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -459,7 +459,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
-        seqs(2, 1),
+        seqs(1, 1),
         ids(snap.snapshotId(), deltaSnapshotId),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(Status.DELETED, Status.EXISTING));
@@ -494,7 +494,7 @@ public class TestRowDelta extends V2TableTestBase {
     int deleteManifestPos = snap.dataManifests(table.io()).get(0).deletedFilesCount() > 0 ? 0 : 1;
     validateManifest(
         snap.dataManifests(table.io()).get(deleteManifestPos),
-        seqs(2),
+        seqs(1),
         ids(snap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -510,7 +510,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
-        seqs(2, 1),
+        seqs(1, 1),
         ids(snap.snapshotId(), deltaSnapshotId),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(Status.DELETED, Status.EXISTING));
@@ -543,7 +543,7 @@ public class TestRowDelta extends V2TableTestBase {
     Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests(table.io()).size());
     validateManifest(
         snap.dataManifests(table.io()).get(0),
-        seqs(2),
+        seqs(1),
         ids(snap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -552,7 +552,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 delete manifest", 1, snap.deleteManifests(table.io()).size());
     validateDeleteManifest(
         snap.deleteManifests(table.io()).get(0),
-        seqs(2, 2),
+        seqs(1, 1),
         ids(snap.snapshotId(), snap.snapshotId()),
         files(FILE_A_DELETES, FILE_B_DELETES),
         statuses(Status.DELETED, Status.DELETED));
@@ -580,7 +580,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 data manifest", 1, deleteSnap.dataManifests(table.io()).size());
     validateManifest(
         deleteSnap.dataManifests(table.io()).get(0),
-        seqs(2),
+        seqs(1),
         ids(deleteSnap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -612,7 +612,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 delete manifest", 1, nextSnap.deleteManifests(table.io()).size());
     validateDeleteManifest(
         nextSnap.deleteManifests(table.io()).get(0),
-        seqs(3),
+        seqs(1),
         ids(nextSnap.snapshotId()),
         files(FILE_A_DELETES),
         statuses(Status.DELETED));
@@ -640,7 +640,7 @@ public class TestRowDelta extends V2TableTestBase {
         "Should produce 1 data manifest", 1, deleteSnap.dataManifests(table.io()).size());
     validateManifest(
         deleteSnap.dataManifests(table.io()).get(0),
-        seqs(2),
+        seqs(1),
         ids(deleteSnap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -669,7 +669,7 @@ public class TestRowDelta extends V2TableTestBase {
         nextSnap.dataManifests(table.io()).get(0).deletedFilesCount() > 0 ? 0 : 1;
     validateManifest(
         nextSnap.dataManifests(table.io()).get(deleteManifestPos),
-        seqs(2),
+        seqs(1),
         ids(deleteSnap.snapshotId()),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -1304,7 +1304,7 @@ public class TestRowDelta extends V2TableTestBase {
 
     validateManifest(
         mergedDataManifest,
-        seqs(1, 3),
+        seqs(1, 1),
         ids(currentSnapshotId, currentSnapshotId),
         files(dataFile2, dataFile1),
         statuses(Status.ADDED, Status.DELETED));

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -69,12 +69,12 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest, FILE_IO).entries()) {
       if (entry.file().path().equals(FILE_A.path())) {
         V2Assert.assertEquals(
-            "FILE_A sequence number should be 1", 1, entry.sequenceNumber().longValue());
+            "FILE_A sequence number should be 1", 1, entry.dataSequenceNumber().longValue());
       }
 
       if (entry.file().path().equals(FILE_B.path())) {
         V2Assert.assertEquals(
-            "FILE_b sequence number should be 2", 2, entry.sequenceNumber().longValue());
+            "FILE_b sequence number should be 2", 2, entry.dataSequenceNumber().longValue());
       }
     }
   }
@@ -238,7 +238,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
             .collect(Collectors.toList())
             .get(0);
     validateManifest(
-        manifestFile, seqs(4), ids(commitId4), files(FILE_A), statuses(Status.DELETED));
+        manifestFile, seqs(1), ids(commitId4), files(FILE_A), statuses(Status.DELETED));
     V2Assert.assertEquals("Snapshot sequence number should be 4", 4, snap4.sequenceNumber());
     V2Assert.assertEquals(
         "Last sequence number should be 4", 4, readMetadata().lastSequenceNumber());

--- a/format/spec.md
+++ b/format/spec.md
@@ -411,12 +411,12 @@ A manifest file must store the partition spec and other metadata as properties i
 
 The schema of a manifest file is a struct called `manifest_entry` with the following fields:
 
-| v1         | v2         | Field id, name           | Type                                                      | Description                                                                           |
-| ---------- | ---------- |--------------------------|-----------------------------------------------------------|---------------------------------------------------------------------------------------|
-| _required_ | _required_ | **`0  status`**          | `int` with meaning: `0: EXISTING` `1: ADDED` `2: DELETED` | Used to track additions and deletions. Deletes are informational only and not used in scans.                                                 |
-| _required_ | _optional_ | **`1  snapshot_id`**     | `long`                                                    | Snapshot id where the file was added, or deleted if status is 2. Inherited when null. |
-|            | _optional_ | **`3  sequence_number`** | `long`                                                    | Sequence number when the file was added. Inherited when null.                         |
-| _required_ | _required_ | **`2  data_file`**       | `data_file` `struct` (see below)                          | File path, partition tuple, metrics, ...                                              |
+| v1         | v2         | Field id, name           | Type                                                      | Description                                                                                  |
+| ---------- | ---------- |--------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| _required_ | _required_ | **`0  status`**          | `int` with meaning: `0: EXISTING` `1: ADDED` `2: DELETED` | Used to track additions and deletions. Deletes are informational only and not used in scans. |
+| _required_ | _optional_ | **`1  snapshot_id`**     | `long`                                                    | Snapshot id where the file was added, or deleted if status is 2. Inherited when null.        |
+|            | _optional_ | **`3  sequence_number`** | `long`                                                    | Data sequence number of the file. Inherited when null.                                       |
+| _required_ | _required_ | **`2  data_file`**       | `data_file` `struct` (see below)                          | File path, partition tuple, metrics, ...                                                     |
 
 `data_file` is a struct with the following fields:
 
@@ -464,6 +464,7 @@ When a file is added to the dataset, its manifest entry should store the snapsho
 When a file is replaced or deleted from the dataset, its manifest entry fields store the snapshot ID in which the file was deleted and status 2 (deleted). The file may be deleted from the file system when the snapshot in which it was deleted is garbage collected, assuming that older snapshots have also been garbage collected [1].
 
 Iceberg v2 adds a sequence number to the entry and makes the snapshot id optional. Both fields, `sequence_number` and `snapshot_id`, are inherited from manifest metadata when `null`. That is, if the field is `null` for an entry, then the entry must inherit its value from the manifest file's metadata, stored in the manifest list [2].
+The `sequence_number` field represents the data sequence number and must never change after a file is added to the dataset. 
 
 Notes:
 
@@ -474,9 +475,10 @@ Notes:
 
 Manifests track the sequence number when a data or delete file was added to the table.
 
-When adding new file, its sequence number is set to `null` because the snapshot's sequence number is not assigned until the snapshot is successfully committed. When reading, sequence numbers are inherited by replacing `null` with the manifest's sequence number from the manifest list.
+When adding a new file, its sequence number is set to `null` because the snapshot's sequence number is not assigned until the snapshot is successfully committed. When reading, sequence numbers are inherited by replacing `null` with the manifest's sequence number from the manifest list.
+It is also possible to add a new file that logically belongs to an older sequence number. In that case, the sequence number must be provided explicitly and not inherited.
 
-When writing an existing file to a new manifest, the sequence number must be non-null and set to the sequence number that was inherited.
+When writing an existing file to a new manifest or marking an existing file as deleted, the sequence number must be non-null and set to the original data sequence number of the file that was either inherited or provided at the commit time.
 
 Inheriting sequence numbers through the metadata tree allows writing a new manifest without a known sequence number, so that a manifest can be written once and reused in commit retries. To change a sequence number for a retry, only the manifest list must be rewritten.
 
@@ -535,7 +537,7 @@ Manifest list files store `manifest_file`, a struct with the following fields:
 | _required_ | _required_ | **`502 partition_spec_id`**    | `int`                                       | ID of a partition spec used to write the manifest; must be listed in table metadata `partition-specs` |
 |            | _required_ | **`517 content`**              | `int` with meaning: `0: data`, `1: deletes` | The type of files tracked by the manifest, either data or delete files; 0 for all v1 manifests |
 |            | _required_ | **`515 sequence_number`**      | `long`                                      | The sequence number when the manifest was added to the table; use 0 when reading v1 manifest lists |
-|            | _required_ | **`516 min_sequence_number`**  | `long`                                      | The minimum sequence number of all data or delete files in the manifest; use 0 when reading v1 manifest lists |
+|            | _required_ | **`516 min_sequence_number`**  | `long`                                      | The minimum sequence number of all live data or delete files in the manifest; use 0 when reading v1 manifest lists |
 | _required_ | _required_ | **`503 added_snapshot_id`**    | `long`                                      | ID of the snapshot where the  manifest file was added |
 | _optional_ | _required_ | **`504 added_files_count`**    | `int`                                       | Number of entries in the manifest that have status `ADDED` (1), when `null` this is assumed to be non-zero |
 | _optional_ | _required_ | **`505 existing_files_count`** | `int`                                       | Number of entries in the manifest that have status `EXISTING` (0), when `null` this is assumed to be non-zero |


### PR DESCRIPTION
This PR fixes the behavior of `sequence_number` in `ManifestEntry` to always represent the data sequence number.