### PR TITLE
[python_legacy] BOTO_STS_CLIENT lazy initialization

### DIFF
--- a/python_legacy/iceberg/core/filesystem/s3_filesystem.py
+++ b/python_legacy/iceberg/core/filesystem/s3_filesystem.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from functools import lru_cache
 import io
 import logging
-from functools import lru_cache
 import re
 import time
 from urllib.parse import urlparse

--- a/python_legacy/iceberg/core/filesystem/s3_filesystem.py
+++ b/python_legacy/iceberg/core/filesystem/s3_filesystem.py
@@ -17,9 +17,9 @@
 
 import io
 import logging
+from functools import lru_cache
 import re
 import time
-from functools import lru_cache
 from urllib.parse import urlparse
 
 import boto3

--- a/python_legacy/iceberg/core/filesystem/s3_filesystem.py
+++ b/python_legacy/iceberg/core/filesystem/s3_filesystem.py
@@ -40,7 +40,7 @@ ROLE_ARN = "default"
 AUTOREFRESH_SESSION = None
 
 
-@lru_cache
+@lru_cache()
 def get_sts_client():
     return boto3.client('sts')
 

--- a/python_legacy/iceberg/core/filesystem/s3_filesystem.py
+++ b/python_legacy/iceberg/core/filesystem/s3_filesystem.py
@@ -34,7 +34,7 @@ _logger = logging.getLogger(__name__)
 
 
 S3_CLIENT = dict()
-BOTO_STS_CLIENT = boto3.client('sts')
+BOTO_STS_CLIENT = None
 CONF = None
 ROLE_ARN = "default"
 AUTOREFRESH_SESSION = None
@@ -71,6 +71,9 @@ def refresh_sts_session_keys():
     params = {"RoleArn": ROLE_ARN,
               "RoleSessionName": "iceberg_python_client_{}".format(int(time.time() * 1000.00))}
 
+    global BOTO_STS_CLIENT
+    if not BOTO_STS_CLIENT:
+        BOTO_STS_CLIENT = boto3.client('sts')
     sts_creds = BOTO_STS_CLIENT.assume_role(**params).get("Credentials")
     credentials = {"access_key": sts_creds.get("AccessKeyId"),
                    "secret_key": sts_creds.get("SecretAccessKey"),


### PR DESCRIPTION
Importing s3_filesystem module will initialize boto client which will generate network IO, thus make this as lazy initialization.

I can't find similar thing in python module right now, please suggest if I should change other places for similar reasons.