### PR TITLE
PyArrow should convert timestamps to microseconds.

### DIFF
--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -352,12 +352,12 @@ def _(_: TimeType) -> pa.DataType:
 
 @_iceberg_to_pyarrow_type.register
 def _(_: TimestampType) -> pa.DataType:
-    return pa.timestamp(unit="ms")
+    return pa.timestamp(unit="us")
 
 
 @_iceberg_to_pyarrow_type.register
 def _(_: TimestamptzType) -> pa.DataType:
-    return pa.timestamp(unit="ms", tz="+00:00")
+    return pa.timestamp(unit="us", tz="+00:00")
 
 
 @_iceberg_to_pyarrow_type.register

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -364,12 +364,12 @@ def test_time_type_to_pyarrow():
 
 def test_timestamp_type_to_pyarrow():
     iceberg_type = TimestampType()
-    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.timestamp(unit="ms")
+    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.timestamp(unit="us")
 
 
 def test_timestamptz_type_to_pyarrow():
     iceberg_type = TimestamptzType()
-    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.timestamp(unit="ms", tz="+00:00")
+    assert visit(iceberg_type, _ConvertToArrowSchema()) == pa.timestamp(unit="us", tz="+00:00")
 
 
 def test_string_type_to_pyarrow():


### PR DESCRIPTION
The Iceberg spec keeps timestamp in microsecond format so we should convert to a PyArrow type that doesn't lose precision.

The [Iceberg spec](https://iceberg.apache.org/docs/latest/schemas/) indicates timestamps "stored as microseconds."

I don't yet have any unit tests that validate this fix. I found the issue testing @Fokko's new code with my own internal table where I got the following error:
```
Traceback (most recent call last):
  File "/read_test.py", line 47, in <module>
    at = ds.to_table()
  File "pyarrow/_dataset.pyx", line 331, in pyarrow._dataset.Dataset.to_table
  File "pyarrow/_dataset.pyx", line 2577, in pyarrow._dataset.Scanner.to_table
  File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Casting from timestamp[us, tz=UTC] to timestamp[ms] would lose data: 1658494247644732
```

cc @Fokko @samredai 