### PR TITLE
Core: Handle statistics file clean up from expireSnapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -88,22 +88,22 @@ abstract class FileCleanupStrategy {
 
   protected Set<String> expiredStatisticsFilesLocations(
       TableMetadata beforeExpiration, TableMetadata afterExpiration) {
-    Set<String> statisticsFilesLocationBeforeExpiry = allStatisticsFilesLocation(beforeExpiration);
-    Set<String> statisticsFilesLocationAfterExpiry = allStatisticsFilesLocation(afterExpiration);
-    statisticsFilesLocationBeforeExpiry.removeAll(statisticsFilesLocationAfterExpiry);
-    return statisticsFilesLocationBeforeExpiry;
+    Set<String> statsFileLocationsBeforeExpiration = statsFileLocations(beforeExpiration);
+    Set<String> statsFileLocationsAfterExpiration = statsFileLocations(afterExpiration);
+
+    return Sets.difference(statsFileLocationsBeforeExpiration, statsFileLocationsAfterExpiration);
   }
 
-  private Set<String> allStatisticsFilesLocation(TableMetadata tableMetadata) {
-    Set<String> allStatisticsFilesLocation = Sets.newHashSet();
+  private Set<String> statsFileLocations(TableMetadata tableMetadata) {
+    Set<String> statsFileLocations = Sets.newHashSet();
 
     if (tableMetadata.statisticsFiles() != null) {
-      allStatisticsFilesLocation =
+      statsFileLocations =
           tableMetadata.statisticsFiles().stream()
               .map(StatisticsFile::path)
               .collect(Collectors.toSet());
     }
 
-    return allStatisticsFilesLocation;
+    return statsFileLocations;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -95,15 +95,15 @@ abstract class FileCleanupStrategy {
   }
 
   private Set<String> allStatisticsFilesLocation(TableMetadata tableMetadata) {
-    Set<String> allStatisticsFilesLocation;
+    Set<String> allStatisticsFilesLocation = Sets.newHashSet();
+
     if (tableMetadata.statisticsFiles() != null) {
       allStatisticsFilesLocation =
           tableMetadata.statisticsFiles().stream()
               .map(StatisticsFile::path)
               .collect(Collectors.toSet());
-    } else {
-      allStatisticsFilesLocation = Sets.newHashSet();
     }
+
     return allStatisticsFilesLocation;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -264,6 +264,14 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
     LOG.warn("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));
     deleteFiles(manifestsToDelete, "manifest");
     deleteFiles(manifestListsToDelete, "manifest list");
+
+    if (!beforeExpiration.statisticsFiles().isEmpty()) {
+      Set<String> expiredStatisticsFilesLocations =
+          expiredStatisticsFilesLocations(beforeExpiration, afterExpiration);
+      LOG.warn(
+          "Statistics files to delete: {}", Joiner.on(", ").join(expiredStatisticsFilesLocations));
+      deleteFiles(expiredStatisticsFilesLocations, "statistics files");
+    }
   }
 
   private Set<String> findFilesToDelete(

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -260,15 +260,15 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
         findFilesToDelete(manifestsToScan, manifestsToRevert, validIds, afterExpiration);
 
     deleteFiles(filesToDelete, "data");
-    LOG.warn("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
-    LOG.warn("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));
+    LOG.debug("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
+    LOG.debug("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));
     deleteFiles(manifestsToDelete, "manifest");
     deleteFiles(manifestListsToDelete, "manifest list");
 
     if (!beforeExpiration.statisticsFiles().isEmpty()) {
       Set<String> expiredStatisticsFilesLocations =
           expiredStatisticsFilesLocations(beforeExpiration, afterExpiration);
-      LOG.warn(
+      LOG.debug(
           "Statistics files to delete: {}", Joiner.on(", ").join(expiredStatisticsFilesLocations));
       deleteFiles(expiredStatisticsFilesLocations, "statistics files");
     }

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
@@ -260,16 +259,12 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
         findFilesToDelete(manifestsToScan, manifestsToRevert, validIds, afterExpiration);
 
     deleteFiles(filesToDelete, "data");
-    LOG.debug("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
-    LOG.debug("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));
     deleteFiles(manifestsToDelete, "manifest");
     deleteFiles(manifestListsToDelete, "manifest list");
 
     if (!beforeExpiration.statisticsFiles().isEmpty()) {
       Set<String> expiredStatisticsFilesLocations =
           expiredStatisticsFilesLocations(beforeExpiration, afterExpiration);
-      LOG.debug(
-          "Statistics files to delete: {}", Joiner.on(", ").join(expiredStatisticsFilesLocations));
       deleteFiles(expiredStatisticsFilesLocations, "statistics files");
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
@@ -81,6 +81,11 @@ class ReachableFileCleanup extends FileCleanupStrategy {
     }
 
     deleteFiles(manifestListsToDelete, "manifest list");
+
+    if (!beforeExpiration.statisticsFiles().isEmpty()) {
+      deleteFiles(
+          expiredStatisticsFilesLocations(beforeExpiration, afterExpiration), "statistics files");
+    }
   }
 
   private Set<ManifestFile> pruneReferencedManifests(

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1211,6 +1211,7 @@ public class TableMetadata implements Serializable {
         if (idsToRemove.contains(snapshotId)) {
           snapshotsById.remove(snapshotId);
           changes.add(new MetadataUpdate.RemoveSnapshot(snapshotId));
+          removeStatistics(snapshotId);
         } else {
           retainedSnapshots.add(snapshot);
         }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1294,11 +1294,11 @@ public class TestRemoveSnapshots extends TableTestBase {
     commitStats(table, statisticsFile1);
 
     table.newAppend().appendFile(FILE_B).commit();
-    // Note: RewriteDataFiles may reuse statistics files across operations.
-    // This test reuses stats for append just to mimic this scenario without having to run
-    // RewriteDataFiles.
+    // If an expired snapshot's stats file is reused for some reason by the live snapshots,
+    // that stats file should not get deleted from the file system as the live snapshots still
+    // reference it.
     StatisticsFile statisticsFile2 =
-        reuseStatsForCurrentSnapshot(table.currentSnapshot().snapshotId(), statisticsFile1);
+        reuseStatsFile(table.currentSnapshot().snapshotId(), statisticsFile1);
     commitStats(table, statisticsFile2);
 
     Assert.assertEquals("Should have 2 statistics file", 2, table.statisticsFiles().size());
@@ -1624,8 +1624,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     }
   }
 
-  private StatisticsFile reuseStatsForCurrentSnapshot(
-      long snapshotId, StatisticsFile statisticsFile) {
+  private StatisticsFile reuseStatsFile(long snapshotId, StatisticsFile statisticsFile) {
     return new GenericStatisticsFile(
         snapshotId,
         statisticsFile.path(),


### PR DESCRIPTION
Currently, Statistics files are safeguarded against orphan_files cleanup. But they are never cleaned up from table metadata and from the storage once the snapshots are expired/deleted.

Hence, this PR adds a change to handle the Statistics file cleanup during expire_snapshot.

Note that this is just for API level clean up (`table#expireSnapshots`) 

Clean-up from expired snapshots spark action/procedure will be built on top of it in a follow-up PR. 