### PR TITLE
Docs: Fix incorrect glue catalog class name for Hive

### DIFF
--- a/docs/hive.md
+++ b/docs/hive.md
@@ -178,7 +178,7 @@ SET iceberg.catalog.hadoop.warehouse=hdfs://example.com:8020/warehouse;
 Register an AWS `GlueCatalog` called `glue`:
 
 ```
-SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.GlueCatalog;
+SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog;
 SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
 SET iceberg.catalog.glue.lock.table=myGlueLockTable;
 ```


### PR DESCRIPTION
### About the change

corrects the glue catalog class path name when using (Glue catalog with Hive engine).