### PR TITLE
Spark-3.3: Handle statistics file clean up from expireSnapshots action/procedure

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -66,6 +66,10 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.io.DataWriter<T>::add(T)"
       justification: "Removing deprecated method"
   "1.1.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedStatisticsFilesCount()"
+      justification: "{Handle Statistics file deletion from expire snapshots action/procedure}"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.removed"
       old: "class org.apache.iceberg.rest.HTTPClientFactory"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -66,10 +66,6 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.io.DataWriter<T>::add(T)"
       justification: "Removing deprecated method"
   "1.1.0":
-    org.apache.iceberg:iceberg-api:
-    - code: "java.method.addedToInterface"
-      new: "method long org.apache.iceberg.actions.ExpireSnapshots.Result::deletedStatisticsFilesCount()"
-      justification: "{Handle Statistics file deletion from expire snapshots action/procedure}"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.removed"
       old: "class org.apache.iceberg.rest.HTTPClientFactory"

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -115,6 +115,8 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
     long deletedManifestListsCount();
 
     /** Returns the number of deleted statistics files. */
-    long deletedStatisticsFilesCount();
+    default long deletedStatisticsFilesCount() {
+      return 0L;
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -30,6 +30,7 @@ import org.immutables.value.Value;
  * <p>Similar to {@link org.apache.iceberg.ExpireSnapshots} but may use a query engine to distribute
  * parts of the work.
  */
+@Value.Enclosing
 public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots.Result> {
   /**
    * Expires a specific {@link Snapshot} identified by id.

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.io.SupportsBulkOperations;
+import org.immutables.value.Value;
 
 /**
  * An action that expires snapshots in a table.
@@ -98,6 +99,7 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
   ExpireSnapshots executeDeleteWith(ExecutorService executorService);
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
     /** Returns the number of deleted data files. */
     long deletedDataFilesCount();
@@ -115,6 +117,7 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
     long deletedManifestListsCount();
 
     /** Returns the number of deleted statistics files. */
+    @Value.Default
     default long deletedStatisticsFilesCount() {
       return 0L;
     }

--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -113,5 +113,8 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
 
     /** Returns the number of deleted manifest lists. */
     long deletedManifestListsCount();
+
+    /** Returns the number of deleted statistics files. */
+    long deletedStatisticsFilesCount();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -20,6 +20,8 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.hadoop.Util;
@@ -137,25 +139,21 @@ public class ReachableFileUtil {
    * @return the location of statistics files
    */
   public static List<String> statisticsFilesLocations(Table table) {
-    return statisticsFilesLocations(table, null);
+    return statisticsFilesLocations(table, statisticsFile -> true);
   }
 
   /**
-   * Returns locations of statistics files matching the given snapshotIds in a table.
+   * Returns locations of statistics files for a table matching the given predicate .
    *
    * @param table table for which statistics files needs to be listed
-   * @param snapshotIds ids of snapshots for which statistics files will be returned. When null,
-   *     returns location of all the statistics files in a table.
+   * @param predicate predicate for filtering the statistics files
    * @return the location of statistics files
    */
-  public static List<String> statisticsFilesLocations(Table table, Set<Long> snapshotIds) {
-    List<String> statisticsFilesLocations = Lists.newArrayList();
-    for (StatisticsFile statisticsFile : table.statisticsFiles()) {
-      if (snapshotIds == null || snapshotIds.contains(statisticsFile.snapshotId())) {
-        statisticsFilesLocations.add(statisticsFile.path());
-      }
-    }
-
-    return statisticsFilesLocations;
+  public static List<String> statisticsFilesLocations(
+      Table table, Predicate<StatisticsFile> predicate) {
+    return table.statisticsFiles().stream()
+        .filter(predicate)
+        .map(StatisticsFile::path)
+        .collect(Collectors.toList());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -137,9 +137,23 @@ public class ReachableFileUtil {
    * @return the location of statistics files
    */
   public static List<String> statisticsFilesLocations(Table table) {
+    return statisticsFilesLocations(table, null);
+  }
+
+  /**
+   * Returns locations of statistics files matching the given snapshotIds in a table.
+   *
+   * @param table table for which statistics files needs to be listed
+   * @param snapshotIds ids of snapshots for which statistics files will be returned. When null,
+   *     returns location of all the statistics files in a table.
+   * @return the location of statistics files
+   */
+  public static List<String> statisticsFilesLocations(Table table, Set<Long> snapshotIds) {
     List<String> statisticsFilesLocations = Lists.newArrayList();
     for (StatisticsFile statisticsFile : table.statisticsFiles()) {
-      statisticsFilesLocations.add(statisticsFile.path());
+      if (snapshotIds == null || snapshotIds.contains(statisticsFile.snapshotId())) {
+        statisticsFilesLocations.add(statisticsFile.path());
+      }
     }
 
     return statisticsFilesLocations;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
@@ -25,6 +25,7 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
   private final long deletedEqDeleteFilesCount;
   private final long deletedManifestsCount;
   private final long deletedManifestListsCount;
+  private final long deletedStatisticsFilesCount;
 
   public BaseExpireSnapshotsActionResult(
       long deletedDataFilesCount, long deletedManifestsCount, long deletedManifestListsCount) {
@@ -33,6 +34,7 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
     this.deletedEqDeleteFilesCount = 0;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
+    this.deletedStatisticsFilesCount = 0;
   }
 
   public BaseExpireSnapshotsActionResult(
@@ -46,6 +48,22 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
     this.deletedEqDeleteFilesCount = deletedEqDeleteFilesCount;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
+    this.deletedStatisticsFilesCount = 0;
+  }
+
+  public BaseExpireSnapshotsActionResult(
+      long deletedDataFilesCount,
+      long deletedPosDeleteFilesCount,
+      long deletedEqDeleteFilesCount,
+      long deletedManifestsCount,
+      long deletedManifestListsCount,
+      long deletedStatisticsFilesCount) {
+    this.deletedDataFilesCount = deletedDataFilesCount;
+    this.deletedPosDeleteFilesCount = deletedPosDeleteFilesCount;
+    this.deletedEqDeleteFilesCount = deletedEqDeleteFilesCount;
+    this.deletedManifestsCount = deletedManifestsCount;
+    this.deletedManifestListsCount = deletedManifestListsCount;
+    this.deletedStatisticsFilesCount = deletedStatisticsFilesCount;
   }
 
   @Override
@@ -71,5 +89,10 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
   @Override
   public long deletedManifestListsCount() {
     return deletedManifestListsCount;
+  }
+
+  @Override
+  public long deletedStatisticsFilesCount() {
+    return deletedStatisticsFilesCount;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.actions;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
 
   private final long deletedDataFilesCount;
@@ -25,7 +27,6 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
   private final long deletedEqDeleteFilesCount;
   private final long deletedManifestsCount;
   private final long deletedManifestListsCount;
-  private final long deletedStatisticsFilesCount;
 
   public BaseExpireSnapshotsActionResult(
       long deletedDataFilesCount, long deletedManifestsCount, long deletedManifestListsCount) {
@@ -34,7 +35,6 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
     this.deletedEqDeleteFilesCount = 0;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
-    this.deletedStatisticsFilesCount = 0;
   }
 
   public BaseExpireSnapshotsActionResult(
@@ -48,22 +48,6 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
     this.deletedEqDeleteFilesCount = deletedEqDeleteFilesCount;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
-    this.deletedStatisticsFilesCount = 0;
-  }
-
-  public BaseExpireSnapshotsActionResult(
-      long deletedDataFilesCount,
-      long deletedPosDeleteFilesCount,
-      long deletedEqDeleteFilesCount,
-      long deletedManifestsCount,
-      long deletedManifestListsCount,
-      long deletedStatisticsFilesCount) {
-    this.deletedDataFilesCount = deletedDataFilesCount;
-    this.deletedPosDeleteFilesCount = deletedPosDeleteFilesCount;
-    this.deletedEqDeleteFilesCount = deletedEqDeleteFilesCount;
-    this.deletedManifestsCount = deletedManifestsCount;
-    this.deletedManifestListsCount = deletedManifestListsCount;
-    this.deletedStatisticsFilesCount = deletedStatisticsFilesCount;
   }
 
   @Override
@@ -89,10 +73,5 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
   @Override
   public long deletedManifestListsCount() {
     return deletedManifestListsCount;
-  }
-
-  @Override
-  public long deletedStatisticsFilesCount() {
-    return deletedStatisticsFilesCount;
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -507,10 +507,11 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
         table.statisticsFiles().stream()
             .filter(statisticsFile -> statisticsFile.snapshotId() == statisticsFile1.snapshotId())
             .collect(Collectors.toList());
-    Assertions.assertThat(statsWithSnapshotId1.isEmpty())
+    Assertions.assertThat(statsWithSnapshotId1)
         .as(
             "Statistics file entry in TableMetadata should be deleted for the snapshot %s",
-            statisticsFile1.snapshotId());
+            statisticsFile1.snapshotId())
+        .isEmpty();
     Assertions.assertThat(table.statisticsFiles())
         .as(
             "Statistics file entry in TableMetadata should be present for the snapshot %s",
@@ -518,11 +519,13 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
         .extracting(StatisticsFile::snapshotId)
         .containsExactly(statisticsFile2.snapshotId());
 
-    Assertions.assertThat(new File(statsFileLocation1).exists())
+    Assertions.assertThat(new File(statsFileLocation1))
         .as("Statistics file should not exist for snapshot %s", statisticsFile1.snapshotId())
-        .isFalse();
-    Assertions.assertThat(new File(statsFileLocation2).exists())
-        .as("Statistics file should exist for snapshot %s", statisticsFile2.snapshotId());
+        .doesNotExist();
+
+    Assertions.assertThat(new File(statsFileLocation2))
+        .as("Statistics file should exist for snapshot %s", statisticsFile2.snapshotId())
+        .exists();
   }
 
   private StatisticsFile writeStatsFile(
@@ -551,6 +554,6 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
 
   private String statsFileLocation(String tableLocation) {
     String statsFileName = "stats-file-" + UUID.randomUUID();
-    return tableLocation + "/metadata/" + statsFileName;
+    return tableLocation.replaceFirst("file:", "") + "/metadata/" + statsFileName;
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -80,6 +80,7 @@ abstract class BaseSparkAction<ThisT> {
 
   protected static final String MANIFEST = "Manifest";
   protected static final String MANIFEST_LIST = "Manifest List";
+  protected static final String STATISTICS_FILES = "Statistics Files";
   protected static final String OTHERS = "Others";
 
   protected static final String FILE_PATH = "file_path";
@@ -200,6 +201,12 @@ abstract class BaseSparkAction<ThisT> {
     return toFileInfoDS(manifestLists, MANIFEST_LIST);
   }
 
+  protected Dataset<FileInfo> statisticsFileDS(Table table, Set<Long> snapshotIds) {
+    List<String> statisticsFilesLocations =
+        ReachableFileUtil.statisticsFilesLocations(table, snapshotIds);
+    return toFileInfoDS(statisticsFilesLocations, STATISTICS_FILES);
+  }
+
   protected Dataset<FileInfo> otherMetadataFileDS(Table table) {
     return otherMetadataFileDS(table, false /* include all reachable old metadata locations */);
   }
@@ -297,6 +304,7 @@ abstract class BaseSparkAction<ThisT> {
     private final AtomicLong equalityDeleteFilesCount = new AtomicLong(0L);
     private final AtomicLong manifestsCount = new AtomicLong(0L);
     private final AtomicLong manifestListsCount = new AtomicLong(0L);
+    private final AtomicLong statisticsFilesCount = new AtomicLong(0L);
     private final AtomicLong otherFilesCount = new AtomicLong(0L);
 
     public void deletedFiles(String type, int numFiles) {
@@ -344,6 +352,10 @@ abstract class BaseSparkAction<ThisT> {
         manifestListsCount.incrementAndGet();
         LOG.debug("Deleted manifest list: {}", path);
 
+      } else if (STATISTICS_FILES.equalsIgnoreCase(type)) {
+        statisticsFilesCount.incrementAndGet();
+        LOG.debug("Deleted statistics file: {}", path);
+
       } else if (OTHERS.equalsIgnoreCase(type)) {
         otherFilesCount.incrementAndGet();
         LOG.debug("Deleted other metadata file: {}", path);
@@ -373,6 +385,10 @@ abstract class BaseSparkAction<ThisT> {
       return manifestListsCount.get();
     }
 
+    public long statisticsFilesCount() {
+      return statisticsFilesCount.get();
+    }
+
     public long otherFilesCount() {
       return otherFilesCount.get();
     }
@@ -383,6 +399,7 @@ abstract class BaseSparkAction<ThisT> {
           + equalityDeleteFilesCount()
           + manifestsCount()
           + manifestListsCount()
+          + statisticsFilesCount()
           + otherFilesCount();
     }
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -211,8 +211,8 @@ abstract class BaseSparkAction<ThisT> {
       predicate = statisticsFile -> snapshotIds.contains(statisticsFile.snapshotId());
     }
 
-    return toFileInfoDS(
-        ReachableFileUtil.statisticsFilesLocations(table, predicate), STATISTICS_FILES);
+    List<String> statisticsFiles = ReachableFileUtil.statisticsFilesLocations(table, predicate);
+    return toFileInfoDS(statisticsFiles, STATISTICS_FILES);
   }
 
   protected Dataset<FileInfo> otherMetadataFileDS(Table table) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -331,6 +331,9 @@ abstract class BaseSparkAction<ThisT> {
       } else if (MANIFEST_LIST.equalsIgnoreCase(type)) {
         manifestListsCount.addAndGet(numFiles);
 
+      } else if (STATISTICS_FILES.equalsIgnoreCase(type)) {
+        statisticsFilesCount.addAndGet(numFiles);
+
       } else if (OTHERS.equalsIgnoreCase(type)) {
         otherFilesCount.addAndGet(numFiles);
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -245,7 +245,8 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     Table staticTable = newStaticTable(metadata, table.io());
     return contentFileDS(staticTable, snapshotIds)
         .union(manifestDS(staticTable, snapshotIds))
-        .union(manifestListDS(staticTable, snapshotIds));
+        .union(manifestListDS(staticTable, snapshotIds))
+        .union(statisticsFileDS(staticTable, snapshotIds));
   }
 
   private Set<Long> findExpiredSnapshotIds(
@@ -282,6 +283,7 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
         summary.positionDeleteFilesCount(),
         summary.equalityDeleteFilesCount(),
         summary.manifestsCount(),
-        summary.manifestListsCount());
+        summary.manifestListsCount(),
+        summary.statisticsFilesCount());
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.ExpireSnapshots;
-import org.apache.iceberg.actions.ImmutableResult;
+import org.apache.iceberg.actions.ImmutableExpireSnapshots;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -277,7 +277,8 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     }
 
     LOG.info("Deleted {} total files", summary.totalFilesCount());
-    return ImmutableResult.builder()
+
+    return ImmutableExpireSnapshots.Result.builder()
         .deletedDataFilesCount(summary.dataFilesCount())
         .deletedPositionDeleteFilesCount(summary.positionDeleteFilesCount())
         .deletedEqualityDeleteFilesCount(summary.equalityDeleteFilesCount())

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -32,8 +32,8 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.actions.BaseExpireSnapshotsActionResult;
 import org.apache.iceberg.actions.ExpireSnapshots;
+import org.apache.iceberg.actions.ImmutableResult;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -277,13 +277,13 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     }
 
     LOG.info("Deleted {} total files", summary.totalFilesCount());
-
-    return new BaseExpireSnapshotsActionResult(
-        summary.dataFilesCount(),
-        summary.positionDeleteFilesCount(),
-        summary.equalityDeleteFilesCount(),
-        summary.manifestsCount(),
-        summary.manifestListsCount(),
-        summary.statisticsFilesCount());
+    return ImmutableResult.builder()
+        .deletedDataFilesCount(summary.dataFilesCount())
+        .deletedPositionDeleteFilesCount(summary.positionDeleteFilesCount())
+        .deletedEqualityDeleteFilesCount(summary.equalityDeleteFilesCount())
+        .deletedManifestsCount(summary.manifestsCount())
+        .deletedManifestListsCount(summary.manifestListsCount())
+        .deletedStatisticsFilesCount(summary.statisticsFilesCount())
+        .build();
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -67,7 +67,9 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             new StructField(
                 "deleted_manifest_files_count", DataTypes.LongType, true, Metadata.empty()),
             new StructField(
-                "deleted_manifest_lists_count", DataTypes.LongType, true, Metadata.empty())
+                "deleted_manifest_lists_count", DataTypes.LongType, true, Metadata.empty()),
+            new StructField(
+                "deleted_statistics_files_count", DataTypes.LongType, true, Metadata.empty())
           });
 
   public static ProcedureBuilder builder() {
@@ -159,7 +161,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
             result.deletedPositionDeleteFilesCount(),
             result.deletedEqualityDeleteFilesCount(),
             result.deletedManifestsCount(),
-            result.deletedManifestListsCount());
+            result.deletedManifestListsCount(),
+            result.deletedStatisticsFilesCount());
     return new InternalRow[] {row};
   }
 


### PR DESCRIPTION
This PR handles the spark action/procedure side of the statistics file clean-up for expire_snapshots. 
It is a follow-up based on the core functionality of https://github.com/apache/iceberg/pull/6090