### PR TITLE
Spark 3.2: Fix nullability in merge-on-read projections

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -20,6 +20,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.ProjectingInternalRow
 import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
@@ -54,6 +55,7 @@ import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
 import org.apache.spark.sql.catalyst.plans.logical.UpdateAction
 import org.apache.spark.sql.catalyst.plans.logical.WriteDelta
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils._
+import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
 import org.apache.spark.sql.connector.expressions.FieldReference
 import org.apache.spark.sql.connector.expressions.NamedReference
 import org.apache.spark.sql.connector.iceberg.catalog.SupportsRowLevelOperations
@@ -62,6 +64,8 @@ import org.apache.spark.sql.connector.iceberg.write.SupportsDelta
 import org.apache.spark.sql.connector.write.RowLevelOperationTable
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
 
 /**
  * Assigns a rewrite plan for v2 tables that support rewriting data to handle MERGE statements.
@@ -297,7 +301,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
 
     // build a plan to write the row delta to the table
     val writeRelation = relation.copy(table = operationTable)
-    val projections = buildWriteDeltaProjections(mergeRows, rowAttrs, rowIdAttrs, metadataAttrs)
+    val projections = buildMergeDeltaProjections(mergeRows, rowAttrs, rowIdAttrs, metadataAttrs)
     WriteDelta(writeRelation, mergeRows, relation, projections)
   }
 
@@ -383,5 +387,56 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
 
   private def resolveAttrRef(ref: NamedReference, plan: LogicalPlan): AttributeReference = {
     ExtendedV2ExpressionUtils.resolveRef[AttributeReference](ref, plan)
+  }
+
+  private def buildMergeDeltaProjections(
+      mergeRows: MergeRows,
+      rowAttrs: Seq[Attribute],
+      rowIdAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute]): WriteDeltaProjections = {
+
+    val outputAttrs = mergeRows.output
+
+    val outputs = mergeRows.matchedOutputs ++ mergeRows.notMatchedOutputs
+    val insertAndUpdateOutputs = outputs.filterNot(_.head == Literal(DELETE_OPERATION))
+    val updateAndDeleteOutputs = outputs.filterNot(_.head == Literal(INSERT_OPERATION))
+
+    val rowProjection = if (rowAttrs.nonEmpty) {
+      Some(newLazyProjection(insertAndUpdateOutputs, outputAttrs, rowAttrs))
+    } else {
+      None
+    }
+
+    val rowIdProjection = newLazyProjection(updateAndDeleteOutputs, outputAttrs, rowIdAttrs)
+
+    val metadataProjection = if (metadataAttrs.nonEmpty) {
+      Some(newLazyProjection(updateAndDeleteOutputs, outputAttrs, metadataAttrs))
+    } else {
+      None
+    }
+
+    WriteDeltaProjections(rowProjection, rowIdProjection, metadataProjection)
+  }
+
+  // the projection is done by name, ignoring expr IDs
+  private def newLazyProjection(
+      outputs: Seq[Seq[Expression]],
+      outputAttrs: Seq[Attribute],
+      projectedAttrs: Seq[Attribute]): ProjectingInternalRow = {
+
+    val projectedOrdinals = projectedAttrs.map(attr => outputAttrs.indexWhere(_.name == attr.name))
+
+    val structFields = projectedAttrs.zip(projectedOrdinals).map { case (attr, ordinal) =>
+      // output attr is nullable if at least one action may produce null for that attr
+      // but row ID and metadata attrs are projected only in update/delete actions and
+      // row attrs are projected only in insert/update actions
+      // that's why the projection schema must rely only on relevant action outputs
+      // instead of blindly inheriting the output attr nullability
+      val nullable = outputs.exists(output => output(ordinal).nullable)
+      StructField(attr.name, attr.dataType, nullable, attr.metadata)
+    }
+    val schema = StructType(structFields)
+
+    ProjectingInternalRow(schema, projectedOrdinals)
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -20,9 +20,7 @@ package org.apache.iceberg.spark.extensions;
 
 import java.util.Map;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.Test;
 
 public class TestCopyOnWriteMerge extends TestMerge {
 
@@ -39,38 +37,5 @@ public class TestCopyOnWriteMerge extends TestMerge {
   @Override
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(TableProperties.MERGE_MODE, "copy-on-write");
-  }
-
-  @Test
-  public void testMergeWithTableWithNonNullableColumn() {
-    createAndInitTable(
-        "id INT NOT NULL, dep STRING",
-        "{ \"id\": 1, \"dep\": \"emp-id-one\" }\n" + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
-
-    createOrReplaceView(
-        "source",
-        "id INT NOT NULL, dep STRING",
-        "{ \"id\": 2, \"dep\": \"emp-id-2\" }\n"
-            + "{ \"id\": 1, \"dep\": \"emp-id-1\" }\n"
-            + "{ \"id\": 6, \"dep\": \"emp-id-6\" }");
-
-    sql(
-        "MERGE INTO %s AS t USING source AS s "
-            + "ON t.id == s.id "
-            + "WHEN MATCHED AND t.id = 1 THEN "
-            + "  UPDATE SET * "
-            + "WHEN MATCHED AND t.id = 6 THEN "
-            + "  DELETE "
-            + "WHEN NOT MATCHED AND s.id = 2 THEN "
-            + "  INSERT *",
-        tableName);
-
-    ImmutableList<Object[]> expectedRows =
-        ImmutableList.of(
-            row(1, "emp-id-1"), // updated
-            row(2, "emp-id-2") // new
-            );
-    assertEquals(
-        "Should have expected rows", expectedRows, sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }


### PR DESCRIPTION
This is a cherry-pick of #5880 to Spark 3.2.