### PR TITLE
Core: Parallelize the determining of reachable manifests during file cleanup

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -56,7 +56,7 @@ abstract class FileCleanupStrategy {
           .select(
               "manifest_path", "manifest_length", "added_snapshot_id", "deleted_data_files_count");
 
-  protected CloseableIterable<ManifestFile> readManifestFiles(Snapshot snapshot) {
+  protected CloseableIterable<ManifestFile> readManifests(Snapshot snapshot) {
     if (snapshot.manifestListLocation() != null) {
       return Avro.read(fileIO.newInputFile(snapshot.manifestListLocation()))
           .rename("manifest_file", GenericManifestFile.class.getName())

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -127,7 +127,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                     exc))
         .run(
             snapshot -> {
-              try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
+              try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot)) {
                 for (ManifestFile manifest : manifests) {
                   validManifests.add(manifest.path());
 
@@ -210,7 +210,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                 }
 
                 // find any manifests that are no longer needed
-                try (CloseableIterable<ManifestFile> manifests = readManifestFiles(snapshot)) {
+                try (CloseableIterable<ManifestFile> manifests = readManifests(snapshot)) {
                   for (ManifestFile manifest : manifests) {
                     if (!validManifests.contains(manifest.path())) {
                       manifestsToDelete.add(manifest.path());


### PR DESCRIPTION
Follow up PR to https://github.com/apache/iceberg/pull/5669. 

1.) Parallelizing determining the reachable manifests given a set of snapshots

2.) Cleaning up issues in log messages https://github.com/apache/iceberg/pull/5669#discussion_r993986722 and  https://github.com/apache/iceberg/pull/5669#discussion_r993984959

