### PR TITLE
API,Core: SnapshotManager to be created through Transaction

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -156,6 +156,16 @@ public interface Transaction {
   ExpireSnapshots expireSnapshots();
 
   /**
+   * Create a new {@link ManageSnapshots manage snapshot API} to manage snapshots in this table.
+   *
+   * @return a new {@link ManageSnapshots}
+   */
+  default ManageSnapshots manageSnapshots() {
+    throw new UnsupportedOperationException(
+        "Managing snapshots is not supported by " + getClass().getName());
+  }
+
+  /**
    * Apply the pending changes from all actions and commit.
    *
    * @throws ValidationException If any update cannot be applied to the current table metadata.

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -104,6 +104,10 @@ public class BaseTransaction implements Transaction {
     return transactionTable;
   }
 
+  public String tableName() {
+    return tableName;
+  }
+
   public TableMetadata startMetadata() {
     return current;
   }
@@ -246,6 +250,13 @@ public class BaseTransaction implements Transaction {
     expire.deleteWith(enqueueDelete);
     updates.add(expire);
     return expire;
+  }
+
+  @Override
+  public ManageSnapshots manageSnapshots() {
+    SnapshotManager snapshotManager = new SnapshotManager(this);
+    updates.add(snapshotManager);
+    return snapshotManager;
   }
 
   CherryPickOperation cherryPick() {

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -112,6 +112,11 @@ class CommitCallbackTransaction implements Transaction {
   }
 
   @Override
+  public ManageSnapshots manageSnapshots() {
+    return wrapped.manageSnapshots();
+  }
+
+  @Override
   public void commitTransaction() {
     wrapped.commitTransaction();
     callback.run();

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -22,6 +22,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class SnapshotManager implements ManageSnapshots {
 
+  private final boolean isExternalTransaction;
   private final BaseTransaction transaction;
   private UpdateSnapshotReferencesOperation updateSnapshotReferencesOperation;
 
@@ -30,6 +31,13 @@ public class SnapshotManager implements ManageSnapshots {
         ops.current() != null, "Cannot manage snapshots: table %s does not exist", tableName);
     this.transaction =
         new BaseTransaction(tableName, ops, BaseTransaction.TransactionType.SIMPLE, ops.refresh());
+    this.isExternalTransaction = false;
+  }
+
+  SnapshotManager(BaseTransaction transaction) {
+    Preconditions.checkArgument(transaction != null, "Invalid input transaction: null");
+    this.transaction = transaction;
+    this.isExternalTransaction = true;
   }
 
   @Override
@@ -155,6 +163,8 @@ public class SnapshotManager implements ManageSnapshots {
   @Override
   public void commit() {
     commitIfRefUpdatesExist();
-    transaction.commitTransaction();
+    if (!isExternalTransaction) {
+      transaction.commitTransaction();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -632,4 +632,82 @@ public class TestSnapshotManager extends TableTestBase {
     long currentSnapshotId = table.currentSnapshot().snapshotId();
     table.manageSnapshots().rollbackTo(currentSnapshotId).commit();
   }
+
+  @Test
+  public void testSnapshotManagerThroughTransaction() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Snapshot snapshotAfterFirstAppend = readMetadata().currentSnapshot();
+    validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
+
+    table.newAppend().appendFile(FILE_B).commit();
+    validateSnapshot(snapshotAfterFirstAppend, readMetadata().currentSnapshot(), FILE_B);
+    Assert.assertEquals("Table should be on version 2 after appending twice", 2, (int) version());
+
+    TableMetadata base = readMetadata();
+    Transaction txn = table.newTransaction();
+
+    Assert.assertSame(
+        "Base metadata should not change when transaction is created", base, readMetadata());
+    Assert.assertEquals(
+        "Table should be on version 2 after creating transaction", 2, (int) version());
+
+    ManageSnapshots manageSnapshots = txn.manageSnapshots();
+    Assert.assertNotNull(manageSnapshots);
+
+    Assert.assertSame(
+        "Base metadata should not change when manageSnapshots is created", base, readMetadata());
+    Assert.assertEquals(
+        "Table should be on version 2 after creating manageSnapshots", 2, (int) version());
+
+    manageSnapshots.rollbackTo(snapshotAfterFirstAppend.snapshotId()).commit();
+
+    Assert.assertSame(
+        "Base metadata should not change when invoking rollbackTo", base, readMetadata());
+    Assert.assertEquals(
+        "Table should be on version 2 after invoking rollbackTo", 2, (int) version());
+
+    txn.commitTransaction();
+
+    Assert.assertEquals(snapshotAfterFirstAppend, readMetadata().currentSnapshot());
+    validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
+    Assert.assertEquals(
+        "Table should be on version 3 after invoking rollbackTo", 3, (int) version());
+  }
+
+  @Test
+  public void testSnapshotManagerThroughTransactionMultiOperation() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Snapshot snapshotAfterFirstAppend = readMetadata().currentSnapshot();
+    validateSnapshot(null, snapshotAfterFirstAppend, FILE_A);
+
+    table.newAppend().appendFile(FILE_B).commit();
+    validateSnapshot(snapshotAfterFirstAppend, readMetadata().currentSnapshot(), FILE_B);
+    Assert.assertEquals("Table should be on version 2 after appending twice", 2, (int) version());
+
+    TableMetadata base = readMetadata();
+    Transaction txn = table.newTransaction();
+
+    txn.manageSnapshots().rollbackTo(snapshotAfterFirstAppend.snapshotId()).commit();
+    txn.updateProperties().set("some_prop", "some_prop_value").commit();
+    Assert.assertSame(
+        "Base metadata should not change when transaction is not committed", base, readMetadata());
+    Assert.assertEquals(
+        "Table should remain on version 2 when transaction is not committed", 2, (int) version());
+
+    txn.commitTransaction();
+
+    Assert.assertEquals(snapshotAfterFirstAppend, readMetadata().currentSnapshot());
+    Assert.assertEquals(
+        "Table should be on version 3 after invoking rollbackTo", 3, (int) version());
+  }
+
+  @Test
+  public void testSnapshotManagerInvalidParameters() throws Exception {
+    Assert.assertThrows(
+        "Incorrect input transaction: null",
+        IllegalArgumentException.class,
+        () -> {
+          new SnapshotManager(null);
+        });
+  }
 }


### PR DESCRIPTION
Currently, SnapshotManager encapsulates its own BaseTransaction object and there is no way to expose it opposed to for example ExpireSnapshots that can be created through the Transaction API. As a result the operations in SnapshotManager can't run in the same transaction with the operations in e.g. BaseTransaction.

One real world use-case would be from Apache Impala where each transactional operation through the Iceberg API has to set some Catalog properties (CATALOG_SERVICE_ID, CATALOG_VERSION) in the same transaction. For explanation see this ticket:
https://issues.apache.org/jira/browse/IMPALA-11508