### PR TITLE
Python: Fix PyArrowFileIO caching

### DIFF
--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -266,8 +266,8 @@ def test_deleting_s3_file_no_permission():
     s3fs_mock = MagicMock()
     s3fs_mock.delete_file.side_effect = OSError("AWS Error [code 15]")
 
-    with patch.object(PyArrowFileIO, "_get_fs_and_path") as submocked:
-        submocked.return_value = (s3fs_mock, "bar/foo.txt")
+    with patch.object(PyArrowFileIO, "_get_fs") as submocked:
+        submocked.return_value = s3fs_mock
 
         with pytest.raises(PermissionError) as exc_info:
             PyArrowFileIO().delete("s3://foo/bar.txt")
@@ -281,8 +281,8 @@ def test_deleting_s3_file_not_found():
     s3fs_mock = MagicMock()
     s3fs_mock.delete_file.side_effect = OSError("Path does not exist")
 
-    with patch.object(PyArrowFileIO, "_get_fs_and_path") as submocked:
-        submocked.return_value = (s3fs_mock, "bar/foo.txt")
+    with patch.object(PyArrowFileIO, "_get_fs") as submocked:
+        submocked.return_value = s3fs_mock
 
         with pytest.raises(FileNotFoundError) as exc_info:
             PyArrowFileIO().delete("s3://foo/bar.txt")


### PR DESCRIPTION
The path was part of the lru_cache call, meaning that for each different file it would miss the cache. Also refactored the path/location structure since PyArrow requires URLs without a scheme.