### PR TITLE
Spark 3.3: Relocate all Netty dependencies

### DIFF
--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -65,8 +65,9 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.apache.parquet'
-      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      // to make sure netty libs only come from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
       exclude group: 'org.roaringbitmap'
     }
 
@@ -89,8 +90,9 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
-      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      // to make sure netty libs only come from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
     }
     testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
@@ -145,8 +147,9 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.apache.parquet'
-      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      // to make sure netty libs only come from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
       exclude group: 'org.roaringbitmap'
     }
 
@@ -258,7 +261,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
     // relocate Arrow and related deps to shade Iceberg specific version
-    relocate 'io.netty.buffer', 'org.apache.iceberg.shaded.io.netty.buffer'
+    relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
     relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'


### PR DESCRIPTION
This PR contains a change to relocate all Netty dependencies, including `netty-common`. Prior to this, we relocated only `netty-buffer` and `netty-common` libs were packaged in the runtime jar.

Below is the content of the runtime jar before this change.

<img width="734" alt="image" src="https://user-images.githubusercontent.com/6235869/199587870-a1ecad98-7211-4a88-aa74-f354c0b260d5.png">
