### PR TITLE
Python: Cleanup inconsistency in OAuth responses

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 _ENV_CONFIG = Config()
 
 TYPE = "type"
+URI = "uri"
 
 
 class CatalogType(Enum):
@@ -97,7 +98,9 @@ def load_catalog(name: str, **properties: str | None) -> Catalog:
         if inferred_catalog_type := infer_catalog_type(conf):
             catalog_type = inferred_catalog_type
         else:
-            raise ValueError(f"Invalid configuration. Could not determine the catalog type: {properties}")
+            raise ValueError(
+                f"URI missing, please provide using --uri, the config or environment variable PYICEBERG_CATALOG__{name.upper()}__URI"
+            )
 
     if catalog_type:
         return AVAILABLE_CATALOGS[catalog_type](name, conf)

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -231,7 +231,7 @@ class RestCatalog(Catalog):
         if SEMICOLON in credential:
             client_id, client_secret = credential.split(SEMICOLON)
         else:
-            client_id, client_secret = credential, None
+            client_id, client_secret = None, credential
         data = {GRANT_TYPE: CLIENT_CREDENTIALS, CLIENT_ID: client_id, CLIENT_SECRET: client_secret, SCOPE: CATALOG_SCOPE}
         url = self.url(Endpoints.get_token, prefixed=False)
         # Uses application/x-www-form-urlencoded by default

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -228,10 +228,10 @@ class RestCatalog(Catalog):
         return url + endpoint.format(**kwargs)
 
     def _fetch_access_token(self, credential: str) -> str:
-        if SEMICOLON not in credential:
-            raise ValueError("Expected semicolon in the credential to separate the client id and secret.")
-
-        client_id, client_secret = credential.split(SEMICOLON)
+        if SEMICOLON in credential:
+            client_id, client_secret = credential.split(SEMICOLON)
+        else:
+            client_id, client_secret = credential, None
         data = {GRANT_TYPE: CLIENT_CREDENTIALS, CLIENT_ID: client_id, CLIENT_SECRET: client_secret, SCOPE: CATALOG_SCOPE}
         url = self.url(Endpoints.get_token, prefixed=False)
         # Uses application/x-www-form-urlencoded by default

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -65,14 +65,7 @@ def run(ctx: Context, catalog: str, verbose: bool, output: str, uri: Optional[st
         ctx.obj["output"] = JsonOutput(verbose=verbose)
 
     try:
-        try:
-            ctx.obj["catalog"] = load_catalog(catalog, **properties)
-        except ValueError as exc:
-            if not uri:
-                raise ValueError(
-                    f"URI missing, please provide using --uri, the config or environment variable PYICEBERG_CATALOG__{catalog.upper()}__URI"
-                ) from exc
-            raise exc
+        ctx.obj["catalog"] = load_catalog(catalog, **properties)
     except Exception as e:
         ctx.obj["output"].exception(e)
         ctx.exit(1)

--- a/python/pyiceberg/exceptions.py
+++ b/python/pyiceberg/exceptions.py
@@ -44,10 +44,6 @@ class RESTError(Exception):
     """Raises when there is an unknown response from the REST Catalog"""
 
 
-class BadCredentialsError(RESTError):
-    """Raises when providing invalid credentials"""
-
-
 class BadRequestError(RESTError):
     """Raises when an invalid request is being made"""
 


### PR DESCRIPTION
401 also returns oauth token reponse
https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L170-L178

- This also removes the `BadCredentialsError` and replaces it with the `OAuthError`.
- Checks if there is a semicolon in the credential, and throws a nice error if not.