### PR TITLE
Spark: Iceberg bug 5935 fix where some methods of Spark3Util do not set current session in spark's threadlocal

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -655,7 +655,7 @@ public class Spark3Util {
    * to get the latest one.
    *
    * @param spark SparkSession used for looking up catalog references and tables
-   * @param name The multipart identifier of the Iceberg table
+   * @param name  The multipart identifier of the Iceberg table
    * @return an Iceberg table
    */
   public static org.apache.iceberg.Table loadIcebergTable(SparkSession spark, String name)
@@ -671,10 +671,10 @@ public class Spark3Util {
     } catch (Exception e) {
       if (e instanceof ParseException) {
         throw (ParseException) e;
-      } else  if (e instanceof NoSuchTableException) {
+      } else if (e instanceof NoSuchTableException) {
         throw (NoSuchTableException) e;
-      } else if (e instanceof RuntimeException){
-        throw (RuntimeException)e;
+      } else if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
       } else {
         // wrap it
         throw new RuntimeException(e);
@@ -685,7 +685,7 @@ public class Spark3Util {
   /**
    * Returns the underlying Iceberg Catalog object represented by a Spark Catalog
    *
-   * @param spark SparkSession used for looking up catalog reference
+   * @param spark       SparkSession used for looking up catalog reference
    * @param catalogName The name of the Spark Catalog being referenced
    * @return the Iceberg catalog class being wrapped by the Spark Catalog
    */
@@ -694,16 +694,16 @@ public class Spark3Util {
       return executeWithSession(spark, () -> {
         CatalogPlugin catalogPlugin = spark.sessionState().catalogManager().catalog(catalogName);
         Preconditions.checkArgument(
-          catalogPlugin instanceof HasIcebergCatalog,
-          String.format(
-            "Cannot load Iceberg catalog from catalog %s because it does not contain an Iceberg Catalog. "
-              + "Actual Class: %s",
-            catalogName, catalogPlugin.getClass().getName()));
+            catalogPlugin instanceof HasIcebergCatalog,
+            String.format(
+                "Cannot load Iceberg catalog from catalog %s because it does not contain an Iceberg Catalog. "
+                    + "Actual Class: %s",
+                catalogName, catalogPlugin.getClass().getName()));
         return ((HasIcebergCatalog) catalogPlugin).icebergCatalog();
       });
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
-        throw (RuntimeException)e;
+        throw (RuntimeException) e;
       } else {
         // wrap it
         throw new RuntimeException(e);
@@ -750,13 +750,13 @@ public class Spark3Util {
    * A modified version of Spark's LookupCatalog.CatalogAndIdentifier.unapply Attempts to find the
    * catalog and identifier a multipart identifier represents
    *
-   * @param spark Spark session to use for resolution
-   * @param nameParts Multipart identifier representing a table
+   * @param spark          Spark session to use for resolution
+   * @param nameParts      Multipart identifier representing a table
    * @param defaultCatalog Catalog to use if none is specified
    * @return The CatalogPlugin and Identifier for the table
    */
   public static CatalogAndIdentifier catalogAndIdentifier(
-    SparkSession spark, List<String> nameParts, CatalogPlugin defaultCatalog) {
+      SparkSession spark, List<String> nameParts, CatalogPlugin defaultCatalog) {
     try {
       return executeWithSession(spark, () -> {
         CatalogManager catalogManager = spark.sessionState().catalogManager();
@@ -769,18 +769,18 @@ public class Spark3Util {
         }
 
         Pair<CatalogPlugin, Identifier> catalogIdentifier =
-          SparkUtil.catalogAndIdentifier(
-            nameParts,
-            catalogName -> {
-              try {
-                return catalogManager.catalog(catalogName);
-              } catch (Exception e) {
-                return null;
-              }
-            },
-            Identifier::of,
-            defaultCatalog,
-            currentNamespace);
+            SparkUtil.catalogAndIdentifier(
+                nameParts,
+                catalogName -> {
+                  try {
+                    return catalogManager.catalog(catalogName);
+                  } catch (Exception e) {
+                    return null;
+                  }
+                },
+                Identifier::of,
+                defaultCatalog,
+                currentNamespace);
         return new CatalogAndIdentifier(catalogIdentifier);
       });
     } catch (Exception e) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -23,12 +23,12 @@ import static org.apache.iceberg.NullOrder.NULLS_LAST;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.SparkSession;
@@ -134,14 +134,19 @@ public class TestSpark3Util extends SparkTestBase {
     String testTableName = "default.testtable";
     SparkSession hiveSupportSession = spark.newSession();
     try {
-      hiveSupportSession.conf().set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION().key(),
-        SparkSessionCatalog.class.getName());
+      hiveSupportSession
+          .conf()
+          .set(
+              SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION().key(),
+              SparkSessionCatalog.class.getName());
       hiveSupportSession.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
 
       // create an iceberg table
-      String tableString = String.format("CREATE TABLE %s (id bigint, data string)" +
-          " USING iceberg PARTITIONED BY (data) TBLPROPERTIES('%s'='%s')", testTableName,
-        TableProperties.FORMAT_VERSION, "2");
+      String tableString =
+          String.format(
+              "CREATE TABLE %s (id bigint, data string)"
+                  + " USING iceberg PARTITIONED BY (data) TBLPROPERTIES('%s'='%s')",
+              testTableName, TableProperties.FORMAT_VERSION, "2");
       hiveSupportSession.sql(tableString);
       // Now load the created iceberg table
       Spark3Util.loadIcebergTable(hiveSupportSession, testTableName);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -23,13 +23,16 @@ import static org.apache.iceberg.NullOrder.NULLS_LAST;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -120,6 +123,31 @@ public class TestSpark3Util extends SparkTestBase {
     Catalog catalog = Spark3Util.loadIcebergCatalog(spark, "test_cat");
     Assert.assertTrue(
         "Should retrieve underlying catalog class", catalog instanceof CachingCatalog);
+  }
+
+  // Bug 5935
+  @Test
+  public void testCurrentSessionSetAsActive() throws Exception {
+    stopMetastoreAndSpark();
+    startMetastoreAndSpark();
+    Assert.assertFalse(spark.conf().contains(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION().key()));
+    String testTableName = "default.testtable";
+    SparkSession hiveSupportSession = spark.newSession();
+    try {
+      hiveSupportSession.conf().set(SQLConf.V2_SESSION_CATALOG_IMPLEMENTATION().key(),
+        SparkSessionCatalog.class.getName());
+      hiveSupportSession.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
+
+      // create an iceberg table
+      String tableString = String.format("CREATE TABLE %s (id bigint, data string)" +
+          " USING iceberg PARTITIONED BY (data) TBLPROPERTIES('%s'='%s')", testTableName,
+        TableProperties.FORMAT_VERSION, "2");
+      hiveSupportSession.sql(tableString);
+      // Now load the created iceberg table
+      Spark3Util.loadIcebergTable(hiveSupportSession, testTableName);
+    } finally {
+      hiveSupportSession.sql(String.format("drop table if exists %s", testTableName));
+    }
   }
 
   private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {


### PR DESCRIPTION
Some of the functions of Spark3Util which are internally invoking the catalog being used by the current SparkSession, do not get the right Catalog Instance, as the current session is not being set as the active one , in the ThreadLocal of SparkSession. As a result , the catalog instance being retrieved is the wrong one ( of the default spark session which got created first).

The bug shows up if a new session is created and iceberg's SparkSessionCatalog is set in the new session instead of the original Session.

The Spark3Util's code sets the session as active one.