### PR TITLE
Docs: Typo in loading table from DataFrameReader

### DIFF
--- a/docs/spark-queries.md
+++ b/docs/spark-queries.md
@@ -78,10 +78,10 @@ val df = spark.table("prod.db.table")
 Iceberg 0.11.0 adds multi-catalog support to `DataFrameReader` in both Spark 3.x and 2.4.
 
 Paths and table names can be loaded with Spark's `DataFrameReader` interface. How tables are loaded depends on how
-the identifier is specified. When using `spark.read.format("iceberg").path(table)` or `spark.table(table)` the `table`
+the identifier is specified. When using `spark.read.format("iceberg").load(table)` or `spark.table(table)` the `table`
 variable can take a number of forms as listed below:
 
-*  `file:/path/to/table`: loads a HadoopTable at given path
+*  `file:///path/to/table`: loads a HadoopTable at given path
 *  `tablename`: loads `currentCatalog.currentNamespace.tablename`
 *  `catalog.tablename`: loads `tablename` from the specified catalog.
 *  `namespace.tablename`: loads `namespace.tablename` from current catalog

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -47,9 +47,9 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 /**
  * The IcebergSource loads/writes tables with format "iceberg". It can load paths and tables.
  *
- * <p>How paths/tables are loaded when using spark.read().format("iceberg").path(table)
+ * <p>How paths/tables are loaded when using spark.read().format("iceberg").load(table)
  *
- * <p>table = "file:/path/to/table" -&gt; loads a HadoopTable at given path table = "tablename"
+ * <p>table = "file:///path/to/table" -&gt; loads a HadoopTable at given path table = "tablename"
  * -&gt; loads currentCatalog.currentNamespace.tablename table = "catalog.tablename" -&gt; load
  * "tablename" from the specified catalog. table = "namespace.tablename" -&gt; load
  * "namespace.tablename" from current catalog table = "catalog.namespace.tablename" -&gt;


### PR DESCRIPTION
Was trying to follow this documentation to load a table from HadoopCatalog, and noticed this snippet does not work as is for me (Spark 3.2).

