### PR TITLE
API: Update expression sanitization for relative dates and times

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -42,13 +42,13 @@ public class ExpressionUtil {
   private static final long FIVE_MINUTES_IN_MICROS = TimeUnit.MINUTES.toMicros(5);
   private static final long THREE_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(3);
   private static final long NINETY_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(90);
-  private static final Pattern DATE = Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\d");
-  private static final Pattern TIME = Pattern.compile("\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?");
+  private static final Pattern DATE = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
+  private static final Pattern TIME = Pattern.compile("\\d{2}:\\d{2}(:\\d{2}(.\\d{1,6})?)?");
   private static final Pattern TIMESTAMP =
-      Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?");
+      Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2}(.\\d{1,6})?)?");
   private static final Pattern TIMESTAMPTZ =
       Pattern.compile(
-          "\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?([-+]\\d\\d:\\d\\d|Z)");
+          "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}(:\\d{2}(.\\d{1,6})?)?([-+]\\d{2}:\\d{2}|Z)");
   static final int LONG_IN_PREDICATE_ABBREVIATION_THRESHOLD = 10;
   private static final int LONG_IN_PREDICATE_ABBREVIATION_MIN_GAIN = 5;
 

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -195,13 +195,13 @@ public class ExpressionUtil {
   }
 
   private static class StringSanitizer extends ExpressionVisitors.ExpressionVisitor<String> {
-    private final long now;
+    private final long nowMicros;
     private final int today;
 
     private StringSanitizer() {
       long nowMillis = System.currentTimeMillis();
       OffsetDateTime nowDateTime = Instant.ofEpochMilli(nowMillis).atOffset(ZoneOffset.UTC);
-      this.now = nowMillis * 1000;
+      this.nowMicros = nowMillis * 1000;
       this.today = (int) ChronoUnit.DAYS.between(EPOCH, nowDateTime);
     }
 
@@ -258,23 +258,23 @@ public class ExpressionUtil {
         case NOT_NAN:
           return "not_nan(" + term + ")";
         case LT:
-          return term + " < " + sanitize(pred.literal(), now, today);
+          return term + " < " + sanitize(pred.literal(), nowMicros, today);
         case LT_EQ:
-          return term + " <= " + sanitize(pred.literal(), now, today);
+          return term + " <= " + sanitize(pred.literal(), nowMicros, today);
         case GT:
-          return term + " > " + sanitize(pred.literal(), now, today);
+          return term + " > " + sanitize(pred.literal(), nowMicros, today);
         case GT_EQ:
-          return term + " >= " + sanitize(pred.literal(), now, today);
+          return term + " >= " + sanitize(pred.literal(), nowMicros, today);
         case EQ:
-          return term + " = " + sanitize(pred.literal(), now, today);
+          return term + " = " + sanitize(pred.literal(), nowMicros, today);
         case NOT_EQ:
-          return term + " != " + sanitize(pred.literal(), now, today);
+          return term + " != " + sanitize(pred.literal(), nowMicros, today);
         case IN:
           return term
               + " IN "
               + abbreviateValues(
                       pred.literals().stream()
-                          .map(lit -> sanitize(lit, now, today))
+                          .map(lit -> sanitize(lit, nowMicros, today))
                           .collect(Collectors.toList()))
                   .stream()
                   .collect(Collectors.joining(", ", "(", ")"));
@@ -283,14 +283,14 @@ public class ExpressionUtil {
               + " NOT IN "
               + abbreviateValues(
                       pred.literals().stream()
-                          .map(lit -> sanitize(lit, now, today))
+                          .map(lit -> sanitize(lit, nowMicros, today))
                           .collect(Collectors.toList()))
                   .stream()
                   .collect(Collectors.joining(", ", "(", ")"));
         case STARTS_WITH:
-          return term + " STARTS WITH " + sanitize(pred.literal(), now, today);
+          return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
-          return term + " NOT STARTS WITH " + sanitize(pred.literal(), now, today);
+          return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -33,11 +38,17 @@ import org.apache.iceberg.types.Types;
 public class ExpressionUtil {
   private static final Function<Object, Integer> HASH_FUNC =
       Transforms.bucket(Integer.MAX_VALUE).bind(Types.StringType.get());
+  private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+  private static final long FIVE_MINUTES_IN_MICROS = TimeUnit.MINUTES.toMicros(5);
+  private static final long THREE_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(3);
+  private static final long NINETY_DAYS_IN_HOURS = TimeUnit.DAYS.toHours(90);
   private static final Pattern DATE = Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\d");
   private static final Pattern TIME = Pattern.compile("\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?");
   private static final Pattern TIMESTAMP =
+      Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?");
+  private static final Pattern TIMESTAMPTZ =
       Pattern.compile(
-          "\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?([-+]\\d\\d:\\d\\d)?");
+          "\\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d(:\\d\\d(.\\d{1,6})?)?([-+]\\d\\d:\\d\\d|Z)");
   static final int LONG_IN_PREDICATE_ABBREVIATION_THRESHOLD = 10;
   private static final int LONG_IN_PREDICATE_ABBREVIATION_MIN_GAIN = 5;
 
@@ -54,7 +65,7 @@ public class ExpressionUtil {
    * @return a sanitized Expression
    */
   public static Expression sanitize(Expression expr) {
-    return ExpressionVisitors.visit(expr, ExpressionSanitizer.INSTANCE);
+    return ExpressionVisitors.visit(expr, new ExpressionSanitizer());
   }
 
   /**
@@ -68,7 +79,7 @@ public class ExpressionUtil {
    * @return a sanitized expression string
    */
   public static String toSanitizedString(Expression expr) {
-    return ExpressionVisitors.visit(expr, StringSanitizer.INSTANCE);
+    return ExpressionVisitors.visit(expr, new StringSanitizer());
   }
 
   /**
@@ -111,7 +122,15 @@ public class ExpressionUtil {
 
   private static class ExpressionSanitizer
       extends ExpressionVisitors.ExpressionVisitor<Expression> {
-    private static final ExpressionSanitizer INSTANCE = new ExpressionSanitizer();
+    private final long now;
+    private final int today;
+
+    private ExpressionSanitizer() {
+      long nowMillis = System.currentTimeMillis();
+      OffsetDateTime nowDateTime = Instant.ofEpochMilli(nowMillis).atOffset(ZoneOffset.UTC);
+      this.now = nowMillis * 1000;
+      this.today = (int) ChronoUnit.DAYS.between(EPOCH, nowDateTime);
+    }
 
     @Override
     public Expression alwaysTrue() {
@@ -161,11 +180,12 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
-          return new UnboundPredicate<>(pred.op(), pred.term(), (T) sanitize(pred.literal()));
+          return new UnboundPredicate<>(
+              pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
         case NOT_IN:
           Iterable<String> iter =
-              () -> pred.literals().stream().map(ExpressionUtil::sanitize).iterator();
+              () -> pred.literals().stream().map(lit -> sanitize(lit, now, today)).iterator();
           return new UnboundPredicate<>(pred.op(), pred.term(), (Iterable<T>) iter);
         default:
           throw new UnsupportedOperationException(
@@ -175,7 +195,15 @@ public class ExpressionUtil {
   }
 
   private static class StringSanitizer extends ExpressionVisitors.ExpressionVisitor<String> {
-    private static final StringSanitizer INSTANCE = new StringSanitizer();
+    private final long now;
+    private final int today;
+
+    private StringSanitizer() {
+      long nowMillis = System.currentTimeMillis();
+      OffsetDateTime nowDateTime = Instant.ofEpochMilli(nowMillis).atOffset(ZoneOffset.UTC);
+      this.now = nowMillis * 1000;
+      this.today = (int) ChronoUnit.DAYS.between(EPOCH, nowDateTime);
+    }
 
     @Override
     public String alwaysTrue() {
@@ -230,23 +258,23 @@ public class ExpressionUtil {
         case NOT_NAN:
           return "not_nan(" + term + ")";
         case LT:
-          return term + " < " + sanitize(pred.literal());
+          return term + " < " + sanitize(pred.literal(), now, today);
         case LT_EQ:
-          return term + " <= " + sanitize(pred.literal());
+          return term + " <= " + sanitize(pred.literal(), now, today);
         case GT:
-          return term + " > " + sanitize(pred.literal());
+          return term + " > " + sanitize(pred.literal(), now, today);
         case GT_EQ:
-          return term + " >= " + sanitize(pred.literal());
+          return term + " >= " + sanitize(pred.literal(), now, today);
         case EQ:
-          return term + " = " + sanitize(pred.literal());
+          return term + " = " + sanitize(pred.literal(), now, today);
         case NOT_EQ:
-          return term + " != " + sanitize(pred.literal());
+          return term + " != " + sanitize(pred.literal(), now, today);
         case IN:
           return term
               + " IN "
               + abbreviateValues(
                       pred.literals().stream()
-                          .map(ExpressionUtil::sanitize)
+                          .map(lit -> sanitize(lit, now, today))
                           .collect(Collectors.toList()))
                   .stream()
                   .collect(Collectors.joining(", ", "(", ")"));
@@ -255,14 +283,14 @@ public class ExpressionUtil {
               + " NOT IN "
               + abbreviateValues(
                       pred.literals().stream()
-                          .map(ExpressionUtil::sanitize)
+                          .map(lit -> sanitize(lit, now, today))
                           .collect(Collectors.toList()))
                   .stream()
                   .collect(Collectors.joining(", ", "(", ")"));
         case STARTS_WITH:
-          return term + " STARTS WITH " + sanitize(pred.literal());
+          return term + " STARTS WITH " + sanitize(pred.literal(), now, today);
         case NOT_STARTS_WITH:
-          return term + " NOT STARTS WITH " + sanitize(pred.literal());
+          return term + " NOT STARTS WITH " + sanitize(pred.literal(), now, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -279,7 +307,7 @@ public class ExpressionUtil {
         abbreviatedList.addAll(distinctValues);
         abbreviatedList.add(
             String.format(
-                "... (%d values hidden, %d in total) ...",
+                "... (%d values hidden, %d in total)",
                 sanitizedValues.size() - distinctValues.size(), sanitizedValues.size()));
         return abbreviatedList;
       }
@@ -287,24 +315,29 @@ public class ExpressionUtil {
     return sanitizedValues;
   }
 
-  private static String sanitize(Literal<?> literal) {
+  private static String sanitize(Literal<?> literal, long now, int today) {
     if (literal instanceof Literals.StringLiteral) {
       CharSequence value = ((Literals.StringLiteral) literal).value();
       if (DATE.matcher(value).matches()) {
-        return "(date)";
+        Literal<Integer> date = Literal.of(value).to(Types.DateType.get());
+        return sanitizeDate(date.value(), today);
+      } else if (TIMESTAMP.matcher(value).matches()) {
+        Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withoutZone());
+        return sanitizeTimestamp(ts.value(), now);
+      } else if (TIMESTAMPTZ.matcher(value).matches()) {
+        Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withZone());
+        return sanitizeTimestamp(ts.value(), now);
       } else if (TIME.matcher(value).matches()) {
         return "(time)";
-      } else if (TIMESTAMP.matcher(value).matches()) {
-        return "(timestamp)";
       } else {
         return sanitizeString(value);
       }
     } else if (literal instanceof Literals.DateLiteral) {
-      return "(date)";
+      return sanitizeDate(((Literals.DateLiteral) literal).value(), today);
+    } else if (literal instanceof Literals.TimestampLiteral) {
+      return sanitizeTimestamp(((Literals.TimestampLiteral) literal).value(), now);
     } else if (literal instanceof Literals.TimeLiteral) {
       return "(time)";
-    } else if (literal instanceof Literals.TimestampLiteral) {
-      return "(timestamp)";
     } else if (literal instanceof Literals.IntegerLiteral) {
       return sanitizeNumber(((Literals.IntegerLiteral) literal).value(), "int");
     } else if (literal instanceof Literals.LongLiteral) {
@@ -317,6 +350,36 @@ public class ExpressionUtil {
       // for uuid, decimal, fixed, and binary, match the string result
       return sanitizeString(literal.value().toString());
     }
+  }
+
+  private static String sanitizeDate(int days, int today) {
+    String isPast = today > days ? "ago" : "from-now";
+    int diff = Math.abs(today - days);
+    if (diff == 0) {
+      return "(date-today)";
+    } else if (diff < 90) {
+      return "(date-" + diff + "-days-" + isPast + ")";
+    }
+
+    return "(date)";
+  }
+
+  private static String sanitizeTimestamp(long micros, long now) {
+    String isPast = now > micros ? "ago" : "from-now";
+    long diff = Math.abs(now - micros);
+    if (diff < FIVE_MINUTES_IN_MICROS) {
+      return "(timestamp-about-now)";
+    }
+
+    long hours = TimeUnit.MICROSECONDS.toHours(diff);
+    if (hours <= THREE_DAYS_IN_HOURS) {
+      return "(timestamp-" + hours + "-hours-" + isPast + ")";
+    } else if (hours < NINETY_DAYS_IN_HOURS) {
+      long days = hours / 24;
+      return "(timestamp-" + days + "-days-" + isPast + ")";
+    }
+
+    return "(timestamp)";
   }
 
   private static String sanitizeNumber(Number value, String type) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -472,10 +472,7 @@ public class TestExpressionUtil {
 
   @Test
   public void testSanitizeTimestamptzPast() {
-    String ninetyMinutesAgoUtc =
-        OffsetDateTime.now()
-            .minusMinutes(90)
-            .toString();
+    String ninetyMinutesAgoUtc = OffsetDateTime.now().minusMinutes(90).toString();
 
     assertEquals(
         Expressions.equal("test", "(timestamp-1-hours-ago)"),
@@ -497,10 +494,7 @@ public class TestExpressionUtil {
 
   @Test
   public void testSanitizeTimestamptzLastWeek() {
-    String lastWeekUtc =
-        OffsetDateTime.now()
-            .minusWeeks(1)
-            .toString();
+    String lastWeekUtc = OffsetDateTime.now().minusWeeks(1).toString();
 
     assertEquals(
         Expressions.equal("test", "(timestamp-7-days-ago)"),
@@ -522,10 +516,7 @@ public class TestExpressionUtil {
 
   @Test
   public void testSanitizeTimestamptzFuture() {
-    String ninetyMinutesFromNowUtc =
-        OffsetDateTime.now()
-            .plusMinutes(90)
-            .toString();
+    String ninetyMinutesFromNowUtc = OffsetDateTime.now().plusMinutes(90).toString();
 
     assertEquals(
         Expressions.equal("test", "(timestamp-1-hours-from-now)"),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -397,7 +397,7 @@ public class TestExpressionUtil {
   public void testSanitizeTimestampLastWeek() {
     String lastWeekLocal =
         OffsetDateTime.now()
-            .minusWeeks(1)
+            .minusHours(180)
             .atZoneSameInstant(ZoneOffset.UTC)
             .toLocalDateTime()
             .toString();
@@ -494,7 +494,7 @@ public class TestExpressionUtil {
 
   @Test
   public void testSanitizeTimestamptzLastWeek() {
-    String lastWeekUtc = OffsetDateTime.now().minusWeeks(1).toString();
+    String lastWeekUtc = OffsetDateTime.now().minusHours(180).toString();
 
     assertEquals(
         Expressions.equal("test", "(timestamp-7-days-ago)"),


### PR DESCRIPTION
This updates expression sanitization to produce relative date/time strings rather than generic `(date)` and `(timestamp)` literals.

For dates within the last 90 days, the sanitized values are shown in days relative to the current date: `(date-today)`, `(date-N-days-ago)`, and `(date-N-days-from-now)`. For timestamps, the sanitized values are shown relative to the current timestamp in hours or in days: `(timestamp-about-now)` within 5 minutes, `(timestamp-N-hours-ago)` within 3 days, and `(timestamp-N-days-from-now)` within 90 days.

Thanks to @kbendick for originally suggesting this.