### PR TITLE
Parquet: support nested fields when assigning fallback ids

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -18,10 +18,8 @@
  */
 package org.apache.iceberg.parquet;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -29,9 +27,10 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -128,14 +127,14 @@ public class ParquetSchemaUtil {
 
   public static MessageType addFallbackIds(MessageType fileSchema) {
     MessageTypeBuilder builder = org.apache.parquet.schema.Types.buildMessage();
-    Queue<Pair<Type, List<String>>> queue = new LinkedList<>();
+    Queue<Pair<Type, List<String>>> queue = new ArrayDeque<>();
     enqueueFields(fileSchema.getFields(), queue, Collections.emptyList());
     // generate a map of field path to the desired ID, IDs are computed in BFS order
-    Map<List<String>, Integer> pathToId = new HashMap<>();
+    Map<List<String>, Integer> pathToId = Maps.newHashMap();
     int ordinal = 1; // ids are assigned starting at 1
     while (!queue.isEmpty()) {
       Pair<Type, List<String>> current = queue.remove();
-      List<String> currentPath = new ArrayList<>(current.second());
+      List<String> currentPath = Lists.newArrayList(current.second());
       currentPath.add(current.first().getName());
       if (!current.first().isPrimitive()) {
         enqueueFields(current.first().asGroupType().getFields(), queue, currentPath);
@@ -143,39 +142,47 @@ public class ParquetSchemaUtil {
       pathToId.put(currentPath, ordinal);
       ordinal += 1;
     }
-    applyFieldIds(fileSchema.getFields(), pathToId, new ArrayList<>()).forEach(builder::addField);
+    applyFieldIds(fileSchema.getFields(), pathToId, Lists.newArrayList())
+        .forEach(builder::addField);
     return builder.named(fileSchema.getName());
   }
 
-  private static void enqueueFields(List<Type> fields, Queue<Pair<Type, List<String>>> queue, List<String> currentPath) {
-    fields.forEach(field -> {
-      if (field.getName().equals("list") || field.getName().equals("key_value")) {
-        // skip to the list element or map key_value field
-        List<String> path = new ArrayList<>(currentPath);
-        path.add(field.getName());
-        enqueueFields(field.asGroupType().getFields(), queue, path);
-      } else {
-        queue.add(Pair.of(field, currentPath));
-      }
-    });
+  private static void enqueueFields(
+      List<Type> fields, Queue<Pair<Type, List<String>>> queue, List<String> currentPath) {
+    fields.forEach(
+        field -> {
+          if (field.getName().equals("list") || field.getName().equals("key_value")) {
+            // skip to the list element or map key_value field
+            List<String> path = Lists.newArrayList(currentPath);
+            path.add(field.getName());
+            enqueueFields(field.asGroupType().getFields(), queue, path);
+          } else {
+            queue.add(Pair.of(field, currentPath));
+          }
+        });
   }
 
-  private static List<Type> applyFieldIds(List<Type> input, Map<List<String>, Integer> pathToId, List<String> parentPath) {
-    return input.stream().map(type -> {
-      List<String> currentPath = new ArrayList<>(parentPath);
-      currentPath.add(type.getName());
-      Type returnType = type;
-      if (type instanceof GroupType) {
-        GroupType groupType = (GroupType) type;
-        List<Type> childTypesWithIds = applyFieldIds(groupType.getFields(), pathToId, currentPath);
-        returnType = groupType.withNewFields(childTypesWithIds);
-      }
-      if (pathToId.containsKey(currentPath)) {
-        return returnType.withId(pathToId.get(currentPath));
-      } else {
-        return returnType;
-      }
-    }).collect(Collectors.toList());
+  private static List<Type> applyFieldIds(
+      List<Type> input, Map<List<String>, Integer> pathToId, List<String> parentPath) {
+    return input.stream()
+        .map(
+            type -> {
+              List<String> currentPath = Lists.newArrayList(parentPath);
+              currentPath.add(type.getName());
+              Type returnType = type;
+              if (type instanceof GroupType) {
+                GroupType groupType = (GroupType) type;
+                List<Type> childTypesWithIds =
+                    applyFieldIds(groupType.getFields(), pathToId, currentPath);
+                returnType = groupType.withNewFields(childTypesWithIds);
+              }
+              if (pathToId.containsKey(currentPath)) {
+                return returnType.withId(pathToId.get(currentPath));
+              } else {
+                return returnType;
+              }
+            })
+        .collect(Collectors.toList());
   }
 
   public static MessageType applyNameMapping(MessageType fileSchema, NameMapping nameMapping) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.parquet;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.util.LinkedList;
+import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappingUtil;
@@ -387,6 +389,41 @@ public class TestParquetSchemaUtil {
 
     Schema actualSchema = ParquetSchemaUtil.convert(parquetScehma);
     Assert.assertEquals("Schema must match", expectedSchema.asStruct(), actualSchema.asStruct());
+  }
+
+  @Test
+  public void testAddFallbackIds() {
+    String messageType = "message schema_without_ids {"
+        + "  required double top_level_field;"
+        + "  required group map_field (MAP) {"
+        + "    repeated group key_value (MAP_KEY_VALUE) {"
+        + "      required binary key (STRING);"
+        + "      required binary value (STRING);"
+        + "    }"
+        + "  }"
+        + "  required group nested_parent {"
+        + "    required double nested_child;"
+        + "  }"
+        + "  required group list_field (LIST) {"
+        + "    repeated group list {"
+        + "      required group element {"
+        + "        required double amount;"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "}";
+    MessageType schemaWithoutIds = MessageTypeParser.parseMessageType(messageType);
+    MessageType schemaWithIds = ParquetSchemaUtil.addFallbackIds(schemaWithoutIds);
+
+    Assert.assertEquals(new Type.ID(1), schemaWithIds.getType("top_level_field").getId());
+    Assert.assertEquals(new Type.ID(2), schemaWithIds.getType("map_field").getId());
+    Assert.assertEquals(new Type.ID(3), schemaWithIds.getType("nested_parent").getId());
+    Assert.assertEquals(new Type.ID(4), schemaWithIds.getType("list_field").getId());
+    Assert.assertEquals(new Type.ID(5), schemaWithIds.getType("map_field", "key_value", "key").getId());
+    Assert.assertEquals(new Type.ID(6), schemaWithIds.getType("map_field", "key_value", "value").getId());
+    Assert.assertEquals(new Type.ID(7), schemaWithIds.getType("nested_parent", "nested_child").getId());
+    Assert.assertEquals(new Type.ID(8), schemaWithIds.getType("list_field", "list", "element").getId());
+    Assert.assertEquals(new Type.ID(9), schemaWithIds.getType("list_field", "list", "element", "amount").getId());
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.parquet;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-import java.util.LinkedList;
-import java.util.Queue;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappingUtil;
@@ -393,25 +391,26 @@ public class TestParquetSchemaUtil {
 
   @Test
   public void testAddFallbackIds() {
-    String messageType = "message schema_without_ids {"
-        + "  required double top_level_field;"
-        + "  required group map_field (MAP) {"
-        + "    repeated group key_value (MAP_KEY_VALUE) {"
-        + "      required binary key (STRING);"
-        + "      required binary value (STRING);"
-        + "    }"
-        + "  }"
-        + "  required group nested_parent {"
-        + "    required double nested_child;"
-        + "  }"
-        + "  required group list_field (LIST) {"
-        + "    repeated group list {"
-        + "      required group element {"
-        + "        required double amount;"
-        + "      }"
-        + "    }"
-        + "  }"
-        + "}";
+    String messageType =
+        "message schema_without_ids {"
+            + "  required double top_level_field;"
+            + "  required group map_field (MAP) {"
+            + "    repeated group key_value (MAP_KEY_VALUE) {"
+            + "      required binary key (STRING);"
+            + "      required binary value (STRING);"
+            + "    }"
+            + "  }"
+            + "  required group nested_parent {"
+            + "    required double nested_child;"
+            + "  }"
+            + "  required group list_field (LIST) {"
+            + "    repeated group list {"
+            + "      required group element {"
+            + "        required double amount;"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}";
     MessageType schemaWithoutIds = MessageTypeParser.parseMessageType(messageType);
     MessageType schemaWithIds = ParquetSchemaUtil.addFallbackIds(schemaWithoutIds);
 
@@ -419,11 +418,16 @@ public class TestParquetSchemaUtil {
     Assert.assertEquals(new Type.ID(2), schemaWithIds.getType("map_field").getId());
     Assert.assertEquals(new Type.ID(3), schemaWithIds.getType("nested_parent").getId());
     Assert.assertEquals(new Type.ID(4), schemaWithIds.getType("list_field").getId());
-    Assert.assertEquals(new Type.ID(5), schemaWithIds.getType("map_field", "key_value", "key").getId());
-    Assert.assertEquals(new Type.ID(6), schemaWithIds.getType("map_field", "key_value", "value").getId());
-    Assert.assertEquals(new Type.ID(7), schemaWithIds.getType("nested_parent", "nested_child").getId());
-    Assert.assertEquals(new Type.ID(8), schemaWithIds.getType("list_field", "list", "element").getId());
-    Assert.assertEquals(new Type.ID(9), schemaWithIds.getType("list_field", "list", "element", "amount").getId());
+    Assert.assertEquals(
+        new Type.ID(5), schemaWithIds.getType("map_field", "key_value", "key").getId());
+    Assert.assertEquals(
+        new Type.ID(6), schemaWithIds.getType("map_field", "key_value", "value").getId());
+    Assert.assertEquals(
+        new Type.ID(7), schemaWithIds.getType("nested_parent", "nested_child").getId());
+    Assert.assertEquals(
+        new Type.ID(8), schemaWithIds.getType("list_field", "list", "element").getId());
+    Assert.assertEquals(
+        new Type.ID(9), schemaWithIds.getType("list_field", "list", "element", "amount").getId());
   }
 
   @Test


### PR DESCRIPTION
The current implementation for addFallbackIds will not set IDs on fields outside of the top level. If you have a parquet file without IDs and nested fields, you will fail to read that file correctly.