### PR TITLE
docs:Add an example of CTAS with PARTITIONED BY (rebased, fix #3854)

### DIFF
--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -102,6 +102,9 @@ CREATE TABLE prod.db.sample
 USING iceberg
 AS SELECT ...
 ```
+
+The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
+
 ```sql
 CREATE TABLE prod.db.sample
 USING iceberg
@@ -109,8 +112,6 @@ PARTITIONED BY (part)
 TBLPROPERTIES ('key'='value')
 AS SELECT ...
 ```
-
-The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
 
 ## `REPLACE TABLE ... AS SELECT`
 

--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -102,6 +102,13 @@ CREATE TABLE prod.db.sample
 USING iceberg
 AS SELECT ...
 ```
+```sql
+CREATE TABLE prod.db.sample
+USING iceberg
+PARTITIONED BY (part)
+TBLPROPERTIES ('key'='value')
+AS SELECT ...
+```
 
 ## `REPLACE TABLE ... AS SELECT`
 

--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -110,6 +110,8 @@ TBLPROPERTIES ('key'='value')
 AS SELECT ...
 ```
 
+The newly created table won't inherit the partition spec and table properties from the source table in SELECT, you can use PARTITIONED BY and TBLPROPERTIES in CTAS to declare partition spec and table properties for the new table.
+
 ## `REPLACE TABLE ... AS SELECT`
 
 Iceberg supports RTAS as an atomic operation when using a [`SparkCatalog`](../spark-configuration#catalog-configuration). RTAS is supported, but is not atomic when using [`SparkSessionCatalog`](../spark-configuration#replacing-the-session-catalog).


### PR DESCRIPTION
This is just a rebased version of #4606 opened by @kyle-cx since the spark-ddl.md file has been moved up one directory.