### PR TITLE
Core: Fix TestSnapshotUtil time random disorder

### DIFF
--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -75,9 +75,9 @@ public class TestSnapshotUtil {
 
     this.table = TestTables.create(tableDir, "test", SCHEMA, SPEC, 2);
     table.newFastAppend().appendFile(FILE_A).commit();
-    this.snapshotAId = table.currentSnapshot().snapshotId();
-
-    snapshotATimestamp = System.currentTimeMillis();
+    Snapshot snapshotA = table.currentSnapshot();
+    this.snapshotAId = snapshotA.snapshotId();
+    this.snapshotATimestamp = snapshotA.timestampMillis() + 1;
 
     table.newFastAppend().appendFile(FILE_A).commit();
     this.snapshotBId = table.currentSnapshot().snapshotId();

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -77,7 +78,9 @@ public class TestSnapshotUtil {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snapshotA = table.currentSnapshot();
     this.snapshotAId = snapshotA.snapshotId();
-    this.snapshotATimestamp = snapshotA.timestampMillis() + 1;
+    this.snapshotATimestamp = snapshotA.timestampMillis();
+
+    TestHelpers.waitUntilAfter(snapshotATimestamp);
 
     table.newFastAppend().appendFile(FILE_A).commit();
     this.snapshotBId = table.currentSnapshot().snapshotId();
@@ -129,7 +132,7 @@ public class TestSnapshotUtil {
     snapshot = SnapshotUtil.oldestAncestorOf(table, snapshotDId);
     Assert.assertEquals(snapshotAId, snapshot.snapshotId());
 
-    snapshot = SnapshotUtil.oldestAncestorAfter(table, snapshotATimestamp);
+    snapshot = SnapshotUtil.oldestAncestorAfter(table, snapshotATimestamp + 1);
     Assert.assertEquals(snapshotBId, snapshot.snapshotId());
   }
 


### PR DESCRIPTION
Fixed a random bug. Test case failed when the commit time was equal to the current system time. Introduce it in #6005 

Fix to use `snapshot time +1`