### PR TITLE
Core: Increase inferred column metrics limit to 100

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -266,7 +266,7 @@ public class TableProperties {
 
   public static final String METRICS_MAX_INFERRED_COLUMN_DEFAULTS =
       "write.metadata.metrics.max-inferred-column-defaults";
-  public static final int METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT = 32;
+  public static final int METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT = 100;
 
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -208,7 +208,7 @@ public abstract class TestWriterMetrics<T> {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create
 
-    int numColumns = 33;
+    int numColumns = TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT + 1;
     List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));
@@ -236,7 +236,7 @@ public abstract class TestWriterMetrics<T> {
 
     // start at 1 because IDs were reassigned in the table
     int id = 1;
-    for (; id <= 32; id += 1) {
+    for (; id <= TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT; id += 1) {
       Assert.assertNotNull("Should have lower bound metrics", dataFile.lowerBounds().get(id));
       Assert.assertNotNull("Should have upper bound metrics", dataFile.upperBounds().get(id));
       Assert.assertNull(
@@ -262,7 +262,7 @@ public abstract class TestWriterMetrics<T> {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create
 
-    int numColumns = 33;
+    int numColumns = TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS_DEFAULT + 1;
     List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));


### PR DESCRIPTION
This patch seems to be present in 1.0.0 but missing in master.