### PR TITLE
Core: Add scan report for incremental Table scans

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
 public class TypeUtil {
 
@@ -116,6 +117,10 @@ public class TypeUtil {
 
   public static Set<Integer> getProjectedIds(Schema schema) {
     return ImmutableSet.copyOf(getIdsInternal(schema.asStruct(), true));
+  }
+
+  public static List<String> getProjectedFieldNames(Schema schema, Iterable<Integer> projectedIds) {
+    return Streams.stream(projectedIds).map(schema::findColumnName).collect(Collectors.toList());
   }
 
   public static Set<Integer> getProjectedIds(Type type) {

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
@@ -78,6 +78,8 @@ class BaseIncrementalAppendScan
             .filter(manifestFile -> snapshotIds.contains(manifestFile.snapshotId()))
             .toSet();
 
+    scanMetrics().totalDataManifests().increment((long) manifests.size());
+
     ManifestGroup manifestGroup =
         new ManifestGroup(tableOps().io(), manifests)
             .caseSensitive(isCaseSensitive())
@@ -88,6 +90,7 @@ class BaseIncrementalAppendScan
                     snapshotIds.contains(manifestEntry.snapshotId())
                         && manifestEntry.status() == ManifestEntry.Status.ADDED)
             .specsById(tableOps().current().specsById())
+            .scanMetrics(scanMetrics())
             .ignoreDeleted();
 
     if (context().ignoreResiduals()) {

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -81,7 +81,8 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public IncrementalChangelogScan newIncrementalChangelogScan() {
-    return new BaseIncrementalChangelogScan(ops, this);
+    return new BaseIncrementalChangelogScan(
+        ops, this, schema(), new TableScanContext().reportWith(reporter));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.ExpressionUtil;
@@ -134,7 +133,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
       Listeners.notifyAll(new ScanEvent(table().name(), snapshot.snapshotId(), filter(), schema()));
       List<Integer> projectedFieldIds = Lists.newArrayList(TypeUtil.getProjectedIds(schema()));
       List<String> projectedFieldNames =
-          projectedFieldIds.stream().map(schema()::findColumnName).collect(Collectors.toList());
+          TypeUtil.getProjectedFieldNames(schema(), projectedFieldIds);
 
       Timer.Timed planningDuration = scanMetrics().totalPlanningDuration().start();
 

--- a/core/src/main/java/org/apache/iceberg/metrics/IncrementalScanReport.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/IncrementalScanReport.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expression;
+import org.immutables.value.Value;
+
+/**
+ * An incremental scan report that contains all relevant information from an incremental Table Scan.
+ */
+@Value.Immutable
+public interface IncrementalScanReport extends MetricsReport {
+
+  String tableName();
+
+  long fromSnapshotId();
+
+  long toSnapshotId();
+
+  Expression filter();
+
+  int schemaId();
+
+  List<Integer> projectedFieldIds();
+
+  List<String> projectedFieldNames();
+
+  ScanMetricsResult scanMetrics();
+
+  Map<String, String> metadata();
+}

--- a/core/src/main/java/org/apache/iceberg/metrics/IncrementalScanReportParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/IncrementalScanReportParser.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.expressions.ExpressionParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class IncrementalScanReportParser {
+  private static final String TABLE_NAME = "table-name";
+  private static final String FROM_SNAPSHOT_ID = "from-snapshot-id";
+  private static final String TO_SNAPSHOT_ID = "to-snapshot-id";
+  private static final String FILTER = "filter";
+  private static final String SCHEMA_ID = "schema-id";
+  private static final String PROJECTED_FIELD_IDS = "projected-field-ids";
+  private static final String PROJECTED_FIELD_NAMES = "projected-field-names";
+  private static final String METRICS = "metrics";
+  private static final String METADATA = "metadata";
+
+  private IncrementalScanReportParser() {}
+
+  public static String toJson(IncrementalScanReport scanReport) {
+    return toJson(scanReport, false);
+  }
+
+  public static String toJson(IncrementalScanReport scanReport, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(scanReport, gen), pretty);
+  }
+
+  public static void toJson(IncrementalScanReport scanReport, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
+
+    gen.writeStartObject();
+    toJsonWithoutStartEnd(scanReport, gen);
+    gen.writeEndObject();
+  }
+
+  /**
+   * This serializes the {@link IncrementalScanReport} without writing a start/end object and is
+   * mainly used by {@link org.apache.iceberg.rest.requests.ReportMetricsRequestParser}.
+   *
+   * @param scanReport The {@link IncrementalScanReport} to serialize
+   * @param gen The {@link JsonGenerator} to use
+   * @throws IOException If an error occurs while serializing
+   */
+  public static void toJsonWithoutStartEnd(IncrementalScanReport scanReport, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != scanReport, "Invalid scan report: null");
+
+    gen.writeStringField(TABLE_NAME, scanReport.tableName());
+    gen.writeNumberField(FROM_SNAPSHOT_ID, scanReport.fromSnapshotId());
+    gen.writeNumberField(TO_SNAPSHOT_ID, scanReport.toSnapshotId());
+
+    gen.writeFieldName(FILTER);
+    ExpressionParser.toJson(scanReport.filter(), gen);
+
+    gen.writeNumberField(SCHEMA_ID, scanReport.schemaId());
+
+    JsonUtil.writeIntegerArray(PROJECTED_FIELD_IDS, scanReport.projectedFieldIds(), gen);
+    JsonUtil.writeStringArray(PROJECTED_FIELD_NAMES, scanReport.projectedFieldNames(), gen);
+
+    gen.writeFieldName(METRICS);
+    ScanMetricsResultParser.toJson(scanReport.scanMetrics(), gen);
+
+    if (!scanReport.metadata().isEmpty()) {
+      JsonUtil.writeStringMap(METADATA, scanReport.metadata(), gen);
+    }
+  }
+
+  public static IncrementalScanReport fromJson(String json) {
+    return JsonUtil.parse(json, IncrementalScanReportParser::fromJson);
+  }
+
+  public static IncrementalScanReport fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse scan report from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse scan report from non-object: %s", json);
+
+    ImmutableIncrementalScanReport.Builder builder =
+        ImmutableIncrementalScanReport.builder()
+            .tableName(JsonUtil.getString(TABLE_NAME, json))
+            .fromSnapshotId(JsonUtil.getLong(FROM_SNAPSHOT_ID, json))
+            .toSnapshotId(JsonUtil.getLong(TO_SNAPSHOT_ID, json))
+            .filter(ExpressionParser.fromJson(JsonUtil.get(FILTER, json)))
+            .schemaId(JsonUtil.getInt(SCHEMA_ID, json))
+            .projectedFieldIds(JsonUtil.getIntegerList(PROJECTED_FIELD_IDS, json))
+            .projectedFieldNames(JsonUtil.getStringList(PROJECTED_FIELD_NAMES, json))
+            .scanMetrics(ScanMetricsResultParser.fromJson(JsonUtil.get(METRICS, json)));
+
+    if (json.has(METADATA)) {
+      builder.metadata(JsonUtil.getStringMap(METADATA, json));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.requests;
 
 import java.util.Locale;
 import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.IncrementalScanReport;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -31,7 +32,8 @@ public interface ReportMetricsRequest extends RESTRequest {
 
   enum ReportType {
     SCAN_REPORT,
-    COMMIT_REPORT;
+    COMMIT_REPORT,
+    INCREMENTAL_SCAN_REPORT;
 
     static ReportType fromString(String reportType) {
       Preconditions.checkArgument(null != reportType, "Invalid report type: null");
@@ -59,6 +61,8 @@ public interface ReportMetricsRequest extends RESTRequest {
       reportType = ReportType.SCAN_REPORT;
     } else if (report instanceof CommitReport) {
       reportType = ReportType.COMMIT_REPORT;
+    } else if (report instanceof IncrementalScanReport) {
+      reportType = ReportType.INCREMENTAL_SCAN_REPORT;
     }
 
     Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequestParser.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.Locale;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.metrics.CommitReportParser;
+import org.apache.iceberg.metrics.IncrementalScanReport;
+import org.apache.iceberg.metrics.IncrementalScanReportParser;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.metrics.ScanReportParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -59,6 +61,11 @@ public class ReportMetricsRequestParser {
       CommitReportParser.toJsonWithoutStartEnd((CommitReport) request.report(), gen);
     }
 
+    if (ReportType.INCREMENTAL_SCAN_REPORT == request.reportType()) {
+      IncrementalScanReportParser.toJsonWithoutStartEnd(
+          (IncrementalScanReport) request.report(), gen);
+    }
+
     gen.writeEndObject();
   }
 
@@ -91,6 +98,13 @@ public class ReportMetricsRequestParser {
       return ImmutableReportMetricsRequest.builder()
           .reportType(type)
           .report(CommitReportParser.fromJson(json))
+          .build();
+    }
+
+    if (ReportType.INCREMENTAL_SCAN_REPORT == type) {
+      return ImmutableReportMetricsRequest.builder()
+          .reportType(type)
+          .report(IncrementalScanReportParser.fromJson(json))
           .build();
     }
 

--- a/core/src/test/java/org/apache/iceberg/metrics/TestIncrementalScanReportParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestIncrementalScanReportParser.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestIncrementalScanReportParser {
+
+  @Test
+  public void nullScanReport() {
+    Assertions.assertThatThrownBy(() -> IncrementalScanReportParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse scan report from null object");
+
+    Assertions.assertThatThrownBy(() -> IncrementalScanReportParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scan report: null");
+  }
+
+  @Test
+  public void missingFields() {
+    Assertions.assertThatThrownBy(() -> IncrementalScanReportParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: table-name");
+
+    Assertions.assertThatThrownBy(
+            () -> IncrementalScanReportParser.fromJson("{\"table-name\":\"roundTripTableName\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing long: from-snapshot-id");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing long: to-snapshot-id");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":true}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing int: schema-id");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":true,"
+                        + "\"schema-id\" : 4,\"projected-field-ids\" : [ 1, 2, 3 ],\"projected-field-names\" : [ \"c1\", \"c2\", \"c3\" ]}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: metrics");
+  }
+
+  @Test
+  public void extraFields() {
+    ScanMetrics scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
+    scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
+    scanMetrics.resultDataFiles().increment(5L);
+    scanMetrics.resultDeleteFiles().increment(5L);
+    scanMetrics.scannedDataManifests().increment(5L);
+    scanMetrics.skippedDataManifests().increment(5L);
+    scanMetrics.totalFileSizeInBytes().increment(1024L);
+    scanMetrics.totalDataManifests().increment(5L);
+    scanMetrics.totalFileSizeInBytes().increment(45L);
+    scanMetrics.totalDeleteFileSizeInBytes().increment(23L);
+    scanMetrics.skippedDataFiles().increment(3L);
+    scanMetrics.skippedDeleteFiles().increment(3L);
+    scanMetrics.scannedDeleteManifests().increment(3L);
+    scanMetrics.skippedDeleteManifests().increment(3L);
+    scanMetrics.indexedDeleteFiles().increment(10L);
+    scanMetrics.positionalDeleteFiles().increment(6L);
+    scanMetrics.equalityDeleteFiles().increment(4L);
+
+    String tableName = "roundTripTableName";
+    IncrementalScanReport scanReport =
+        ImmutableIncrementalScanReport.builder()
+            .tableName(tableName)
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .fromSnapshotId(23L)
+            .toSnapshotId(45L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics))
+            .build();
+
+    Assertions.assertThat(
+            IncrementalScanReportParser.fromJson(
+                "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,"
+                    + "\"filter\":true,\"schema-id\": 4,\"projected-field-ids\": [ 1, 2, 3 ],\"projected-field-names\": [ \"c1\", \"c2\", \"c3\" ],"
+                    + "\"metrics\":{\"total-planning-duration\":{\"count\":1,\"time-unit\":\"nanoseconds\",\"total-duration\":600000000000},"
+                    + "\"result-data-files\":{\"unit\":\"count\",\"value\":5},"
+                    + "\"result-delete-files\":{\"unit\":\"count\",\"value\":5},"
+                    + "\"total-data-manifests\":{\"unit\":\"count\",\"value\":5},"
+                    + "\"total-delete-manifests\":{\"unit\":\"count\",\"value\":0},"
+                    + "\"scanned-data-manifests\":{\"unit\":\"count\",\"value\":5},"
+                    + "\"skipped-data-manifests\":{\"unit\":\"count\",\"value\":5},"
+                    + "\"total-file-size-in-bytes\":{\"unit\":\"bytes\",\"value\":1069},"
+                    + "\"total-delete-file-size-in-bytes\":{\"unit\":\"bytes\",\"value\":23},"
+                    + "\"skipped-data-files\":{\"unit\":\"count\",\"value\":3},"
+                    + "\"skipped-delete-files\":{\"unit\":\"count\",\"value\":3},"
+                    + "\"scanned-delete-manifests\":{\"unit\":\"count\",\"value\":3},"
+                    + "\"skipped-delete-manifests\":{\"unit\":\"count\",\"value\":3},"
+                    + "\"indexed-delete-files\":{\"unit\":\"count\",\"value\":10},"
+                    + "\"equality-delete-files\":{\"unit\":\"count\",\"value\":4},"
+                    + "\"positional-delete-files\":{\"unit\":\"count\",\"value\":6},"
+                    + "\"extra-metric\":\"extra-val\"},"
+                    + "\"extra\":\"extraVal\"}"))
+        .isEqualTo(scanReport);
+  }
+
+  @Test
+  public void invalidTableName() {
+    Assertions.assertThatThrownBy(() -> IncrementalScanReportParser.fromJson("{\"table-name\":23}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse to a string value: table-name: 23");
+  }
+
+  @Test
+  public void invalidSnapshotId() {
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":\"invalid\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse to a long value: from-snapshot-id: \"invalid\"");
+  }
+
+  @Test
+  public void invalidExpressionFilter() {
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":23,\"schema-id\":23}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse expression from non-object: 23");
+  }
+
+  @Test
+  public void invalidSchema() {
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":true,\"schema-id\":\"23\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse to an integer value: schema-id: \"23\"");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":true,\"schema-id\":23,\"projected-field-ids\": [\"1\"],\"metrics\":{}}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse integer from non-int value in projected-field-ids: \"1\"");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                IncrementalScanReportParser.fromJson(
+                    "{\"table-name\":\"roundTripTableName\",\"from-snapshot-id\":23,\"to-snapshot-id\":45,\"filter\":true,\"schema-id\":23,\"projected-field-ids\": [1],\"projected-field-names\": [1],\"metrics\":{}}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string from non-text value in projected-field-names: 1");
+  }
+
+  @Test
+  public void roundTripSerde() {
+    ScanMetrics scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
+    scanMetrics.totalPlanningDuration().record(10, TimeUnit.MINUTES);
+    scanMetrics.resultDataFiles().increment(5L);
+    scanMetrics.resultDeleteFiles().increment(5L);
+    scanMetrics.scannedDataManifests().increment(5L);
+    scanMetrics.skippedDataManifests().increment(5L);
+    scanMetrics.totalFileSizeInBytes().increment(1024L);
+    scanMetrics.totalDataManifests().increment(5L);
+    scanMetrics.totalFileSizeInBytes().increment(45L);
+    scanMetrics.totalDeleteFileSizeInBytes().increment(23L);
+    scanMetrics.skippedDataFiles().increment(3L);
+    scanMetrics.skippedDeleteFiles().increment(3L);
+    scanMetrics.scannedDeleteManifests().increment(3L);
+    scanMetrics.skippedDeleteManifests().increment(3L);
+    scanMetrics.indexedDeleteFiles().increment(10L);
+    scanMetrics.positionalDeleteFiles().increment(6L);
+    scanMetrics.equalityDeleteFiles().increment(4L);
+
+    String tableName = "roundTripTableName";
+
+    IncrementalScanReport scanReport =
+        ImmutableIncrementalScanReport.builder()
+            .tableName(tableName)
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .fromSnapshotId(23L)
+            .toSnapshotId(45L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"table-name\" : \"roundTripTableName\",\n"
+            + "  \"from-snapshot-id\" : 23,\n"
+            + "  \"to-snapshot-id\" : 45,\n"
+            + "  \"filter\" : true,\n"
+            + "  \"schema-id\" : 4,\n"
+            + "  \"projected-field-ids\" : [ 1, 2, 3 ],\n"
+            + "  \"projected-field-names\" : [ \"c1\", \"c2\", \"c3\" ],\n"
+            + "  \"metrics\" : {\n"
+            + "    \"total-planning-duration\" : {\n"
+            + "      \"count\" : 1,\n"
+            + "      \"time-unit\" : \"nanoseconds\",\n"
+            + "      \"total-duration\" : 600000000000\n"
+            + "    },\n"
+            + "    \"result-data-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 5\n"
+            + "    },\n"
+            + "    \"result-delete-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 5\n"
+            + "    },\n"
+            + "    \"total-data-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 5\n"
+            + "    },\n"
+            + "    \"total-delete-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 0\n"
+            + "    },\n"
+            + "    \"scanned-data-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 5\n"
+            + "    },\n"
+            + "    \"skipped-data-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 5\n"
+            + "    },\n"
+            + "    \"total-file-size-in-bytes\" : {\n"
+            + "      \"unit\" : \"bytes\",\n"
+            + "      \"value\" : 1069\n"
+            + "    },\n"
+            + "    \"total-delete-file-size-in-bytes\" : {\n"
+            + "      \"unit\" : \"bytes\",\n"
+            + "      \"value\" : 23\n"
+            + "    },\n"
+            + "    \"skipped-data-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 3\n"
+            + "    },\n"
+            + "    \"skipped-delete-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 3\n"
+            + "    },\n"
+            + "    \"scanned-delete-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 3\n"
+            + "    },\n"
+            + "    \"skipped-delete-manifests\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 3\n"
+            + "    },\n"
+            + "    \"indexed-delete-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 10\n"
+            + "    },\n"
+            + "    \"equality-delete-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 4\n"
+            + "    },\n"
+            + "    \"positional-delete-files\" : {\n"
+            + "      \"unit\" : \"count\",\n"
+            + "      \"value\" : 6\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+
+    String json = IncrementalScanReportParser.toJson(scanReport, true);
+    Assertions.assertThat(IncrementalScanReportParser.fromJson(json)).isEqualTo(scanReport);
+    Assertions.assertThat(json).isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerdeWithNoopMetrics() {
+    String tableName = "roundTripTableName";
+    IncrementalScanReport scanReport =
+        ImmutableIncrementalScanReport.builder()
+            .tableName(tableName)
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .fromSnapshotId(23L)
+            .toSnapshotId(45L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"table-name\" : \"roundTripTableName\",\n"
+            + "  \"from-snapshot-id\" : 23,\n"
+            + "  \"to-snapshot-id\" : 45,\n"
+            + "  \"filter\" : true,\n"
+            + "  \"schema-id\" : 4,\n"
+            + "  \"projected-field-ids\" : [ 1, 2, 3 ],\n"
+            + "  \"projected-field-names\" : [ \"c1\", \"c2\", \"c3\" ],\n"
+            + "  \"metrics\" : { }\n"
+            + "}";
+
+    String json = IncrementalScanReportParser.toJson(scanReport, true);
+    Assertions.assertThat(IncrementalScanReportParser.fromJson(json)).isEqualTo(scanReport);
+    Assertions.assertThat(json).isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerdeWithMetadata() {
+    String tableName = "roundTripTableName";
+    IncrementalScanReport scanReport =
+        ImmutableIncrementalScanReport.builder()
+            .tableName(tableName)
+            .schemaId(4)
+            .addProjectedFieldIds(1, 2, 3)
+            .addProjectedFieldNames("c1", "c2", "c3")
+            .fromSnapshotId(23L)
+            .toSnapshotId(45L)
+            .filter(Expressions.alwaysTrue())
+            .scanMetrics(ScanMetricsResult.fromScanMetrics(ScanMetrics.noop()))
+            .metadata(ImmutableMap.of("k1", "v1", "k2", "v2"))
+            .build();
+
+    String expectedJson =
+        "{\n"
+            + "  \"table-name\" : \"roundTripTableName\",\n"
+            + "  \"from-snapshot-id\" : 23,\n"
+            + "  \"to-snapshot-id\" : 45,\n"
+            + "  \"filter\" : true,\n"
+            + "  \"schema-id\" : 4,\n"
+            + "  \"projected-field-ids\" : [ 1, 2, 3 ],\n"
+            + "  \"projected-field-names\" : [ \"c1\", \"c2\", \"c3\" ],\n"
+            + "  \"metrics\" : { },\n"
+            + "  \"metadata\" : {\n"
+            + "    \"k1\" : \"v1\",\n"
+            + "    \"k2\" : \"v2\"\n"
+            + "  }\n"
+            + "}";
+
+    String json = IncrementalScanReportParser.toJson(scanReport, true);
+    Assertions.assertThat(IncrementalScanReportParser.fromJson(json)).isEqualTo(scanReport);
+    Assertions.assertThat(json).isEqualTo(expectedJson);
+  }
+}

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1896,6 +1896,7 @@ components:
       anyOf:
         - $ref: '#/components/schemas/ScanReport'
         - $ref: '#/components/schemas/CommitReport'
+        - $ref: '#/components/schemas/IncrementalScanReport'
       required:
         - report-type
       properties:
@@ -1956,6 +1957,53 @@ components:
           format: int64
         operation:
           type: string
+        metrics:
+          $ref: '#/components/schemas/Metrics'
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    IncrementalScanReport:
+      type: object
+      required:
+        - table-name
+        - from-snapshot-id
+        - to-snapshot-id
+        - filter
+        - schema-id
+        - projected-field-ids
+        - projected-field-names
+        - metrics
+      properties:
+        table-name:
+          type: string
+        snapshot-id:
+          type: integer
+          format: int64
+        sequence-number:
+          type: integer
+          format: int64
+        operation:
+          type: string
+        from-snapshot-id:
+          type: integer
+          format: int64
+        to-snapshot-id:
+          type: integer
+          format: int64
+        filter:
+          $ref: '#/components/schemas/Expression'
+        schema-id:
+          type: integer
+        projected-field-ids:
+          type: array
+          items:
+            type: integer
+        projected-field-names:
+          type: array
+          items:
+            type: string
         metrics:
           $ref: '#/components/schemas/Metrics'
         metadata:


### PR DESCRIPTION
currently depends on https://github.com/apache/iceberg/pull/6058 but will be rebased once it's in