### PR TITLE
Flink 1.15: Support change log scan task 

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkReadConf.java
@@ -190,4 +190,8 @@ public class FlinkReadConf {
         .defaultValue(FlinkReadOptions.MAX_ALLOWED_PLANNING_FAILURES_OPTION.defaultValue())
         .parse();
   }
+
+  public String scanMode() {
+    return confParser.stringConf().option(FlinkReadOptions.SCAN_MODE.key()).parseOptional();
+  }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkReadOptions.java
@@ -109,4 +109,7 @@ public class FlinkReadOptions {
   public static final String MAX_ALLOWED_PLANNING_FAILURES = "max-allowed-planning-failures";
   public static final ConfigOption<Integer> MAX_ALLOWED_PLANNING_FAILURES_OPTION =
       ConfigOptions.key(PREFIX + MAX_ALLOWED_PLANNING_FAILURES).intType().defaultValue(3);
+
+  public static final ConfigOption<String> SCAN_MODE =
+      ConfigOptions.key("scan-mode").stringType().noDefaultValue();
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -43,10 +43,8 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
   private static final long serialVersionUID = 1L;
 
   private final TableLoader tableLoader;
-  private final FileIO io;
-  private final EncryptionManager encryption;
   private final ScanContext context;
-  private final FileScanTaskReader rowDataReader;
+  private final ScanTaskReader<RowData> rowDataReader;
 
   private transient DataIterator<RowData> iterator;
   private transient long currentReadCount = 0L;
@@ -58,8 +56,6 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
       EncryptionManager encryption,
       ScanContext context) {
     this.tableLoader = tableLoader;
-    this.io = io;
-    this.encryption = encryption;
     this.context = context;
 
     tableLoader.open();
@@ -73,6 +69,9 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
               context.project(),
               context.nameMapping(),
               context.caseSensitive(),
+              null,
+              io,
+              encryption,
               context.filters());
     }
   }
@@ -114,7 +113,7 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
 
   @Override
   public void open(FlinkInputSplit split) {
-    this.iterator = new DataIterator<>(rowDataReader, split.getTask(), io, encryption);
+    this.iterator = new DataIterator<>(rowDataReader, split.getTask());
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileChangeLogReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileChangeLogReader.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.AddedRowsScanTask;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeletedDataFileScanTask;
+import org.apache.iceberg.DeletedRowsScanTask;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.flink.data.RowDataProjection;
+import org.apache.iceberg.flink.data.RowDataUtil;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.PartitionUtil;
+
+@Internal
+public class RowDataFileChangeLogReader extends RowDataFileScanTaskReader {
+
+  public RowDataFileChangeLogReader(
+      Schema tableSchema,
+      Schema projectedSchema,
+      boolean caseSensitive,
+      String nameMapping,
+      ScanTaskGroup<? extends ScanTask> taskGroup,
+      FileIO io,
+      EncryptionManager encryption,
+      List<Expression> filters) {
+    super(
+        tableSchema,
+        projectedSchema,
+        nameMapping,
+        caseSensitive,
+        taskGroup,
+        io,
+        encryption,
+        filters);
+  }
+
+  @Override
+  protected Stream<ContentFile<?>> referencedFiles(ScanTask task) {
+    if (task instanceof AddedRowsScanTask) {
+      return addedRowsScanTaskFiles((AddedRowsScanTask) task);
+    } else if (task instanceof DeletedRowsScanTask) {
+      throw new UnsupportedOperationException("Deleted rows scan task is not supported yet");
+    } else if (task instanceof DeletedDataFileScanTask) {
+      return deletedDataFileScanTaskFiles((DeletedDataFileScanTask) task);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported changelog scan task type: " + task.getClass().getName());
+    }
+  }
+
+  @Override
+  public CloseableIterator<RowData> open(ScanTask scanTask) {
+    return openChangelogScanTask((ChangelogScanTask) scanTask, projectedSchema()).iterator();
+  }
+
+  private CloseableIterable<RowData> openChangelogScanTask(
+      ChangelogScanTask task, Schema requestedSchema) {
+    if (task instanceof AddedRowsScanTask) {
+      return openAddedRowsScanTask((AddedRowsScanTask) task, requestedSchema);
+    } else if (task instanceof DeletedRowsScanTask) {
+      throw new UnsupportedOperationException("Deleted rows scan task is not supported yet");
+    } else if (task instanceof DeletedDataFileScanTask) {
+      return openDeletedDataFileScanTask((DeletedDataFileScanTask) task, requestedSchema);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported changelog scan task type: " + task.getClass().getName());
+    }
+  }
+
+  private CloseableIterable<RowData> openAddedRowsScanTask(
+      AddedRowsScanTask task, Schema requestedSchema) {
+    DataFile file = task.file();
+    String filePath = file.path().toString();
+    FileFormat format = file.format();
+    long start = task.start();
+    long length = task.length();
+    Expression residual = task.residual();
+    InputFile inputFile = inputFile(filePath);
+
+    FlinkDeleteFilter deletes =
+        new FlinkDeleteFilter(filePath, task.deletes(), tableSchema(), requestedSchema);
+
+    Schema partitionSchema = TypeUtil.select(projectedSchema(), task.spec().identitySourceIds());
+
+    Map<Integer, ?> idToConstant =
+        partitionSchema.columns().isEmpty()
+            ? ImmutableMap.of()
+            : PartitionUtil.constantsMap(task, RowDataUtil::convertConstant);
+
+    return getRowData(
+        format, start, length, residual, inputFile, deletes, idToConstant, RowKind.INSERT);
+  }
+
+  private CloseableIterable<RowData> openDeletedDataFileScanTask(
+      DeletedDataFileScanTask task, Schema requestedSchema) {
+    DataFile file = task.file();
+    long start = task.start();
+    long length = task.length();
+    Expression residual = task.residual();
+    String filePath = file.path().toString();
+    FileFormat format = file.format();
+    InputFile inputFile = inputFile(filePath);
+
+    FlinkDeleteFilter deletes =
+        new FlinkDeleteFilter(filePath, task.existingDeletes(), tableSchema(), requestedSchema);
+    Schema partitionSchema = TypeUtil.select(projectedSchema(), task.spec().identitySourceIds());
+
+    Map<Integer, ?> idToConstant =
+        partitionSchema.columns().isEmpty()
+            ? ImmutableMap.of()
+            : PartitionUtil.constantsMap(task, RowDataUtil::convertConstant);
+
+    return getRowData(
+        format, start, length, residual, inputFile, deletes, idToConstant, RowKind.DELETE);
+  }
+
+  private static Stream<ContentFile<?>> deletedDataFileScanTaskFiles(DeletedDataFileScanTask task) {
+    DeletedDataFileScanTask deletedDataFileScanTask = task;
+    DataFile file = deletedDataFileScanTask.file();
+    List<DeleteFile> existingDeletes = deletedDataFileScanTask.existingDeletes();
+    return Stream.concat(Stream.of(file), existingDeletes.stream());
+  }
+
+  private CloseableIterable<RowData> getRowData(
+      FileFormat format,
+      long start,
+      long length,
+      Expression residual,
+      InputFile inputFile,
+      FlinkDeleteFilter deletes,
+      Map<Integer, ?> idToConstant,
+      RowKind rowKind) {
+    CloseableIterable<RowData> iterable =
+        deletes.filter(
+            newIterable(
+                inputFile,
+                format,
+                start,
+                length,
+                residual,
+                deletes.requiredSchema(),
+                idToConstant));
+
+    CloseableIterable<RowData> dataWithKind =
+        CloseableIterable.transform(
+            iterable,
+            rowData -> {
+              rowData.setRowKind(rowKind);
+              return rowData;
+            });
+
+    // Project the RowData to remove the extra meta columns.
+    if (!projectedSchema().sameSchema(deletes.requiredSchema())) {
+      RowDataProjection rowDataProjection =
+          RowDataProjection.create(
+              deletes.requiredRowType(),
+              deletes.requiredSchema().asStruct(),
+              projectedSchema().asStruct());
+      return CloseableIterable.transform(dataWithKind, rowDataProjection::wrap);
+    }
+
+    return dataWithKind;
+  }
+
+  private static Stream<ContentFile<?>> addedRowsScanTaskFiles(AddedRowsScanTask task) {
+    AddedRowsScanTask addedRowsScanTask = task;
+    DataFile file = addedRowsScanTask.file();
+    List<DeleteFile> deletes = addedRowsScanTask.deletes();
+    return Stream.concat(Stream.of(file), deletes.stream());
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -65,6 +65,7 @@ public class ScanContext implements Serializable {
   private final Integer planParallelism;
   private final int maxPlanningSnapshotCount;
   private final int maxAllowedPlanningFailures;
+  private final String scanMode;
 
   private ScanContext(
       boolean caseSensitive,
@@ -91,7 +92,8 @@ public class ScanContext implements Serializable {
       String branch,
       String tag,
       String startTag,
-      String endTag) {
+      String endTag,
+      String scanMode) {
     this.caseSensitive = caseSensitive;
     this.snapshotId = snapshotId;
     this.tag = tag;
@@ -118,6 +120,7 @@ public class ScanContext implements Serializable {
     this.planParallelism = planParallelism;
     this.maxPlanningSnapshotCount = maxPlanningSnapshotCount;
     this.maxAllowedPlanningFailures = maxAllowedPlanningFailures;
+    this.scanMode = scanMode;
 
     validate();
   }
@@ -244,6 +247,10 @@ public class ScanContext implements Serializable {
     return limit;
   }
 
+  public String scanMode() {
+    return scanMode;
+  }
+
   public boolean includeColumnStats() {
     return includeColumnStats;
   }
@@ -284,6 +291,7 @@ public class ScanContext implements Serializable {
         .project(schema)
         .filters(filters)
         .limit(limit)
+        .scanMode(scanMode)
         .includeColumnStats(includeColumnStats)
         .exposeLocality(exposeLocality)
         .planParallelism(planParallelism)
@@ -312,6 +320,7 @@ public class ScanContext implements Serializable {
         .project(schema)
         .filters(filters)
         .limit(limit)
+        .scanMode(scanMode)
         .includeColumnStats(includeColumnStats)
         .exposeLocality(exposeLocality)
         .planParallelism(planParallelism)
@@ -347,6 +356,7 @@ public class ScanContext implements Serializable {
     private Schema projectedSchema;
     private List<Expression> filters;
     private long limit = FlinkReadOptions.LIMIT_OPTION.defaultValue();
+    private String scanMode = FlinkReadOptions.SCAN_MODE.defaultValue();
     private boolean includeColumnStats =
         FlinkReadOptions.INCLUDE_COLUMN_STATS_OPTION.defaultValue();
     private boolean exposeLocality;
@@ -459,6 +469,11 @@ public class ScanContext implements Serializable {
       return this;
     }
 
+    public Builder scanMode(String newScanMode) {
+      this.scanMode = newScanMode;
+      return this;
+    }
+
     public Builder includeColumnStats(boolean newIncludeColumnStats) {
       this.includeColumnStats = newIncludeColumnStats;
       return this;
@@ -509,7 +524,8 @@ public class ScanContext implements Serializable {
           .planParallelism(flinkReadConf.workerPoolSize())
           .includeColumnStats(flinkReadConf.includeColumnStats())
           .maxPlanningSnapshotCount(flinkReadConf.maxPlanningSnapshotCount())
-          .maxAllowedPlanningFailures(maxAllowedPlanningFailures);
+          .maxAllowedPlanningFailures(maxAllowedPlanningFailures)
+          .scanMode(flinkReadConf.scanMode());
     }
 
     public ScanContext build() {
@@ -538,7 +554,8 @@ public class ScanContext implements Serializable {
           branch,
           tag,
           startTag,
-          endTag);
+          endTag,
+          scanMode);
     }
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanMode.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanMode.java
@@ -18,18 +18,27 @@
  */
 package org.apache.iceberg.flink.source;
 
-import java.io.Serializable;
-import org.apache.flink.annotation.Internal;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.encryption.InputFilesDecryptor;
-import org.apache.iceberg.io.CloseableIterator;
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
-/**
- * Read a {@link FileScanTask} into a {@link CloseableIterator}
- *
- * @param <T> is the output data type returned by this iterator.
- */
-@Internal
-public interface FileScanTaskReader<T> extends Serializable {
-  CloseableIterator<T> open(FileScanTask fileScanTask, InputFilesDecryptor inputFilesDecryptor);
+public enum ScanMode {
+  BATCH,
+  INCREMENTAL_APPEND_SCAN,
+  CHANGELOG_SCAN;
+
+  public static ScanMode checkScanMode(ScanContext context) {
+
+    if (!Strings.isNullOrEmpty(context.scanMode())) {
+      return ScanMode.valueOf(context.scanMode().toUpperCase(Locale.ROOT));
+    }
+
+    if (context.startSnapshotId() != null
+        || context.endSnapshotId() != null
+        || context.startTag() != null
+        || context.endTag() != null) {
+      return ScanMode.INCREMENTAL_APPEND_SCAN;
+    } else {
+      return ScanMode.BATCH;
+    }
+  }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanTaskReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/ScanTaskReader.java
@@ -18,35 +18,23 @@
  */
 package org.apache.iceberg.flink.source;
 
-import org.apache.avro.generic.GenericRecord;
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.io.CloseableIterator;
 
-public class AvroGenericRecordFileScanTaskReader implements ScanTaskReader<GenericRecord> {
-  private final RowDataFileScanTaskReader rowDataReader;
-  private final RowDataToAvroGenericRecordConverter converter;
-  private ScanTaskGroup<? extends ScanTask> taskGroup;
+/**
+ * Read a {@link ScanTask} into a {@link CloseableIterator}
+ *
+ * @param <T> is the output data type returned by this iterator.
+ */
+@Internal
+public interface ScanTaskReader<T> extends Serializable {
 
-  public AvroGenericRecordFileScanTaskReader(
-      RowDataFileScanTaskReader rowDataReader, RowDataToAvroGenericRecordConverter converter) {
-    this.rowDataReader = rowDataReader;
-    this.converter = converter;
-  }
+  CloseableIterator<T> open(ScanTask scanTask);
 
-  @Override
-  public CloseableIterator<GenericRecord> open(ScanTask fileScanTask) {
-    return CloseableIterator.transform(rowDataReader.open(fileScanTask), converter);
-  }
+  ScanTaskGroup<? extends ScanTask> taskGroup();
 
-  @Override
-  public ScanTaskGroup<? extends ScanTask> taskGroup() {
-    return taskGroup;
-  }
-
-  @Override
-  public void taskGroup(ScanTaskGroup<? extends ScanTask> newTaskGroup) {
-    this.taskGroup = newTaskGroup;
-    rowDataReader.taskGroup(newTaskGroup);
-  }
+  void taskGroup(ScanTaskGroup<? extends ScanTask> taskGroup);
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
@@ -38,8 +38,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 public class AvroGenericRecordReaderFunction extends DataIteratorReaderFunction<GenericRecord> {
   private final String tableName;
   private final Schema readSchema;
-  private final FileIO io;
-  private final EncryptionManager encryption;
   private final RowDataFileScanTaskReader rowDataReader;
 
   private transient RowDataToAvroGenericRecordConverter converter;
@@ -73,19 +71,15 @@ public class AvroGenericRecordReaderFunction extends DataIteratorReaderFunction<
     super(new ListDataIteratorBatcher<>(config));
     this.tableName = tableName;
     this.readSchema = readSchema(tableSchema, projectedSchema);
-    this.io = io;
-    this.encryption = encryption;
     this.rowDataReader =
-        new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive, filters);
+        new RowDataFileScanTaskReader(
+            tableSchema, readSchema, nameMapping, caseSensitive, null, io, encryption, filters);
   }
 
   @Override
   protected DataIterator<GenericRecord> createDataIterator(IcebergSourceSplit split) {
     return new DataIterator<>(
-        new AvroGenericRecordFileScanTaskReader(rowDataReader, lazyConverter()),
-        split.task(),
-        io,
-        encryption);
+        new AvroGenericRecordFileScanTaskReader(rowDataReader, lazyConverter()), split.task());
   }
 
   private RowDataToAvroGenericRecordConverter lazyConverter() {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -30,7 +30,6 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
-import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.io.CloseableIterator;
@@ -124,7 +123,7 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   }
 
   private long calculateBytes(IcebergSourceSplit split) {
-    return split.task().files().stream().map(FileScanTask::length).reduce(0L, Long::sum);
+    return split.task().sizeBytes();
   }
 
   private long calculateBytes(SplitsChange<IcebergSourceSplit> splitsChanges) {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/MetaDataReaderFunction.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/MetaDataReaderFunction.java
@@ -22,40 +22,29 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.flink.source.DataTaskReader;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /** Reading metadata tables (like snapshots, manifests, etc.) */
 @Internal
 public class MetaDataReaderFunction extends DataIteratorReaderFunction<RowData> {
   private final Schema readSchema;
-  private final FileIO io;
-  private final EncryptionManager encryption;
 
-  public MetaDataReaderFunction(
-      ReadableConfig config,
-      Schema tableSchema,
-      Schema projectedSchema,
-      FileIO io,
-      EncryptionManager encryption) {
+  public MetaDataReaderFunction(ReadableConfig config, Schema tableSchema, Schema projectedSchema) {
     super(
         new ArrayPoolDataIteratorBatcher<>(
             config,
             new RowDataRecordFactory(
                 FlinkSchemaUtil.convert(readSchema(tableSchema, projectedSchema)))));
     this.readSchema = readSchema(tableSchema, projectedSchema);
-    this.io = io;
-    this.encryption = encryption;
   }
 
   @Override
   public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
-    return new DataIterator<>(new DataTaskReader(readSchema), split.task(), io, encryption);
+    return new DataIterator<>(new DataTaskReader(readSchema), split.task());
   }
 
   private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowChangeLogReaderFunction.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowChangeLogReaderFunction.java
@@ -26,12 +26,12 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.DataIterator;
-import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
+import org.apache.iceberg.flink.source.RowDataFileChangeLogReader;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
+public class RowChangeLogReaderFunction extends DataIteratorReaderFunction<RowData> {
   private final Schema tableSchema;
   private final Schema readSchema;
   private final String nameMapping;
@@ -40,7 +40,7 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
   private final EncryptionManager encryption;
   private final List<Expression> filters;
 
-  public RowDataReaderFunction(
+  public RowChangeLogReaderFunction(
       ReadableConfig config,
       Schema tableSchema,
       Schema projectedSchema,
@@ -63,22 +63,22 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
     this.filters = filters;
   }
 
+  private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {
+    Preconditions.checkNotNull(tableSchema, "Table schema can't be null");
+    return projectedSchema == null ? tableSchema : projectedSchema;
+  }
+
   @Override
-  public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
+  protected DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
     return new DataIterator<>(
-        new RowDataFileScanTaskReader(
+        new RowDataFileChangeLogReader(
             tableSchema,
             readSchema,
-            nameMapping,
             caseSensitive,
+            nameMapping,
             split.task(),
             io,
             encryption,
             filters));
-  }
-
-  private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {
-    Preconditions.checkNotNull(tableSchema, "Table schema can't be null");
-    return projectedSchema == null ? tableSchema : projectedSchema;
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceChangeLogSplit.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceChangeLogSplit.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.split;
+
+import java.util.Collection;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+
+public class IcebergSourceChangeLogSplit extends IcebergSourceSplit {
+
+  protected IcebergSourceChangeLogSplit(
+      ScanTaskGroup<ChangelogScanTask> task, int fileOffset, long recordOffset) {
+    super(task, fileOffset, recordOffset);
+  }
+
+  @Override
+  public String splitId() {
+    return task().toString();
+  }
+
+  @Override
+  protected String toString(Collection<? extends ScanTask> files) {
+    return files.toString();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public ScanTaskGroup<ChangelogScanTask> task() {
+    return (ScanTaskGroup<ChangelogScanTask>) super.task();
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceCombinedSplit.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceCombinedSplit.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.split;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+
+public class IcebergSourceCombinedSplit extends IcebergSourceSplit {
+
+  public IcebergSourceCombinedSplit(CombinedScanTask task, int fileOffset, long recordOffset) {
+    super(task, fileOffset, recordOffset);
+  }
+
+  @Override
+  public String splitId() {
+    return MoreObjects.toStringHelper(this)
+        .add("files", toString(((CombinedScanTask) task()).files()))
+        .toString();
+  }
+
+  @Override
+  public CombinedScanTask task() {
+    return (CombinedScanTask) super.task();
+  }
+
+  @Override
+  protected String toString(Collection<? extends ScanTask> files) {
+    return Iterables.toString(
+        files.stream()
+            .map(t -> (FileScanTask) t)
+            .map(
+                fileScanTask ->
+                    MoreObjects.toStringHelper(fileScanTask)
+                        .add("file", fileScanTask.file().path().toString())
+                        .add("start", fileScanTask.start())
+                        .add("length", fileScanTask.length())
+                        .toString())
+            .collect(Collectors.toList()));
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("files", toString(((CombinedScanTask) task()).tasks()))
+        .add("fileOffset", fileOffset())
+        .add("recordOffset", recordOffset())
+        .toString();
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -33,11 +33,13 @@ public class SplitComparators {
   public static SerializableComparator<IcebergSourceSplit> fileSequenceNumber() {
     return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
       Preconditions.checkArgument(
-          o1.task().files().size() == 1 && o2.task().files().size() == 1,
+          o1.task().filesCount() == 1 && o2.task().filesCount() == 1,
           "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
 
-      Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
-      Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();
+      Long seq1 =
+          o1.task().asCombinedScanTask().files().iterator().next().file().fileSequenceNumber();
+      Long seq2 =
+          o2.task().asCombinedScanTask().files().iterator().next().file().fileSequenceNumber();
 
       Preconditions.checkNotNull(
           seq1,

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergSourceChangeLogSQL.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergSourceChangeLogSQL.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestIcebergSourceChangeLogSQL extends FlinkCatalogTestBase {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private final boolean isStreamingJob;
+  private final Map<String, String> tableUpsertProps = Maps.newHashMap();
+  private TableEnvironment tEnv;
+
+  public TestIcebergSourceChangeLogSQL(
+      String catalogName,
+      Namespace baseNamespace,
+      FileFormat format,
+      Boolean isStreamingJob,
+      String formatVersion) {
+    super(catalogName, baseNamespace);
+    this.isStreamingJob = isStreamingJob;
+    tableUpsertProps.put(TableProperties.FORMAT_VERSION, formatVersion);
+    tableUpsertProps.put(TableProperties.DEFAULT_FILE_FORMAT, format.name());
+  }
+
+  @Parameterized.Parameters(
+      name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}, formatVersion={4}")
+  public static Iterable<Object[]> parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (FileFormat format :
+        new FileFormat[] {FileFormat.AVRO, FileFormat.ORC, FileFormat.PARQUET}) {
+      // Only test with one catalog as this is a file operation concern.
+      // FlinkCatalogTestBase requires the catalog name start with testhadoop if using hadoop
+      // catalog.
+      String catalogName = "testhadoop";
+      Namespace baseNamespace = Namespace.of("default");
+      parameters.add(new Object[] {catalogName, baseNamespace, format, false, "1"});
+      parameters.add(new Object[] {catalogName, baseNamespace, format, false, "2"});
+    }
+    return parameters;
+  }
+
+  @Override
+  protected TableEnvironment getTableEnv() {
+    if (tEnv == null) {
+      synchronized (this) {
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(
+            FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE.key(), true);
+        EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
+        settingsBuilder.withConfiguration(configuration);
+        if (isStreamingJob) {
+          settingsBuilder.inStreamingMode();
+          StreamExecutionEnvironment env =
+              StreamExecutionEnvironment.getExecutionEnvironment(
+                  MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG);
+          env.enableCheckpointing(400);
+          env.setMaxParallelism(2);
+          env.setParallelism(2);
+          tEnv = StreamTableEnvironment.create(env, settingsBuilder.build());
+        } else {
+          settingsBuilder.inBatchMode();
+          tEnv = TableEnvironment.create(settingsBuilder.build());
+        }
+      }
+    }
+    return tEnv;
+  }
+
+  @Override
+  @Before
+  public void before() {
+    super.before();
+    sql("CREATE DATABASE IF NOT EXISTS %s", flinkDatabase);
+    sql("USE CATALOG %s", catalogName);
+    sql("USE %s", DATABASE);
+  }
+
+  @Override
+  @After
+  public void clean() {
+    sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
+    super.clean();
+  }
+
+  @Test
+  public void testChangeLogRead() {
+    Assume.assumeFalse("  ", isStreamingJob);
+
+    String tableName = "test_upsert_query";
+    LocalDate dt20220301 = LocalDate.of(2022, 3, 1);
+    LocalDate dt20220302 = LocalDate.of(2022, 3, 2);
+
+    sql(
+        "CREATE TABLE %s(id INT NOT NULL, data STRING NOT NULL, dt DATE) "
+            + "PARTITIONED BY (dt) WITH %s",
+        tableName, toWithClause(tableUpsertProps));
+
+    try {
+      sql(
+          "INSERT INTO %s VALUES " + "(1, 'a', DATE '2022-03-01')," + "(3, 'c', DATE '2022-03-02')",
+          tableName);
+
+      sql("INSERT OVERWRITE %s VALUES " + "(1, 'a2', DATE '2022-03-01')", tableName);
+
+      List<Row> rowsOn20220301 =
+          Lists.newArrayList(
+              Row.ofKind(RowKind.INSERT, 1, "a2", dt20220301),
+              Row.ofKind(RowKind.DELETE, 1, "a", dt20220301),
+              Row.ofKind(RowKind.INSERT, 1, "a", dt20220301),
+              Row.ofKind(RowKind.INSERT, 3, "c", dt20220302));
+      TestHelpers.assertRows(
+          sql(
+              "SELECT * FROM %s /*+ OPTIONS('scan-mode'='CHANGELOG_SCAN')*/ order by id",
+              tableName),
+          rowsOn20220301);
+    } finally {
+      sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, tableName);
+    }
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergSourceChangeLogScan.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestIcebergSourceChangeLogScan.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.data.RowDataToRowMapper;
+import org.apache.iceberg.flink.source.IcebergSource;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.StreamingStartingStrategy;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceChangeLogScan {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Rule
+  public final HadoopTableResource tableResource =
+      new HadoopTableResource(TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE, SCHEMA);
+
+  public static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()),
+          required(2, "data", Types.StringType.get()),
+          required(3, "dt", Types.StringType.get()));
+
+  @Test
+  public void testChangeLogStreamingTable() throws Exception {
+    // snapshot1
+    Row row1 = Row.ofKind(RowKind.INSERT, 1, "aaa", "2021-01-01");
+    DataFile dataFile = writeFile("2021-01-01", tableResource.table(), row1);
+    tableResource.table().newAppend().appendFile(dataFile).commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .scanMode("CHANGELOG_SCAN")
+            .monitorInterval(Duration.ofMillis(10L))
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+
+    try (CloseableIterator<Row> iter =
+        createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      List<Row> result1 = waitForResult(iter, 1);
+      TestHelpers.assertRows(result1, ImmutableList.of(row1));
+
+      // snapshot2
+      Row row2 = Row.ofKind(RowKind.INSERT, 2, "bbb", "2021-01-02");
+      DataFile dataFile2 = writeFile("2021-01-02", tableResource.table(), row2);
+      tableResource.table().newAppend().appendFile(dataFile2).commit();
+
+      List<Row> result2 = waitForResult(iter, 1);
+      TestHelpers.assertRows(result2, ImmutableList.of(row2));
+
+      // snapshot3
+      tableResource.table().newDelete().deleteFile(dataFile).commit();
+
+      List<Row> result3 = waitForResult(iter, 1);
+      Row row1Delete = Row.ofKind(RowKind.DELETE, 1, "aaa", "2021-01-01");
+      TestHelpers.assertRows(result3, ImmutableList.of(row1Delete));
+    }
+  }
+
+  private DataFile writeFile(String partition, Table table, Row... rows) throws IOException {
+    GenericAppenderHelper appender =
+        new GenericAppenderHelper(table, FileFormat.AVRO, TEMPORARY_FOLDER);
+
+    GenericRecord gRecord = GenericRecord.create(table.schema());
+    List<Record> records = Lists.newArrayList();
+    for (Row row : rows) {
+      records.add(
+          gRecord.copy(
+              "id", row.getField(0),
+              "data", row.getField(1),
+              "dt", row.getField(2)));
+    }
+
+    return appender.writeFile(org.apache.iceberg.TestHelpers.Row.of(partition, 0), records);
+  }
+
+  private DataStream<Row> createStream(ScanContext scanContext) throws Exception {
+    // start the source and collect output
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    DataStream<Row> stream =
+        env.fromSource(
+                IcebergSource.forRowData()
+                    .tableLoader(tableResource.tableLoader())
+                    .assignerFactory(new SimpleSplitAssignerFactory())
+                    .streaming(scanContext.isStreaming())
+                    .streamingStartingStrategy(scanContext.streamingStartingStrategy())
+                    .startSnapshotTimestamp(scanContext.startSnapshotTimestamp())
+                    .startSnapshotId(scanContext.startSnapshotId())
+                    .monitorInterval(Duration.ofMillis(100L))
+                    .scanMode(scanContext.scanMode())
+                    .build(),
+                WatermarkStrategy.noWatermarks(),
+                "icebergSource",
+                TypeInformation.of(RowData.class))
+            .map(new RowDataToRowMapper(FlinkSchemaUtil.convert(tableResource.table().schema())));
+    return stream;
+  }
+
+  public static List<Row> waitForResult(CloseableIterator<Row> iter, int limit) {
+    List<Row> results = Lists.newArrayListWithCapacity(limit);
+    while (results.size() < limit) {
+      if (iter.hasNext()) {
+        results.add(iter.next());
+      } else {
+        break;
+      }
+    }
+    return results;
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -139,8 +139,7 @@ public class TestIcebergSourceContinuous {
             .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
             .build();
 
-    Assert.assertEquals(
-        FlinkSplitPlanner.ScanMode.BATCH, FlinkSplitPlanner.checkScanMode(scanContext));
+    Assert.assertEquals(ScanMode.BATCH, ScanMode.checkScanMode(scanContext));
 
     try (CloseableIterator<Row> iter =
         createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -78,7 +78,7 @@ public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestB
 
   protected void assertGetNext(SplitAssigner assigner, Long expectedSequenceNumber) {
     GetSplitResult result = assigner.getNext(null);
-    ContentFile file = result.split().task().files().iterator().next().file();
+    ContentFile file = result.split().task().asCombinedScanTask().files().iterator().next().file();
     Assert.assertEquals(expectedSequenceNumber, file.fileSequenceNumber());
   }
 }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/IcebergTestingReaderOutput.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/IcebergTestingReaderOutput.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.List;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/** A {@code ReaderOutput} for testing that collects the emitted records. */
+public class IcebergTestingReaderOutput implements ReaderOutput<RowData> {
+
+  private final List<RowData> emittedRecords = Lists.newArrayList();
+  private final RowDataSerializer serializer;
+
+  public IcebergTestingReaderOutput(RowType rowType) {
+    serializer = new RowDataSerializer(rowType);
+  }
+
+  @Override
+  public void collect(RowData record) {
+    emittedRecords.add(serializer.copy(record));
+  }
+
+  @Override
+  public void collect(RowData record, long timestamp) {
+    collect(record);
+  }
+
+  @Override
+  public void emitWatermark(Watermark watermark) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void markIdle() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void markActive() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public SourceOutput<RowData> createOutputForSplit(String splitId) {
+    return this;
+  }
+
+  @Override
+  public void releaseOutputForSplit(String splitId) {}
+
+  // ------------------------------------------------------------------------
+
+  public List<RowData> getEmittedRecords() {
+    return emittedRecords;
+  }
+
+  public void clearEmittedRecords() {
+    emittedRecords.clear();
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderFunctionTestBase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderFunctionTestBase.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.split.IcebergSourceCombinedSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -92,7 +93,7 @@ public abstract class ReaderFunctionTestBase<T> {
     CombinedScanTask combinedScanTask =
         ReaderUtil.createCombinedScanTask(
             recordBatchList, TEMPORARY_FOLDER, fileFormat, appenderFactory);
-    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask);
+    IcebergSourceSplit split = IcebergSourceCombinedSplit.fromCombinedScanTask(combinedScanTask);
     CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader =
         readerFunction().apply(split);
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -20,9 +20,9 @@ package org.apache.iceberg.flink.source.reader;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import org.apache.flink.table.data.RowData;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.CombinedScanTask;
@@ -85,10 +85,14 @@ public class ReaderUtil {
   public static DataIterator<RowData> createDataIterator(CombinedScanTask combinedTask) {
     return new DataIterator<>(
         new RowDataFileScanTaskReader(
-            TestFixtures.SCHEMA, TestFixtures.SCHEMA, null, true, Collections.emptyList()),
-        combinedTask,
-        new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
-        new PlaintextEncryptionManager());
+            TestFixtures.SCHEMA,
+            TestFixtures.SCHEMA,
+            null,
+            true,
+            combinedTask,
+            new HadoopFileIO(new Configuration()),
+            new PlaintextEncryptionManager(),
+            null));
   }
 
   public static List<List<Record>> createRecordBatchList(

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceChangeLogReader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceChangeLogReader.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.ChangelogScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.split.IcebergSourceChangeLogSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceChangeLogReader {
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  private static final Schema SCHEMA = TestFixtures.SCHEMA;
+
+  @Rule
+  public final HadoopTableResource tableResource =
+      new HadoopTableResource(
+          TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE, SCHEMA, TestFixtures.SPEC);
+
+  private Table table;
+  private DataFile dataFile1;
+  private DataFile dataFile2;
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private final Row row1 = Row.ofKind(RowKind.INSERT, "aa", 1L, "2021-01-01");
+  private final Row row2 = Row.ofKind(RowKind.INSERT, "bb", 2L, "2021-01-01");
+  private final Row row3 = Row.ofKind(RowKind.INSERT, "cc", 3L, "2021-01-01");
+  private final Row row4 = Row.ofKind(RowKind.INSERT, "dd", 4L, "2021-01-01");
+  private final Row row5 = Row.ofKind(RowKind.INSERT, "ee", 5L, "2021-01-01");
+
+  private final Row row6 = Row.ofKind(RowKind.INSERT, "ff", 6L, "2021-01-03");
+  private final Row row7 = Row.ofKind(RowKind.INSERT, "gg", 7L, "2021-01-03");
+  private final Row row8 = Row.ofKind(RowKind.INSERT, "qq", 8L, "2021-01-03");
+
+  private final List<Row> rows1 = Lists.newArrayList(row1, row2, row3, row4, row5);
+  private final List<Row> rows1Delete =
+      Lists.newArrayList(
+          Row.ofKind(RowKind.DELETE, "aa", 1L, "2021-01-01"),
+          Row.ofKind(RowKind.DELETE, "bb", 2L, "2021-01-01"),
+          Row.ofKind(RowKind.DELETE, "cc", 3L, "2021-01-01"),
+          Row.ofKind(RowKind.DELETE, "dd", 4L, "2021-01-01"),
+          Row.ofKind(RowKind.DELETE, "ee", 5L, "2021-01-01"));
+  private final List<Row> rows3 = Lists.newArrayList(row6, row7, row8);
+
+  @Before
+  public void before() throws IOException {
+    table = tableResource.table();
+
+    // write data to files
+    dataFile1 = writeFile("2021-01-01", row1, row2, row3, row4, row5);
+    dataFile2 = writeFile("2021-01-03", row6, row7, row8);
+  }
+
+  @Test
+  public void testInsert() throws Exception {
+    table.newAppend().appendFile(dataFile1).commit();
+    table.newDelete().deleteFile(dataFile1).commit();
+
+    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups = newScan().planTasks();
+
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    reader.start();
+    IcebergTestingReaderOutput readerOutput =
+        new IcebergTestingReaderOutput(FlinkSchemaUtil.convert(table.schema()));
+
+    for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
+      IcebergSourceChangeLogSplit split = IcebergSourceSplit.fromChangeLogScanTask(taskGroup);
+      reader.addSplits(Arrays.asList(split));
+    }
+    while (readerOutput.getEmittedRecords().size() < 10) {
+      reader.pollNext(readerOutput);
+    }
+
+    List<RowData> emittedRecords = readerOutput.getEmittedRecords();
+    List<Row> expected = Lists.newArrayList();
+    expected.addAll(rows1);
+    expected.addAll(rows1Delete);
+
+    List<Row> result =
+        org.apache.iceberg.flink.TestHelpers.convertRowDataToRow(
+            emittedRecords, TestFixtures.ROW_TYPE);
+    org.apache.iceberg.flink.TestHelpers.assertRows(result, expected);
+
+    reader.pollNext(readerOutput);
+  }
+
+  @Test
+  public void testMixDeleteAndInsert() throws Exception {
+    table.newAppend().appendFile(dataFile1).commit();
+    table.newDelete().deleteFile(dataFile1).commit();
+    table.newAppend().appendFile(dataFile2).commit();
+
+    CloseableIterable<ScanTaskGroup<ChangelogScanTask>> taskGroups = newScan().planTasks();
+
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    reader.start();
+
+    IcebergTestingReaderOutput readerOutput =
+        new IcebergTestingReaderOutput(FlinkSchemaUtil.convert(table.schema()));
+    for (ScanTaskGroup<ChangelogScanTask> taskGroup : taskGroups) {
+      IcebergSourceChangeLogSplit split = IcebergSourceSplit.fromChangeLogScanTask(taskGroup);
+      reader.addSplits(Arrays.asList(split));
+    }
+
+    while (readerOutput.getEmittedRecords().size() < 13) {
+      reader.pollNext(readerOutput);
+    }
+
+    List<RowData> emittedRecords = readerOutput.getEmittedRecords();
+
+    List<Row> expected = Lists.newArrayList();
+    expected.addAll(rows1);
+    expected.addAll(rows1Delete);
+    expected.addAll(rows3);
+
+    List<Row> result =
+        org.apache.iceberg.flink.TestHelpers.convertRowDataToRow(
+            emittedRecords, TestFixtures.ROW_TYPE);
+    org.apache.iceberg.flink.TestHelpers.assertRows(result, expected);
+
+    reader.pollNext(readerOutput);
+  }
+
+  private IncrementalChangelogScan newScan() {
+    return table.newIncrementalChangelogScan();
+  }
+
+  private DataFile writeFile(String partition, Row... rows) throws IOException {
+    GenericAppenderHelper appender =
+        new GenericAppenderHelper(table, FileFormat.AVRO, TEMPORARY_FOLDER);
+
+    GenericRecord gRecord = GenericRecord.create(table.schema());
+    List<Record> records = Lists.newArrayList();
+    for (Row row : rows) {
+      records.add(
+          gRecord.copy(
+              "data", row.getField(0),
+              "id", row.getField(1),
+              "dt", row.getField(2)));
+    }
+
+    return appender.writeFile(org.apache.iceberg.TestHelpers.Row.of(partition, 0), records);
+  }
+
+  private IcebergSourceReader createReader(
+      MetricGroup metricGroup, SourceReaderContext readerContext) {
+    IcebergSourceReaderMetrics readerMetrics =
+        new IcebergSourceReaderMetrics(metricGroup, "db.tbl");
+    RowChangeLogReaderFunction readerFunction =
+        new RowChangeLogReaderFunction(
+            new Configuration(),
+            TestFixtures.SCHEMA,
+            TestFixtures.SCHEMA,
+            null,
+            true,
+            new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
+            new PlaintextEncryptionManager(),
+            null);
+    return new IcebergSourceReader<>(readerMetrics, readerFunction, null, readerContext);
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
@@ -49,15 +49,17 @@ public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
 
   @Override
   protected ReaderFunction<RowData> readerFunction() {
-    return new RowDataReaderFunction(
-        new Configuration(),
-        TestFixtures.SCHEMA,
-        TestFixtures.SCHEMA,
-        null,
-        true,
-        new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
-        new PlaintextEncryptionManager(),
-        Collections.emptyList());
+    DataIteratorReaderFunction rowDataReaderFunction =
+        new RowDataReaderFunction(
+            new Configuration(),
+            TestFixtures.SCHEMA,
+            TestFixtures.SCHEMA,
+            null,
+            true,
+            new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
+            new PlaintextEncryptionManager(),
+            Collections.emptyList());
+    return rowDataReaderFunction;
   }
 
   @Override


### PR DESCRIPTION
## What is the purpose of the change

Support for Changlog scanning in the new Flink Source(FLIP-27)

It can be turned on in the following ways:

```
SELECT * FROM tableName /*+ OPTIONS('scan-mode'='CHANGELOG_SCAN')*/

ScanContext scanContext =
    ScanContext.builder()
        .scanMode("CHANGELOG_SCAN")
        ......
        .build();
```


## Brief change log

* Add a Reader for ChangeLog
* Refactor the Split 


## Verifying this change
* Several test cases have been added