### PR TITLE
Core: Replace projected Schema with schemaId/fieldIds/fieldNames in ScanReport

### DIFF
--- a/core/src/main/java/org/apache/iceberg/metrics/ScanReport.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanReport.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.metrics;
 
-import org.apache.iceberg.Schema;
+import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 import org.immutables.value.Value;
 
@@ -32,7 +32,11 @@ public interface ScanReport extends MetricsReport {
 
   Expression filter();
 
-  Schema projection();
+  int schemaId();
+
+  List<Integer> projectedFieldIds();
+
+  List<String> projectedFieldNames();
 
   ScanMetricsResult scanMetrics();
 }

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1915,8 +1915,6 @@ components:
           type: array
           items:
             type: string
-        projection:
-          $ref: '#/components/schemas/Schema'
         metrics:
           $ref: '#/components/schemas/Metrics'
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1837,6 +1837,46 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/MetricResult'
+      example:
+        "metrics": {
+          "total-planning-duration": {
+            "count": 1,
+            "time-unit": "nanoseconds",
+            "total-duration": 2644235116
+          },
+          "result-data-files": {
+            "unit": "count",
+            "value": 1,
+          },
+          "result-delete-files": {
+            "unit": "count",
+            "value": 0,
+          },
+          "total-data-manifests": {
+            "unit": "count",
+            "value": 1,
+          },
+          "total-delete-manifests": {
+            "unit": "count",
+            "value": 0,
+          },
+          "scanned-data-manifests": {
+            "unit": "count",
+            "value": 1,
+          },
+          "skipped-data-manifests": {
+            "unit": "count",
+            "value": 0,
+          },
+          "total-file-size-bytes": {
+            "unit": "bytes",
+            "value": 10,
+          },
+          "total-delete-file-size-bytes": {
+            "unit": "bytes",
+            "value": 0,
+          }
+        }
 
     ReportMetricsRequest:
       anyOf:
@@ -1853,7 +1893,9 @@ components:
         - table-name
         - snapshot-id
         - filter
-        - projection
+        - schema-id
+        - projected-field-ids
+        - projected-field-names
         - metrics
       properties:
         table-name:
@@ -1863,50 +1905,20 @@ components:
           format: int64
         filter:
           $ref: '#/components/schemas/Expression'
+        schema-id:
+          type: integer
+        projected-field-ids:
+          type: array
+          items:
+            type: integer
+        projected-field-names:
+          type: array
+          items:
+            type: string
         projection:
           $ref: '#/components/schemas/Schema'
         metrics:
           $ref: '#/components/schemas/Metrics'
-          example:
-            "metrics": {
-              "total-planning-duration": {
-                "count": 1,
-                "time-unit": "nanoseconds",
-                "total-duration": 2644235116
-              },
-              "result-data-files": {
-                "unit": "count",
-                "value": 1,
-              },
-              "result-delete-files": {
-                "unit": "count",
-                "value": 0,
-              },
-              "total-data-manifests": {
-                "unit": "count",
-                "value": 1,
-              },
-              "total-delete-manifests": {
-                "unit": "count",
-                "value": 0,
-              },
-              "scanned-data-manifests": {
-                "unit": "count",
-                "value": 1,
-              },
-              "skipped-data-manifests": {
-                "unit": "count",
-                "value": 0,
-              },
-              "total-file-size-bytes": {
-                "unit": "bytes",
-                "value": 10,
-              },
-              "total-delete-file-size-bytes": {
-                "unit": "bytes",
-                "value": 0,
-              }
-            }
 
 
   #############################


### PR DESCRIPTION
The motivation behind this change is that the projected schema might get quite big and contain information such as doc comments, which make it quite hard to read/consume. This change makes sure that we only include the minimal set of information from a schema
(schemaId/fieldIds/fieldNames).