### PR TITLE
Build: Show executed tests on CI only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,7 +177,12 @@ subprojects {
     maxHeapSize = "1500m"
 
     testLogging {
-      events "failed"
+      // see also https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+      if ("true".equalsIgnoreCase(System.getenv('GITHUB_ACTIONS'))) {
+        events "failed", "passed"
+      } else {
+        events "failed"
+      }
       exceptionFormat "full"
     }
   }


### PR DESCRIPTION
This has been added a while ago by #1212 but then got removed by #2013. Sometimes it's quite helpful to know whether a particular test has been executed on CI by looking at the Gradle output

This PR makes sure that the executed tests are only shown on CI and not during local test execution.

@rdblue do you see any major drawback to doing this (other than having bigger log files)? I've been multiple times in the past in a situation where I wanted to double-check that a particular test has been really part of CI. 
The most recent case was after I added some integration tests with https://github.com/apache/iceberg/pull/6001. It would have been quite useful to know that those integration tests have been executed as part of CI - currently you can only see that the `integrationTest` task has been running, but you don't have a way of knowing that the test(s) have been executed.