### PR TITLE
Core: Don't fail scan planning if REST metric reporting fails

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -304,12 +304,16 @@ public class RESTSessionCatalog extends BaseSessionCatalog
       MetricsReport report,
       Supplier<Map<String, String>> headers) {
     reporter.report(report);
-    client.post(
-        paths.metrics(tableIdentifier),
-        ReportMetricsRequest.of(report),
-        null,
-        headers,
-        ErrorHandlers.defaultErrorHandler());
+    try {
+      client.post(
+          paths.metrics(tableIdentifier),
+          ReportMetricsRequest.of(report),
+          null,
+          headers,
+          ErrorHandlers.defaultErrorHandler());
+    } catch (Exception e) {
+      LOG.warn("Failed to report metrics to REST endpoint for table {}", tableIdentifier, e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Metrics reporting via REST could temporarily fail for multiple reasons, such as Network hiccups or timeouts. That shouldn't interfere with scan planning overall.