### PR TITLE
Core: Pass purgeRequested flag to REST server

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -229,6 +229,13 @@ public class CatalogHandlers {
     }
   }
 
+  public static void purgeTable(Catalog catalog, TableIdentifier ident) {
+    boolean dropped = catalog.dropTable(ident, true);
+    if (!dropped) {
+      throw new NoSuchTableException("Table does not exist: %s", ident);
+    }
+  }
+
   public static LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
     Table table = catalog.loadTable(ident);
 

--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -272,10 +272,11 @@ public class HTTPClient implements RESTClient {
   @Override
   public <T extends RESTResponse> T delete(
       String path,
+      Map<String, String> queryParams,
       Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler) {
-    return execute(Method.DELETE, path, null, null, responseType, headers, errorHandler);
+    return execute(Method.DELETE, path, queryParams, null, responseType, headers, errorHandler);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -37,14 +37,24 @@ public interface RESTClient extends Closeable {
 
   default <T extends RESTResponse> T delete(
       String path,
+      Map<String, String> queryParams,
       Class<T> responseType,
       Supplier<Map<String, String>> headers,
       Consumer<ErrorResponse> errorHandler) {
-    return delete(path, responseType, headers.get(), errorHandler);
+    return delete(path, queryParams, responseType, headers.get(), errorHandler);
+  }
+
+  default <T extends RESTResponse> T delete(
+      String path,
+      Class<T> responseType,
+      Supplier<Map<String, String>> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return delete(path, ImmutableMap.of(), responseType, headers.get(), errorHandler);
   }
 
   <T extends RESTResponse> T delete(
       String path,
+      Map<String, String> queryParams,
       Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -223,8 +223,20 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   @Override
-  public boolean purgeTable(SessionContext context, TableIdentifier ident) {
-    throw new UnsupportedOperationException("Purge is not supported");
+  public boolean purgeTable(SessionContext context, TableIdentifier identifier) {
+    checkIdentifierIsValid(identifier);
+
+    try {
+      client.delete(
+          paths.table(identifier),
+          ImmutableMap.of("purgeRequested", "true"),
+          null,
+          headers(context),
+          ErrorHandlers.tableErrorHandler());
+      return true;
+    } catch (NoSuchTableException e) {
+      return false;
+    }
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -800,6 +800,24 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testDropTableWithPurge() {
+    C catalog = catalog();
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    Assert.assertFalse("Table should not exist before create", catalog.tableExists(TABLE));
+
+    catalog.buildTable(TABLE, SCHEMA).create();
+    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+
+    boolean dropped = catalog.dropTable(TABLE, true);
+    Assert.assertTrue("Should drop a table that does exist", dropped);
+    Assert.assertFalse("Table should not exist after drop", catalog.tableExists(TABLE));
+  }
+
+  @Test
   public void testDropMissingTable() {
     C catalog = catalog();
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -219,7 +219,7 @@ public class TestHTTPClient {
         restClient.head(path, headers, onError);
         return null;
       case DELETE:
-        return restClient.delete(path, Item.class, headers, onError);
+        return restClient.delete(path, Item.class, () -> headers, onError);
       default:
         throw new IllegalArgumentException(String.format("Invalid method: %s", method));
     }


### PR DESCRIPTION
The motivation behind this change is that the REST server should know whether a `purge` was requested or not, rather than having the REST client throw an error.