### PR TITLE
Spark: Optimize Preconditions.checkArgument in procedures

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -98,7 +98,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -96,7 +96,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return withIcebergTable(
         tableIdent,

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -98,7 +98,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -96,7 +96,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return withIcebergTable(
         tableIdent,

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -97,7 +97,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -102,7 +102,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     Map<String, String> equalSchemes = Maps.newHashMap();
     if (!args.isNullAt(6)) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -97,7 +97,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     return modifyIcebergTable(
         tableIdent,

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -102,7 +102,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
     Preconditions.checkArgument(
         maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
-        "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
+        "max_concurrent_deletes should have value > 0, value: %s",
+        maxConcurrentDeletes);
 
     Map<String, String> equalSchemes = Maps.newHashMap();
     if (!args.isNullAt(6)) {


### PR DESCRIPTION
Removed the redundant space before `value`, and avoid the string concatenation by passing the `maxConcurrentDeletes` as an argument.

This is a follow-up, found after https://github.com/apache/iceberg/pull/6083.