### PR TITLE
Core/Spark: Fix kryo deserialization of `SerializableTable`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -82,7 +82,7 @@ public class SerializableTable implements Table, Serializable {
     this.io = fileIO(table);
     this.encryption = table.encryption();
     this.locationProvider = table.locationProvider();
-    this.refs = table.refs();
+    this.refs = SerializableMap.copyOf(table.refs());
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
@@ -51,6 +52,18 @@ public class TestTableSerialization extends HadoopTableTestBase {
     table.updateSchema().addColumn("new_col", Types.IntegerType.get()).commit();
 
     TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));
+    Table serializableTable = SerializableTable.copyOf(table);
+    TestHelpers.assertSerializedAndLoadedMetadata(
+        serializableTable, TestHelpers.KryoHelpers.roundTripSerialize(serializableTable));
+  }
+
+  @Test
+  public void testSerializableTableWithSnapshot() throws IOException, ClassNotFoundException {
+    table.newAppend().appendFile(FILE_A).commit();
+    TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));
+    Table serializableTable = SerializableTable.copyOf(table);
+    TestHelpers.assertSerializedAndLoadedMetadata(
+        serializableTable, TestHelpers.KryoHelpers.roundTripSerialize(serializableTable));
   }
 
   @Test
@@ -75,6 +88,9 @@ public class TestTableSerialization extends HadoopTableTestBase {
       Table metadataTable = getMetaDataTable(table, type);
       TestHelpers.assertSerializedAndLoadedMetadata(
           metadataTable, TestHelpers.roundTripSerialize(metadataTable));
+      Table serializableTable = SerializableTable.copyOf(metadataTable);
+      TestHelpers.assertSerializedAndLoadedMetadata(
+          serializableTable, TestHelpers.KryoHelpers.roundTripSerialize(serializableTable));
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/5974