### PR TITLE
Closes #5988 - Allow configuration of Hive MetastoreClient using Catalog properties

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -85,8 +85,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
     }
 
     // Forward all catalog properties that begin with `hive.` into configuration for use in setting
-    // up the
-    // MetastoreClient
+    // up the MetastoreClient
     for (Map.Entry<String, String> entry : properties.entrySet()) {
       if (entry.getKey().startsWith(HIVE_PROPERTY_PREFIX)) {
         this.conf.set(entry.getKey(), entry.getValue());

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -62,6 +62,7 @@ import org.slf4j.LoggerFactory;
 public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespaces, Configurable {
   public static final String LIST_ALL_TABLES = "list-all-tables";
   public static final String LIST_ALL_TABLES_DEFAULT = "false";
+  private static final String HIVE_PROPERTY_PREFIX = "hive.";
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
@@ -81,6 +82,15 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
     if (conf == null) {
       LOG.warn("No Hadoop Configuration was set, using the default environment Configuration");
       this.conf = new Configuration();
+    }
+
+    // Forward all catalog properties that begin with `hive.` into configuration for use in setting
+    // up the
+    // MetastoreClient
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      if (entry.getKey().startsWith(HIVE_PROPERTY_PREFIX)) {
+        this.conf.set(entry.getKey(), entry.getValue());
+      }
     }
 
     if (properties.containsKey(CatalogProperties.URI)) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -153,6 +153,18 @@ public class TestHiveCatalog extends HiveMetastoreTest {
   }
 
   @Test
+  public void testInitializeWithHiveProperties() {
+    HiveCatalog catalog = new HiveCatalog();
+    Map<String, String> props = Maps.newHashMap();
+    props.put(HiveConf.ConfVars.METASTORE_TOKEN_SIGNATURE.varname, "alias1");
+    props.put("non.forwarding.signature", "alias2");
+    catalog.initialize("hive", props);
+    Assertions.assertEquals(
+        "alias1", catalog.getConf().get(HiveConf.ConfVars.METASTORE_TOKEN_SIGNATURE.varname));
+    Assertions.assertNull(catalog.getConf().get("non.forwarding.signature"));
+  }
+
+  @Test
   public void testToStringWithoutSetConf() {
     Assertions.assertDoesNotThrow(
         () -> {


### PR DESCRIPTION
## Why?
Currently Iceberg limits the Hive properties that can be configured onto a catalog to `uri -> hive.metastore.uris` and `warehouse -> hive.metastore.warehouse.dir`.

This limits the ability to configure the metastore client being set up. For example in a secure set up when using delegation tokens we need to configure different values for `hive.metastore.token.signature` for each metastore service.

We need a means for configuring each client differently on some properties and others are generic as derived from the classpath.

## What?
In this patch we allow any catalog properties that start with `hive.` to be passed on to the configuration used for creating the MetastoreClient.

## Testing?
Unit test was added to verify the above functionality and no regression failures.