### PR TITLE
Core: Use explicit JSON Parser for namespace creation request

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -51,8 +51,8 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.NamespaceCreateRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
@@ -104,7 +104,7 @@ public class CatalogHandlers {
   }
 
   public static CreateNamespaceResponse createNamespace(
-      SupportsNamespaces catalog, CreateNamespaceRequest request) {
+      SupportsNamespaces catalog, NamespaceCreateRequest request) {
     Namespace namespace = request.namespace();
     catalog.createNamespace(namespace, request.properties());
     return CreateNamespaceResponse.builder()

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -42,7 +42,10 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
 import org.apache.iceberg.rest.auth.OAuth2Util;
+import org.apache.iceberg.rest.requests.ImmutableNamespaceCreateRequest;
 import org.apache.iceberg.rest.requests.ImmutableReportMetricsRequest;
+import org.apache.iceberg.rest.requests.NamespaceCreateRequest;
+import org.apache.iceberg.rest.requests.NamespaceCreateRequestParser;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequestParser;
 import org.apache.iceberg.rest.requests.UpdateRequirementParser;
@@ -83,7 +86,13 @@ public class RESTSerializers {
         .addDeserializer(ReportMetricsRequest.class, new ReportMetricsRequestDeserializer<>())
         .addSerializer(ImmutableReportMetricsRequest.class, new ReportMetricsRequestSerializer<>())
         .addDeserializer(
-            ImmutableReportMetricsRequest.class, new ReportMetricsRequestDeserializer<>());
+            ImmutableReportMetricsRequest.class, new ReportMetricsRequestDeserializer<>())
+        .addSerializer(NamespaceCreateRequest.class, new NamespaceCreateRequestSerializer<>())
+        .addDeserializer(NamespaceCreateRequest.class, new NamespaceCreateRequestDeserializer<>())
+        .addSerializer(
+            ImmutableNamespaceCreateRequest.class, new NamespaceCreateRequestSerializer<>())
+        .addDeserializer(
+            ImmutableNamespaceCreateRequest.class, new NamespaceCreateRequestDeserializer<>());
     mapper.registerModule(module);
   }
 
@@ -278,6 +287,24 @@ public class RESTSerializers {
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
       return (T) ReportMetricsRequestParser.fromJson(jsonNode);
+    }
+  }
+
+  public static class NamespaceCreateRequestSerializer<T extends NamespaceCreateRequest>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      NamespaceCreateRequestParser.toJson(request, gen);
+    }
+  }
+
+  public static class NamespaceCreateRequestDeserializer<T extends NamespaceCreateRequest>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) NamespaceCreateRequestParser.fromJson(jsonNode);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -65,8 +65,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.auth.OAuth2Util.AuthSession;
-import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.ImmutableNamespaceCreateRequest;
+import org.apache.iceberg.rest.requests.NamespaceCreateRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
@@ -334,8 +335,8 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   @Override
   public void createNamespace(
       SessionContext context, Namespace namespace, Map<String, String> metadata) {
-    CreateNamespaceRequest request =
-        CreateNamespaceRequest.builder().withNamespace(namespace).setProperties(metadata).build();
+    NamespaceCreateRequest request =
+        ImmutableNamespaceCreateRequest.builder().namespace(namespace).properties(metadata).build();
 
     // for now, ignore the response because there is no way to return it
     client.post(

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
@@ -19,15 +19,18 @@
 package org.apache.iceberg.rest.requests;
 
 import java.util.Map;
-import java.util.Objects;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RESTRequest;
 
-/** A REST request to create a namespace, with an optional set of properties. */
+/**
+ * A REST request to create a namespace, with an optional set of properties.
+ *
+ * @deprecated Will be removed in 1.2.0 - Use {@link NamespaceCreateRequest}
+ */
+@Deprecated
 public class CreateNamespaceRequest implements RESTRequest {
 
   private Namespace namespace;
@@ -69,30 +72,25 @@ public class CreateNamespaceRequest implements RESTRequest {
   }
 
   public static class Builder {
-    private Namespace namespace;
-    private final ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+    private final ImmutableNamespaceCreateRequest.Builder builder;
 
-    private Builder() {}
+    private Builder() {
+      builder = ImmutableNamespaceCreateRequest.builder();
+    }
 
     public Builder withNamespace(Namespace ns) {
-      Preconditions.checkNotNull(ns, "Invalid namespace: null");
-      this.namespace = ns;
+      builder.namespace(ns);
       return this;
     }
 
     public Builder setProperties(Map<String, String> props) {
-      Preconditions.checkNotNull(props, "Invalid collection of properties: null");
-      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
-      Preconditions.checkArgument(
-          !props.containsValue(null),
-          "Invalid value for properties %s: null",
-          Maps.filterValues(props, Objects::isNull).keySet());
-      properties.putAll(props);
+      builder.properties(props);
       return this;
     }
 
     public CreateNamespaceRequest build() {
-      return new CreateNamespaceRequest(namespace, properties.build());
+      ImmutableNamespaceCreateRequest build = builder.build();
+      return new CreateNamespaceRequest(build.namespace(), build.properties());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/NamespaceCreateRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/NamespaceCreateRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface NamespaceCreateRequest extends RESTRequest {
+
+  Namespace namespace();
+
+  @Value.Default
+  default Map<String, String> properties() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  default void validate() {
+    // nothing to do here as it's not possible to create an invalid NamespaceCreateRequest
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/NamespaceCreateRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/NamespaceCreateRequestParser.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class NamespaceCreateRequestParser {
+
+  private static final String NAMESPACE = "namespace";
+  private static final String PROPERTIES = "properties";
+
+  private NamespaceCreateRequestParser() {}
+
+  public static String toJson(NamespaceCreateRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(NamespaceCreateRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(NamespaceCreateRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid namespace creation request: null");
+
+    gen.writeStartObject();
+
+    gen.writeArrayFieldStart(NAMESPACE);
+    for (String level : request.namespace().levels()) {
+      gen.writeString(level);
+    }
+    gen.writeEndArray();
+
+    if (!request.properties().isEmpty()) {
+      gen.writeObjectFieldStart(PROPERTIES);
+      for (Map.Entry<String, String> pair : request.properties().entrySet()) {
+        gen.writeStringField(pair.getKey(), pair.getValue());
+      }
+      gen.writeEndObject();
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static NamespaceCreateRequest fromJson(String json) {
+    return JsonUtil.parse(json, NamespaceCreateRequestParser::fromJson);
+  }
+
+  public static NamespaceCreateRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse namespace creation request from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse namespace creation request from non-object: %s", json);
+
+    Namespace namespace = Namespace.of(JsonUtil.getStringArray(JsonUtil.get(NAMESPACE, json)));
+    ImmutableNamespaceCreateRequest.Builder builder =
+        ImmutableNamespaceCreateRequest.builder().namespace(namespace);
+    if (json.has(PROPERTIES)) {
+      builder.properties(JsonUtil.getStringMap(PROPERTIES, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -40,8 +40,8 @@ import org.apache.iceberg.exceptions.UnprocessableEntityException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.NamespaceCreateRequest;
 import org.apache.iceberg.rest.requests.RenameTableRequest;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
@@ -101,7 +101,7 @@ public class RESTCatalogAdapter implements RESTClient {
     CREATE_NAMESPACE(
         HTTPMethod.POST,
         "v1/namespaces",
-        CreateNamespaceRequest.class,
+        NamespaceCreateRequest.class,
         CreateNamespaceResponse.class),
     LOAD_NAMESPACE(HTTPMethod.GET, "v1/namespaces/{namespace}", null, GetNamespaceResponse.class),
     DROP_NAMESPACE(HTTPMethod.DELETE, "v1/namespaces/{namespace}"),
@@ -266,7 +266,7 @@ public class RESTCatalogAdapter implements RESTClient {
 
       case CREATE_NAMESPACE:
         if (asNamespaceCatalog != null) {
-          CreateNamespaceRequest request = castRequest(CreateNamespaceRequest.class, body);
+          NamespaceCreateRequest request = castRequest(NamespaceCreateRequest.class, body);
           return castResponse(
               responseType, CatalogHandlers.createNamespace(asNamespaceCatalog, request));
         }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -116,21 +116,21 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
     AssertHelpers.assertThrows(
         "The builder should not allow using null for the namespace",
         NullPointerException.class,
-        "Invalid namespace: null",
+        "namespace",
         () -> CreateNamespaceRequest.builder().withNamespace(null).build());
 
     AssertHelpers.assertThrows(
         "The builder should not allow passing a null collection of properties",
         NullPointerException.class,
-        "Invalid collection of properties: null",
+        null,
         () -> CreateNamespaceRequest.builder().setProperties(null).build());
 
     Map<String, String> mapWithNullKey = Maps.newHashMap();
     mapWithNullKey.put(null, "hello");
     AssertHelpers.assertThrows(
         "The builder should not allow using null as a key in the properties to set",
-        IllegalArgumentException.class,
-        "Invalid property: null",
+        NullPointerException.class,
+        "properties key",
         () -> CreateNamespaceRequest.builder().setProperties(mapWithNullKey).build());
 
     Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
@@ -138,8 +138,8 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
     mapWithMultipleNullValues.put("b", "b");
     AssertHelpers.assertThrows(
         "The builder should not allow using null as a value in the properties to set",
-        IllegalArgumentException.class,
-        "Invalid value for properties [a]: null",
+        NullPointerException.class,
+        "properties value for key: a",
         () -> CreateNamespaceRequest.builder().setProperties(mapWithMultipleNullValues).build());
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestNamespaceCreateRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestNamespaceCreateRequestParser.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestNamespaceCreateRequestParser {
+
+  @Test
+  public void nullCheck() {
+    Assertions.assertThatThrownBy(() -> NamespaceCreateRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace creation request: null");
+
+    Assertions.assertThatThrownBy(() -> NamespaceCreateRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse namespace creation request from null object");
+  }
+
+  @Test
+  public void missingFields() {
+    Assertions.assertThatThrownBy(() -> NamespaceCreateRequestParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: namespace");
+  }
+
+  @Test
+  public void namespaceWithoutProperties() {
+    NamespaceCreateRequest expected =
+        ImmutableNamespaceCreateRequest.builder()
+            .namespace(Namespace.of("accounting", "tax"))
+            .build();
+
+    NamespaceCreateRequest actual =
+        NamespaceCreateRequestParser.fromJson("{\"namespace\":[\"accounting\",\"tax\"]}");
+    Assertions.assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void invalidNamespaceType() {
+    Assertions.assertThatThrownBy(
+            () -> NamespaceCreateRequestParser.fromJson("{\"namespace\":\"accounting%1Ftax\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string array from non-array: \"accounting%1Ftax\"");
+  }
+
+  @Test
+  public void invalidPropertiesType() {
+    Assertions.assertThatThrownBy(
+            () ->
+                NamespaceCreateRequestParser.fromJson(
+                    "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":[]}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse from non-object value: properties: []");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                NamespaceCreateRequestParser.fromJson(
+                    "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":null}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse from non-object value: properties: null");
+  }
+
+  @Test
+  public void emptyProperties() {
+    Assertions.assertThat(
+            NamespaceCreateRequestParser.fromJson(
+                "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{}}"))
+        .isEqualTo(
+            ImmutableNamespaceCreateRequest.builder()
+                .namespace(Namespace.of("accounting", "tax"))
+                .build());
+  }
+
+  @Test
+  public void emptyNamespace() {
+    Assertions.assertThat(NamespaceCreateRequestParser.fromJson("{\"namespace\":[]}"))
+        .isEqualTo(ImmutableNamespaceCreateRequest.builder().namespace(Namespace.empty()).build());
+  }
+
+  @Test
+  public void roundTripSerde() {
+    NamespaceCreateRequest request =
+        ImmutableNamespaceCreateRequest.builder()
+            .namespace(Namespace.of("accounting", "tax"))
+            .properties(ImmutableMap.of("a", "1", "b", "2"))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"namespace\" : [ \"accounting\", \"tax\" ],\n"
+            + "  \"properties\" : {\n"
+            + "    \"a\" : \"1\",\n"
+            + "    \"b\" : \"2\"\n"
+            + "  }\n"
+            + "}";
+
+    String json = NamespaceCreateRequestParser.toJson(request, true);
+    Assertions.assertThat(json).isEqualTo(expectedJson);
+
+    Assertions.assertThat(NamespaceCreateRequestParser.fromJson(json)).isEqualTo(request);
+  }
+}


### PR DESCRIPTION
The idea here is that we move away from reflection-based ser/de in REST request/response classes by introducing an explicit JSON Parser. The API definition of the request/response class becomes very slim & clean. This PR does that for the `CreateNamespaceRequest`.