### PR TITLE
AWS: Add AwsKmsClient implementation

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.encryption;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
+import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
+import software.amazon.awssdk.services.kms.model.DisableKeyRequest;
+
+public class TestAwsKmsClient {
+  static Map<String, String> properties;
+  static AwsKmsClient awsKmsClient;
+  static KmsClient kms;
+
+  static String wrappingKeyId;
+
+  @BeforeClass
+  public static void beforeClass() {
+    awsKmsClient = new AwsKmsClient();
+    properties = new HashMap<>();
+    kms = AwsClientFactories.from(properties).kms();
+    awsKmsClient.initialize(kms);
+    CreateKeyResponse response = kms.createKey(CreateKeyRequest.builder().build());
+    wrappingKeyId = response.keyMetadata().keyId();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    kms.disableKey(DisableKeyRequest.builder().keyId(wrappingKeyId).build());
+  }
+
+  @Test
+  public void testGenerateKey() {
+    org.apache.iceberg.encryption.KmsClient.KeyGenerationResult result =
+        awsKmsClient.generateKey(wrappingKeyId);
+    Assert.assertNotNull("Should successfully generate a plainTextKey", result.key());
+    Assert.assertNotNull("Should successfully generate a wrapped key", result.key());
+  }
+
+  @Test
+  public void testWrapKey() {
+    org.apache.iceberg.encryption.KmsClient.KeyGenerationResult result =
+        awsKmsClient.generateKey(wrappingKeyId);
+    ByteBuffer plainTextKey = result.key();
+    String wrappedKey = awsKmsClient.wrapKey(plainTextKey, wrappingKeyId);
+    Assert.assertNotNull("Should successfully encrypt the plainTextKey", wrappedKey);
+  }
+
+  @Test
+  public void testUnwrapKey() {
+    org.apache.iceberg.encryption.KmsClient.KeyGenerationResult result =
+        awsKmsClient.generateKey(wrappingKeyId);
+    String wrappedKey = result.wrappedKey();
+    ByteBuffer plainTextKey = awsKmsClient.unwrapKey(wrappedKey, wrappingKeyId);
+    Assert.assertNotNull("Should successfully decrypt the wrappedKey", plainTextKey);
+    Assert.assertEquals(
+        "The resulting plaintext key should be consistent", result.key(), plainTextKey);
+  }
+
+  @Test
+  public void testWrapAndUnwrapKey() {
+    org.apache.iceberg.encryption.KmsClient.KeyGenerationResult result =
+        awsKmsClient.generateKey(wrappingKeyId);
+    ByteBuffer plainTextKey = result.key();
+    String wrappedKey = awsKmsClient.wrapKey(plainTextKey, wrappingKeyId);
+    ByteBuffer unrappedKey = awsKmsClient.unwrapKey(wrappedKey, wrappingKeyId);
+    Assert.assertEquals("The plaintext key should be consistent", plainTextKey, unrappedKey);
+  }
+}

--- a/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
@@ -59,7 +59,7 @@ public class TestAwsKmsClient {
     org.apache.iceberg.encryption.KmsClient.KeyGenerationResult result =
         awsKmsClient.generateKey(wrappingKeyId);
     Assert.assertNotNull("Should successfully generate a plainTextKey", result.key());
-    Assert.assertNotNull("Should successfully generate a wrapped key", result.key());
+    Assert.assertNotNull("Should successfully generate a wrapped key", result.wrappedKey());
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.aws.encryption;
 
+import com.google.common.collect.Maps;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.iceberg.aws.AwsClientFactories;
 import org.junit.AfterClass;
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
 import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
 import software.amazon.awssdk.services.kms.model.DisableKeyRequest;
 
+@SuppressWarnings({"VisibilityModifier"})
 public class TestAwsKmsClient {
   static Map<String, String> properties;
   static AwsKmsClient awsKmsClient;
@@ -41,7 +42,7 @@ public class TestAwsKmsClient {
   @BeforeClass
   public static void beforeClass() {
     awsKmsClient = new AwsKmsClient();
-    properties = new HashMap<>();
+    properties = Maps.newHashMap();
     kms = AwsClientFactories.from(properties).kms();
     awsKmsClient.initialize(kms);
     CreateKeyResponse response = kms.createKey(CreateKeyRequest.builder().build());
@@ -67,7 +68,7 @@ public class TestAwsKmsClient {
         awsKmsClient.generateKey(wrappingKeyId);
     ByteBuffer plainTextKey = result.key();
     String wrappedKey = awsKmsClient.wrapKey(plainTextKey, wrappingKeyId);
-    Assert.assertNotNull("Should successfully encrypt the plainTextKey", wrappedKey);
+    Assert.assertNotNull("Should successfully wrap the plainTextKey", wrappedKey);
   }
 
   @Test
@@ -76,7 +77,7 @@ public class TestAwsKmsClient {
         awsKmsClient.generateKey(wrappingKeyId);
     String wrappedKey = result.wrappedKey();
     ByteBuffer plainTextKey = awsKmsClient.unwrapKey(wrappedKey, wrappingKeyId);
-    Assert.assertNotNull("Should successfully decrypt the wrappedKey", plainTextKey);
+    Assert.assertNotNull("Should successfully unwrap the wrappedKey", plainTextKey);
     Assert.assertEquals(
         "The resulting plaintext key should be consistent", result.key(), plainTextKey);
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
@@ -18,10 +18,10 @@
  */
 package org.apache.iceberg.aws.encryption;
 
-import com.google.common.collect.Maps;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -31,7 +31,7 @@ import software.amazon.awssdk.services.kms.model.CreateKeyRequest;
 import software.amazon.awssdk.services.kms.model.CreateKeyResponse;
 import software.amazon.awssdk.services.kms.model.DisableKeyRequest;
 
-@SuppressWarnings({"VisibilityModifier"})
+@SuppressWarnings("VisibilityModifier")
 public class TestAwsKmsClient {
   static Map<String, String> properties;
   static AwsKmsClient awsKmsClient;
@@ -42,7 +42,7 @@ public class TestAwsKmsClient {
   @BeforeClass
   public static void beforeClass() {
     awsKmsClient = new AwsKmsClient();
-    properties = Maps.newHashMap();
+    properties = ImmutableMap.of();
     kms = AwsClientFactories.from(properties).kms();
     awsKmsClient.initialize(kms);
     CreateKeyResponse response = kms.createKey(CreateKeyRequest.builder().build());

--- a/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
@@ -102,7 +102,7 @@ public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
   }
 
   @VisibleForTesting
-  void initialize(KmsClient kms) {
-    this.kms = kms;
+  void initialize(KmsClient client) {
+    this.kms = client;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
@@ -55,7 +55,6 @@ public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
       throw e;
     }
     String wrappedKey = Base64.getEncoder().encodeToString(response.ciphertextBlob().asByteArray());
-    ;
     return wrappedKey;
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws.encryption;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkBytes;
@@ -37,6 +38,8 @@ public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
   private KmsClient kms;
   private static final Logger LOG = LoggerFactory.getLogger(AwsKmsClient.class);
 
+  public AwsKmsClient() {}
+
   @Override
   public String wrapKey(ByteBuffer key, String wrappingKeyId) {
     EncryptResponse response = null;
@@ -46,7 +49,7 @@ public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
           kms.encrypt(
               EncryptRequest.builder().keyId(wrappingKeyId).plaintext(plainTextKey).build());
     } catch (Exception e) {
-      LOG.error("Fail to wrap key {} with wrappingKeyId {}", key.toString(), wrappingKeyId, e);
+      LOG.error("Fail to wrap key {} with wrappingKeyId {}", key, wrappingKeyId, e);
       throw e;
     }
     String wrappedKey = response.ciphertextBlob().asUtf8String();
@@ -95,6 +98,11 @@ public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
 
   @Override
   public void initialize(Map<String, String> properties) {
-    this.kms = AwsClientFactories.from(properties).kms();
+    initialize(AwsClientFactories.from(properties).kms());
+  }
+
+  @VisibleForTesting
+  void initialize(KmsClient kms) {
+    this.kms = kms;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/encryption/AwsKmsClient.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.encryption;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.EncryptRequest;
+import software.amazon.awssdk.services.kms.model.EncryptResponse;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+
+public class AwsKmsClient implements org.apache.iceberg.encryption.KmsClient {
+
+  private KmsClient kms;
+  private static final Logger LOG = LoggerFactory.getLogger(AwsKmsClient.class);
+
+  @Override
+  public String wrapKey(ByteBuffer key, String wrappingKeyId) {
+    EncryptResponse response = null;
+    SdkBytes plainTextKey = SdkBytes.fromByteBuffer(key);
+    try {
+      response =
+          kms.encrypt(
+              EncryptRequest.builder().keyId(wrappingKeyId).plaintext(plainTextKey).build());
+    } catch (Exception e) {
+      LOG.error("Fail to wrap key {} with wrappingKeyId {}", key.toString(), wrappingKeyId, e);
+      throw e;
+    }
+    String wrappedKey = response.ciphertextBlob().asUtf8String();
+    return wrappedKey;
+  }
+
+  /** AWS KMS supports key generation */
+  @Override
+  public boolean supportsKeyGeneration() {
+    return true;
+  }
+
+  @Override
+  public KeyGenerationResult generateKey(String wrappingKeyId) {
+    GenerateDataKeyResponse response = null;
+    try {
+      response = kms.generateDataKey(GenerateDataKeyRequest.builder().keyId(wrappingKeyId).build());
+
+    } catch (Exception e) {
+      LOG.error("Fail to generate key with wrappingKeyId {}", wrappingKeyId, e);
+      throw e;
+    }
+
+    ByteBuffer plainTextKey = response.plaintext().asByteBuffer();
+    String wrappedKey = response.ciphertextBlob().asUtf8String();
+    return new KeyGenerationResult(plainTextKey, wrappedKey);
+  }
+
+  @Override
+  public ByteBuffer unwrapKey(String wrappedKey, String wrappingKeyId) {
+    DecryptResponse response = null;
+    try {
+      response =
+          kms.decrypt(
+              DecryptRequest.builder()
+                  .ciphertextBlob(SdkBytes.fromUtf8String(wrappedKey))
+                  .keyId(wrappingKeyId)
+                  .build());
+    } catch (Exception e) {
+      LOG.error("Fail to decrypt key {} with wrappingKeyId {}", wrappedKey, wrappingKeyId, e);
+      throw e;
+    }
+    ByteBuffer plainTextKey = response.plaintext().asByteBuffer();
+    return plainTextKey;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    this.kms = AwsClientFactories.from(properties).kms();
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/encryption/TestAwsKmsClient.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.encryption;
+
+import java.nio.ByteBuffer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.DecryptRequest;
+import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.EncryptRequest;
+import software.amazon.awssdk.services.kms.model.EncryptResponse;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+
+public class TestAwsKmsClient {
+  private KmsClient kms;
+
+  private AwsKmsClient awsKmsClient;
+
+  @Before
+  public void before() {
+    kms = Mockito.mock(KmsClient.class);
+    awsKmsClient = new AwsKmsClient();
+    awsKmsClient.initialize(kms);
+  }
+
+  @Test
+  public void testSupportsKeyGeneration() {
+    Assert.assertTrue("AWS KMS supports key generation", awsKmsClient.supportsKeyGeneration());
+  }
+
+  @Test
+  public void testGenerateKey() {
+    String testWrappingKeyId = "testGenerateKey";
+    String expectedPlainText = "testPlain";
+    String expectedWrappedKey = "testWrappedKey";
+    Mockito.doReturn(
+            GenerateDataKeyResponse.builder()
+                .keyId(testWrappingKeyId)
+                .plaintext(SdkBytes.fromUtf8String(expectedPlainText))
+                .ciphertextBlob(SdkBytes.fromUtf8String(expectedWrappedKey))
+                .build())
+        .when(kms)
+        .generateDataKey(Mockito.any(GenerateDataKeyRequest.class));
+    org.apache.iceberg.encryption.KmsClient.KeyGenerationResult keyGenResult =
+        awsKmsClient.generateKey(testWrappingKeyId);
+    Assert.assertEquals(
+        "The test plaintext key should be testPlain",
+        SdkBytes.fromUtf8String(expectedPlainText),
+        SdkBytes.fromByteBuffer(keyGenResult.key()));
+    Assert.assertEquals(
+        "The test wrapped key should be testWrappedKey",
+        expectedWrappedKey,
+        keyGenResult.wrappedKey());
+  }
+
+  @Test
+  public void testWrapKey() {
+    String testWrappingKeyId = "testWrapKey";
+    String testPlainText = "testPlain";
+    String testWrappedKey = "testWrappedKey";
+    ByteBuffer testKey = SdkBytes.fromUtf8String(testPlainText).asByteBuffer();
+    Mockito.doReturn(
+            EncryptResponse.builder()
+                .keyId(testWrappingKeyId)
+                .ciphertextBlob(SdkBytes.fromUtf8String(testWrappedKey))
+                .build())
+        .when(kms)
+        .encrypt(Mockito.any(EncryptRequest.class));
+    String resultWrappedKey = awsKmsClient.wrapKey(testKey, testWrappingKeyId);
+    Assert.assertEquals(
+        "The wrapped key should be testWrappedKey", testWrappedKey, resultWrappedKey);
+  }
+
+  @Test
+  public void testUnwrapKey() {
+    String testWrappingKeyId = "testUnwrapKey";
+    String testPlainText = "testPlain";
+    String testWrappedKey = "testWrappedKey";
+    SdkBytes rawPlaintextKey = SdkBytes.fromUtf8String(testPlainText);
+    Mockito.doReturn(
+            DecryptResponse.builder().keyId(testWrappingKeyId).plaintext(rawPlaintextKey).build())
+        .when(kms)
+        .decrypt(Mockito.any(DecryptRequest.class));
+
+    ByteBuffer resultPlaintextKey = awsKmsClient.unwrapKey(testWrappedKey, testWrappingKeyId);
+    Assert.assertEquals(
+        "The result plaintext should be testPlain",
+        rawPlaintextKey.asByteBuffer(),
+        resultPlaintextKey);
+  }
+}


### PR DESCRIPTION
- Add `AwsKmsClient`, which implements the `KmsClient` interface.
- Add unit tests
- Add integration tests