### PR TITLE
Core: Partial Update

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -104,6 +104,8 @@ public interface ContentFile<F> {
    */
   List<Integer> equalityFieldIds();
 
+  List<Integer> partialFieldIds();
+
   /**
    * Returns the sort order id of this file, which describes how the file is ordered. This
    * information will be useful for merging data and equality delete files more efficiently when

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -102,7 +102,14 @@ public interface DataFile extends ContentFile<DataFile> {
   int PARTITION_ID = 102;
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
-  // NEXT ID TO ASSIGN: 142
+
+  Types.NestedField PARTIAL_IDS =
+      optional(
+          142,
+          "partial_ids",
+          ListType.ofRequired(143, IntegerType.get()),
+          "partial comparison field IDs");
+  // NEXT ID TO ASSIGN: 144
 
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
@@ -123,7 +130,8 @@ public interface DataFile extends ContentFile<DataFile> {
         KEY_METADATA,
         SPLIT_OFFSETS,
         EQUALITY_IDS,
-        SORT_ORDER_ID);
+        SORT_ORDER_ID,
+        PARTIAL_IDS);
   }
 
   /** @return the content stored in the file; one of DATA, POSITION_DELETES, or EQUALITY_DELETES */
@@ -134,6 +142,11 @@ public interface DataFile extends ContentFile<DataFile> {
 
   @Override
   default List<Integer> equalityFieldIds() {
+    return null;
+  }
+
+  @Override
+  default List<Integer> partialFieldIds() {
     return null;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/FileContent.java
+++ b/api/src/main/java/org/apache/iceberg/FileContent.java
@@ -22,7 +22,8 @@ package org.apache.iceberg;
 public enum FileContent {
   DATA(0),
   POSITION_DELETES(1),
-  EQUALITY_DELETES(2);
+  EQUALITY_DELETES(2),
+  PARTIAL_UPDATE(3);
 
   private final int id;
 

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -75,6 +75,7 @@ abstract class BaseFile<F>
   private int[] equalityIds = null;
   private byte[] keyMetadata = null;
   private Integer sortOrderId;
+  private int[] partialIds = null;
 
   // cached schema
   private transient Schema avroSchema = null;
@@ -132,6 +133,7 @@ abstract class BaseFile<F>
       Map<Integer, ByteBuffer> upperBounds,
       List<Long> splitOffsets,
       int[] equalityFieldIds,
+      int[] partialIds,
       Integer sortOrderId,
       ByteBuffer keyMetadata) {
     this.partitionSpecId = specId;
@@ -159,6 +161,7 @@ abstract class BaseFile<F>
     this.upperBounds = SerializableByteBufferMap.wrap(upperBounds);
     this.splitOffsets = ArrayUtil.toLongArray(splitOffsets);
     this.equalityIds = equalityFieldIds;
+    this.partialIds = partialIds;
     this.sortOrderId = sortOrderId;
     this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
   }
@@ -208,6 +211,11 @@ abstract class BaseFile<F>
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
             : null;
     this.sortOrderId = toCopy.sortOrderId;
+
+    this.partialIds =
+        toCopy.partialIds != null
+            ? Arrays.copyOf(toCopy.partialIds, toCopy.partialIds.length)
+            : null;
   }
 
   /** Constructor for Java serialization. */
@@ -294,6 +302,9 @@ abstract class BaseFile<F>
         this.sortOrderId = (Integer) value;
         return;
       case 17:
+        this.partialIds = ArrayUtil.toIntArray((List<Integer>) value);
+        return;
+      case 18:
         this.fileOrdinal = (long) value;
         return;
       default:
@@ -349,6 +360,8 @@ abstract class BaseFile<F>
       case 16:
         return sortOrderId;
       case 17:
+        return partialFieldIds();
+      case 18:
         return fileOrdinal;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
@@ -446,6 +459,11 @@ abstract class BaseFile<F>
   }
 
   @Override
+  public List<Integer> partialFieldIds() {
+    return ArrayUtil.toIntList(partialIds);
+  }
+
+  @Override
   public Integer sortOrderId() {
     return sortOrderId;
   }
@@ -478,6 +496,7 @@ abstract class BaseFile<F>
         .add("split_offsets", splitOffsets == null ? "null" : splitOffsets())
         .add("equality_ids", equalityIds == null ? "null" : equalityFieldIds())
         .add("sort_order_id", sortOrderId)
+        .add("partial_ids", equalityIds == null ? "null" : partialFieldIds())
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -41,6 +41,7 @@ public class FileMetadata {
     private final int specId;
     private FileContent content = null;
     private int[] equalityFieldIds = null;
+    private int[] partialFieldIds = null;
     private PartitionData partitionData;
     private String filePath = null;
     private FileFormat format = null;
@@ -113,6 +114,13 @@ public class FileMetadata {
     public Builder ofEqualityDeletes(int... fieldIds) {
       this.content = FileContent.EQUALITY_DELETES;
       this.equalityFieldIds = fieldIds;
+      return this;
+    }
+
+    public Builder ofPartialDeletes(int[] newEqualityFieldIds, int[] newPartialFieldIds) {
+      this.content = FileContent.PARTIAL_UPDATE;
+      this.equalityFieldIds = newEqualityFieldIds;
+      this.partialFieldIds = newPartialFieldIds;
       return this;
     }
 
@@ -222,6 +230,8 @@ public class FileMetadata {
               sortOrderId == null, "Position delete file should not have sort order");
           break;
         case EQUALITY_DELETES:
+
+        case PARTIAL_UPDATE:
           if (sortOrderId == null) {
             sortOrderId = SortOrder.unsorted().orderId();
           }
@@ -246,6 +256,7 @@ public class FileMetadata {
               lowerBounds,
               upperBounds),
           equalityFieldIds,
+          partialFieldIds,
           sortOrderId,
           keyMetadata);
     }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -57,6 +57,7 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
         metrics.upperBounds(),
         splitOffsets,
         null,
+        null,
         sortOrderId,
         keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -39,6 +39,7 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
       long fileSizeInBytes,
       Metrics metrics,
       int[] equalityFieldIds,
+      int[] partialFieldIds,
       Integer sortOrderId,
       ByteBuffer keyMetadata) {
     super(
@@ -57,6 +58,7 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
         metrics.upperBounds(),
         null,
         equalityFieldIds,
+        partialFieldIds,
         sortOrderId,
         keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -221,12 +221,14 @@ public class SnapshotSummary {
     private int addedPosDeleteFiles = 0;
     private int removedPosDeleteFiles = 0;
     private int addedDeleteFiles = 0;
+    private int addedPartialFiles = 0;
     private int removedDeleteFiles = 0;
     private long addedRecords = 0L;
     private long deletedRecords = 0L;
     private long addedPosDeletes = 0L;
     private long removedPosDeletes = 0L;
     private long addedEqDeletes = 0L;
+    private long addedPartialUpdates = 0L;
     private long removedEqDeletes = 0L;
     private boolean trustSizeAndDeleteCounts = true;
 
@@ -290,6 +292,12 @@ public class SnapshotSummary {
           this.addedEqDeleteFiles += 1;
           this.addedEqDeletes += file.recordCount();
           break;
+        case PARTIAL_UPDATE:
+          this.addedDeleteFiles += 1;
+          this.addedPartialFiles += 1;
+          this.addedPartialUpdates += file.recordCount();
+          break;
+
         default:
           throw new UnsupportedOperationException(
               "Unsupported file content type: " + file.content());

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -271,7 +271,8 @@ class V2Metadata {
         DataFile.KEY_METADATA,
         DataFile.SPLIT_OFFSETS,
         DataFile.EQUALITY_IDS,
-        DataFile.SORT_ORDER_ID);
+        DataFile.SORT_ORDER_ID,
+        DataFile.PARTIAL_IDS);
   }
 
   static class IndexedManifestEntry<F extends ContentFile<F>>
@@ -443,6 +444,8 @@ class V2Metadata {
           return wrapped.equalityFieldIds();
         case 15:
           return wrapped.sortOrderId();
+        case 16:
+          return wrapped.partialFieldIds();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -535,6 +538,11 @@ class V2Metadata {
     @Override
     public List<Integer> equalityFieldIds() {
       return wrapped.equalityFieldIds();
+    }
+
+    @Override
+    public List<Integer> partialFieldIds() {
+      return wrapped.partialFieldIds();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/deletes/PartialDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PartialDeleteWriter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.DeleteWriteResult;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class PartialDeleteWriter<T> implements FileWriter<T, DeleteWriteResult> {
+  private final FileAppender<T> appender;
+  private final FileFormat format;
+  private final String location;
+  private final PartitionSpec spec;
+  private final StructLike partition;
+  private final ByteBuffer keyMetadata;
+  private final int[] equalityFieldIds;
+  private final int[] partialFieldIds;
+  private final SortOrder sortOrder;
+  private DeleteFile deleteFile = null;
+
+  public PartialDeleteWriter(
+      FileAppender<T> appender,
+      FileFormat format,
+      String location,
+      PartitionSpec spec,
+      StructLike partition,
+      EncryptionKeyMetadata keyMetadata,
+      SortOrder sortOrder,
+      int[] equalityFieldIds,
+      int[] partialFieldIds) {
+    this.appender = appender;
+    this.format = format;
+    this.location = location;
+    this.spec = spec;
+    this.partition = partition;
+    this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
+    this.sortOrder = sortOrder;
+    this.equalityFieldIds = equalityFieldIds;
+    this.partialFieldIds = partialFieldIds;
+  }
+
+  @Override
+  public void write(T row) {
+    appender.add(row);
+  }
+
+  @Override
+  public long length() {
+    return appender.length();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (deleteFile == null) {
+      appender.close();
+      this.deleteFile =
+          FileMetadata.deleteFileBuilder(spec)
+              .ofPartialDeletes(equalityFieldIds, partialFieldIds)
+              .withFormat(format)
+              .withPath(location)
+              .withPartition(partition)
+              .withEncryptionKeyMetadata(keyMetadata)
+              .withFileSizeInBytes(appender.length())
+              .withMetrics(appender.metrics())
+              .withSortOrder(sortOrder)
+              .build();
+    }
+  }
+
+  public DeleteFile toDeleteFile() {
+    Preconditions.checkState(deleteFile != null, "Cannot create delete file from unclosed writer");
+    return deleteFile;
+  }
+
+  @Override
+  public DeleteWriteResult result() {
+    return new DeleteWriteResult(toDeleteFile());
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.io;
 
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PartialDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 
@@ -61,6 +63,19 @@ public interface FileAppenderFactory<T> {
    */
   EqualityDeleteWriter<T> newEqDeleteWriter(
       EncryptedOutputFile outputFile, FileFormat format, StructLike partition);
+
+  /**
+   * Create a new {@link PartialDeleteWriter}.
+   *
+   * @param outputFile an OutputFile used to create an output stream.
+   * @param format a file format
+   * @param partition a tuple of partition values
+   * @return a newly created {@link PartialDeleteWriter} for partial updates.
+   */
+  default PartialDeleteWriter<Record> newPartialWriter(
+      EncryptedOutputFile outputFile, FileFormat format, StructLike partition) {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
 
   /**
    * Create a new {@link PositionDeleteWriter}.

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -131,7 +131,7 @@ public class TestManifestReader extends TableTestBase {
       for (DataFile file : reader) {
         Assert.assertEquals("Position should match", (Long) expectedPos, file.pos());
         Assert.assertEquals(
-            "Position from field index should match", expectedPos, ((BaseFile) file).get(17));
+            "Position from field index should match", expectedPos, ((BaseFile) file).get(18));
         expectedPos += 1;
       }
     }
@@ -148,7 +148,7 @@ public class TestManifestReader extends TableTestBase {
       for (DeleteFile file : reader) {
         Assert.assertEquals("Position should match", (Long) expectedPos, file.pos());
         Assert.assertEquals(
-            "Position from field index should match", expectedPos, ((BaseFile) file).get(17));
+            "Position from field index should match", expectedPos, ((BaseFile) file).get(18));
         expectedPos += 1;
       }
     }

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -81,6 +81,7 @@ public class TestManifestWriterVersions {
 
   private static final List<Integer> EQUALITY_IDS = ImmutableList.of(1);
   private static final int[] EQUALITY_ID_ARR = new int[] {1};
+  private static final int[] PARTIAL_ID_ARR = new int[] {1};
 
   private static final DeleteFile DELETE_FILE =
       new GenericDeleteFile(
@@ -92,6 +93,7 @@ public class TestManifestWriterVersions {
           22905L,
           METRICS,
           EQUALITY_ID_ARR,
+          PARTIAL_ID_ARR,
           SORT_ORDER_ID,
           null);
 

--- a/data/src/test/java/org/apache/iceberg/data/PartialReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/PartialReadTests.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ArrayUtil;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public abstract class PartialReadTests {
+  // Schema passed to create tables
+  public static final Schema DATE_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "dt", Types.DateType.get()),
+          Types.NestedField.required(2, "data", Types.StringType.get()),
+          Types.NestedField.required(3, "data2", Types.StringType.get()),
+          Types.NestedField.required(4, "id", Types.IntegerType.get()));
+
+  // Partition spec used to create tables
+  public static final PartitionSpec DATE_SPEC =
+      PartitionSpec.builderFor(DATE_SCHEMA).day("dt").build();
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  protected String tableName = null;
+  protected String dateTableName = null;
+  protected Table table = null;
+  protected Table dateTable = null;
+  protected List<Record> records = null;
+  private List<Record> dateRecords = null;
+  protected DataFile dataFile = null;
+
+  @Before
+  public void writeTestDataFile() throws IOException {
+    this.dateTableName = "test2";
+    this.dateTable = createTable(dateTableName, DATE_SCHEMA, DATE_SPEC);
+
+    GenericRecord record = GenericRecord.create(dateTable.schema());
+    this.dateRecords = Lists.newArrayList();
+
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(4);
+    overwriteValues.put("dt", LocalDate.parse("2021-09-01"));
+    overwriteValues.put("data", "a");
+    overwriteValues.put("data2", "a2");
+    overwriteValues.put("id", 1);
+    dateRecords.add(record.copy(overwriteValues));
+
+    overwriteValues.put("dt", LocalDate.parse("2021-09-02"));
+    overwriteValues.put("data", "b");
+    overwriteValues.put("data2", "b2");
+    overwriteValues.put("id", 2);
+    dateRecords.add(record.copy(overwriteValues));
+
+    DataFile dataFile1 =
+        FileHelpers.writeDataFile(
+            dateTable,
+            Files.localOutput(temp.newFile()),
+            Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-01"))),
+            dateRecords);
+
+    dateTable.newAppend().appendFile(dataFile1).commit();
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    dropTable("test");
+    dropTable("test2");
+  }
+
+  protected abstract Table createTable(String name, Schema schema, PartitionSpec spec)
+      throws IOException;
+
+  protected abstract void dropTable(String name) throws IOException;
+
+  protected abstract StructLikeSet rowSet(String name, Table testTable, String... columns)
+      throws IOException;
+
+  protected boolean countPartial() {
+    return false;
+  }
+
+  /**
+   * This will only be called after calling rowSet(String, Table, String...), and only if
+   * countDeletes() is true.
+   */
+  protected long deleteCount() {
+    return 0L;
+  }
+
+  protected void checkPartialCount(long expectedPartials) {
+    if (countPartial()) {
+      long actualPartials = deleteCount();
+      Assert.assertEquals(
+          "Table should contain expected number of deletes", expectedPartials, actualPartials);
+    }
+  }
+
+  // todo need more tests for partial update
+
+  @Test
+  public void testPartialData() throws IOException {
+    Schema partialFullSchema = dateTable.schema().select("dt", "data", "id");
+    Schema eqDeleteSchema = dateTable.schema().select("dt", "id");
+    Schema partialDataSchema = dateTable.schema().select("data");
+
+    Record dataPartial = GenericRecord.create(partialFullSchema);
+    List<Record> dataDeletes =
+        Lists.newArrayList(
+            dataPartial.copy("dt", LocalDate.parse("2021-09-01"), "data", "a3", "id", 1));
+
+    DeleteFile partialFile =
+        FileHelpers.writePartialFile(
+            dateTable,
+            Files.localOutput(temp.newFile()),
+            Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-01"))),
+            dataDeletes,
+            eqDeleteSchema,
+            partialDataSchema,
+            partialFullSchema);
+
+    dateTable.newRowDelta().addDeletes(partialFile).commit();
+
+    List<Record> expectedDateRecords = Lists.newArrayList();
+    GenericRecord record = GenericRecord.create(dateTable.schema());
+
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(4);
+    overwriteValues.put("dt", LocalDate.parse("2021-09-01"));
+    overwriteValues.put("data", "a3");
+    overwriteValues.put("data2", "a2");
+    overwriteValues.put("id", 1);
+    expectedDateRecords.add(record.copy(overwriteValues));
+
+    overwriteValues.put("dt", LocalDate.parse("2021-09-02"));
+    overwriteValues.put("data", "b");
+    overwriteValues.put("data2", "b2");
+    overwriteValues.put("id", 2);
+    expectedDateRecords.add(record.copy(overwriteValues));
+
+    StructLikeSet expected = rowSetWithoutIds(dateTable, expectedDateRecords);
+
+    StructLikeSet actual = rowSet(dateTableName, dateTable, "*");
+
+    Assert.assertEquals("Table should contain expected rows", expected, actual);
+  }
+
+  protected static StructLikeSet rowSetWithoutIds(
+      Table table, List<Record> recordList, int... idsToRemove) {
+    Set<Integer> deletedIds = Sets.newHashSet(ArrayUtil.toIntList(idsToRemove));
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    recordList.stream()
+        .filter(row -> !deletedIds.contains(row.getField("id")))
+        .map(record -> new InternalRecordWrapper(table.schema().asStruct()).wrap(record))
+        .forEach(set::add);
+    return set;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -215,6 +215,12 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
     }
 
     @Override
+    protected RowData combineRecord(
+        RowData record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return inputFilesDecryptor.getInputFile(location);
     }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -215,6 +215,12 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
     }
 
     @Override
+    protected RowData combineRecord(
+        RowData record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return inputFilesDecryptor.getInputFile(location);
     }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -215,6 +215,12 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
     }
 
     @Override
+    protected RowData combineRecord(
+        RowData record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return inputFilesDecryptor.getInputFile(location);
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestInputFormatReaderDeletes2.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestInputFormatReaderDeletes2.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.mr;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.data.InternalRecordWrapper;
+import org.apache.iceberg.data.PartialReadTests;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestInputFormatReaderDeletes2 extends PartialReadTests {
+  private final Configuration conf = new Configuration();
+  private final HadoopTables tables = new HadoopTables(conf);
+  private TestHelper helper;
+
+  // parametrized variables
+  private final String inputFormat;
+  private final FileFormat fileFormat;
+
+  @Parameterized.Parameters(name = "inputFormat = {0}, fileFormat={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      {"IcebergInputFormat", FileFormat.AVRO},
+    };
+  }
+
+  @Before
+  @Override
+  public void writeTestDataFile() throws IOException {
+    conf.set(CatalogUtil.ICEBERG_CATALOG_TYPE, Catalogs.LOCATION);
+    super.writeTestDataFile();
+  }
+
+  public TestInputFormatReaderDeletes2(String inputFormat, FileFormat fileFormat) {
+    this.inputFormat = inputFormat;
+    this.fileFormat = fileFormat;
+  }
+
+  @Override
+  protected Table createTable(String name, Schema schema, PartitionSpec spec) throws IOException {
+    Table table;
+
+    File location = temp.newFolder(inputFormat, fileFormat.name());
+    Assert.assertTrue(location.delete());
+    helper = new TestHelper(conf, tables, location.toString(), schema, spec, fileFormat, temp);
+    table = helper.createTable();
+
+    TableOperations ops = ((BaseTable) table).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+
+    return table;
+  }
+
+  @Override
+  protected void dropTable(String name) {
+    tables.dropTable(helper.table().location());
+  }
+
+  @Override
+  public StructLikeSet rowSet(String name, Table table, String... columns) {
+    InputFormatConfig.ConfigBuilder builder =
+        new InputFormatConfig.ConfigBuilder(conf).readFrom(table.location());
+    Schema projected = table.schema().select(columns);
+    StructLikeSet set = StructLikeSet.create(projected.asStruct());
+
+    set.addAll(
+        TestIcebergInputFormats.TESTED_INPUT_FORMATS.stream()
+            .filter(recordFactory -> recordFactory.name().equals(inputFormat))
+            .map(
+                recordFactory ->
+                    recordFactory.create(builder.project(projected).conf()).getRecords())
+            .flatMap(List::stream)
+            .map(record -> new InternalRecordWrapper(projected.asStruct()).wrap(record))
+            .collect(Collectors.toList()));
+
+    return set;
+  }
+}

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -190,6 +190,12 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return RowDataReader.this.getInputFile(location);
     }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -190,6 +190,12 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return RowDataReader.this.getInputFile(location);
     }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -155,6 +155,12 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return BatchDataReader.this.getInputFile(location);
     }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -190,6 +190,12 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return RowDataReader.this.getInputFile(location);
     }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -262,6 +262,12 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return BaseReader.this.getInputFile(location);
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -262,6 +262,12 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     }
 
     @Override
+    protected InternalRow combineRecord(
+        InternalRow record, StructLike partialRecord, Schema partialSchema) {
+      throw new UnsupportedOperationException("Partial updates are not yet supported.");
+    }
+
+    @Override
     protected InputFile getInputFile(String location) {
       return BaseReader.this.getInputFile(location);
     }


### PR DESCRIPTION
# Proposal: Partial Updates

## motivation



Take feature engineering as an example, there are thousands or even tens of thousands of columns in the table, but the task will update only a few of them. Currently, if want to update a row, we need to fetch  all the columns, which is very inefficient. If we support partial updates, we only need to generate data files with equality and updated columns on write, which greatly improves throughput and reduces complexity ( You do not need to query the values of other columns that do not need to be changed). When reading, we combine the data file with the partial update file, which has some similarities to COR. In addition, to improve the read efficiency, a background asynchronous task can be used to merge files when the system is idle.

### Partial Update Files

Partial updates files identify updated rows in a collection of data files by one or more column values, and includes one or more columns of the updated rows that need to be updated.

Partial updates files store any subset of a table’s columns and use the table’s field ids. The *equality columns* are the columns of the file used to match data rows. The p*artial columns* are columns of the file used to update the specified column of the matching data row.

The partial columns in a data row is updated to the new value if its equality columns values are equal to all equality columns for any row in an partial update file that applies to the row’s data file.

For example, a table with the following data:

```text
 1: id | 2: category | 3: name
-------|-------------|---------
 1     | marsupial   | Koala
 2     | toy         | Teddy
 3     | NULL        | Grizzly
 4     | NULL        | Polar
```

The equality `id = 3` and `name = Lily` could be written as the following partial update files:

```text
equality_ids=[1]
partial_ids=[3]

 1: id | 3: name
-------|---------
 3     | Lily
```

After applying the partially update file, will have the following data::

```text
 1: id | 2: category | 3: name
-------|-------------|---------
 1     | marsupial   | Koala
 2     | toy         | Teddy
 3     | NULL        | Lily
 4     | NULL        | Polar
```

Illustration:

![image](https://user-images.githubusercontent.com/59213263/197661183-acb6c06d-355e-4323-8bc1-e347db32a33c.png)

In this example, we will find the id1 and id3  in the a.file, then update its Col1 to the new value.

![image](https://user-images.githubusercontent.com/59213263/197661874-3384e5f5-579b-4f98-baf4-47ebd4c08d76.png)

In this example, we add a new column to the table and insert a partial update file that contains only the new columns. It might look more like an Insert, except we're inserting new columns for the old row, rather than inserting new rows.

### Brief change log

This PR consists of two parts:

* Evolution of the table format specification, mainly partial update file
* Partial update files Write\Read 


### Flaw

Through verification and discussion with @chenjunjiedada , this PR caches the Parental file in memory like  EQ DELETE, so it actually faces problems with data loading, OOM, etc.



P.S. :
This is an internal feature that is under development and has **not yet been completed**. I wanted to hear from the community early on, so I raised this PR before it was finished. Of course, there's the engine integration part, but I think this PR is the core part of it, and we should talk about it there first to try and get on the same page.

With this approach, we can solve a large number of business scenarios. Internally, we have implemented it with Flink and achieved satisfactory results in validation.

What is our community's view of it? Hope to receive your feedback.