### PR TITLE
Spark 3.3: Use separate scan during file filtering in copy-on-write operations

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -259,8 +259,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     // getting a process-level lock per table to avoid concurrent commit attempts to the same table
     // from the same
     // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
-    // ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
-    // tableLevelMutex.lock();
+    ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
+    tableLevelMutex.lock();
     HiveLockHeartbeat hiveLockHeartbeat = null;
     try {
       lockId = Optional.of(acquireLock());
@@ -383,7 +383,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         hiveLockHeartbeat.cancel();
       }
 
-      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, null);
+      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
     }
 
     LOG.info(
@@ -700,7 +700,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       LOG.error("Failed to cleanup metadata file at {}", metadataLocation, e);
     } finally {
       unlock(lockId);
-      // tableLevelMutex.unlock();
+      tableLevelMutex.unlock();
     }
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -259,8 +259,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     // getting a process-level lock per table to avoid concurrent commit attempts to the same table
     // from the same
     // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
-    ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
-    tableLevelMutex.lock();
+    // ReentrantLock tableLevelMutex = commitLockCache.get(fullName, t -> new ReentrantLock(true));
+    // tableLevelMutex.lock();
     HiveLockHeartbeat hiveLockHeartbeat = null;
     try {
       lockId = Optional.of(acquireLock());
@@ -383,7 +383,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         hiveLockHeartbeat.cancel();
       }
 
-      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, tableLevelMutex);
+      cleanupMetadataAndUnlock(commitStatus, newMetadataLocation, lockId, null);
     }
 
     LOG.info(
@@ -700,7 +700,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       LOG.error("Failed to cleanup metadata file at {}", metadataLocation, e);
     } finally {
       unlock(lockId);
-      tableLevelMutex.unlock();
+      // tableLevelMutex.unlock();
     }
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -135,6 +135,11 @@ public class TestHiveMetastore {
     start(new HiveConf(new Configuration(), TestHiveMetastore.class), DEFAULT_POOL_SIZE);
   }
 
+  /** Starts a TestHiveMetastore with a custom connection pool size and the default HiveConf. */
+  public void start(int poolSize) {
+    start(new HiveConf(new Configuration(), TestHiveMetastore.class), poolSize);
+  }
+
   /**
    * Starts a TestHiveMetastore with the default connection pool size (5) with the provided
    * HiveConf.

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelCommandDynamicPruning.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelCommandDynamicPruning.scala
@@ -48,7 +48,9 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
 import org.apache.spark.sql.catalyst.trees.TreePattern.SORT
 import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits
 import scala.collection.compat.immutable.ArraySeq
 
 /**
@@ -58,6 +60,8 @@ import scala.collection.compat.immutable.ArraySeq
  * Row-based rewrite plans are subject to usual runtime filtering.
  */
 case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[LogicalPlan] with PredicateHelper {
+
+  import ExtendedDataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     // apply special dynamic filtering only for plans that don't support deltas
@@ -69,16 +73,24 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
       // use reference equality to find exactly the required scan relations
       val newRewritePlan = rewritePlan transformUp {
         case r: DataSourceV2ScanRelation if r.scan eq scan =>
-          val pruningKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](
-            ArraySeq.unsafeWrapArray(scan.filterAttributes), r)
-          val dynamicPruningCond = buildDynamicPruningCondition(r, command, pruningKeys)
-          val filter = Filter(dynamicPruningCond, r)
-          // always optimize dynamic filtering subqueries for row-level commands as it is important
-          // to rewrite introduced predicates as joins because Spark recently stopped optimizing
-          // dynamic subqueries to facilitate broadcast reuse
-          optimizeSubquery(filter)
+          // use the original table instance that was loaded for this row-level operation
+          // in order to leverage a regular batch scan in the group filter query
+          val originalTable = r.relation.table.asRowLevelOperationTable.table
+          val relation = r.relation.copy(table = originalTable)
+          val matchingRowsPlan = buildMatchingRowsPlan(relation, command)
+
+          val filterAttrs = ArraySeq.unsafeWrapArray(scan.filterAttributes)
+          val buildKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](filterAttrs, matchingRowsPlan)
+          val pruningKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](filterAttrs, r)
+          val dynamicPruningCond = buildDynamicPruningCond(matchingRowsPlan, buildKeys, pruningKeys)
+
+          Filter(dynamicPruningCond, r)
       }
-      command.withNewRewritePlan(newRewritePlan)
+
+      // always optimize dynamic filtering subqueries for row-level commands as it is important
+      // to rewrite introduced predicates as joins because Spark recently stopped optimizing
+      // dynamic subqueries to facilitate broadcast reuse
+      command.withNewRewritePlan(optimizeSubquery(newRewritePlan))
   }
 
   private def isCandidate(command: RowLevelCommand): Boolean = command.condition match {
@@ -86,10 +98,9 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
     case _ => false
   }
 
-  private def buildDynamicPruningCondition(
-      relation: DataSourceV2ScanRelation,
-      command: RowLevelCommand,
-      pruningKeys: Seq[Attribute]): Expression = {
+  private def buildMatchingRowsPlan(
+      relation: DataSourceV2Relation,
+      command: RowLevelCommand): LogicalPlan = {
 
     // construct a filtering plan with the original scan relation
     val matchingRowsPlan = command match {
@@ -113,23 +124,23 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
     }
 
     // clone the original relation in the filtering plan and assign new expr IDs to avoid conflicts
-    val transformedMatchingRowsPlan = matchingRowsPlan transformUpWithNewOutput {
-      case r: DataSourceV2ScanRelation if r eq relation =>
+    matchingRowsPlan transformUpWithNewOutput {
+      case r: DataSourceV2Relation if r eq relation =>
         val oldOutput = r.output
         val newOutput = oldOutput.map(_.newInstance())
         r.copy(output = newOutput) -> oldOutput.zip(newOutput)
     }
+  }
 
-    val filterableScan = relation.scan.asInstanceOf[SupportsRuntimeFiltering]
-    val buildKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](
-      ArraySeq.unsafeWrapArray(filterableScan.filterAttributes),
-      transformedMatchingRowsPlan)
-    val buildQuery = Project(buildKeys, transformedMatchingRowsPlan)
+  private def buildDynamicPruningCond(
+      matchingRowsPlan: LogicalPlan,
+      buildKeys: Seq[Attribute],
+      pruningKeys: Seq[Attribute]): Expression = {
+
+    val buildQuery = Project(buildKeys, matchingRowsPlan)
     val dynamicPruningSubqueries = pruningKeys.zipWithIndex.map { case (key, index) =>
       DynamicPruningSubquery(key, buildQuery, buildKeys, index, onlyInBroadcast = false)
     }
-
-    // combine all dynamic subqueries to produce the final condition
     dynamicPruningSubqueries.reduce(And)
   }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -45,7 +45,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
   @BeforeClass
   public static void startMetastoreAndSpark() {
     SparkTestBase.metastore = new TestHiveMetastore();
-    metastore.start();
+    metastore.start(10);
     SparkTestBase.hiveConf = metastore.hiveConf();
 
     SparkTestBase.spark =

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -45,7 +45,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
   @BeforeClass
   public static void startMetastoreAndSpark() {
     SparkTestBase.metastore = new TestHiveMetastore();
-    metastore.start(10);
+    metastore.start(25);
     SparkTestBase.hiveConf = metastore.hiveConf();
 
     SparkTestBase.spark =

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -45,7 +45,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
   @BeforeClass
   public static void startMetastoreAndSpark() {
     SparkTestBase.metastore = new TestHiveMetastore();
-    metastore.start(25);
+    metastore.start();
     SparkTestBase.hiveConf = metastore.hiveConf();
 
     SparkTestBase.spark =

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -55,6 +55,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
             .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
             .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
             .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+            .config("spark.hadoop.iceberg.hive.lock-timeout-ms", "30000")
             .config("spark.sql.shuffle.partitions", "4")
             .config("spark.sql.hive.metastorePartitionPruningFallbackOnException", "true")
             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -45,7 +45,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
   @BeforeClass
   public static void startMetastoreAndSpark() {
     SparkTestBase.metastore = new TestHiveMetastore();
-    metastore.start();
+    metastore.start(25);
     SparkTestBase.hiveConf = metastore.hiveConf();
 
     SparkTestBase.spark =

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -85,7 +85,8 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         SparkCatalog.class.getName(),
         ImmutableMap.of(
             "type", "hive",
-            "default-namespace", "default"),
+            "default-namespace", "default",
+            "clients", "1"),
         "orc",
         true,
         WRITE_DISTRIBUTION_MODE_NONE
@@ -95,7 +96,8 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
         SparkCatalog.class.getName(),
         ImmutableMap.of(
             "type", "hive",
-            "default-namespace", "default"),
+            "default-namespace", "default",
+            "clients", "1"),
         "parquet",
         true,
         WRITE_DISTRIBUTION_MODE_NONE

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,10 +18,26 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.spark.sql.Encoders;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteDelete extends TestDelete {
 
@@ -39,5 +55,64 @@ public class TestCopyOnWriteDelete extends TestDelete {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.DELETE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public void testDeleteWithConcurrentTableRefresh() throws InterruptedException {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitUnpartitionedTable();
+    createOrReplaceView("deleted_ids", Collections.singletonList(1), Encoders.INT());
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // delete thread
+    Future<?> deleteFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_ids)", tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(deleteFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -18,10 +18,26 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.spark.sql.Encoders;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteMerge extends TestMerge {
 
@@ -39,5 +55,69 @@ public class TestCopyOnWriteMerge extends TestMerge {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public void testMergeWithConcurrentTableRefresh() throws InterruptedException {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitTable("id INT, dep STRING");
+    createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, MERGE_ISOLATION_LEVEL, "snapshot");
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // merge thread
+    Future<?> mergeFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql(
+                    "MERGE INTO %s t USING source s "
+                        + "ON t.id == s.value "
+                        + "WHEN MATCHED THEN "
+                        + "  UPDATE SET dep = 'x'",
+                    tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(mergeFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -18,10 +18,24 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteUpdate extends TestUpdate {
 
@@ -39,5 +53,63 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.UPDATE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public void testUpdateWithConcurrentTableRefresh() throws InterruptedException {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitTable("id INT, dep STRING");
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, UPDATE_ISOLATION_LEVEL, "snapshot");
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // update thread
+    Future<?> updateFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(updateFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -50,6 +50,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
@@ -1017,11 +1018,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
+              SparkSession sparkSession = spark.cloneSession();
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
                 while (barrier.get() < numOperations * 2) {
                   sleep(10);
                 }
-                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
               }
             });
@@ -1083,11 +1085,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
+              SparkSession sparkSession = spark.cloneSession();
               for (int numOperations = 0; numOperations < 20; numOperations++) {
                 while (barrier.get() < numOperations * 2) {
                   sleep(10);
                 }
-                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
               }
             });

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -81,6 +81,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS source");
+    try {
+      metastore.reset();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Test

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -81,11 +81,6 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS source");
-    try {
-      metastore.reset();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Test

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -87,11 +87,12 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
   }
 
   @After
-  public void removeTables() {
+  public void removeTables() throws Exception {
     sql("DROP TABLE IF EXISTS %s", tableName);
     sql("DROP TABLE IF EXISTS updated_id");
     sql("DROP TABLE IF EXISTS updated_dep");
     sql("DROP TABLE IF EXISTS deleted_employee");
+    metastore.reset();
   }
 
   @Test

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -471,6 +471,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                           "Executed %d UPDATEs and %d APPENDs",
                           numUpdates.get(), numAppends.get()));
                 }
+                Thread.yield();
               }
             });
 
@@ -497,6 +498,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                           "Executed %d UPDATEs and %d APPENDs",
                           numUpdates.get(), numAppends.get()));
                 }
+                Thread.yield();
               }
             });
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -92,7 +92,6 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("DROP TABLE IF EXISTS updated_id");
     sql("DROP TABLE IF EXISTS updated_dep");
     sql("DROP TABLE IF EXISTS deleted_employee");
-    metastore.reset();
   }
 
   @Test

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -446,6 +446,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicInteger numUpdates = new AtomicInteger(0);
+    AtomicInteger numAppends = new AtomicInteger(0);
 
     // update thread
     Future<?> updateFuture =
@@ -457,6 +459,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                 }
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
                 barrier.incrementAndGet();
+                numUpdates.incrementAndGet();
+                if (numUpdates.get() > 100) {
+                  throw new RuntimeException(
+                      String.format(
+                          "Executed %d UPDATEs and %d APPENDs",
+                          numUpdates.get(), numAppends.get()));
+                }
               }
             });
 
@@ -471,6 +480,13 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                 }
                 sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
+                numAppends.incrementAndGet();
+                if (numAppends.get() > 100) {
+                  throw new RuntimeException(
+                      String.format(
+                          "Executed %d UPDATEs and %d APPENDs",
+                          numUpdates.get(), numAppends.get()));
+                }
               }
             });
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -59,6 +59,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
@@ -462,11 +463,12 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
+              SparkSession sparkSession = spark.cloneSession();
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
                 while (barrier.get() < numOperations * 2) {
                   sleep(10);
                 }
-                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
               }
             });
@@ -522,11 +524,12 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
+              SparkSession sparkSession = spark.cloneSession();
               for (int numOperations = 0; numOperations < 20; numOperations++) {
                 while (barrier.get() < numOperations * 2) {
                   sleep(10);
                 }
-                sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+                sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
               }
             });

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -465,7 +465,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                 sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
                 barrier.incrementAndGet();
                 numUpdates.incrementAndGet();
-                if (numUpdates.get() > 10) {
+                if (numUpdates.get() >= 2) {
                   throw new RuntimeException(
                       String.format(
                           "Executed %d UPDATEs and %d APPENDs",
@@ -492,7 +492,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
                 sparkSession.sql(String.format("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName));
                 barrier.incrementAndGet();
                 numAppends.incrementAndGet();
-                if (numAppends.get() > 10) {
+                if (numAppends.get() >= 2) {
                   throw new RuntimeException(
                       String.format(
                           "Executed %d UPDATEs and %d APPENDs",
@@ -523,6 +523,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
       throws InterruptedException, ExecutionException {
     // cannot run tests with concurrency for Hadoop tables without atomic renames
     Assume.assumeFalse(catalogName.equalsIgnoreCase("testhadoop"));
+
+    System.out.println("!!! START !!!");
 
     createAndInitTable("id INT, dep STRING");
 


### PR DESCRIPTION
This PR enables using a separate scan during file filtering in row-level copy-on-write operations. This means the runtime filter subquery will now be able to push down filters into row groups as well as prune columns. This should make the initial filtering phase more efficient.