### PR TITLE
Core: Deprecate HTTPClientFactory / Allow configuring ObjectMapper for HTTPClient

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
@@ -29,7 +29,10 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * Takes in the full configuration for the {@link RESTSessionCatalog}, which should already have
  * called the server's initial configuration route. Using the merged configuration, an instance of
  * {@link RESTClient} is obtained that can be used with the RESTCatalog.
+ *
+ * @deprecated Will be removed in 1.2.0. Use {@link HTTPClient#builder()} directly.
  */
+@Deprecated
 public class HTTPClientFactory implements Function<Map<String, String>, RESTClient> {
 
   @VisibleForTesting static final String CLIENT_VERSION_HEADER = "X-Client-Version";

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -46,7 +47,9 @@ public class RESTCatalog
   private final SupportsNamespaces nsDelegate;
 
   public RESTCatalog() {
-    this(SessionCatalog.SessionContext.createEmpty(), new HTTPClientFactory());
+    this(
+        SessionCatalog.SessionContext.createEmpty(),
+        config -> HTTPClient.builder().uri(config.get(CatalogProperties.URI)).build());
   }
 
   public RESTCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -112,7 +112,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   private volatile ScheduledExecutorService refreshExecutor = null;
 
   public RESTSessionCatalog() {
-    this(new HTTPClientFactory());
+    this(config -> HTTPClient.builder().uri(config.get(CatalogProperties.URI)).build());
   }
 
   RESTSessionCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -34,7 +34,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.responses.ErrorResponse;
@@ -66,7 +65,7 @@ public class TestHTTPClient {
   @BeforeClass
   public static void beforeClass() {
     mockServer = startClientAndServer(PORT);
-    restClient = new HTTPClientFactory().apply(ImmutableMap.of(CatalogProperties.URI, URI));
+    restClient = HTTPClient.builder().uri(URI).build();
     icebergBuildGitCommitShort = IcebergBuild.gitCommitShortId();
     icebergBuildFullVersion = IcebergBuild.fullVersion();
   }
@@ -182,9 +181,8 @@ public class TestHTTPClient {
         request("/" + path)
             .withMethod(method.name().toUpperCase(Locale.ROOT))
             .withHeader("Authorization", "Bearer " + BEARER_AUTH_TOKEN)
-            .withHeader(HTTPClientFactory.CLIENT_VERSION_HEADER, icebergBuildFullVersion)
-            .withHeader(
-                HTTPClientFactory.CLIENT_GIT_COMMIT_SHORT_HEADER, icebergBuildGitCommitShort);
+            .withHeader(HTTPClient.CLIENT_VERSION_HEADER, icebergBuildFullVersion)
+            .withHeader(HTTPClient.CLIENT_GIT_COMMIT_SHORT_HEADER, icebergBuildGitCommitShort);
 
     if (method.usesRequestBody()) {
       mockRequest = mockRequest.withBody(asJson);

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -144,7 +144,10 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             ImmutableMap.of("credential", "user:12345"),
             ImmutableMap.of());
 
-    this.restCatalog = new RESTCatalog(context, (config) -> new HTTPClientFactory().apply(config));
+    this.restCatalog =
+        new RESTCatalog(
+            context,
+            (config) -> HTTPClient.builder().uri(config.get(CatalogProperties.URI)).build());
     restCatalog.setConf(conf);
     restCatalog.initialize(
         "prod",
@@ -263,8 +266,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     AssertHelpers.assertThrows(
         "Configuration passed to initialize must have uri",
-        IllegalArgumentException.class,
-        "REST Catalog server URI is required",
+        NullPointerException.class,
+        "Invalid uri for http client: null",
         () -> restCat.initialize("prod", ImmutableMap.of()));
 
     restCat.close();


### PR DESCRIPTION
I think we don't need to have `HTTPClientFactory` in order to init a `HTTPClient` as it requires to pass a map with the URI. We can rather just use the `HTTPClient.builder()` directly with the URI.

Additionally, this allows to pass the `HTTPClient` a custom `ObjectMapper` rather than always defaulting to `RESTObjectMapper.mapper()`