### PR TITLE
API: Simplify the ManifestEvaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -148,10 +148,6 @@ public class ManifestEvaluator {
         return ROWS_CANNOT_MATCH;
       }
 
-      if (allValuesAreNull(stats.get(pos), ref.type().typeId())) {
-        return ROWS_CANNOT_MATCH;
-      }
-
       return ROWS_MIGHT_MATCH;
     }
 


### PR DESCRIPTION
While writing tests for Python, I noticed some unreachable code. This also allows us to simplify the logic here by inlining the `allValuesAreNull` function.

The `allValuesAreNull` check is redundant for the `isNan` check.

Because we first check if there are NaN values:

```java
@Override
public <T> Boolean isNaN(BoundReference<T> ref) {
  int pos = Accessors.toPosition(ref.accessor());

  if (stats.get(pos).containsNaN() != null && !stats.get(pos).containsNaN()) {
    return ROWS_CANNOT_MATCH;
  }

  if (allValuesAreNull(stats.get(pos), ref.type().typeId())) {
    return ROWS_CANNOT_MATCH; // Unreachable code
  }

  return ROWS_MIGHT_MATCH;
}
```

And then we do the same in the `allValuesAreNull`:

```java
private boolean allValuesAreNull(PartitionFieldSummary summary, Type.TypeID typeId) {
  // containsNull encodes whether at least one partition value is null,
  // lowerBound is null if all partition values are null
  boolean allNull = summary.containsNull() && summary.lowerBound() == null;

  if (allNull && (Type.TypeID.DOUBLE.equals(typeId) || Type.TypeID.FLOAT.equals(typeId))) {
    // floating point types may include NaN values, which we check separately.
    // In case bounds don't include NaN value, containsNaN needs to be checked against.
    allNull = summary.containsNaN() != null && !summary.containsNaN();
  }
  return allNull;
}
```

Since the `isNan` can only be applied to Floats and Doubles, we always take the branch and it will set `allNull` to false. Therefore, never take the branch.