### PR TITLE
Docs: Update spotless apply command for non-default versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Iceberg is built using Gradle with Java 1.8 or Java 11.
 
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
-* To fix code style: `./gradlew spotlessApply`
-  The above command applies to default versions. 
-  Need to pass the non-default versions via `-DsparkVersions`, `-DflinkVersions`, `-DhiveVersions` argument
+* To fix code style for default versions: `./gradlew spotlessApply`
+  To fix code style for non-default versions, the following flags need to be passed: `-DsparkVersions`, `-DflinkVersions`, `-DhiveVersions`.
+  Example: `./gradlew spotlessApply -DflinkVersions=1.13,1.14,1.15 -DsparkVersions=2.4,3.0,3.1,3.2,3.3 -DhiveVersions=2,3`
 
 Iceberg table support is organized in library modules:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Iceberg is built using Gradle with Java 1.8 or Java 11.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style: `./gradlew spotlessApply`
+  The above command applies to default versions. 
+  Need to pass the non-default versions via `-DsparkVersions`, `-DflinkVersions`, `-DhiveVersions` argument
 
 Iceberg table support is organized in library modules:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Iceberg is built using Gradle with Java 1.8 or Java 11.
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style for default versions: `./gradlew spotlessApply`
   To fix code style for non-default versions, the following flags need to be passed: `-DsparkVersions`, `-DflinkVersions`, `-DhiveVersions`.
-  Example: `./gradlew spotlessApply -DflinkVersions=1.13,1.14,1.15 -DsparkVersions=2.4,3.0,3.1,3.2,3.3 -DhiveVersions=2,3`
+  Example: `./gradlew spotlessApply -DflinkVersions=1.14,1.15 -DsparkVersions=2.4,3.0,3.1,3.2,3.3 -DhiveVersions=2,3`
 
 Iceberg table support is organized in library modules:
 


### PR DESCRIPTION
While working on https://github.com/apache/iceberg/pull/6096, I learnt that `./gradlew spotlessApply` only works on default versions. I assumed that it works for all the folders. Which was not true.

Hence, updating the document for new users.