### PR TITLE
Nessie: no longer push whole metadata JSON to Nessie

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -18,28 +18,18 @@
  */
 package org.apache.iceberg.nessie;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.util.JsonUtil;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
-import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
 
 public final class NessieUtil {
@@ -98,38 +88,5 @@ public final class NessieUtil {
   private static String commitAuthor(Map<String, String> catalogOptions) {
     return Optional.ofNullable(catalogOptions.get(CatalogProperties.USER))
         .orElseGet(() -> System.getProperty("user.name"));
-  }
-
-  static TableMetadata tableMetadataFromIcebergTable(
-      FileIO io, IcebergTable table, String metadataLocation) {
-    TableMetadata deserialized;
-    if (table.getMetadata() != null) {
-      String jsonString;
-      try (StringWriter writer = new StringWriter()) {
-        try (JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
-          generator.writeObject(table.getMetadata().getMetadata());
-        }
-        jsonString = writer.toString();
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to generate JSON string from metadata", e);
-      }
-      deserialized = TableMetadataParser.fromJson(metadataLocation, jsonString);
-    } else {
-      deserialized = TableMetadataParser.read(io, metadataLocation);
-    }
-    return deserialized;
-  }
-
-  static JsonNode tableMetadataAsJsonNode(TableMetadata metadata) {
-    JsonNode newMetadata;
-    try {
-      String jsonString = TableMetadataParser.toJson(metadata);
-      try (JsonParser parser = JsonUtil.factory().createParser(jsonString)) {
-        newMetadata = parser.readValueAs(JsonNode.class);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    return newMetadata;
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieUtil.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieUtil.java
@@ -18,87 +18,13 @@
  */
 package org.apache.iceberg.nessie;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Collections;
-import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.SortOrder;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.Types.NestedField;
-import org.apache.iceberg.types.Types.StringType;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.projectnessie.model.CommitMeta;
-import org.projectnessie.model.GenericMetadata;
-import org.projectnessie.model.IcebergTable;
-import org.projectnessie.model.ImmutableIcebergTable;
 
 public class TestNessieUtil {
-
-  @Test
-  public void testTableMetadataJsonRoundtrip() {
-    // Construct a dummy TableMetadata object
-    Map<String, String> properties = Collections.singletonMap("property-key", "property-value");
-    String location = "obj://foo/bar/baz";
-    TableMetadata tableMetadata =
-        TableMetadata.newTableMetadata(
-            new Schema(1, NestedField.of(1, false, "column", StringType.get())),
-            PartitionSpec.unpartitioned(),
-            SortOrder.unsorted(),
-            location,
-            properties);
-
-    // Produce a generic JsonNode from the TableMetadata
-    JsonNode jsonNode = NessieUtil.tableMetadataAsJsonNode(tableMetadata);
-    Assertions.assertThat(jsonNode)
-        .asInstanceOf(InstanceOfAssertFactories.type(JsonNode.class))
-        .extracting(
-            n -> n.get("format-version").asLong(-2L),
-            n -> n.get("location").asText("x"),
-            n -> n.get("properties").get("property-key").asText())
-        .containsExactly(1L, location, "property-value");
-
-    // Create a Nessie IcebergTable object with the JsonNode as the metadata
-    IcebergTable icebergTableNoMetadata = IcebergTable.of(location, 0L, 1, 2, 3, "cid");
-    IcebergTable icebergTable =
-        ImmutableIcebergTable.builder()
-            .from(icebergTableNoMetadata)
-            .metadata(GenericMetadata.of("iceberg", jsonNode))
-            .build();
-
-    // Deserialize the TableMetadata from Nessie IcebergTable
-    TableMetadata deserializedMetadata =
-        NessieUtil.tableMetadataFromIcebergTable(null, icebergTable, location);
-
-    // (Could compare tableMetadata against deserializedMetadata, but TableMetadata has no equals())
-
-    // Produce a JsonNode from the deserializedMetadata and compare that against jsonNode
-    JsonNode deserializedJsonNode = NessieUtil.tableMetadataAsJsonNode(deserializedMetadata);
-    Assertions.assertThat(deserializedJsonNode).isEqualTo(jsonNode);
-  }
-
-  @Test
-  public void testTableMetadataFromFileIO() {
-    String location = "obj://foo/bar/baz";
-    FileIO fileIoMock = Mockito.mock(FileIO.class);
-    IcebergTable icebergTableNoMetadata = IcebergTable.of(location, 0L, 1, 2, 3, "cid");
-
-    // Check that newInputFile() is called when IcebergTable has no metadata
-    Mockito.when(fileIoMock.newInputFile(location))
-        .thenThrow(new RuntimeException("newInputFile called"));
-    Assertions.assertThatThrownBy(
-            () ->
-                NessieUtil.tableMetadataFromIcebergTable(
-                    fileIoMock, icebergTableNoMetadata, location))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage("newInputFile called");
-  }
 
   @Test
   public void testBuildingCommitMetadataWithNullCatalogOptions() {


### PR DESCRIPTION
The table metadata JSON can become quite big, actually too big, hitting HTTP limits. This change removes the previously introduced storage of Iceberg metadata in Nessie. We will come up with a better solution.