### PR TITLE
AWS: Fix NotSerializableException when using AssumeRoleAwsClientFactory in Spark

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -34,7 +34,6 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private AwsProperties awsProperties;
-  private AssumeRoleRequest assumeRoleRequest;
 
   @Override
   public S3Client s3() {
@@ -80,8 +79,11 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     Preconditions.checkNotNull(
         awsProperties.clientAssumeRoleRegion(),
         "Cannot initialize AssumeRoleClientConfigFactory with null region");
+  }
 
-    this.assumeRoleRequest =
+  protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
+      T clientBuilder) {
+    AssumeRoleRequest assumeRoleRequest =
         AssumeRoleRequest.builder()
             .roleArn(awsProperties.clientAssumeRoleArn())
             .roleSessionName(genSessionName())
@@ -89,10 +91,6 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
             .externalId(awsProperties.clientAssumeRoleExternalId())
             .tags(awsProperties.stsClientAssumeRoleTags())
             .build();
-  }
-
-  protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
-      T clientBuilder) {
     clientBuilder
         .credentialsProvider(
             StsAssumeRoleCredentialsProvider.builder()

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -34,6 +34,7 @@ import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private AwsProperties awsProperties;
+  private String roleSessionName;
 
   @Override
   public S3Client s3() {
@@ -73,6 +74,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   @Override
   public void initialize(Map<String, String> properties) {
     this.awsProperties = new AwsProperties(properties);
+    this.roleSessionName = genSessionName();
     Preconditions.checkNotNull(
         awsProperties.clientAssumeRoleArn(),
         "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
@@ -86,7 +88,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     AssumeRoleRequest assumeRoleRequest =
         AssumeRoleRequest.builder()
             .roleArn(awsProperties.clientAssumeRoleArn())
-            .roleSessionName(genSessionName())
+            .roleSessionName(roleSessionName)
             .durationSeconds(awsProperties.clientAssumeRoleTimeoutSec())
             .externalId(awsProperties.clientAssumeRoleExternalId())
             .tags(awsProperties.stsClientAssumeRoleTags())

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.aws;
 
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.SerializationUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -69,6 +71,53 @@ public class TestAwsClientFactories {
         ValidationException.class,
         "S3 client access key ID and secret access key must be set at the same time",
         () -> AwsClientFactories.from(properties));
+  }
+
+  @Test
+  public void testDefaultAwsClientFactorySerializable() {
+    Map<String, String> properties = Maps.newHashMap();
+    AwsClientFactory defaultAwsClientFactory = AwsClientFactories.from(properties);
+    byte[] serializedFactoryBytes = SerializationUtil.serializeToBytes(defaultAwsClientFactory);
+    AwsClientFactory deserializedClientFactory =
+        SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
+    Assert.assertTrue(
+        "DefaultAwsClientFactory should be serializable",
+        deserializedClientFactory instanceof AwsClientFactories.DefaultAwsClientFactory);
+  }
+
+  @Test
+  public void testAssumeRoleAwsClientFactorySerializable() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    AwsClientFactory assumeRoleAwsClientFactory = AwsClientFactories.from(properties);
+    byte[] serializedFactoryBytes = SerializationUtil.serializeToBytes(assumeRoleAwsClientFactory);
+    AwsClientFactory deserializedClientFactory =
+        SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
+    Assert.assertTrue(
+        "AssumeRoleAwsClientFactory should be serializable",
+        deserializedClientFactory instanceof AssumeRoleAwsClientFactory);
+  }
+
+  @Test
+  public void testLakeFormationAwsClientFactorySerializable() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_FACTORY, LakeFormationAwsClientFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    properties.put(
+        AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX
+            + LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER,
+        "emr");
+    AwsClientFactory lakeFormationAwsClientFactory = AwsClientFactories.from(properties);
+    byte[] serializedFactoryBytes =
+        SerializationUtil.serializeToBytes(lakeFormationAwsClientFactory);
+    AwsClientFactory deserializedClientFactory =
+        SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
+    Assert.assertTrue(
+        "LakeFormationAwsClientFactory should be serializable",
+        deserializedClientFactory instanceof LakeFormationAwsClientFactory);
   }
 
   public static class CustomFactory implements AwsClientFactory {

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -18,8 +18,10 @@
  */
 package org.apache.iceberg.aws;
 
+import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -77,6 +79,15 @@ public class TestAwsClientFactories {
   public void testDefaultAwsClientFactorySerializable() {
     Map<String, String> properties = Maps.newHashMap();
     AwsClientFactory defaultAwsClientFactory = AwsClientFactories.from(properties);
+    try {
+      AwsClientFactory roundTripResult =
+          TestHelpers.KryoHelpers.roundTripSerialize(defaultAwsClientFactory);
+      Assert.assertTrue(
+          "DefaultAwsClientFactory should be serializable",
+          roundTripResult instanceof AwsClientFactories.DefaultAwsClientFactory);
+    } catch (IOException e) {
+      Assert.fail("kryoSerializer should serialize and deserialize DefaultAwsClientFactory");
+    }
     byte[] serializedFactoryBytes = SerializationUtil.serializeToBytes(defaultAwsClientFactory);
     AwsClientFactory deserializedClientFactory =
         SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
@@ -92,6 +103,15 @@ public class TestAwsClientFactories {
     properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
     properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
     AwsClientFactory assumeRoleAwsClientFactory = AwsClientFactories.from(properties);
+    try {
+      AwsClientFactory roundTripResult =
+          TestHelpers.KryoHelpers.roundTripSerialize(assumeRoleAwsClientFactory);
+      Assert.assertTrue(
+          "AssumeRoleAwsClientFactory should be serializable",
+          roundTripResult instanceof AssumeRoleAwsClientFactory);
+    } catch (IOException e) {
+      Assert.fail("kryoSerializer should serialize and deserialize AssumeRoleAwsClientFactory");
+    }
     byte[] serializedFactoryBytes = SerializationUtil.serializeToBytes(assumeRoleAwsClientFactory);
     AwsClientFactory deserializedClientFactory =
         SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
@@ -111,6 +131,15 @@ public class TestAwsClientFactories {
             + LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER,
         "emr");
     AwsClientFactory lakeFormationAwsClientFactory = AwsClientFactories.from(properties);
+    try {
+      AwsClientFactory roundTripResult =
+          TestHelpers.KryoHelpers.roundTripSerialize(lakeFormationAwsClientFactory);
+      Assert.assertTrue(
+          "LakeFormationAwsClientFactory should be serializable",
+          roundTripResult instanceof LakeFormationAwsClientFactory);
+    } catch (IOException e) {
+      Assert.fail("kryoSerializer should serialize and deserialize LakeFormationAwsClientFactory");
+    }
     byte[] serializedFactoryBytes =
         SerializationUtil.serializeToBytes(lakeFormationAwsClientFactory);
     AwsClientFactory deserializedClientFactory =


### PR DESCRIPTION
Fix the `NotSerializableException` when using `AssumeRoleAwsClientFactory` to configure the spark using `GlueCatalog`.

Compiled iceberg-spark-runtime-3.1 and tested on Glue 3.0.
The following Scala script triggered the exception before the fix and succeeded after the fix:
```
import org.apache.spark.SparkContext
import org.apache.spark.sql.SparkSession

import org.apache.iceberg.Table
import org.apache.iceberg.aws.glue.GlueCatalog
import org.apache.iceberg.catalog.Catalog
import org.apache.iceberg.aws.AssumeRoleAwsClientFactory
import org.apache.iceberg.catalog.TableIdentifier
import org.apache.iceberg.spark.actions.SparkActions

import scala.jdk.CollectionConverters._

object GlueApp {
    def main(sysArgs: Array[String]) {
        val sparkContext: SparkContext = new SparkContext()
        val spark: SparkSession = SparkSession.builder.
          config("spark.sql.catalog.demo", "org.apache.iceberg.spark.SparkCatalog").
          config("spark.sql.catalog.demo.warehouse", "s3://gluetestjonas/warehouse").
          config("spark.sql.catalog.demo.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog").
          config("spark.sql.catalog.demo.client.factory", "org.apache.iceberg.aws.AssumeRoleAwsClientFactory").
          config("spark.sql.catalog.demo.client.assume-role.arn", "arn:aws:iam::481640105715:role/jonasjiang_gluejob2").
          config("spark.sql.catalog.demo.client.assume-role.region", "us-east-1").
          config("spark.sql.catalog.demo.client.assume-role.session-name", "mytestname").
          getOrCreate()
          
        spark.sql("CREATE DATABASE IF NOT EXISTS demo.reviewsjonas")
        
        val book_reviews_location = "s3://amazon-reviews-pds/parquet/product_category=Books/*.parquet"
            val book_reviews = spark.read.parquet(book_reviews_location)
            book_reviews.writeTo("demo.reviewsjonas.book_reviews_session_name").
              tableProperty("format-version", "2").
              createOrReplace()
            
            // read using SQL
            // spark.sql("SELECT * FROM demo.reviews.book_reviews").show()
    }
    
 
}
```

