### PR TITLE
Infra: Update slack invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -5,7 +5,7 @@ labels: ["kind:question"]
 body:
   - type: markdown
     attributes:
-      value: "Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-tlv0zjz6-jGJEkHfb1~heMCJA3Uycrg) as well."
+      value: "Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-1htq2z3jn-8aBes6j0aZlfWpbT3~rwrw) as well."
   - type: textarea
     attributes:
       label: Query engine


### PR DESCRIPTION
Recently we have updated slack invite link in [iceberg-docs repo](https://github.com/apache/iceberg-docs/pull/169). It needs to be updated here also.