### PR TITLE
Spark 3.3: Use separate scan during file filtering in copy-on-write operations

### DIFF
--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -140,14 +140,15 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
       exclude group: 'org.roaringbitmap'
     }
 
+    testImplementation project(path: ':iceberg-data')
+    testImplementation project(path: ':iceberg-parquet')
     testImplementation project(path: ':iceberg-hive-metastore')
-    testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}", configuration: 'testArtifacts')
 
     testImplementation "org.apache.avro:avro"
+    testImplementation "org.apache.parquet:parquet-hadoop"
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
     runtimeOnly "org.antlr:antlr4-runtime:4.8"

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelCommandDynamicPruning.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/RowLevelCommandDynamicPruning.scala
@@ -48,7 +48,9 @@ import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.PLAN_EXPRESSION
 import org.apache.spark.sql.catalyst.trees.TreePattern.SORT
 import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits
 import scala.collection.compat.immutable.ArraySeq
 
 /**
@@ -58,6 +60,8 @@ import scala.collection.compat.immutable.ArraySeq
  * Row-based rewrite plans are subject to usual runtime filtering.
  */
 case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[LogicalPlan] with PredicateHelper {
+
+  import ExtendedDataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
     // apply special dynamic filtering only for plans that don't support deltas
@@ -69,16 +73,24 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
       // use reference equality to find exactly the required scan relations
       val newRewritePlan = rewritePlan transformUp {
         case r: DataSourceV2ScanRelation if r.scan eq scan =>
-          val pruningKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](
-            ArraySeq.unsafeWrapArray(scan.filterAttributes), r)
-          val dynamicPruningCond = buildDynamicPruningCondition(r, command, pruningKeys)
-          val filter = Filter(dynamicPruningCond, r)
-          // always optimize dynamic filtering subqueries for row-level commands as it is important
-          // to rewrite introduced predicates as joins because Spark recently stopped optimizing
-          // dynamic subqueries to facilitate broadcast reuse
-          optimizeSubquery(filter)
+          // use the original table instance that was loaded for this row-level operation
+          // in order to leverage a regular batch scan in the group filter query
+          val originalTable = r.relation.table.asRowLevelOperationTable.table
+          val relation = r.relation.copy(table = originalTable)
+          val matchingRowsPlan = buildMatchingRowsPlan(relation, command)
+
+          val filterAttrs = ArraySeq.unsafeWrapArray(scan.filterAttributes)
+          val buildKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](filterAttrs, matchingRowsPlan)
+          val pruningKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](filterAttrs, r)
+          val dynamicPruningCond = buildDynamicPruningCond(matchingRowsPlan, buildKeys, pruningKeys)
+
+          Filter(dynamicPruningCond, r)
       }
-      command.withNewRewritePlan(newRewritePlan)
+
+      // always optimize dynamic filtering subqueries for row-level commands as it is important
+      // to rewrite introduced predicates as joins because Spark recently stopped optimizing
+      // dynamic subqueries to facilitate broadcast reuse
+      command.withNewRewritePlan(optimizeSubquery(newRewritePlan))
   }
 
   private def isCandidate(command: RowLevelCommand): Boolean = command.condition match {
@@ -86,10 +98,9 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
     case _ => false
   }
 
-  private def buildDynamicPruningCondition(
-      relation: DataSourceV2ScanRelation,
-      command: RowLevelCommand,
-      pruningKeys: Seq[Attribute]): Expression = {
+  private def buildMatchingRowsPlan(
+      relation: DataSourceV2Relation,
+      command: RowLevelCommand): LogicalPlan = {
 
     // construct a filtering plan with the original scan relation
     val matchingRowsPlan = command match {
@@ -113,23 +124,23 @@ case class RowLevelCommandDynamicPruning(spark: SparkSession) extends Rule[Logic
     }
 
     // clone the original relation in the filtering plan and assign new expr IDs to avoid conflicts
-    val transformedMatchingRowsPlan = matchingRowsPlan transformUpWithNewOutput {
-      case r: DataSourceV2ScanRelation if r eq relation =>
+    matchingRowsPlan transformUpWithNewOutput {
+      case r: DataSourceV2Relation if r eq relation =>
         val oldOutput = r.output
         val newOutput = oldOutput.map(_.newInstance())
         r.copy(output = newOutput) -> oldOutput.zip(newOutput)
     }
+  }
 
-    val filterableScan = relation.scan.asInstanceOf[SupportsRuntimeFiltering]
-    val buildKeys = ExtendedV2ExpressionUtils.resolveRefs[Attribute](
-      ArraySeq.unsafeWrapArray(filterableScan.filterAttributes),
-      transformedMatchingRowsPlan)
-    val buildQuery = Project(buildKeys, transformedMatchingRowsPlan)
+  private def buildDynamicPruningCond(
+      matchingRowsPlan: LogicalPlan,
+      buildKeys: Seq[Attribute],
+      pruningKeys: Seq[Attribute]): Expression = {
+
+    val buildQuery = Project(buildKeys, matchingRowsPlan)
     val dynamicPruningSubqueries = pruningKeys.zipWithIndex.map { case (key, index) =>
       DynamicPruningSubquery(key, buildQuery, buildKeys, index, onlyInBroadcast = false)
     }
-
-    // combine all dynamic subqueries to produce the final condition
     dynamicPruningSubqueries.reduce(And)
   }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -31,6 +31,8 @@ import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +40,15 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSessionCatalog;
@@ -273,6 +283,32 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
       Thread.sleep(millis);
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  protected DataFile writeDataFile(Table table, List<GenericRecord> records) {
+    try {
+      OutputFile file = Files.localOutput(temp.newFile());
+
+      DataWriter<GenericRecord> dataWriter =
+          Parquet.writeData(file)
+              .forTable(table)
+              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .overwrite()
+              .build();
+
+      try {
+        for (GenericRecord record : records) {
+          dataWriter.write(record);
+        }
+      } finally {
+        dataWriter.close();
+      }
+
+      return dataWriter.toDataFile();
+
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -100,7 +100,6 @@ public class TestCopyOnWriteDelete extends TestDelete {
               }
             });
 
-
     // append thread
     Future<?> appendFuture =
         executorService.submit(

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -128,7 +128,7 @@ public class TestCopyOnWriteDelete extends TestDelete {
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("the table has been concurrently refreshed");
+          .hasMessageContaining("the table has been concurrently modified");
     } finally {
       appendFuture.cancel(true);
     }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -18,10 +18,31 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
+
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.spark.sql.Encoders;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteDelete extends TestDelete {
 
@@ -39,5 +60,81 @@ public class TestCopyOnWriteDelete extends TestDelete {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.DELETE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public synchronized void testDeleteWithConcurrentTableRefresh() throws Exception {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitUnpartitionedTable();
+    createOrReplaceView("deleted_id", Collections.singletonList(1), Encoders.INT());
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, DELETE_ISOLATION_LEVEL, "snapshot");
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // delete thread
+    Future<?> deleteFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                sql("DELETE FROM %s WHERE id IN (SELECT * FROM deleted_id)", tableName);
+
+                barrier.incrementAndGet();
+              }
+            });
+
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              GenericRecord record = GenericRecord.create(table.schema());
+              record.set(0, 1); // id
+              record.set(1, "hr"); // dep
+
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                for (int numAppends = 0; numAppends < 5; numAppends++) {
+                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                  table.newFastAppend().appendFile(dataFile).commit();
+                  sleep(10);
+                }
+
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(deleteFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
@@ -84,6 +85,7 @@ public class TestCopyOnWriteMerge extends TestMerge {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicBoolean shouldAppend = new AtomicBoolean(true);
 
     // merge thread
     Future<?> mergeFuture =
@@ -114,8 +116,12 @@ public class TestCopyOnWriteMerge extends TestMerge {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
+                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
                   sleep(10);
+                }
+
+                if (!shouldAppend.get()) {
+                  return;
                 }
 
                 for (int numAppends = 0; numAppends < 5; numAppends++) {
@@ -135,6 +141,7 @@ public class TestCopyOnWriteMerge extends TestMerge {
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("the table has been concurrently modified");
     } finally {
+      shouldAppend.set(false);
       appendFuture.cancel(true);
     }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -133,7 +133,7 @@ public class TestCopyOnWriteMerge extends TestMerge {
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("the table has been concurrently refreshed");
+          .hasMessageContaining("the table has been concurrently modified");
     } finally {
       appendFuture.cancel(true);
     }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -18,10 +18,31 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+
+import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.spark.sql.Encoders;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteMerge extends TestMerge {
 
@@ -39,5 +60,85 @@ public class TestCopyOnWriteMerge extends TestMerge {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public synchronized void testMergeWithConcurrentTableRefresh() throws Exception {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitTable("id INT, dep STRING");
+    createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, MERGE_ISOLATION_LEVEL, "snapshot");
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // merge thread
+    Future<?> mergeFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                sql(
+                    "MERGE INTO %s t USING source s "
+                        + "ON t.id == s.value "
+                        + "WHEN MATCHED THEN "
+                        + "  UPDATE SET dep = 'x'",
+                    tableName);
+
+                barrier.incrementAndGet();
+              }
+            });
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              GenericRecord record = GenericRecord.create(table.schema());
+              record.set(0, 1); // id
+              record.set(1, "hr"); // dep
+
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                for (int numAppends = 0; numAppends < 5; numAppends++) {
+                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                  table.newFastAppend().appendFile(dataFile).commit();
+                  sleep(10);
+                }
+
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(mergeFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -18,10 +18,29 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
+
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.spark.Spark3Util;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
 
 public class TestCopyOnWriteUpdate extends TestUpdate {
 
@@ -39,5 +58,79 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
   protected Map<String, String> extraTableProperties() {
     return ImmutableMap.of(
         TableProperties.UPDATE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @Test
+  public synchronized void testUpdateWithConcurrentTableRefresh() throws Exception {
+    // this test can only be run with Hive tables as it requires a reliable lock
+    // also, the table cache must be enabled so that the same table instance can be reused
+    Assume.assumeTrue(catalogName.equalsIgnoreCase("testhive"));
+
+    createAndInitTable("id INT, dep STRING");
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')",
+        tableName, UPDATE_ISOLATION_LEVEL, "snapshot");
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'hr')", tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+
+    ExecutorService executorService =
+        MoreExecutors.getExitingExecutorService(
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
+
+    AtomicInteger barrier = new AtomicInteger(0);
+
+    // update thread
+    Future<?> updateFuture =
+        executorService.submit(
+            () -> {
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                sql("UPDATE %s SET id = -1 WHERE id = 1", tableName);
+
+                barrier.incrementAndGet();
+              }
+            });
+
+    // append thread
+    Future<?> appendFuture =
+        executorService.submit(
+            () -> {
+              GenericRecord record = GenericRecord.create(table.schema());
+              record.set(0, 1); // id
+              record.set(1, "hr"); // dep
+
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (barrier.get() < numOperations * 2) {
+                  sleep(10);
+                }
+
+                for (int numAppends = 0; numAppends < 5; numAppends++) {
+                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                  table.newFastAppend().appendFile(dataFile).commit();
+                  sleep(10);
+                }
+
+                barrier.incrementAndGet();
+              }
+            });
+
+    try {
+      Assertions.assertThatThrownBy(updateFuture::get)
+          .isInstanceOf(ExecutionException.class)
+          .cause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("the table has been concurrently refreshed");
+    } finally {
+      appendFuture.cancel(true);
+    }
+
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -125,7 +125,7 @@ public class TestCopyOnWriteUpdate extends TestUpdate {
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining("the table has been concurrently refreshed");
+          .hasMessageContaining("the table has been concurrently modified");
     } finally {
       appendFuture.cancel(true);
     }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -37,8 +37,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
@@ -738,7 +738,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
-    AtomicReference<Exception> appendExceptionRef = new AtomicReference<>(null);
+    AtomicBoolean shouldAppend = new AtomicBoolean(true);
 
     // delete thread
     Future<?> deleteFuture =
@@ -759,30 +759,29 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
-              try {
-                // load the table via the validation catalog to use another table instance
-                Table table = validationCatalog.loadTable(tableIdent);
+              // load the table via the validation catalog to use another table instance
+              Table table = validationCatalog.loadTable(tableIdent);
 
-                GenericRecord record = GenericRecord.create(table.schema());
-                record.set(0, 1); // id
-                record.set(1, "hr"); // dep
+              GenericRecord record = GenericRecord.create(table.schema());
+              record.set(0, 1); // id
+              record.set(1, "hr"); // dep
 
-                for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                  while (barrier.get() < numOperations * 2) {
-                    sleep(10);
-                  }
-
-                  for (int numAppends = 0; numAppends < 5; numAppends++) {
-                    DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
-                    table.newFastAppend().appendFile(dataFile).commit();
-                    sleep(10);
-                  }
-
-                  barrier.incrementAndGet();
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
+                  sleep(10);
                 }
-              } catch (Exception e) {
-                appendExceptionRef.set(e);
-                throw e;
+
+                if (!shouldAppend.get()) {
+                  return;
+                }
+
+                for (int numAppends = 0; numAppends < 5; numAppends++) {
+                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                  table.newFastAppend().appendFile(dataFile).commit();
+                  sleep(10);
+                }
+
+                barrier.incrementAndGet();
               }
             });
 
@@ -795,20 +794,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Found conflicting files that can contain");
     } finally {
+      shouldAppend.set(false);
       appendFuture.cancel(true);
     }
 
-    try {
-      executorService.shutdown();
-      Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
-    } catch (Throwable t) {
-      Exception appendException = appendExceptionRef.get();
-      if (appendException != null && !(appendException instanceof InterruptedException)) {
-        throw new RuntimeException("Insert thread failed", appendException);
-      } else {
-        throw t;
-      }
-    }
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 
   @Test
@@ -831,6 +822,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicBoolean shouldAppend = new AtomicBoolean(true);
 
     // delete thread
     Future<?> deleteFuture =
@@ -859,8 +851,12 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
+                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
                   sleep(10);
+                }
+
+                if (!shouldAppend.get()) {
+                  return;
                 }
 
                 for (int numAppends = 0; numAppends < 5; numAppends++) {
@@ -876,6 +872,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     try {
       deleteFuture.get();
     } finally {
+      shouldAppend.set(false);
       appendFuture.cancel(true);
     }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
@@ -998,6 +999,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicReference<Exception> appendExceptionRef = new AtomicReference<>(null);
 
     // merge thread
     Future<?> mergeFuture =
@@ -1023,25 +1025,30 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
-              // load the table via the validation catalog to use another table instance for inserts
-              Table table = validationCatalog.loadTable(tableIdent);
+              try {
+                // load the table via the validation catalog to use another table instance
+                Table table = validationCatalog.loadTable(tableIdent);
 
-              GenericRecord record = GenericRecord.create(table.schema());
-              record.set(0, 1); // id
-              record.set(1, "hr"); // dep
+                GenericRecord record = GenericRecord.create(table.schema());
+                record.set(0, 1); // id
+                record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
+                for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                  while (barrier.get() < numOperations * 2) {
+                    sleep(10);
+                  }
+
+                  for (int numAppends = 0; numAppends < 5; numAppends++) {
+                    DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                    table.newFastAppend().appendFile(dataFile).commit();
+                    sleep(10);
+                  }
+
+                  barrier.incrementAndGet();
                 }
-
-                for (int numAppends = 0; numAppends < 5; numAppends++) {
-                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
-                  table.newFastAppend().appendFile(dataFile).commit();
-                  sleep(10);
-                }
-
-                barrier.incrementAndGet();
+              } catch (Exception e) {
+                appendExceptionRef.set(e);
+                throw e;
               }
             });
 
@@ -1057,8 +1064,17 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
       appendFuture.cancel(true);
     }
 
-    executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    try {
+      executorService.shutdown();
+      Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    } catch (Throwable t) {
+      Exception appendException = appendExceptionRef.get();
+      if (appendException != null && !(appendException instanceof InterruptedException)) {
+        throw new RuntimeException("Insert thread failed", appendException);
+      } else {
+        throw t;
+      }
+    }
   }
 
   @Test

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -34,8 +34,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
@@ -999,7 +999,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
-    AtomicReference<Exception> appendExceptionRef = new AtomicReference<>(null);
+    AtomicBoolean shouldAppend = new AtomicBoolean(true);
 
     // merge thread
     Future<?> mergeFuture =
@@ -1025,30 +1025,29 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
-              try {
-                // load the table via the validation catalog to use another table instance
-                Table table = validationCatalog.loadTable(tableIdent);
+              // load the table via the validation catalog to use another table instance
+              Table table = validationCatalog.loadTable(tableIdent);
 
-                GenericRecord record = GenericRecord.create(table.schema());
-                record.set(0, 1); // id
-                record.set(1, "hr"); // dep
+              GenericRecord record = GenericRecord.create(table.schema());
+              record.set(0, 1); // id
+              record.set(1, "hr"); // dep
 
-                for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                  while (barrier.get() < numOperations * 2) {
-                    sleep(10);
-                  }
-
-                  for (int numAppends = 0; numAppends < 5; numAppends++) {
-                    DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
-                    table.newFastAppend().appendFile(dataFile).commit();
-                    sleep(10);
-                  }
-
-                  barrier.incrementAndGet();
+              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
+                  sleep(10);
                 }
-              } catch (Exception e) {
-                appendExceptionRef.set(e);
-                throw e;
+
+                if (!shouldAppend.get()) {
+                  return;
+                }
+
+                for (int numAppends = 0; numAppends < 5; numAppends++) {
+                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                  table.newFastAppend().appendFile(dataFile).commit();
+                  sleep(10);
+                }
+
+                barrier.incrementAndGet();
               }
             });
 
@@ -1061,20 +1060,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Found conflicting files that can contain");
     } finally {
+      shouldAppend.set(false);
       appendFuture.cancel(true);
     }
 
-    try {
-      executorService.shutdown();
-      Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
-    } catch (Throwable t) {
-      Exception appendException = appendExceptionRef.get();
-      if (appendException != null && !(appendException instanceof InterruptedException)) {
-        throw new RuntimeException("Insert thread failed", appendException);
-      } else {
-        throw t;
-      }
-    }
+    executorService.shutdown();
+    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
   }
 
   @Test
@@ -1097,6 +1088,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicBoolean shouldAppend = new AtomicBoolean(true);
 
     // merge thread
     Future<?> mergeFuture =
@@ -1130,8 +1122,12 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(1, "hr"); // dep
 
               for (int numOperations = 0; numOperations < 20; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
+                while (shouldAppend.get() && barrier.get() < numOperations * 2) {
                   sleep(10);
+                }
+
+                if (!shouldAppend.get()) {
+                  return;
                 }
 
                 for (int numAppends = 0; numAppends < 5; numAppends++) {
@@ -1147,6 +1143,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     try {
       mergeFuture.get();
     } finally {
+      shouldAppend.set(false);
       appendFuture.cancel(true);
     }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.RowLevelOperationMode;
@@ -447,6 +448,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
             (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 
     AtomicInteger barrier = new AtomicInteger(0);
+    AtomicReference<Exception> appendExceptionRef = new AtomicReference<>(null);
 
     // update thread
     Future<?> updateFuture =
@@ -467,25 +469,30 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Future<?> appendFuture =
         executorService.submit(
             () -> {
-              // load the table via the validation catalog to use another table instance for inserts
-              Table table = validationCatalog.loadTable(tableIdent);
+              try {
+                // load the table via the validation catalog to use another table instance
+                Table table = validationCatalog.loadTable(tableIdent);
 
-              GenericRecord record = GenericRecord.create(table.schema());
-              record.set(0, 1); // id
-              record.set(1, "hr"); // dep
+                GenericRecord record = GenericRecord.create(table.schema());
+                record.set(0, 1); // id
+                record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
-                while (barrier.get() < numOperations * 2) {
-                  sleep(10);
+                for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+                  while (barrier.get() < numOperations * 2) {
+                    sleep(10);
+                  }
+
+                  for (int numAppends = 0; numAppends < 5; numAppends++) {
+                    DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
+                    table.newFastAppend().appendFile(dataFile).commit();
+                    sleep(10);
+                  }
+
+                  barrier.incrementAndGet();
                 }
-
-                for (int numAppends = 0; numAppends < 5; numAppends++) {
-                  DataFile dataFile = writeDataFile(table, ImmutableList.of(record));
-                  table.newFastAppend().appendFile(dataFile).commit();
-                  sleep(10);
-                }
-
-                barrier.incrementAndGet();
+              } catch (Exception e) {
+                appendExceptionRef.set(e);
+                throw e;
               }
             });
 
@@ -501,8 +508,17 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
       appendFuture.cancel(true);
     }
 
-    executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    try {
+      executorService.shutdown();
+      Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    } catch (Throwable t) {
+      Exception appendException = appendExceptionRef.get();
+      if (appendException != null && !(appendException instanceof InterruptedException)) {
+        throw new RuntimeException("Insert thread failed", appendException);
+      } else {
+        throw t;
+      }
+    }
   }
 
   @Test

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -105,7 +105,7 @@ class SparkCopyOnWriteScan extends SparkScan implements SupportsRuntimeFiltering
   public void filter(Filter[] filters) {
     Preconditions.checkState(
         Objects.equals(snapshotId(), currentSnapshotId()),
-        "Runtime file filtering is not possible: the table has been concurrently refreshed. "
+        "Runtime file filtering is not possible: the table has been concurrently modified. "
             + "Row-level operation scan snapshot ID: %s, current table snapshot ID: %s. "
             + "If multiple threads modify the table, use independent Spark sessions in each thread.",
         snapshotId(),


### PR DESCRIPTION
This PR enables using a separate scan during file filtering in row-level copy-on-write operations. This means the runtime filter subquery will now be able to push down filters into row groups as well as prune columns. This should make the initial filtering phase more efficient.