### PR TITLE
Spark: Remove redundant check for max_concurrent_deletes in spark actions

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -113,7 +113,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             action.retainLast(retainLastNum);
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(expireService(maxConcurrentDeletes));
           }
 

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -119,7 +119,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.deleteWith(file -> {});
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(removeService(maxConcurrentDeletes));
           }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -113,7 +113,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             action.retainLast(retainLastNum);
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(expireService(maxConcurrentDeletes));
           }
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -119,7 +119,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.deleteWith(file -> {});
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(removeService(maxConcurrentDeletes));
           }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -112,7 +112,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             action.retainLast(retainLastNum);
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
           }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -152,7 +152,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.deleteWith(file -> {});
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(executorService(maxConcurrentDeletes, "remove-orphans"));
           }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -112,7 +112,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             action.retainLast(retainLastNum);
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
           }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -152,7 +152,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.deleteWith(file -> {});
           }
 
-          if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+          if (maxConcurrentDeletes != null) {
             action.executeDeleteWith(executorService(maxConcurrentDeletes, "remove-orphans"));
           }
 


### PR DESCRIPTION
max_concurrent_deletes is already validated for greater than 0 in the preconditions.

```
Preconditions.checkArgument(
        maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
```