### PR TITLE
HuaweiCloud: Add support for HuaweiCloud OBS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -334,6 +334,39 @@ project(':iceberg-data') {
   }
 }
 
+project(':iceberg-huaweicloud') {
+  dependencies {
+    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    api project(':iceberg-api')
+    implementation project(':iceberg-core')
+    implementation project(':iceberg-common')
+
+    compileOnly 'com.huaweicloud:esdk-obs-java-bundle'
+    compileOnly 'javax.xml.bind:jaxb-api'
+    compileOnly 'javax.activation:activation'
+    compileOnly 'org.glassfish.jaxb:jaxb-runtime'
+    compileOnly("org.apache.hadoop:hadoop-common") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'javax.servlet', module: 'servlet-api'
+      exclude group: 'com.google.code.gson', module: 'gson'
+    }
+
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+    testImplementation 'org.springframework:spring-web'
+    testImplementation('org.springframework.boot:spring-boot-starter-jetty') {
+      exclude module: 'logback-classic'
+      exclude group: 'org.eclipse.jetty.websocket', module: 'javax-websocket-server-impl'
+      exclude group: 'org.eclipse.jetty.websocket', module: 'websocket-server'
+    }
+    testImplementation('org.springframework.boot:spring-boot-starter-web') {
+      exclude module: 'logback-classic'
+      exclude module: 'spring-boot-starter-logging'
+    }
+  }
+}
+
 project(':iceberg-aliyun') {
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudClientFactories.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudClientFactories.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import java.util.Map;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
+
+public class HuaweicloudClientFactories {
+
+  private static final HuaweicloudClientFactory HUAWEICLOUD_CLIENT_FACTORY_DEFAULT =
+      new DefaultHuaweicloudClientFactory();
+
+  private HuaweicloudClientFactories() {}
+
+  public static HuaweicloudClientFactory defaultFactory() {
+    return HUAWEICLOUD_CLIENT_FACTORY_DEFAULT;
+  }
+
+  public static HuaweicloudClientFactory from(Map<String, String> properties) {
+    String factoryImpl =
+        PropertyUtil.propertyAsString(
+            properties,
+            HuaweicloudProperties.CLIENT_FACTORY,
+            DefaultHuaweicloudClientFactory.class.getName());
+    return loadClientFactory(factoryImpl, properties);
+  }
+
+  /**
+   * Load an implemented {@link HuaweicloudClientFactory} based on the class name, and initialize
+   * it.
+   *
+   * @param impl the class name.
+   * @param properties to initialize the factory.
+   * @return an initialized {@link HuaweicloudClientFactory}.
+   */
+  private static HuaweicloudClientFactory loadClientFactory(
+      String impl, Map<String, String> properties) {
+    DynConstructors.Ctor<HuaweicloudClientFactory> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(HuaweicloudClientFactory.class).hiddenImpl(impl).buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize HuaweicloudClientFactory, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    HuaweicloudClientFactory factory;
+    try {
+      factory = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize HuaweicloudClientFactory, %s does not implement HuaweicloudClientFactory.",
+              impl),
+          e);
+    }
+
+    factory.initialize(properties);
+    return factory;
+  }
+
+  static class DefaultHuaweicloudClientFactory implements HuaweicloudClientFactory {
+    private HuaweicloudProperties huaweicloudProperties;
+
+    DefaultHuaweicloudClientFactory() {}
+
+    @Override
+    public IObsClient newOBSClient() {
+      Preconditions.checkNotNull(
+          huaweicloudProperties,
+          "Cannot create huaweicloud obs client before initializing the HuaweicloudClientFactory.");
+
+      return new ObsClient(
+          huaweicloudProperties.accessKeyId(),
+          huaweicloudProperties.accessKeySecret(),
+          huaweicloudProperties.obsEndpoint());
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.huaweicloudProperties = new HuaweicloudProperties(properties);
+    }
+
+    @Override
+    public HuaweicloudProperties huaweicloudProperties() {
+      return huaweicloudProperties;
+    }
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudClientFactory.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudClientFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud;
+
+import com.obs.services.IObsClient;
+import java.io.Serializable;
+import java.util.Map;
+
+public interface HuaweicloudClientFactory extends Serializable {
+
+  /**
+   * Create an huaweicloud OBS client.
+   *
+   * @return obs client.
+   */
+  IObsClient newOBSClient();
+
+  /**
+   * Initialize Huaweicloud client factory from catalog properties.
+   *
+   * @param properties catalog properties
+   */
+  void initialize(Map<String, String> properties);
+
+  /** Returns an initialized {@link HuaweicloudProperties} */
+  HuaweicloudProperties huaweicloudProperties();
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudProperties.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/HuaweicloudProperties.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.PropertyUtil;
+
+public class HuaweicloudProperties implements Serializable {
+  /**
+   * The domain name used to access OBS.
+   *
+   * <p>For more information, see: https://support.huaweicloud.com/ugobs-obs/obs_41_0003.html
+   */
+  public static final String OBS_ENDPOINT = "obs.endpoint";
+
+  /**
+   * OBS verifies the signature of the AK and SK in the user account to ensure that only authorized
+   * accounts can access specified OBS resources. The AccessKey ID is used to identify a user.
+   *
+   * <p>For more information about how to obtain an AccessKey Key ID, see:
+   * https://support.huaweicloud.com/sdk-java-devg-obs/obs_21_0102.html
+   */
+  public static final String CLIENT_ACCESS_KEY_ID = "client.access-key-id";
+
+  /**
+   * OBS verifies the signature of the AK and SK in the user account to ensure that only authorized
+   * accounts can access specified OBS resources. The key used by the user to access the OBS.
+   *
+   * <p>For more information about how to obtain a Secret Access Key, see:
+   * https://support.huaweicloud.com/sdk-java-devg-obs/obs_21_0102.html
+   */
+  public static final String CLIENT_ACCESS_KEY_SECRET = "client.access-key-secret";
+
+  /**
+   * The implementation class of {@link HuaweicloudClientFactory} to customize Huaweicloud client
+   * configurations.
+   */
+  public static final String CLIENT_FACTORY = "client.factory-impl";
+
+  /**
+   * Location to put staging files for uploading to OBS, defaults to the directory value of
+   * java.io.tmpdir.
+   */
+  public static final String OBS_STAGING_DIRECTORY = "obs.staging-dir";
+
+  private final String obsEndpoint;
+  private final String accessKeyId;
+  private final String accessKeySecret;
+  private final String obsStagingDirectory;
+
+  public HuaweicloudProperties() {
+    this(ImmutableMap.of());
+  }
+
+  public HuaweicloudProperties(Map<String, String> properties) {
+    this.obsEndpoint = properties.get(OBS_ENDPOINT);
+    this.accessKeyId = properties.get(CLIENT_ACCESS_KEY_ID);
+    this.accessKeySecret = properties.get(CLIENT_ACCESS_KEY_SECRET);
+    this.obsStagingDirectory =
+        PropertyUtil.propertyAsString(
+            properties, OBS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+  }
+
+  public String obsEndpoint() {
+    return obsEndpoint;
+  }
+
+  public String accessKeyId() {
+    return accessKeyId;
+  }
+
+  public String accessKeySecret() {
+    return accessKeySecret;
+  }
+
+  public String obsStagingDirectory() {
+    return obsStagingDirectory;
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/BaseOBSFile.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/BaseOBSFile.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.exception.ObsException;
+import com.obs.services.model.ObjectMetadata;
+import org.apache.http.HttpStatus;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class BaseOBSFile {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseOBSFile.class);
+  private final IObsClient client;
+  private final OBSURI uri;
+  private HuaweicloudProperties huaweicloudProperties;
+  private ObjectMetadata metadata;
+  private final MetricsContext metrics;
+
+  BaseOBSFile(
+      IObsClient client,
+      OBSURI uri,
+      HuaweicloudProperties huaweicloudProperties,
+      MetricsContext metrics) {
+    this.client = client;
+    this.uri = uri;
+    this.huaweicloudProperties = huaweicloudProperties;
+    this.metrics = metrics;
+  }
+
+  public String location() {
+    return uri.location();
+  }
+
+  public IObsClient client() {
+    return client;
+  }
+
+  public OBSURI uri() {
+    return uri;
+  }
+
+  public HuaweicloudProperties huaweicloudProperties() {
+    return huaweicloudProperties;
+  }
+
+  public boolean exists() {
+    try {
+      return objectMetadata() != null;
+    } catch (ObsException obsException) {
+
+      if (obsException.getResponseCode() == HttpStatus.SC_NOT_FOUND) {
+        return false;
+      }
+
+      throw obsException;
+    }
+  }
+
+  protected ObjectMetadata objectMetadata() {
+    if (metadata == null) {
+      metadata = client.getObjectMetadata(uri().bucket(), uri().key());
+    }
+    LOG.debug("ObjectMetadata: {}", metadata);
+    return metadata;
+  }
+
+  protected MetricsContext metrics() {
+    return metrics;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("file", uri).toString();
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSFileIO.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSFileIO.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.huaweicloud.HuaweicloudClientFactories;
+import org.apache.iceberg.huaweicloud.HuaweicloudClientFactory;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OBSFileIO implements FileIO {
+  private static final Logger LOG = LoggerFactory.getLogger(OBSFileIO.class);
+  private static final String DEFAULT_METRICS_IMPL =
+      "org.apache.iceberg.hadoop.HadoopMetricsContext";
+
+  private SerializableSupplier<IObsClient> obs;
+  private HuaweicloudProperties huaweicloudProperties;
+  private transient volatile IObsClient client;
+  private MetricsContext metrics = MetricsContext.nullMetrics();
+  private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
+
+  /**
+   * No-arg constructor to load the FileIO dynamically.
+   *
+   * <p>All fields are initialized by calling {@link OBSFileIO#initialize(Map)} later.
+   */
+  public OBSFileIO() {}
+
+  /**
+   * Constructor with custom obs supplier and default huaweicloud properties.
+   *
+   * <p>Calling {@link OBSFileIO#initialize(Map)} will overwrite information set in this
+   * constructor.
+   *
+   * @param obs obs supplier
+   */
+  public OBSFileIO(SerializableSupplier<IObsClient> obs) {
+    this.obs = obs;
+    this.huaweicloudProperties = new HuaweicloudProperties();
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    return new OBSInputFile(client(), new OBSURI(path), huaweicloudProperties, metrics);
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    return new OBSOutputFile(client(), new OBSURI(path), huaweicloudProperties, metrics);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    OBSURI location = new OBSURI(path);
+    client().deleteObject(location.bucket(), location.key());
+  }
+
+  private IObsClient client() {
+    if (client == null) {
+      synchronized (this) {
+        if (client == null) {
+          client = obs.get();
+        }
+      }
+    }
+    return client;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    HuaweicloudClientFactory factory = HuaweicloudClientFactories.from(properties);
+    this.huaweicloudProperties = factory.huaweicloudProperties();
+    this.obs = factory::newOBSClient;
+
+    // Report Hadoop metrics if Hadoop is available
+    try {
+      DynConstructors.Ctor<MetricsContext> ctor =
+          DynConstructors.builder(MetricsContext.class)
+              .hiddenImpl(DEFAULT_METRICS_IMPL, String.class)
+              .buildChecked();
+      MetricsContext context = ctor.newInstance("obs");
+      context.initialize(properties);
+      this.metrics = context;
+    } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
+      LOG.warn(
+          "Unable to load metrics class: '{}', falling back to null metrics",
+          DEFAULT_METRICS_IMPL,
+          e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // handles concurrent calls to close()
+    if (isResourceClosed.compareAndSet(false, true)) {
+      if (client != null) {
+        try {
+          client.close();
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to close OBSClient", e);
+        }
+      }
+    }
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSInputFile.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSInputFile.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+
+class OBSInputFile extends BaseOBSFile implements InputFile {
+
+  private Long length = null;
+
+  OBSInputFile(
+      IObsClient client,
+      OBSURI uri,
+      HuaweicloudProperties huaweicloudProperties,
+      MetricsContext metrics) {
+    super(client, uri, huaweicloudProperties, metrics);
+  }
+
+  OBSInputFile(
+      IObsClient client,
+      OBSURI uri,
+      HuaweicloudProperties huaweicloudProperties,
+      long length,
+      MetricsContext metrics) {
+    super(client, uri, huaweicloudProperties, metrics);
+    ValidationException.check(length >= 0, "Invalid file length: %s", length);
+    this.length = length;
+  }
+
+  @Override
+  public long getLength() {
+    if (length == null) {
+      length = objectMetadata().getContentLength();
+    }
+    return length;
+  }
+
+  @Override
+  public SeekableInputStream newStream() {
+    return new OBSInputStream(client(), uri(), metrics());
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSInputStream.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSInputStream.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.model.GetObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OBSInputStream extends SeekableInputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(OBSInputStream.class);
+  private static final int SKIP_SIZE = 1024 * 1024;
+
+  private final StackTraceElement[] createStack;
+  private final IObsClient client;
+  private final OBSURI uri;
+
+  private InputStream stream = null;
+  private long pos = 0;
+  private long next = 0;
+  private boolean closed = false;
+
+  private final Counter<Long> readBytes;
+  private final Counter<Integer> readOperations;
+
+  OBSInputStream(IObsClient client, OBSURI uri) {
+    this(client, uri, MetricsContext.nullMetrics());
+  }
+
+  OBSInputStream(IObsClient client, OBSURI uri, MetricsContext metrics) {
+    this.client = client;
+    this.uri = uri;
+    this.createStack = Thread.currentThread().getStackTrace();
+
+    this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, Unit.BYTES);
+    this.readOperations =
+        metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, Unit.COUNT);
+  }
+
+  @Override
+  public long getPos() {
+    return next;
+  }
+
+  @Override
+  public void seek(long newPos) {
+    Preconditions.checkState(!closed, "Cannot seek: already closed");
+    Preconditions.checkArgument(newPos >= 0, "Position cant not be negative: %s", newPos);
+
+    // this allows a seek beyond the end of the stream but the next read will fail
+    next = newPos;
+  }
+
+  @Override
+  public int read() throws IOException {
+    Preconditions.checkState(!closed, "Cannot read: already closed");
+    positionStream();
+
+    pos += 1;
+    next += 1;
+    readBytes.increment();
+    readOperations.increment();
+
+    return stream.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    Preconditions.checkState(!closed, "Cannot read: already closed");
+    positionStream();
+
+    int bytesRead = stream.read(b, off, len);
+    pos += bytesRead;
+    next += bytesRead;
+    readBytes.increment((long) bytesRead);
+    readOperations.increment();
+
+    return bytesRead;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+
+    super.close();
+    closeStream();
+    closed = true;
+  }
+
+  private void positionStream() throws IOException {
+    if ((stream != null) && (next == pos)) {
+      // already at specified position.
+      return;
+    }
+
+    if ((stream != null) && (next > pos)) {
+      // seeking forwards
+      long skip = next - pos;
+      if (skip <= Math.max(stream.available(), SKIP_SIZE)) {
+        // already buffered or seek is small enough
+        LOG.debug("Read-through seek for {} from {} to offset {}", uri, pos, next);
+        try {
+          ByteStreams.skipFully(stream, skip);
+          pos = next;
+          return;
+        } catch (IOException ignored) {
+          // will retry by re-opening the stream.
+        }
+      }
+    }
+
+    // close the stream and open at desired position.
+    LOG.debug("Seek with new stream for {} to offset {}", uri, next);
+    pos = next;
+    openStream();
+  }
+
+  private void openStream() throws IOException {
+    closeStream();
+    GetObjectRequest request = new GetObjectRequest(uri.bucket(), uri.key());
+    request.setRangeStart(pos);
+    stream = client.getObject(request).getObjectContent();
+  }
+
+  private void closeStream() throws IOException {
+    if (stream != null) {
+      stream.close();
+      stream = null;
+    }
+  }
+
+  @SuppressWarnings("checkstyle:NoFinalizer")
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+    if (!closed) {
+      close(); // releasing resources is more important than printing the warning
+      String trace = Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
+      LOG.warn("Unclosed input stream created by: \n\t{}", trace);
+    }
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputFile.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputFile.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class OBSOutputFile extends BaseOBSFile implements OutputFile {
-  private static final Logger LOG = LoggerFactory.getLogger(BaseOBSFile.class);
+  private static final Logger LOG = LoggerFactory.getLogger(OBSOutputFile.class);
 
   OBSOutputFile(
       IObsClient client,

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputFile.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputFile.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OBSOutputFile extends BaseOBSFile implements OutputFile {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseOBSFile.class);
+
+  OBSOutputFile(
+      IObsClient client,
+      OBSURI uri,
+      HuaweicloudProperties huaweicloudProperties,
+      MetricsContext metrics) {
+    super(client, uri, huaweicloudProperties, metrics);
+  }
+
+  static OBSOutputFile fromLocation(
+      IObsClient client, String location, HuaweicloudProperties huaweicloudProperties) {
+    return new OBSOutputFile(
+        client, new OBSURI(location), huaweicloudProperties, MetricsContext.nullMetrics());
+  }
+
+  @Override
+  public PositionOutputStream create() {
+    if (!exists()) {
+      LOG.debug("Location exists: {}", uri());
+      return createOrOverwrite();
+    } else {
+      throw new AlreadyExistsException("Location already exists: %s", uri());
+    }
+  }
+
+  @Override
+  public PositionOutputStream createOrOverwrite() {
+    return new OBSOutputStream(client(), uri(), huaweicloudProperties(), metrics());
+  }
+
+  @Override
+  public InputFile toInputFile() {
+    return new OBSInputFile(client(), uri(), huaweicloudProperties(), metrics());
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputStream.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSOutputStream.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.model.ObjectMetadata;
+import com.obs.services.model.PutObjectRequest;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OBSOutputStream extends PositionOutputStream {
+  private static final Logger LOG = LoggerFactory.getLogger(OBSOutputStream.class);
+  private final StackTraceElement[] createStack;
+
+  private final IObsClient client;
+  private final OBSURI uri;
+
+  private final File currentStagingFile;
+  private final OutputStream stream;
+  private long pos = 0;
+  private boolean closed = false;
+
+  private final Counter<Long> writeBytes;
+  private final Counter<Integer> writeOperations;
+
+  OBSOutputStream(
+      IObsClient client,
+      OBSURI uri,
+      HuaweicloudProperties huaweicloudProperties,
+      MetricsContext metrics) {
+    this.client = client;
+    this.uri = uri;
+    this.createStack = Thread.currentThread().getStackTrace();
+
+    this.currentStagingFile = newStagingFile(huaweicloudProperties.obsStagingDirectory());
+    this.stream = newStream(currentStagingFile);
+    this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, Unit.BYTES);
+    this.writeOperations =
+        metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, Unit.COUNT);
+  }
+
+  private static File newStagingFile(String obsStagingDirectory) {
+    try {
+      File stagingFile = File.createTempFile("obs-file-io-", ".tmp", new File(obsStagingDirectory));
+      stagingFile.deleteOnExit();
+      return stagingFile;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static OutputStream newStream(File currentStagingFile) {
+    try {
+      return new BufferedOutputStream(new FileOutputStream(currentStagingFile));
+    } catch (FileNotFoundException e) {
+      throw new NotFoundException(e, "Failed to create file: %s", currentStagingFile);
+    }
+  }
+
+  private static InputStream uncheckedInputStream(File file) {
+    try {
+      return Files.newInputStream(file.toPath());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public long getPos() {
+    return pos;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    Preconditions.checkState(!closed, "Already closed.");
+    stream.flush();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    Preconditions.checkState(!closed, "Already closed.");
+    stream.write(b);
+    pos += 1;
+    writeBytes.increment();
+    writeOperations.increment();
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    Preconditions.checkState(!closed, "Already closed.");
+    stream.write(b, off, len);
+    pos += len;
+    writeBytes.increment((long) len);
+    writeOperations.increment();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+
+    super.close();
+    closed = true;
+
+    try {
+      stream.close();
+      completeUploads();
+    } finally {
+      cleanUpStagingFiles();
+    }
+  }
+
+  private void completeUploads() {
+    long contentLength = currentStagingFile.length();
+    if (contentLength == 0) {
+      LOG.debug("Skipping empty upload to OBS");
+      return;
+    }
+
+    LOG.debug("Uploading {} staged bytes to OBS", contentLength);
+    InputStream contentStream = uncheckedInputStream(currentStagingFile);
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(contentLength);
+
+    PutObjectRequest request = new PutObjectRequest(uri.bucket(), uri.key(), contentStream);
+    request.setMetadata(metadata);
+    client.putObject(request);
+  }
+
+  private void cleanUpStagingFiles() {
+    if (!currentStagingFile.delete()) {
+      LOG.warn("Failed to delete staging file: {}", currentStagingFile);
+    }
+  }
+
+  @SuppressWarnings("checkstyle:NoFinalizer")
+  @Override
+  protected void finalize() throws Throwable {
+    super.finalize();
+    if (!closed) {
+      close(); // releasing resources is more important than printing the warning.
+      String trace = Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
+      LOG.warn("Unclosed output stream created by:\n\t{}", trace);
+    }
+  }
+}

--- a/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSURI.java
+++ b/huaweicloud/src/main/java/org/apache/iceberg/huaweicloud/obs/OBSURI.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.internal.utils.ServiceUtils;
+import java.util.Set;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+
+public class OBSURI {
+  private static final String SCHEME_DELIM = "://";
+  private static final String PATH_DELIM = "/";
+  private static final String QUERY_DELIM = "\\?";
+  private static final String FRAGMENT_DELIM = "#";
+  private static final Set<String> VALID_SCHEMES = ImmutableSet.of("https", "obs");
+  private final String location;
+  private final String bucket;
+  private final String key;
+
+  public OBSURI(String location) {
+    Preconditions.checkNotNull(location, "OBS location cannot be null.");
+
+    this.location = location;
+    String[] schemeSplit = location.split(SCHEME_DELIM, -1);
+    ValidationException.check(schemeSplit.length == 2, "Invalid OBS location: %s", location);
+
+    String scheme = schemeSplit[0];
+    ValidationException.check(
+        VALID_SCHEMES.contains(scheme.toLowerCase()),
+        "Invalid scheme: %s in OBS location %s",
+        scheme,
+        location);
+
+    String[] authoritySplit = schemeSplit[1].split(PATH_DELIM, 2);
+    ValidationException.check(
+        authoritySplit.length == 2, "Invalid bucket or key in OBS location: %s", location);
+    ValidationException.check(
+        !authoritySplit[1].trim().isEmpty(), "Missing key in OBS location: %s", location);
+    this.bucket = authoritySplit[0];
+    if (!ServiceUtils.isBucketNameValidDNSName(bucket)) {
+      throw new IllegalArgumentException("BucketNameInvalid:" + bucket);
+    }
+
+    // Strip query and fragment if they exist
+    String path = authoritySplit[1];
+    path = path.split(QUERY_DELIM, -1)[0];
+    path = path.split(FRAGMENT_DELIM, -1)[0];
+    this.key = path;
+    if (!ServiceUtils.isValid(key)) {
+      throw new IllegalArgumentException("ObjectKeyInvalid:" + key);
+    }
+  }
+
+  /** Return OBS bucket name. */
+  public String bucket() {
+    return bucket;
+  }
+
+  /** Return OBS object key name. */
+  public String key() {
+    return key;
+  }
+
+  /** Return original, unmodified OBS URI location. */
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public String toString() {
+    return location;
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/TestHuaweicloudClientFactories.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/TestHuaweicloudClientFactories.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud;
+
+import com.obs.services.ObsClient;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHuaweicloudClientFactories {
+
+  @Test
+  public void testLoadDefault() {
+    Assert.assertEquals(
+        "Default client should be singleton",
+        HuaweicloudClientFactories.defaultFactory(),
+        HuaweicloudClientFactories.defaultFactory());
+
+    HuaweicloudClientFactory defaultFactory = HuaweicloudClientFactories.from(Maps.newHashMap());
+    Assert.assertTrue(
+        "Should load default when factory impl not configured",
+        defaultFactory instanceof HuaweicloudClientFactories.DefaultHuaweicloudClientFactory);
+    Assert.assertNull(
+        "Should have no Huaweicloud properties set",
+        defaultFactory.huaweicloudProperties().accessKeyId());
+
+    HuaweicloudClientFactory defaultFactoryWithConfig =
+        HuaweicloudClientFactories.from(
+            ImmutableMap.of(HuaweicloudProperties.CLIENT_ACCESS_KEY_ID, "key"));
+    Assert.assertTrue(
+        "Should load default when factory impl not configured",
+        defaultFactoryWithConfig
+            instanceof HuaweicloudClientFactories.DefaultHuaweicloudClientFactory);
+    Assert.assertEquals(
+        "Should have access key set",
+        "key",
+        defaultFactoryWithConfig.huaweicloudProperties().accessKeyId());
+  }
+
+  @Test
+  public void testLoadCustom() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HuaweicloudProperties.CLIENT_FACTORY, CustomFactory.class.getName());
+    Assert.assertTrue(
+        "Should load custom class",
+        HuaweicloudClientFactories.from(properties) instanceof CustomFactory);
+  }
+
+  public static class CustomFactory implements HuaweicloudClientFactory {
+
+    HuaweicloudProperties huaweicloudProperties;
+
+    public CustomFactory() {}
+
+    @Override
+    public ObsClient newOBSClient() {
+      return null;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.huaweicloudProperties = new HuaweicloudProperties(properties);
+    }
+
+    @Override
+    public HuaweicloudProperties huaweicloudProperties() {
+      return huaweicloudProperties;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/TestUtility.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/TestUtility.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud;
+
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.huaweicloud.obs.HuaweicloudOBSTestRule;
+import org.apache.iceberg.huaweicloud.obs.OBSURI;
+import org.apache.iceberg.huaweicloud.obs.mock.HuaweicloudOBSMockRule;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestUtility {
+  private static final Logger LOG = LoggerFactory.getLogger(TestUtility.class);
+
+  // System environment variables for Huaweicloud Access Key Pair.
+  private static final String HUAWEICLOUD_TEST_ACCESS_KEY_ID = "HUAWEICLOUD_TEST_ACCESS_KEY_ID";
+  private static final String HUAWEICLOUD_TEST_ACCESS_KEY_SECRET =
+      "HUAWEICLOUD_TEST_ACCESS_KEY_SECRET";
+
+  // System environment variables for Huaweicloud OBS
+  private static final String HUAWEICLOUD_TEST_OBS_RULE_CLASS =
+      "HUAWEICLOUD_TEST_OBS_TEST_RULE_CLASS";
+  private static final String HUAWEICLOUD_TEST_OBS_ENDPOINT = "HUAWEICLOUD_TEST_OBS_ENDPOINT";
+  private static final String HUAWEICLOUD_TEST_OBS_WAREHOUSE = "HUAWEICLOUD_TEST_OBS_WAREHOUSE";
+
+  private TestUtility() {}
+
+  public static HuaweicloudOBSTestRule initialize() {
+    HuaweicloudOBSTestRule testRule;
+
+    String implClass = System.getenv(HUAWEICLOUD_TEST_OBS_RULE_CLASS);
+    if (!Strings.isNullOrEmpty(implClass)) {
+      LOG.info("The initializing HuaweicloudOBSTestRule implementation is: {}", implClass);
+      try {
+        DynConstructors.Ctor<HuaweicloudOBSTestRule> ctor =
+            DynConstructors.builder(HuaweicloudOBSTestRule.class).impl(implClass).buildChecked();
+        testRule = ctor.newInstance();
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot initialize HuaweicloudOBSTestRule, missing no-arg constructor: %s",
+                implClass),
+            e);
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot initialize HuaweicloudOBSTestRule, %s does not implement it.", implClass),
+            e);
+      }
+    } else {
+      LOG.info(
+          "Initializing HuaweicloudOBSTestRule implementation with default HuaweicloudOBSMockRule");
+      testRule = HuaweicloudOBSMockRule.builder().silent().build();
+    }
+
+    return testRule;
+  }
+
+  public static String accessKeyId() {
+    return System.getenv(HUAWEICLOUD_TEST_ACCESS_KEY_ID);
+  }
+
+  public static String accessKeySecret() {
+    return System.getenv(HUAWEICLOUD_TEST_ACCESS_KEY_SECRET);
+  }
+
+  public static String obsEndpoint() {
+    return System.getenv(HUAWEICLOUD_TEST_OBS_ENDPOINT);
+  }
+
+  public static String obsWarehouse() {
+    return System.getenv(HUAWEICLOUD_TEST_OBS_WAREHOUSE);
+  }
+
+  public static String obsBucket() {
+    return obsWarehouseURI().bucket();
+  }
+
+  public static String obsKey() {
+    return obsWarehouseURI().key();
+  }
+
+  private static OBSURI obsWarehouseURI() {
+    String obsWarehouse = obsWarehouse();
+    Preconditions.checkNotNull(
+        obsWarehouse,
+        "Please set a correct Huaweicloud OBS path for environment variable '%s'",
+        HUAWEICLOUD_TEST_OBS_WAREHOUSE);
+
+    return new OBSURI(obsWarehouse);
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/HuaweicloudOBSTestBase.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/HuaweicloudOBSTestBase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import org.apache.iceberg.huaweicloud.TestUtility;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+public abstract class HuaweicloudOBSTestBase {
+  @ClassRule public static final HuaweicloudOBSTestRule OBS_TEST_RULE = TestUtility.initialize();
+
+  private final SerializableSupplier<IObsClient> obsClient = OBS_TEST_RULE::createOBSClient;
+  private final String bucketName = OBS_TEST_RULE.testBucketName();
+  private final String keyPrefix = OBS_TEST_RULE.keyPrefix();
+
+  @Before
+  public void before() {
+    OBS_TEST_RULE.setUpBucket(bucketName);
+  }
+
+  @After
+  public void after() {
+    OBS_TEST_RULE.tearDownBucket(bucketName);
+  }
+
+  protected String location(String key) {
+    return String.format("obs://%s/%s%s", bucketName, keyPrefix, key);
+  }
+
+  protected SerializableSupplier<IObsClient> obsClient() {
+    return obsClient;
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/HuaweicloudOBSTestRule.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/HuaweicloudOBSTestRule.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public interface HuaweicloudOBSTestRule extends TestRule {
+  UUID RANDOM_UUID = UUID.randomUUID();
+
+  /** Returns a specific bucket name for testing purpose. */
+  default String testBucketName() {
+    return String.format("obs-testing-bucket-%s", RANDOM_UUID);
+  }
+
+  @Override
+  default Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        start();
+        try {
+          base.evaluate();
+        } finally {
+          stop();
+        }
+      }
+    };
+  }
+
+  /**
+   * Returns the common key prefix for those newly created objects in test cases. For example, we
+   * set the test bucket to be 'obs-testing-bucket' and the key prefix to be 'iceberg-objects/',
+   * then the produced objects in test cases will be:
+   *
+   * <pre>
+   *   obs://obs-testing-bucket/iceberg-objects/a.dat
+   *   obs://obs-testing-bucket/iceberg-objects/b.dat
+   *   ...
+   * </pre>
+   */
+  String keyPrefix();
+
+  /**
+   * Start the Huaweicloud Object storage services application that the OBS client could connect to.
+   */
+  void start();
+
+  /** Stop the Huaweicloud object storage services. */
+  void stop() throws IOException;
+
+  /** Returns an newly created {@link ObsClient} client. */
+  IObsClient createOBSClient();
+
+  /**
+   * Preparation work of bucket for the test case, for example we need to check the existence of
+   * specific bucket.
+   */
+  void setUpBucket(String bucket);
+
+  /** Clean all the objects that created from this test suite in the bucket. */
+  void tearDownBucket(String bucket);
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/OBSIntegrationTestRule.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/OBSIntegrationTestRule.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import com.obs.services.model.ListObjectsRequest;
+import com.obs.services.model.ObjectListing;
+import com.obs.services.model.ObsObject;
+import java.io.IOException;
+import org.apache.iceberg.huaweicloud.TestUtility;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class OBSIntegrationTestRule implements HuaweicloudOBSTestRule {
+  // Huaweicloud access key pair.
+  private String accessKeyId;
+  private String accessKeySecret;
+
+  // Huaweicloud OBS configure values.
+  private String obsEndpoint;
+  private String obsBucket;
+  private String obsKey;
+
+  private volatile IObsClient lazyClient = null;
+
+  @Override
+  public String testBucketName() {
+    return obsBucket;
+  }
+
+  @Override
+  public String keyPrefix() {
+    return obsKey;
+  }
+
+  @Override
+  public void start() {
+    this.accessKeyId = TestUtility.accessKeyId();
+    this.accessKeySecret = TestUtility.accessKeySecret();
+
+    this.obsEndpoint = TestUtility.obsEndpoint();
+    this.obsBucket = TestUtility.obsBucket();
+    this.obsKey = TestUtility.obsKey();
+  }
+
+  @Override
+  public void stop() throws IOException {
+    if (lazyClient != null) {
+      lazyClient.close();
+      lazyClient = null;
+    }
+  }
+
+  @Override
+  public IObsClient createOBSClient() {
+    Preconditions.checkNotNull(obsEndpoint, "OBS endpoint cannot be null");
+    Preconditions.checkNotNull(accessKeyId, "OBS access key id cannot be null");
+    Preconditions.checkNotNull(accessKeySecret, "OBS access secret cannot be null");
+
+    return new ObsClient(accessKeyId, accessKeySecret, obsEndpoint);
+  }
+
+  @Override
+  public void setUpBucket(String bucket) {
+    Preconditions.checkArgument(
+        obsClient().headBucket(bucket),
+        "Bucket %s does not exist, please create it firstly.",
+        bucket);
+  }
+
+  @Override
+  public void tearDownBucket(String bucket) {
+    int maxKeys = 200;
+    String nextContinuationToken = null;
+    ObjectListing objectListingResult;
+    do {
+      ListObjectsRequest listObjectsV2Request = new ListObjectsRequest(bucket);
+      listObjectsV2Request.setMaxKeys(maxKeys);
+      listObjectsV2Request.setPrefix(obsKey);
+      objectListingResult = obsClient().listObjects(listObjectsV2Request);
+      for (ObsObject s : objectListingResult.getObjects()) {
+        obsClient().deleteObject(bucket, s.getObjectKey());
+      }
+    } while (objectListingResult.isTruncated());
+  }
+
+  private IObsClient obsClient() {
+    if (lazyClient == null) {
+      synchronized (OBSIntegrationTestRule.class) {
+        if (lazyClient == null) {
+          lazyClient = createOBSClient();
+        }
+      }
+    }
+
+    return lazyClient;
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSFileIO.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSFileIO.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URISyntaxException;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.apache.iceberg.util.SerializationUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestOBSFileIO extends HuaweicloudOBSTestBase {
+  private static final String OBS_IMPL_CLASS = OBSFileIO.class.getName();
+  private final Configuration conf = new Configuration();
+  private final Random random = ThreadLocalRandom.current();
+
+  private FileIO fileIO;
+
+  @Before
+  public void beforeFile() {
+    fileIO = new OBSFileIO(obsClient());
+  }
+
+  @After
+  public void afterFile() {
+    if (fileIO != null) {
+      fileIO.close();
+    }
+  }
+
+  @Test
+  public void testOutputFile() throws IOException {
+    String location = randomLocation();
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+
+    OutputFile out = fileIO().newOutputFile(location);
+    writeOBSData(out, data);
+
+    OBSURI uri = new OBSURI(location);
+    Assert.assertTrue(
+        "OBS file should exist", obsClient().get().doesObjectExist(uri.bucket(), uri.key()));
+    Assert.assertEquals("Should have expected location", location, out.location());
+    Assert.assertEquals("Should have expected length", dataSize, obsDataLength(uri));
+    Assert.assertArrayEquals("Should have expected content", data, obsDataContent(uri, dataSize));
+  }
+
+  @Test
+  public void testInputFile() throws IOException {
+    String location = randomLocation();
+    InputFile in = fileIO().newInputFile(location);
+    Assert.assertFalse("OBS file should not exist", in.exists());
+
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+    OutputFile out = fileIO().newOutputFile(location);
+    writeOBSData(out, data);
+
+    Assert.assertTrue("OBS file should exist", in.exists());
+    Assert.assertEquals("Should have expected location", location, in.location());
+    Assert.assertEquals("Should have expected length", dataSize, in.getLength());
+    Assert.assertArrayEquals("Should have expected content", data, inFileContent(in, dataSize));
+  }
+
+  @Test
+  public void testDeleteFile() throws IOException {
+    String location = randomLocation();
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+    OutputFile out = fileIO().newOutputFile(location);
+    writeOBSData(out, data);
+
+    InputFile in = fileIO().newInputFile(location);
+    Assert.assertTrue("OBS file should exist", in.exists());
+    fileIO().deleteFile(in);
+    Assert.assertFalse("OBS file should not exist", fileIO().newInputFile(location).exists());
+  }
+
+  @Test
+  public void testLoadFileIO() {
+    FileIO file = CatalogUtil.loadFileIO(OBS_IMPL_CLASS, ImmutableMap.of(), conf);
+    Assert.assertTrue("Should be OBSFileIO", file instanceof OBSFileIO);
+
+    byte[] data = SerializationUtil.serializeToBytes(file);
+    FileIO expectedFileIO = SerializationUtil.deserializeFromBytes(data);
+    Assert.assertTrue(
+        "The deserialized FileIO should be OBSFileIO", expectedFileIO instanceof OBSFileIO);
+  }
+
+  @Test
+  public void serializeClient() throws URISyntaxException {
+    String endpoint = "iceberg-test-obs.huaweicloud.com";
+    String accessKeyId = UUID.randomUUID().toString();
+    String accessSecret = UUID.randomUUID().toString();
+    SerializableSupplier<IObsClient> pre = () -> new ObsClient(accessKeyId, accessSecret, endpoint);
+
+    byte[] data = SerializationUtil.serializeToBytes(pre);
+    SerializableSupplier<IObsClient> post = SerializationUtil.deserializeFromBytes(data);
+
+    IObsClient client = post.get();
+    Assert.assertTrue("Should be instance of obs client", client instanceof ObsClient);
+  }
+
+  private FileIO fileIO() {
+    return fileIO;
+  }
+
+  private String randomLocation() {
+    return location(String.format("%s.dat", UUID.randomUUID()));
+  }
+
+  private byte[] randomData(int size) {
+    byte[] data = new byte[size];
+    random.nextBytes(data);
+    return data;
+  }
+
+  private long obsDataLength(OBSURI uri) {
+    return obsClient().get().getObject(uri.bucket(), uri.key()).getMetadata().getContentLength();
+  }
+
+  private byte[] obsDataContent(OBSURI uri, int dataSize) throws IOException {
+    try (InputStream is = obsClient().get().getObject(uri.bucket(), uri.key()).getObjectContent()) {
+      byte[] actual = new byte[dataSize];
+      ByteStreams.readFully(is, actual);
+      return actual;
+    }
+  }
+
+  private void writeOBSData(OutputFile out, byte[] data) throws IOException {
+    try (OutputStream os = out.create();
+        InputStream is = new ByteArrayInputStream(data)) {
+      ByteStreams.copy(is, os);
+    }
+  }
+
+  private byte[] inFileContent(InputFile in, int dataSize) throws IOException {
+    try (InputStream is = in.newStream()) {
+      byte[] actual = new byte[dataSize];
+      ByteStreams.readFully(is, actual);
+      return actual;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSInputFile.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSInputFile.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.obs.services.IObsClient;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOBSInputFile extends HuaweicloudOBSTestBase {
+  private final IObsClient obsClient = obsClient().get();
+  private final IObsClient obsMock = mock(IObsClient.class, delegatesTo(obsClient));
+
+  private final HuaweicloudProperties huaweicloudProperties = new HuaweicloudProperties();
+  private final Random random = ThreadLocalRandom.current();
+
+  @Test
+  public void testReadFile() throws Exception {
+    OBSURI uri = randomURI();
+
+    int dataSize = 1024 * 1024 * 10;
+    byte[] data = randomData(dataSize);
+    writeOBSData(uri, data);
+
+    readAndVerify(uri, data);
+  }
+
+  @Test
+  public void testOBSInputFile() {
+    OBSURI uri = randomURI();
+    AssertHelpers.assertThrows(
+        "File length should not be negative",
+        ValidationException.class,
+        "Invalid file length",
+        () ->
+            new OBSInputFile(
+                obsClient().get(), uri, huaweicloudProperties, -1, MetricsContext.nullMetrics()));
+  }
+
+  @Test
+  public void testExists() {
+    OBSURI uri = randomURI();
+
+    InputFile inputFile =
+        new OBSInputFile(obsMock, uri, huaweicloudProperties, MetricsContext.nullMetrics());
+    Assert.assertFalse("OBS file should not exist", inputFile.exists());
+    verify(obsMock, times(1)).getObjectMetadata(uri.bucket(), uri.key());
+    reset(obsMock);
+
+    int dataSize = 1024;
+    byte[] data = randomData(dataSize);
+    writeOBSData(uri, data);
+
+    Assert.assertTrue("OBS file should exist", inputFile.exists());
+    inputFile.exists();
+    verify(obsMock, times(1)).getObjectMetadata(uri.bucket(), uri.key());
+    reset(obsMock);
+  }
+
+  @Test
+  public void testGetLength() {
+    OBSURI uri = randomURI();
+
+    int dataSize = 8;
+    byte[] data = randomData(dataSize);
+    writeOBSData(uri, data);
+
+    verifyLength(obsMock, uri, data, true);
+    verify(obsMock, times(0)).getObjectMetadata(uri.bucket(), uri.key());
+    reset(obsMock);
+
+    verifyLength(obsMock, uri, data, false);
+    verify(obsMock, times(1)).getObjectMetadata(uri.bucket(), uri.key());
+    reset(obsMock);
+  }
+
+  private void readAndVerify(OBSURI uri, byte[] data) throws IOException {
+    InputFile inputFile =
+        new OBSInputFile(
+            obsClient().get(), uri, huaweicloudProperties, MetricsContext.nullMetrics());
+    Assert.assertTrue("OBS file should exist", inputFile.exists());
+    Assert.assertEquals("Should have expected file length", data.length, inputFile.getLength());
+
+    byte[] actual = new byte[data.length];
+    try (SeekableInputStream in = inputFile.newStream()) {
+      ByteStreams.readFully(in, actual);
+    }
+    Assert.assertArrayEquals("Should have same object content", data, actual);
+  }
+
+  private void verifyLength(IObsClient obsClientMock, OBSURI uri, byte[] data, boolean isCache) {
+    InputFile inputFile;
+    if (isCache) {
+      inputFile =
+          new OBSInputFile(
+              obsClientMock, uri, huaweicloudProperties, data.length, MetricsContext.nullMetrics());
+    } else {
+      inputFile =
+          new OBSInputFile(obsClientMock, uri, huaweicloudProperties, MetricsContext.nullMetrics());
+    }
+    inputFile.getLength();
+    Assert.assertEquals("Should have expected file length", data.length, inputFile.getLength());
+  }
+
+  private OBSURI randomURI() {
+    return new OBSURI(location(String.format("%s.dat", UUID.randomUUID())));
+  }
+
+  private byte[] randomData(int size) {
+    byte[] data = new byte[size];
+    random.nextBytes(data);
+    return data;
+  }
+
+  private void writeOBSData(OBSURI uri, byte[] data) {
+    obsClient.putObject(uri.bucket(), uri.key(), new ByteArrayInputStream(data));
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSInputStream.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSInputStream.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import static org.apache.iceberg.AssertHelpers.assertThrows;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.junit.Test;
+
+public class TestOBSInputStream extends HuaweicloudOBSTestBase {
+  private final Random random = ThreadLocalRandom.current();
+
+  @Test
+  public void testRead() throws Exception {
+    OBSURI uri = new OBSURI(location("read.dat"));
+    int dataSize = 1024 * 1024 * 10;
+    byte[] data = randomData(dataSize);
+
+    writeOBSData(uri, data);
+
+    try (SeekableInputStream in = new OBSInputStream(obsClient().get(), uri)) {
+      int readSize = 1024;
+
+      readAndCheck(in, in.getPos(), readSize, data, false);
+      readAndCheck(in, in.getPos(), readSize, data, true);
+
+      // Seek forward in current stream
+      int seekSize = 1024;
+      readAndCheck(in, in.getPos() + seekSize, readSize, data, false);
+      readAndCheck(in, in.getPos() + seekSize, readSize, data, true);
+
+      // Buffered read
+      readAndCheck(in, in.getPos(), readSize, data, true);
+      readAndCheck(in, in.getPos(), readSize, data, false);
+
+      // Seek with new stream
+      long seekNewStreamPosition = 2 * 1024 * 1024;
+      readAndCheck(in, in.getPos() + seekNewStreamPosition, readSize, data, true);
+      readAndCheck(in, in.getPos() + seekNewStreamPosition, readSize, data, false);
+
+      // Backseek and read
+      readAndCheck(in, 0, readSize, data, true);
+      readAndCheck(in, 0, readSize, data, false);
+    }
+  }
+
+  private void readAndCheck(
+      SeekableInputStream in, long rangeStart, int size, byte[] original, boolean buffered)
+      throws IOException {
+    in.seek(rangeStart);
+    assertEquals("Should have the correct position", rangeStart, in.getPos());
+
+    long rangeEnd = rangeStart + size;
+    byte[] actual = new byte[size];
+
+    if (buffered) {
+      ByteStreams.readFully(in, actual);
+    } else {
+      int read = 0;
+      while (read < size) {
+        actual[read++] = (byte) in.read();
+      }
+    }
+
+    assertEquals("Should have the correct position", rangeEnd, in.getPos());
+
+    assertArrayEquals(
+        "Should have expected range data",
+        Arrays.copyOfRange(original, (int) rangeStart, (int) rangeEnd),
+        actual);
+  }
+
+  @Test
+  public void testClose() throws Exception {
+    OBSURI uri = new OBSURI(location("closed.dat"));
+    SeekableInputStream closed = new OBSInputStream(obsClient().get(), uri);
+    closed.close();
+    assertThrows(
+        "Cannot seek the input stream after closed.",
+        IllegalStateException.class,
+        "Cannot seek: already closed",
+        () -> {
+          closed.seek(0);
+          return null;
+        });
+  }
+
+  @Test
+  public void testSeek() throws Exception {
+    OBSURI uri = new OBSURI(location("seek.dat"));
+    byte[] expected = randomData(1024 * 1024);
+
+    writeOBSData(uri, expected);
+
+    try (SeekableInputStream in = new OBSInputStream(obsClient().get(), uri)) {
+      in.seek(expected.length / 2);
+      byte[] actual = new byte[expected.length / 2];
+      ByteStreams.readFully(in, actual);
+      assertArrayEquals(
+          "Should have expected seeking stream",
+          Arrays.copyOfRange(expected, expected.length / 2, expected.length),
+          actual);
+    }
+  }
+
+  private byte[] randomData(int size) {
+    byte[] data = new byte[size];
+    random.nextBytes(data);
+    return data;
+  }
+
+  private void writeOBSData(OBSURI uri, byte[] data) {
+    obsClient().get().putObject(uri.bucket(), uri.key(), new ByteArrayInputStream(data));
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSOutputFile.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSOutputFile.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import com.obs.services.IObsClient;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOBSOutputFile extends HuaweicloudOBSTestBase {
+
+  private final IObsClient obsClient = obsClient().get();
+  private final Random random = ThreadLocalRandom.current();
+  private final HuaweicloudProperties huaweicloudProperties = new HuaweicloudProperties();
+
+  @Test
+  public void testWriteFile() throws IOException {
+    OBSURI uri = randomURI();
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+
+    OutputFile out = OBSOutputFile.fromLocation(obsClient, uri.location(), huaweicloudProperties);
+    try (OutputStream os = out.create();
+        InputStream is = new ByteArrayInputStream(data)) {
+      ByteStreams.copy(is, os);
+    }
+
+    Assert.assertTrue("OBS file should exist", obsClient.doesObjectExist(uri.bucket(), uri.key()));
+    Assert.assertEquals("Object length should match", obsDataLength(uri), dataSize);
+
+    byte[] actual = obsDataContent(uri, dataSize);
+    Assert.assertArrayEquals("Object content should match", data, actual);
+  }
+
+  @Test
+  public void testFromLocation() {
+    AssertHelpers.assertThrows(
+        "Should catch null location when creating obs output file",
+        NullPointerException.class,
+        "location cannot be null",
+        () -> OBSOutputFile.fromLocation(obsClient, null, huaweicloudProperties));
+  }
+
+  @Test
+  public void testCreate() {
+    OBSURI uri = randomURI();
+    int dataSize = 8;
+    byte[] data = randomData(dataSize);
+
+    writeOBSData(uri, data);
+
+    OutputFile out = OBSOutputFile.fromLocation(obsClient, uri.location(), huaweicloudProperties);
+    AssertHelpers.assertThrows(
+        "Should complain about location already exists",
+        AlreadyExistsException.class,
+        "Location already exists",
+        out::create);
+  }
+
+  @Test
+  public void testCreateOrOverwrite() throws IOException {
+    OBSURI uri = randomURI();
+    int dataSize = 8;
+    byte[] data = randomData(dataSize);
+
+    writeOBSData(uri, data);
+
+    int expectSize = 1024;
+    byte[] expect = randomData(expectSize);
+
+    OutputFile out = OBSOutputFile.fromLocation(obsClient, uri.location(), huaweicloudProperties);
+    try (OutputStream os = out.createOrOverwrite();
+        InputStream is = new ByteArrayInputStream(expect)) {
+      ByteStreams.copy(is, os);
+    }
+
+    Assert.assertEquals(
+        String.format("Should overwrite object length from %d to %d", dataSize, expectSize),
+        expectSize,
+        obsDataLength(uri));
+
+    byte[] actual = obsDataContent(uri, expectSize);
+    Assert.assertArrayEquals("Should overwrite object content", expect, actual);
+  }
+
+  @Test
+  public void testLocation() {
+    OBSURI uri = randomURI();
+    OutputFile out =
+        new OBSOutputFile(obsClient, uri, huaweicloudProperties, MetricsContext.nullMetrics());
+    Assert.assertEquals("Location should match", uri.location(), out.location());
+  }
+
+  @Test
+  public void testToInputFile() throws IOException {
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+
+    OutputFile out =
+        new OBSOutputFile(
+            obsClient, randomURI(), huaweicloudProperties, MetricsContext.nullMetrics());
+    try (OutputStream os = out.create();
+        InputStream is = new ByteArrayInputStream(data)) {
+      ByteStreams.copy(is, os);
+    }
+
+    InputFile in = out.toInputFile();
+    Assert.assertTrue("Should be an instance of OBSInputFile", in instanceof OBSInputFile);
+    Assert.assertTrue("OBS file should exist", in.exists());
+    Assert.assertEquals("Should have expected location", out.location(), in.location());
+    Assert.assertEquals("Should have expected length", dataSize, in.getLength());
+
+    byte[] actual = new byte[dataSize];
+    try (InputStream as = in.newStream()) {
+      ByteStreams.readFully(as, actual);
+    }
+    Assert.assertArrayEquals("Should have expected content", data, actual);
+  }
+
+  private OBSURI randomURI() {
+    return new OBSURI(location(String.format("%s.dat", UUID.randomUUID())));
+  }
+
+  private byte[] randomData(int size) {
+    byte[] data = new byte[size];
+    random.nextBytes(data);
+    return data;
+  }
+
+  private void writeOBSData(OBSURI uri, byte[] data) {
+    obsClient.putObject(uri.bucket(), uri.key(), new ByteArrayInputStream(data));
+  }
+
+  private long obsDataLength(OBSURI uri) {
+    return obsClient.getObject(uri.bucket(), uri.key()).getMetadata().getContentLength();
+  }
+
+  private byte[] obsDataContent(OBSURI uri, int dataSize) throws IOException {
+    try (InputStream is = obsClient.getObject(uri.bucket(), uri.key()).getObjectContent()) {
+      byte[] actual = new byte[dataSize];
+      ByteStreams.readFully(is, actual);
+      return actual;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSOutputStream.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSOutputStream.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.huaweicloud.HuaweicloudProperties;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestOBSOutputStream extends HuaweicloudOBSTestBase {
+  private static final Logger LOG = LoggerFactory.getLogger(TestOBSOutputStream.class);
+
+  private final IObsClient obsClient = obsClient().get();
+  private final IObsClient obsMock = mock(ObsClient.class, delegatesTo(obsClient));
+
+  private final Path tmpDir = Files.createTempDirectory("obs-file-io-test-");
+  private static final Random random = ThreadLocalRandom.current();
+
+  private final HuaweicloudProperties props =
+      new HuaweicloudProperties(
+          ImmutableMap.of(HuaweicloudProperties.OBS_STAGING_DIRECTORY, tmpDir.toString()));
+
+  public TestOBSOutputStream() throws IOException {}
+
+  @Test
+  public void testWrite() throws IOException {
+    OBSURI uri = randomURI();
+
+    for (int i = 0; i < 2; i++) {
+      boolean arrayWrite = i % 2 == 0;
+      // Write small file.
+      writeAndVerify(obsMock, uri, data256(), arrayWrite);
+      verify(obsMock, times(1)).putObject(any());
+      reset(obsMock);
+
+      // Write large file.
+      writeAndVerify(obsMock, uri, randomData(32 * 1024 * 1024), arrayWrite);
+      verify(obsMock, times(1)).putObject(any());
+      reset(obsMock);
+    }
+  }
+
+  private void writeAndVerify(IObsClient mock, OBSURI uri, byte[] data, boolean arrayWrite)
+      throws IOException {
+    LOG.info(
+        "Write and verify for arguments uri: {}, data length: {}, arrayWrite: {}",
+        uri,
+        data.length,
+        arrayWrite);
+
+    try (OBSOutputStream out =
+        new OBSOutputStream(mock, uri, props, MetricsContext.nullMetrics())) {
+      if (arrayWrite) {
+        out.write(data);
+        Assert.assertEquals("OBSOutputStream position", data.length, out.getPos());
+      } else {
+        for (int i = 0; i < data.length; i++) {
+          out.write(data[i]);
+          Assert.assertEquals("OBSOutputStream position", i + 1, out.getPos());
+        }
+      }
+    }
+
+    Assert.assertTrue(
+        "OBS object should exist", obsClient.doesObjectExist(uri.bucket(), uri.key()));
+    Assert.assertEquals(
+        "Object length",
+        obsClient.getObject(uri.bucket(), uri.key()).getMetadata().getContentLength().longValue(),
+        data.length);
+
+    byte[] actual = obsDataContent(uri, data.length);
+    Assert.assertArrayEquals("Object content", data, actual);
+
+    // Verify all staging files are cleaned up.
+    Assert.assertEquals(
+        "Staging files should clean up",
+        0,
+        Files.list(Paths.get(props.obsStagingDirectory())).count());
+  }
+
+  private OBSURI randomURI() {
+    return new OBSURI(location(String.format("%s.dat", UUID.randomUUID())));
+  }
+
+  private byte[] data256() {
+    byte[] data = new byte[256];
+    for (int i = 0; i < 256; i++) {
+      data[i] = (byte) i;
+    }
+    return data;
+  }
+
+  private byte[] randomData(int size) {
+    byte[] data = new byte[size];
+    random.nextBytes(data);
+    return data;
+  }
+
+  private byte[] obsDataContent(OBSURI uri, int dataSize) throws IOException {
+    try (InputStream is = obsClient.getObject(uri.bucket(), uri.key()).getObjectContent()) {
+      byte[] actual = new byte[dataSize];
+      ByteStreams.readFully(is, actual);
+      return actual;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSURI.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/TestOBSURI.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestOBSURI {
+
+  @Test
+  public void testUrlParsing() {
+    String location = "obs://bucket/path/to/file";
+    OBSURI uri = new OBSURI(location);
+
+    Assert.assertEquals("bucket", uri.bucket());
+    Assert.assertEquals("path/to/file", uri.key());
+    Assert.assertEquals(location, uri.toString());
+  }
+
+  @Test
+  public void testEncodedString() {
+    String location = "obs://bucket/path%20to%20file";
+    OBSURI uri = new OBSURI(location);
+
+    Assert.assertEquals("bucket", uri.bucket());
+    Assert.assertEquals("path%20to%20file", uri.key());
+    Assert.assertEquals(location, uri.toString());
+  }
+
+  @Test
+  public void missingKey() {
+    AssertHelpers.assertThrows(
+        "Missing key",
+        ValidationException.class,
+        "Missing key in OBS location",
+        () -> new OBSURI("https://bucket/"));
+  }
+
+  @Test
+  public void relativePathing() {
+    AssertHelpers.assertThrows(
+        "Cannot use relative obs location.",
+        ValidationException.class,
+        "Invalid OBS location",
+        () -> new OBSURI("/path/to/file"));
+  }
+
+  @Test
+  public void invalidScheme() {
+    AssertHelpers.assertThrows(
+        "Only support scheme: obs/https",
+        ValidationException.class,
+        "Invalid scheme",
+        () -> new OBSURI("invalid://bucket/"));
+  }
+
+  @Test
+  public void testFragment() {
+    String location = "obs://bucket/path/to/file#print";
+    OBSURI uri = new OBSURI(location);
+
+    Assert.assertEquals("bucket", uri.bucket());
+    Assert.assertEquals("path/to/file", uri.key());
+    Assert.assertEquals(location, uri.toString());
+  }
+
+  @Test
+  public void testQueryAndFragment() {
+    String location = "obs://bucket/path/to/file?query=foo#bar";
+    OBSURI uri = new OBSURI(location);
+
+    assertEquals("bucket", uri.bucket());
+    assertEquals("path/to/file", uri.key());
+    assertEquals(location, uri.toString());
+  }
+
+  @Test
+  public void testValidSchemes() {
+    for (String scheme : Lists.newArrayList("https", "obs")) {
+      OBSURI uri = new OBSURI(scheme + "://bucket/path/to/file");
+      assertEquals("bucket", uri.bucket());
+      assertEquals("path/to/file", uri.key());
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockApp.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockApp.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@SuppressWarnings("checkstyle:AnnotationUseStyle")
+@Configuration
+@EnableAutoConfiguration(
+    exclude = {SecurityAutoConfiguration.class},
+    excludeName = {
+      "org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration"
+    })
+@ComponentScan
+public class HuaweicloudOBSMockApp {
+  private static final Logger LOG = LoggerFactory.getLogger(HuaweicloudOBSMockApp.class);
+
+  static final String PROP_ROOT_DIR = "root-dir";
+
+  static final String PROP_HTTP_PORT = "server.port";
+  static final int PORT_HTTP_PORT_DEFAULT = 9394;
+
+  static final String PROP_SILENT = "silent";
+
+  @Autowired private ConfigurableApplicationContext context;
+
+  public static HuaweicloudOBSMockApp start(Map<String, Object> properties, String... args) {
+    LOG.info("HuaweicloudOBSMockApp is starting");
+
+    Map<String, Object> defaults = Maps.newHashMap();
+    defaults.put(PROP_HTTP_PORT, PORT_HTTP_PORT_DEFAULT);
+
+    Banner.Mode bannerMode = Banner.Mode.CONSOLE;
+
+    if (Boolean.parseBoolean(String.valueOf(properties.remove(PROP_SILENT)))) {
+      defaults.put("logging.level.root", "WARN");
+      bannerMode = Banner.Mode.OFF;
+    }
+
+    final ConfigurableApplicationContext ctx =
+        new SpringApplicationBuilder(HuaweicloudOBSMockApp.class)
+            .properties(defaults)
+            .properties(properties)
+            .bannerMode(bannerMode)
+            .run(args);
+
+    return ctx.getBean(HuaweicloudOBSMockApp.class);
+  }
+
+  public void stop() {
+    SpringApplication.exit(context, () -> 0);
+  }
+
+  @Configuration
+  static class Config implements WebMvcConfigurer {
+
+    @Bean
+    Converter<String, Range> rangeConverter() {
+      return new RangeConverter();
+    }
+
+    /**
+     * Creates an HttpMessageConverter for XML.
+     *
+     * @return The configured {@link MappingJackson2XmlHttpMessageConverter}.
+     */
+    @Bean
+    public MappingJackson2XmlHttpMessageConverter getMessageConverter() {
+      List<MediaType> mediaTypes = Lists.newArrayList();
+      mediaTypes.add(MediaType.APPLICATION_XML);
+      mediaTypes.add(MediaType.APPLICATION_FORM_URLENCODED);
+      mediaTypes.add(MediaType.APPLICATION_OCTET_STREAM);
+
+      final MappingJackson2XmlHttpMessageConverter xmlConverter =
+          new MappingJackson2XmlHttpMessageConverter();
+      xmlConverter.setSupportedMediaTypes(mediaTypes);
+
+      return xmlConverter;
+    }
+  }
+
+  private static class RangeConverter implements Converter<String, Range> {
+
+    private static final Pattern REQUESTED_RANGE_PATTERN =
+        Pattern.compile("^bytes=((\\d*)-(\\d*))((,\\d*-\\d*)*)");
+
+    @Override
+    public Range convert(String rangeString) {
+      Preconditions.checkNotNull(rangeString, "Range value should not be null.");
+
+      final Range range;
+
+      // parsing a range specification of format: "bytes=start-end" - multiple ranges not supported
+      final Matcher matcher = REQUESTED_RANGE_PATTERN.matcher(rangeString.trim());
+      if (matcher.matches()) {
+        final String rangeStart = matcher.group(2);
+        final String rangeEnd = matcher.group(3);
+
+        long start = StringUtils.isEmpty(rangeStart) ? -1L : Long.parseLong(rangeStart);
+        long end = StringUtils.isEmpty(rangeEnd) ? Long.MAX_VALUE : Long.parseLong(rangeEnd);
+        range = new Range(start, end);
+
+        if (matcher.groupCount() == 5 && !"".equals(matcher.group(4))) {
+          throw new IllegalArgumentException(
+              "Unsupported range specification. Only single range specifications allowed");
+        }
+        if (range.start() != -1 && range.start() < 0) {
+          throw new IllegalArgumentException(
+              "Unsupported range specification. A start byte must be supplied");
+        }
+
+        if (range.end() != -1 && range.end() < range.start()) {
+          throw new IllegalArgumentException(
+              "Range header is malformed. End byte is smaller than start byte.");
+        }
+      } else {
+        // Per huaweicloud OBS behavior, return whole object content for illegal header
+        range = new Range(0, Long.MAX_VALUE);
+      }
+
+      return range;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockLocalController.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockLocalController.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
+import static org.springframework.http.HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.obs.services.model.ObsBucket;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestController
+public class HuaweicloudOBSMockLocalController {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(HuaweicloudOBSMockLocalController.class);
+
+  @Autowired private HuaweicloudOBSMockLocalStore localStore;
+
+  private static String filenameFrom(@PathVariable String bucketName, HttpServletRequest request) {
+    String requestUri = request.getRequestURI();
+    return requestUri.substring(requestUri.indexOf(bucketName) + bucketName.length() + 1);
+  }
+
+  @RequestMapping(value = "/{bucketName}", method = RequestMethod.PUT, produces = "application/xml")
+  public void putBucket(@PathVariable String bucketName) throws IOException {
+    if (localStore.getBucket(bucketName) != null) {
+      throw new ObsException(
+          409, OBSErrorCode.BUCKET_ALREADY_EXISTS, bucketName + " already exists.");
+    }
+
+    localStore.createBucket(bucketName);
+  }
+
+  @RequestMapping(
+      value = "/{bucketName}",
+      method = RequestMethod.DELETE,
+      produces = "application/xml")
+  public void deleteBucket(@PathVariable String bucketName) throws IOException {
+    verifyBucketExistence(bucketName);
+
+    localStore.deleteBucket(bucketName);
+  }
+
+  @RequestMapping(value = "/{bucketName:.+}/**", method = RequestMethod.PUT)
+  public ResponseEntity<String> putObject(
+      @PathVariable String bucketName, HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+    String filename = filenameFrom(bucketName, request);
+    try (ServletInputStream inputStream = request.getInputStream()) {
+      ObjectMetadata metadata =
+          localStore.putObject(
+              bucketName,
+              filename,
+              inputStream,
+              request.getContentType(),
+              request.getHeader(HttpHeaders.CONTENT_ENCODING),
+              ImmutableMap.of());
+
+      HttpHeaders responseHeaders = new HttpHeaders();
+      responseHeaders.setETag("\"" + metadata.getContentMD5() + "\"");
+      responseHeaders.setLastModified(metadata.getLastModificationDate());
+
+      return new ResponseEntity<>(responseHeaders, OK);
+    } catch (Exception e) {
+      LOG.error("Failed to put object - bucket: {} - object: {}", bucketName, filename, e);
+      return new ResponseEntity<>(e.getMessage(), INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @RequestMapping(value = "/{bucketName:.+}/**", method = RequestMethod.DELETE)
+  public void deleteObject(@PathVariable String bucketName, HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+
+    localStore.deleteObject(bucketName, filenameFrom(bucketName, request));
+  }
+
+  @RequestMapping(value = "/{bucketName:.+}/**", method = RequestMethod.HEAD)
+  public ResponseEntity<String> getObjectMeta(
+      @PathVariable String bucketName, HttpServletRequest request) {
+    verifyBucketExistence(bucketName);
+    ObjectMetadata metadata = verifyObjectExistence(bucketName, filenameFrom(bucketName, request));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setETag("\"" + metadata.getContentMD5() + "\"");
+    headers.setLastModified(metadata.getLastModificationDate());
+    headers.setContentLength(metadata.getContentLength());
+
+    return new ResponseEntity<>(headers, OK);
+  }
+
+  @SuppressWarnings("checkstyle:AnnotationUseStyle")
+  @RequestMapping(
+      value = "/{bucketName:.+}/**",
+      method = RequestMethod.GET,
+      produces = "application/xml")
+  public void getObject(
+      @PathVariable String bucketName,
+      @RequestHeader(value = "Range", required = false) Range range,
+      HttpServletRequest request,
+      HttpServletResponse response)
+      throws IOException {
+    verifyBucketExistence(bucketName);
+
+    String filename = filenameFrom(bucketName, request);
+    ObjectMetadata metadata = verifyObjectExistence(bucketName, filename);
+
+    if (range != null) {
+      long fileSize = metadata.getContentLength();
+      long bytesToRead = Math.min(fileSize - 1, range.end()) - range.start() + 1;
+      long skipSize = range.start();
+      if (range.start() == -1) {
+        bytesToRead = Math.min(fileSize - 1, range.end());
+        skipSize = fileSize - range.end();
+      }
+      if (range.end() == -1) {
+        bytesToRead = fileSize - range.start();
+      }
+      if (bytesToRead < 0 || fileSize < range.start()) {
+        response.setStatus(REQUESTED_RANGE_NOT_SATISFIABLE.value());
+        response.flushBuffer();
+        return;
+      }
+
+      response.setStatus(PARTIAL_CONTENT.value());
+      response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
+      response.setHeader(
+          HttpHeaders.CONTENT_RANGE,
+          String.format(
+              "bytes %s-%s/%s",
+              range.start(), bytesToRead + range.start() + 1, metadata.getContentLength()));
+      response.setHeader(HttpHeaders.ETAG, "\"" + metadata.getContentMD5() + "\"");
+      response.setDateHeader(HttpHeaders.LAST_MODIFIED, metadata.getLastModificationDate());
+      response.setContentType(metadata.getContentType());
+      response.setContentLengthLong(bytesToRead);
+
+      try (OutputStream outputStream = response.getOutputStream()) {
+        try (FileInputStream fis = new FileInputStream(metadata.getDataFile())) {
+          fis.skip(skipSize);
+          ByteStreams.copy(new BoundedInputStream(fis, bytesToRead), outputStream);
+        }
+      }
+    } else {
+      response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
+      response.setHeader(HttpHeaders.ETAG, "\"" + metadata.getContentMD5() + "\"");
+      response.setDateHeader(HttpHeaders.LAST_MODIFIED, metadata.getLastModificationDate());
+      response.setContentType(metadata.getContentType());
+      response.setContentLengthLong(metadata.getContentLength());
+
+      try (OutputStream outputStream = response.getOutputStream()) {
+        try (FileInputStream fis = new FileInputStream(metadata.getDataFile())) {
+          ByteStreams.copy(fis, outputStream);
+        }
+      }
+    }
+  }
+
+  private void verifyBucketExistence(String bucketName) {
+    ObsBucket bucket = localStore.getBucket(bucketName);
+    if (bucket == null) {
+      throw new ObsException(
+          404, OBSErrorCode.NO_SUCH_BUCKET, "The specified bucket does not exist. ");
+    }
+  }
+
+  private ObjectMetadata verifyObjectExistence(String bucketName, String filename) {
+    ObjectMetadata objectMetadata = null;
+    try {
+      objectMetadata = localStore.getObjectMetadata(bucketName, filename);
+    } catch (IOException e) {
+      LOG.error(
+          "Failed to get the object metadata, bucket: {}, object: {}.", bucketName, filename, e);
+    }
+
+    if (objectMetadata == null) {
+      throw new ObsException(404, OBSErrorCode.NO_SUCH_KEY, "The specify obs key does not exists.");
+    }
+
+    return objectMetadata;
+  }
+
+  @ControllerAdvice
+  public static class OBSMockExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleOBSException(ObsException ex) {
+      LOG.info("Responding with status {} - {}, {}", ex.status, ex.code, ex.message);
+
+      ErrorResponse errorResponse = new ErrorResponse();
+      errorResponse.setCode(ex.getCode());
+      errorResponse.setMessage(ex.getMessage());
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_XML);
+
+      return ResponseEntity.status(ex.status).headers(headers).body(errorResponse);
+    }
+  }
+
+  public static class ObsException extends RuntimeException {
+
+    private final int status;
+    private final String code;
+    private final String message;
+
+    public ObsException(final int status, final String code, final String message) {
+      super(message);
+      this.status = status;
+      this.code = code;
+      this.message = message;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    @Override
+    public String getMessage() {
+      return message;
+    }
+  }
+
+  @JsonRootName("Error")
+  public static class ErrorResponse {
+    @JsonProperty("Code")
+    private String code;
+
+    @JsonProperty("Message")
+    private String message;
+
+    public void setCode(String code) {
+      this.code = code;
+    }
+
+    public void setMessage(String message) {
+      this.message = message;
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockLocalStore.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockLocalStore.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.obs.services.model.ObsBucket;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.directory.api.util.Hex;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HuaweicloudOBSMockLocalStore {
+  private static final Logger LOG = LoggerFactory.getLogger(HuaweicloudOBSMockLocalStore.class);
+
+  private static final String DATA_FILE = ".DATA";
+  private static final String META_FILE = ".META";
+
+  private final File root;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  public HuaweicloudOBSMockLocalStore(
+      @Value("${" + HuaweicloudOBSMockApp.PROP_ROOT_DIR + ":}") String rootDir) {
+    Preconditions.checkNotNull(rootDir, "Root directory cannot be null");
+    this.root = new File(rootDir);
+
+    root.deleteOnExit();
+    root.mkdirs();
+
+    LOG.info("Root directory of local OBS store is {}", root);
+  }
+
+  static String md5sum(String filepath) throws IOException {
+    try (InputStream is = new FileInputStream(filepath)) {
+      return md5sum(is);
+    }
+  }
+
+  static String md5sum(InputStream is) throws IOException {
+    MessageDigest md;
+    try {
+      md = MessageDigest.getInstance("MD5");
+      md.reset();
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    byte[] bytes = new byte[1024];
+    int numBytes;
+
+    while ((numBytes = is.read(bytes)) != -1) {
+      md.update(bytes, 0, numBytes);
+    }
+    return new String(Hex.encodeHex(md.digest())).toUpperCase(Locale.ROOT);
+  }
+
+  private static void inputStreamToFile(InputStream inputStream, File targetFile)
+      throws IOException {
+    try (OutputStream outputStream = new FileOutputStream(targetFile)) {
+      ByteStreams.copy(inputStream, outputStream);
+    }
+  }
+
+  void createBucket(String bucketName) throws IOException {
+    File newBucket = new File(root, bucketName);
+    FileUtils.forceMkdir(newBucket);
+  }
+
+  ObsBucket getBucket(String bucketName) {
+    List<ObsBucket> buckets =
+        findBucketsByFilter(
+            file -> Files.isDirectory(file) && file.getFileName().endsWith(bucketName));
+
+    return buckets.size() > 0 ? buckets.get(0) : null;
+  }
+
+  void deleteBucket(String bucketName) throws IOException {
+    ObsBucket bucket = getBucket(bucketName);
+    Preconditions.checkNotNull(bucket, "Bucket %s shouldn't be null.", bucketName);
+
+    File dir = new File(root, bucket.getBucketName());
+    if (Files.walk(dir.toPath()).anyMatch(p -> p.toFile().isFile())) {
+      throw new HuaweicloudOBSMockLocalController.ObsException(
+          409, OBSErrorCode.BUCKET_NOT_EMPTY, "The bucket you tried to delete is not empty. ");
+    }
+
+    FileUtils.deleteDirectory(dir);
+  }
+
+  ObjectMetadata putObject(
+      String bucketName,
+      String fileName,
+      InputStream dataStream,
+      String contentType,
+      String contentEncoding,
+      Map<String, String> userMetaData)
+      throws IOException {
+    File bucketDir = new File(root, bucketName);
+    assert bucketDir.exists() || bucketDir.mkdirs();
+
+    File dataFile = new File(bucketDir, fileName + DATA_FILE);
+    File metaFile = new File(bucketDir, fileName + META_FILE);
+    if (!dataFile.exists()) {
+      dataFile.getParentFile().mkdirs();
+      dataFile.createNewFile();
+    }
+
+    inputStreamToFile(dataStream, dataFile);
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentLength(dataFile.length());
+    metadata.setContentMD5(md5sum(dataFile.getAbsolutePath()));
+    metadata.setContentType(
+        contentType != null ? contentType : MediaType.APPLICATION_OCTET_STREAM_VALUE);
+    metadata.setContentEncoding(contentEncoding);
+    metadata.setDataFile(dataFile.getAbsolutePath());
+    metadata.setMetaFile(metaFile.getAbsolutePath());
+
+    BasicFileAttributes attributes =
+        Files.readAttributes(dataFile.toPath(), BasicFileAttributes.class);
+    metadata.setLastModificationDate(attributes.lastModifiedTime().toMillis());
+
+    metadata.setUserMetaData(userMetaData);
+
+    objectMapper.writeValue(metaFile, metadata);
+
+    return metadata;
+  }
+
+  void deleteObject(String bucketName, String filename) {
+    File bucketDir = new File(root, bucketName);
+    assert bucketDir.exists();
+
+    File dataFile = new File(bucketDir, filename + DATA_FILE);
+    File metaFile = new File(bucketDir, filename + META_FILE);
+    assert !dataFile.exists() || dataFile.delete();
+    assert !metaFile.exists() || metaFile.delete();
+  }
+
+  ObjectMetadata getObjectMetadata(String bucketName, String filename) throws IOException {
+    File bucketDir = new File(root, bucketName);
+    assert bucketDir.exists();
+
+    File dataFile = new File(bucketDir, filename + DATA_FILE);
+    if (!dataFile.exists()) {
+      return null;
+    }
+
+    File metaFile = new File(bucketDir, filename + META_FILE);
+    return objectMapper.readValue(metaFile, ObjectMetadata.class);
+  }
+
+  private List<ObsBucket> findBucketsByFilter(final DirectoryStream.Filter<Path> filter) {
+    List<ObsBucket> buckets = Lists.newArrayList();
+
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(root.toPath(), filter)) {
+      for (final Path path : stream) {
+        buckets.add(new ObsBucket(path.getFileName().toString(), ""));
+      }
+    } catch (final IOException e) {
+      LOG.error("Could not iterate over Bucket-Folders", e);
+    }
+
+    return buckets;
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockRule.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/HuaweicloudOBSMockRule.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import com.obs.services.IObsClient;
+import com.obs.services.ObsClient;
+import com.obs.services.ObsConfiguration;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.iceberg.huaweicloud.obs.HuaweicloudOBSTestRule;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class HuaweicloudOBSMockRule implements HuaweicloudOBSTestRule {
+
+  private final Map<String, Object> properties;
+
+  private HuaweicloudOBSMockApp obsMockApp;
+
+  private HuaweicloudOBSMockRule(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public String keyPrefix() {
+    return "mock-objects-";
+  }
+
+  @Override
+  public void start() {
+    obsMockApp = HuaweicloudOBSMockApp.start(properties);
+  }
+
+  @Override
+  public void stop() {
+    obsMockApp.stop();
+  }
+
+  @Override
+  public IObsClient createOBSClient() {
+    String endpoint =
+        String.format(
+            "http://localhost:%s",
+            properties.getOrDefault(
+                HuaweicloudOBSMockApp.PROP_HTTP_PORT,
+                HuaweicloudOBSMockApp.PORT_HTTP_PORT_DEFAULT));
+    ObsConfiguration config = new ObsConfiguration();
+    config.setEndPoint(endpoint);
+    config.setPathStyle(true);
+    return new ObsClient("foo", "bar", config);
+  }
+
+  private File rootDir() {
+    Object rootDir = properties.get(HuaweicloudOBSMockApp.PROP_ROOT_DIR);
+    Preconditions.checkNotNull(rootDir, "Root directory cannot be null");
+    return new File(rootDir.toString());
+  }
+
+  @Override
+  public void setUpBucket(String bucket) {
+    createOBSClient().createBucket(bucket);
+  }
+
+  @Override
+  public void tearDownBucket(String bucket) {
+    try {
+      Files.walk(rootDir().toPath())
+          .filter(p -> p.toFile().isFile())
+          .forEach(
+              p -> {
+                try {
+                  Files.delete(p);
+                } catch (IOException e) {
+                  // delete this file quietly.
+                }
+              });
+
+      createOBSClient().deleteBucket(bucket);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static class Builder {
+    private Map<String, Object> props = Maps.newHashMap();
+
+    public Builder silent() {
+      props.put(HuaweicloudOBSMockApp.PROP_SILENT, true);
+      return this;
+    }
+
+    public HuaweicloudOBSTestRule build() {
+      String rootDir = (String) props.get(HuaweicloudOBSMockApp.PROP_ROOT_DIR);
+      if (Strings.isNullOrEmpty(rootDir)) {
+        File dir =
+            new File(
+                FileUtils.getTempDirectory(), "obs-mock-file-store-" + System.currentTimeMillis());
+        rootDir = dir.getAbsolutePath();
+        props.put(HuaweicloudOBSMockApp.PROP_ROOT_DIR, rootDir);
+      }
+      File root = new File(rootDir);
+      root.deleteOnExit();
+      root.mkdir();
+      return new HuaweicloudOBSMockRule(props);
+    }
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/OBSErrorCode.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/OBSErrorCode.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+public interface OBSErrorCode {
+
+  /** Bucket pre-exists */
+  String BUCKET_ALREADY_EXISTS = "BucketAlreadyExists";
+
+  /** Bucket not empty. */
+  String BUCKET_NOT_EMPTY = "BucketNotEmpty";
+
+  /** No bucket meets the requirement specified. */
+  String NO_SUCH_BUCKET = "NoSuchBucket";
+
+  /** File does not exist. */
+  String NO_SUCH_KEY = "NoSuchKey";
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/ObjectMetadata.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/ObjectMetadata.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import java.util.Map;
+
+public class ObjectMetadata {
+
+  private long contentLength;
+
+  // In millis
+  private long lastModificationDate;
+
+  private String contentMD5;
+
+  private String contentType;
+
+  private String contentEncoding;
+
+  private Map<String, String> userMetaData;
+
+  private String dataFile;
+
+  private String metaFile;
+
+  // The following getters and setters are required for Jackson ObjectMapper serialization and
+  // deserialization.
+
+  public long getContentLength() {
+    return contentLength;
+  }
+
+  public void setContentLength(long contentLength) {
+    this.contentLength = contentLength;
+  }
+
+  public long getLastModificationDate() {
+    return lastModificationDate;
+  }
+
+  public void setLastModificationDate(long lastModificationDate) {
+    this.lastModificationDate = lastModificationDate;
+  }
+
+  public String getContentMD5() {
+    return contentMD5;
+  }
+
+  public void setContentMD5(String contentMD5) {
+    this.contentMD5 = contentMD5;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  public String getContentEncoding() {
+    return contentEncoding;
+  }
+
+  public void setContentEncoding(String contentEncoding) {
+    this.contentEncoding = contentEncoding;
+  }
+
+  public Map<String, String> getUserMetaData() {
+    return userMetaData;
+  }
+
+  public void setUserMetaData(Map<String, String> userMetaData) {
+    this.userMetaData = userMetaData;
+  }
+
+  public String getDataFile() {
+    return dataFile;
+  }
+
+  public void setDataFile(String dataFile) {
+    this.dataFile = dataFile;
+  }
+
+  public String getMetaFile() {
+    return metaFile;
+  }
+
+  public void setMetaFile(String metaFile) {
+    this.metaFile = metaFile;
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/Range.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/Range.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+public class Range {
+
+  private final long start;
+  private final long end;
+
+  public Range(long start, long end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public long start() {
+    return start;
+  }
+
+  public long end() {
+    return end;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%d-%d", start, end);
+  }
+}

--- a/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/TestLocalHuaweicloudOBS.java
+++ b/huaweicloud/src/test/java/org/apache/iceberg/huaweicloud/obs/mock/TestLocalHuaweicloudOBS.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.huaweicloud.obs.mock;
+
+import com.obs.services.IObsClient;
+import com.obs.services.exception.ObsException;
+import com.obs.services.model.GetObjectRequest;
+import com.obs.services.model.PutObjectResult;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.iceberg.huaweicloud.TestUtility;
+import org.apache.iceberg.huaweicloud.obs.HuaweicloudOBSTestRule;
+import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class TestLocalHuaweicloudOBS {
+
+  @ClassRule public static final HuaweicloudOBSTestRule OBS_TEST_RULE = TestUtility.initialize();
+
+  private final IObsClient obs = OBS_TEST_RULE.createOBSClient();
+  private final String bucketName = OBS_TEST_RULE.testBucketName();
+  private final Random random = new Random(1);
+
+  private static void assertThrows(Runnable runnable, String expectedErrorCode) {
+    try {
+      runnable.run();
+      Assert.fail("No exception was thrown, expected errorCode: " + expectedErrorCode);
+    } catch (ObsException e) {
+      Assert.assertEquals(expectedErrorCode, e.getErrorCode());
+    }
+  }
+
+  @Before
+  public void before() {
+    OBS_TEST_RULE.setUpBucket(bucketName);
+  }
+
+  @After
+  public void after() {
+    OBS_TEST_RULE.tearDownBucket(bucketName);
+  }
+
+  @Test
+  public void testBuckets() {
+    Assume.assumeTrue(
+        "Huaweicloud integration test cannot delete existing bucket from test environment.",
+        OBS_TEST_RULE.getClass() == HuaweicloudOBSMockRule.class);
+
+    Assert.assertTrue(doesBucketExist(bucketName));
+    assertThrows(() -> obs.createBucket(bucketName), OBSErrorCode.BUCKET_ALREADY_EXISTS);
+
+    obs.deleteBucket(bucketName);
+    Assert.assertFalse(doesBucketExist(bucketName));
+
+    obs.createBucket(bucketName);
+    Assert.assertTrue(doesBucketExist(bucketName));
+  }
+
+  @Test
+  public void testDeleteBucket() {
+    Assume.assumeTrue(
+        "Huaweicloud integration test cannot delete existing bucket from test environment.",
+        OBS_TEST_RULE.getClass() == HuaweicloudOBSMockRule.class);
+
+    String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
+    assertThrows(() -> obs.deleteBucket(bucketNotExist), OBSErrorCode.NO_SUCH_BUCKET);
+
+    byte[] bytes = new byte[2000];
+    random.nextBytes(bytes);
+
+    obs.putObject(bucketName, "object1", wrap(bytes));
+
+    obs.putObject(bucketName, "object2", wrap(bytes));
+
+    assertThrows(() -> obs.deleteBucket(bucketName), OBSErrorCode.BUCKET_NOT_EMPTY);
+
+    obs.deleteObject(bucketName, "object1");
+    assertThrows(() -> obs.deleteBucket(bucketName), OBSErrorCode.BUCKET_NOT_EMPTY);
+
+    obs.deleteObject(bucketName, "object2");
+    obs.deleteBucket(bucketName);
+    Assert.assertFalse(doesBucketExist(bucketName));
+
+    obs.createBucket(bucketName);
+  }
+
+  @Test
+  public void testPutObject() throws IOException {
+    byte[] bytes = new byte[4 * 1024];
+    random.nextBytes(bytes);
+
+    String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
+    assertThrows(
+        () -> obs.putObject(bucketNotExist, "object", wrap(bytes)), OBSErrorCode.NO_SUCH_BUCKET);
+
+    PutObjectResult result = obs.putObject(bucketName, "object", wrap(bytes));
+    Assert.assertEquals(
+        HuaweicloudOBSMockLocalStore.md5sum(wrap(bytes)), result.getEtag().replace("\"", ""));
+  }
+
+  @Test
+  public void testDoesObjectExist() {
+    Assert.assertFalse(obs.doesObjectExist(bucketName, "key"));
+
+    byte[] bytes = new byte[4 * 1024];
+    random.nextBytes(bytes);
+    obs.putObject(bucketName, "key", wrap(bytes));
+
+    Assert.assertTrue(obs.doesObjectExist(bucketName, "key"));
+    obs.deleteObject(bucketName, "key");
+  }
+
+  @Test
+  public void testGetObject() throws IOException {
+    String bucketNotExist = String.format("bucket-not-existing-%s", UUID.randomUUID());
+    assertThrows(() -> obs.getObject(bucketNotExist, "key"), OBSErrorCode.NO_SUCH_BUCKET);
+
+    assertThrows(() -> obs.getObject(bucketName, "key"), OBSErrorCode.NO_SUCH_KEY);
+
+    byte[] bytes = new byte[2000];
+    random.nextBytes(bytes);
+
+    obs.putObject(bucketName, "key", new ByteArrayInputStream(bytes));
+
+    byte[] actual = new byte[2000];
+    try (InputStream is = obs.getObject(bucketName, "key").getObjectContent()) {
+      ByteStreams.readFully(is, actual);
+    }
+    Assert.assertArrayEquals(bytes, actual);
+    obs.deleteObject(bucketName, "key");
+  }
+
+  @Test
+  public void testGetObjectWithRange() throws IOException {
+
+    byte[] bytes = new byte[100];
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = (byte) i;
+    }
+    obs.putObject(bucketName, "key", new ByteArrayInputStream(bytes));
+
+    int start = 0;
+    int end = 0;
+    testRange(bytes, start, end);
+
+    start = 0;
+    end = 1;
+    testRange(bytes, start, end);
+
+    start = 1;
+    end = 9;
+    testRange(bytes, start, end);
+
+    start = 0;
+    end = 99;
+    testRange(bytes, start, end);
+
+    obs.deleteObject(bucketName, "key");
+  }
+
+  private void testRange(byte[] bytes, int start, int end) throws IOException {
+    byte[] testBytes;
+    byte[] actual;
+    int len;
+    if (start == -1 && end == -1) {
+      len = bytes.length;
+      actual = new byte[len];
+      testBytes = new byte[len];
+      System.arraycopy(bytes, 0, testBytes, 0, len);
+    } else if (start == -1) {
+      len = end;
+      actual = new byte[len];
+      testBytes = new byte[len];
+      System.arraycopy(bytes, bytes.length - end, testBytes, 0, len);
+    } else if (end == -1) {
+      len = bytes.length - start;
+      actual = new byte[len];
+      testBytes = new byte[len];
+      System.arraycopy(bytes, start, testBytes, 0, len);
+    } else {
+      len = end - start + 1;
+      actual = new byte[len];
+      testBytes = new byte[len];
+      System.arraycopy(bytes, start, testBytes, 0, len);
+    }
+
+    GetObjectRequest getObjectRequest;
+    getObjectRequest = new GetObjectRequest(bucketName, "key");
+    getObjectRequest.setRangeStart((long) start);
+    getObjectRequest.setRangeEnd((long) end);
+    try (InputStream is = obs.getObject(getObjectRequest).getObjectContent()) {
+      ByteStreams.readFully(is, actual);
+    }
+    Assert.assertArrayEquals(testBytes, actual);
+  }
+
+  private InputStream wrap(byte[] data) {
+    return new ByteArrayInputStream(data);
+  }
+
+  private boolean doesBucketExist(String bucket) {
+    try {
+      obs.createBucket(bucket);
+      obs.deleteBucket(bucket);
+      return false;
+    } catch (ObsException obsException) {
+      if (Objects.equals(obsException.getResponseCode(), HttpStatus.SC_CONFLICT)) {
+        return true;
+      }
+      throw obsException;
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include 'hive-metastore'
 include 'nessie'
 include 'gcp'
 include 'dell'
+include 'huaweicloud'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -51,6 +52,7 @@ project(':hive-metastore').name = 'iceberg-hive-metastore'
 project(':nessie').name = 'iceberg-nessie'
 project(':gcp').name = 'iceberg-gcp'
 project(':dell').name = 'iceberg-dell'
+project(':huaweicloud').name = 'iceberg-huaweicloud'
 
 List<String> knownFlinkVersions = System.getProperty("knownFlinkVersions").split(",")
 String flinkVersionsString = System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")

--- a/versions.props
+++ b/versions.props
@@ -28,6 +28,7 @@ org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
 org.immutables:value = 2.9.2
+com.huaweicloud:esdk-obs-java-bundle = 3.22.3
 
 # test deps
 org.junit.vintage:junit-vintage-engine = 5.8.2


### PR DESCRIPTION
Co-authored-by: gaona <nanagoo127@163.com>
Co-authored-by: Liwei Li <hililiwei@gmail.com>

This PR is used to integrate HUAWEI CLOUD object storage （OBS）.
1. Upload, download, and delete files.
2. Supports encrypted transmission.




Added support for Huawei Cloud OBS.
