### PR TITLE
Infra: Add 1.0.0 in issue template dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "0.14.1 (latest release)"
+        - "1.0.0 (latest release)"
+        - "0.14.1"
         - "0.14.0"
         - "0.13.1"
         - "0.13.0"


### PR DESCRIPTION
No option to select latest release while reporting issue. Hence, added.