### PR TITLE
AwsProperties prints format specifier in IllegalArgumentException message

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -829,8 +829,9 @@ public class AwsProperties implements Serializable {
               properties, S3FILEIO_MULTIPART_SIZE, S3FILEIO_MULTIPART_SIZE_DEFAULT);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
-          "Input malformed or exceeded maximum multipart upload size 5GB: %s"
-              + properties.get(S3FILEIO_MULTIPART_SIZE));
+          String.format(
+              "Input malformed or exceeded maximum multipart upload size 5GB: %s",
+              properties.get(S3FILEIO_MULTIPART_SIZE)));
     }
     this.s3FileIoMultipartThresholdFactor =
         PropertyUtil.propertyAsDouble(


### PR DESCRIPTION
Proposing to fix exception message that contains an unnecessary format specifier string `%s`.
cc: @pvary 