### PR TITLE
Flink: Fix NoClassDefFound with Flink runtime jar / Add integration test

### DIFF
--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -117,6 +117,13 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
   tasks.jar.dependsOn tasks.shadowJar
 
+  sourceSets {
+    integration {
+      java.srcDir "$projectDir/src/integration/java"
+      resources.srcDir "$projectDir/src/integration/resources"
+    }
+  }
+
   configurations {
     implementation {
       // included in Flink
@@ -146,6 +153,56 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     // for dropwizard histogram metrics implementation
     implementation "org.apache.flink:flink-metrics-dropwizard:${flinkVersion}"
+
+    // for integration testing with the flink-runtime-jar
+    // all of those dependencies are required because the integration test extends FlinkTestBase
+    integrationCompileOnly project(':iceberg-api')
+    integrationImplementation 'org.junit.vintage:junit-vintage-engine'
+    integrationImplementation 'org.assertj:assertj-core'
+    integrationImplementation project(path: ":iceberg-flink:iceberg-flink-${flinkMajorVersion}", configuration: "testArtifacts")
+    integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+    integrationImplementation("org.apache.flink:flink-test-utils_${scalaVersion}:${flinkVersion}") {
+      exclude group: "org.apache.curator", module: 'curator-test'
+      exclude group: 'junit'
+    }
+
+    integrationImplementation "org.apache.flink:flink-table-api-java-bridge_${scalaVersion}:${flinkVersion}"
+    integrationImplementation "org.apache.flink:flink-table-planner_${scalaVersion}:${flinkVersion}"
+
+    integrationImplementation "org.apache.hadoop:hadoop-common"
+    integrationImplementation "org.apache.hadoop:hadoop-hdfs"
+    integrationImplementation("org.apache.hadoop:hadoop-minicluster") {
+      exclude group: 'org.apache.avro', module: 'avro'
+    }
+
+    integrationImplementation("org.apache.hive:hive-metastore") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hbase'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'co.cask.tephra'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
+      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+      exclude group: 'com.tdunning', module: 'json'
+      exclude group: 'javax.transaction', module: 'transaction-api'
+      exclude group: 'com.zaxxer', module: 'HikariCP'
+    }
+
+    integrationImplementation("org.apache.hive:hive-exec::core") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hive', module: 'hive-llap-tez'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'com.google.protobuf', module: 'protobuf-java'
+      exclude group: 'org.apache.calcite'
+      exclude group: 'org.apache.calcite.avatica'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
   }
 
   shadowJar {
@@ -174,6 +231,16 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     classifier null
   }
+
+  task integrationTest(type: Test) {
+    description = "Test Flink Runtime Jar against Flink ${flinkMajorVersion}"
+    group = "verification"
+    testClassesDirs = sourceSets.integration.output.classesDirs
+    classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
+    inputs.file(shadowJar.archiveFile.get().asFile.path)
+  }
+  integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -119,7 +119,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
   configurations {
     implementation {
-      exclude group: 'org.apache.flink'
       // included in Flink
       exclude group: 'org.slf4j'
       exclude group: 'org.apache.commons'
@@ -132,7 +131,9 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   }
 
   dependencies {
-    implementation project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}")
+    implementation(project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}")) {
+      exclude group: 'org.apache.flink'
+    }
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-aliyun')) {
       exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
@@ -144,7 +145,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     }
 
     // for dropwizard histogram metrics implementation
-    implementation "org.apache.flink:flink-metrics-dropwizard:${flinkMajorVersion}"
+    implementation "org.apache.flink:flink-metrics-dropwizard:${flinkVersion}"
   }
 
   shadowJar {

--- a/flink/v1.14/flink-runtime/src/integration/java/org/apache/iceberg/flink/IcebergConnectorSmokeTest.java
+++ b/flink/v1.14/flink-runtime/src/integration/java/org/apache/iceberg/flink/IcebergConnectorSmokeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.util.Map;
+
+public class IcebergConnectorSmokeTest extends TestIcebergConnector {
+
+  public IcebergConnectorSmokeTest(
+      String catalogName, Map<String, String> properties, boolean isStreaming) {
+    super(catalogName, properties, isStreaming);
+  }
+}

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -119,6 +119,13 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
   tasks.jar.dependsOn tasks.shadowJar
 
+  sourceSets {
+    integration {
+      java.srcDir "$projectDir/src/integration/java"
+      resources.srcDir "$projectDir/src/integration/resources"
+    }
+  }
+
   configurations {
     implementation {
       // included in Flink
@@ -148,6 +155,56 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     // for dropwizard histogram metrics implementation
     implementation "org.apache.flink:flink-metrics-dropwizard:${flinkVersion}"
+
+    // for integration testing with the flink-runtime-jar
+    // all of those dependencies are required because the integration test extends FlinkTestBase
+    integrationCompileOnly project(':iceberg-api')
+    integrationImplementation 'org.junit.vintage:junit-vintage-engine'
+    integrationImplementation 'org.assertj:assertj-core'
+    integrationImplementation project(path: ":iceberg-flink:iceberg-flink-${flinkMajorVersion}", configuration: "testArtifacts")
+    integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+    integrationImplementation("org.apache.flink:flink-test-utils:${flinkVersion}") {
+      exclude group: "org.apache.curator", module: 'curator-test'
+      exclude group: 'junit'
+    }
+
+    integrationImplementation "org.apache.flink:flink-table-api-java-bridge:${flinkVersion}"
+    integrationImplementation "org.apache.flink:flink-table-planner_${scalaVersion}:${flinkVersion}"
+
+    integrationImplementation "org.apache.hadoop:hadoop-common"
+    integrationImplementation "org.apache.hadoop:hadoop-hdfs"
+    integrationImplementation("org.apache.hadoop:hadoop-minicluster") {
+      exclude group: 'org.apache.avro', module: 'avro'
+    }
+
+    integrationImplementation("org.apache.hive:hive-metastore") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hbase'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'co.cask.tephra'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
+      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+      exclude group: 'com.tdunning', module: 'json'
+      exclude group: 'javax.transaction', module: 'transaction-api'
+      exclude group: 'com.zaxxer', module: 'HikariCP'
+    }
+
+    integrationImplementation("org.apache.hive:hive-exec::core") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hive', module: 'hive-llap-tez'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'com.google.protobuf', module: 'protobuf-java'
+      exclude group: 'org.apache.calcite'
+      exclude group: 'org.apache.calcite.avatica'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
   }
 
   shadowJar {
@@ -176,6 +233,16 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     classifier null
   }
+
+  task integrationTest(type: Test) {
+    description = "Test Flink Runtime Jar against Flink ${flinkMajorVersion}"
+    group = "verification"
+    testClassesDirs = sourceSets.integration.output.classesDirs
+    classpath = sourceSets.integration.runtimeClasspath + files(shadowJar.archiveFile.get().asFile.path)
+    inputs.file(shadowJar.archiveFile.get().asFile.path)
+  }
+  integrationTest.dependsOn shadowJar
+  check.dependsOn integrationTest
 
   jar {
     enabled = false

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -121,7 +121,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
   configurations {
     implementation {
-      exclude group: 'org.apache.flink'
       // included in Flink
       exclude group: 'org.slf4j'
       exclude group: 'org.apache.commons'
@@ -134,7 +133,9 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   }
 
   dependencies {
-    implementation project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}")
+    implementation(project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}")) {
+      exclude group: 'org.apache.flink'
+    }
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-aliyun')) {
       exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'
@@ -146,7 +147,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     }
 
     // for dropwizard histogram metrics implementation
-    implementation "org.apache.flink:flink-metrics-dropwizard:${flinkMajorVersion}"
+    implementation "org.apache.flink:flink-metrics-dropwizard:${flinkVersion}"
   }
 
   shadowJar {

--- a/flink/v1.15/flink-runtime/src/integration/java/org/apache/iceberg/flink/IcebergConnectorSmokeTest.java
+++ b/flink/v1.15/flink-runtime/src/integration/java/org/apache/iceberg/flink/IcebergConnectorSmokeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.util.Map;
+
+public class IcebergConnectorSmokeTest extends TestIcebergConnector {
+
+  public IcebergConnectorSmokeTest(
+      String catalogName, Map<String, String> properties, boolean isStreaming) {
+    super(catalogName, properties, isStreaming);
+  }
+}


### PR DESCRIPTION
#5410 added monitor metrics for Flink and the intention there was to include `org.apache.flink:flink-metrics-dropwizard` into the runtime jar. However, due to `exclude group: 'org.apache.flink'` for the entire `implementation` configuration, that dependency never made it into the jar. This can also be seen by looking at the latest [Flink Runtime Jar](https://repository.apache.org/content/groups/snapshots/org/apache/iceberg/iceberg-flink-runtime-1.15/0.15.0-SNAPSHOT/iceberg-flink-runtime-1.15-0.15.0-20221018.002238-86.jar) that is being published to the Snapshot repo.

When using that runtime jar, things will fail with a `NoClassDefFoundError` as can be seen below:
```
java.lang.NoClassDefFoundError: com/codahale/metrics/Reservoir
	at org.apache.iceberg.flink.sink.IcebergStreamWriter.open(IcebergStreamWriter.java:55)
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:107)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreGates(StreamTask.java:700)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:676)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:643)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:948)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:917)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:741)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:563)
	at java.base/java.lang.Thread.run(Unknown Source)
```

This PR moves the exclude out of the entire `implementation` configuration and also makes sure that the correct resolvable version (1.15.0 rather than 1.15) of `org.apache.flink:flink-metrics-dropwizard` is being selected.

@stevenzwu could you review this one please?