### PR TITLE
API: Hash floats -0.0 and 0.0 to the same bucket

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -43,12 +43,24 @@ public class BucketUtil {
     return MURMUR3.hashLong(value).asInt();
   }
 
+  private static long doubleToLongBits(double value) {
+    long bits = Double.doubleToLongBits(value);
+
+    // Change negative zero (-0.0) to positive zero (0.0). As IEEE 754
+    // mandates 0.0 == -0.0, both should also produce the same hash value.
+    if (bits == Long.MIN_VALUE) {
+      bits = 0L;
+    }
+
+    return bits;
+  }
+
   public static int hash(float value) {
-    return MURMUR3.hashLong(Double.doubleToLongBits((double) value)).asInt();
+    return MURMUR3.hashLong(doubleToLongBits((double) value)).asInt();
   }
 
   public static int hash(double value) {
-    return MURMUR3.hashLong(Double.doubleToLongBits(value)).asInt();
+    return MURMUR3.hashLong(doubleToLongBits(value)).asInt();
   }
 
   public static int hash(CharSequence value) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -65,10 +65,17 @@ public class TestBucketing {
     Assert.assertEquals("Spec example: hash(true) = 1392991556", 1392991556, BucketUtil.hash(1));
     Assert.assertEquals("Spec example: hash(34) = 2017239379", 2017239379, BucketUtil.hash(34));
     Assert.assertEquals("Spec example: hash(34L) = 2017239379", 2017239379, BucketUtil.hash(34L));
+
     Assert.assertEquals(
         "Spec example: hash(17.11F) = -142385009", -142385009, BucketUtil.hash(1.0F));
     Assert.assertEquals(
         "Spec example: hash(17.11D) = -142385009", -142385009, BucketUtil.hash(1.0D));
+    Assert.assertEquals("Spec example: hash(0.0F) = 1669671676", 1669671676, BucketUtil.hash(0.0F));
+    Assert.assertEquals(
+        "Spec example: hash(-0.0F) = 1669671676", 1669671676, BucketUtil.hash(-0.0F));
+    Assert.assertEquals("Spec example: hash(0.0) = 1669671676", 1669671676, BucketUtil.hash(0.0));
+    Assert.assertEquals("Spec example: hash(-0.0) = 1669671676", 1669671676, BucketUtil.hash(-0.0));
+
     Assert.assertEquals(
         "Spec example: hash(decimal2(14.20)) = -500754589",
         -500754589,
@@ -167,6 +174,76 @@ public class TestBucketing {
         "Float and Double bucket results should match",
         BucketUtil.hash(randomFloat),
         BucketUtil.hash((double) randomFloat));
+  }
+
+  @Test
+  public void testFloatNegativeZero() {
+    Assert.assertEquals(
+        "Positive and negative 0.0f should have the same hash",
+        BucketUtil.hash(-0.0f),
+        BucketUtil.hash(0.0f));
+  }
+
+  @Test
+  public void testDoubleNegativeZero() {
+    Assert.assertEquals(
+        "Positive and negative 0.0 should have the same hash",
+        BucketUtil.hash(-0.0),
+        BucketUtil.hash(0.0));
+  }
+
+  @Test
+  public void testFloatNaN() {
+    double canonicalNaN = Double.longBitsToDouble(0x7ff8000000000000L);
+
+    // All bit patterns in the range 0x7f800001 to 0x7fffffff
+    // and 0xff800001 to 0xffffffff are considered NaNs.
+    float[] testNaNs = {
+      Float.NaN,
+      Float.intBitsToFloat(0x7f800001),
+      Float.intBitsToFloat(0x7f9abcde),
+      Float.intBitsToFloat(0x7fedcba9),
+      Float.intBitsToFloat(0x7fffffff),
+      Float.intBitsToFloat(0xff800001),
+      Float.intBitsToFloat(0xff9abcde),
+      Float.intBitsToFloat(0xffedcba9),
+      Float.intBitsToFloat(0xffffffff),
+    };
+
+    for (float value : testNaNs) {
+      Assert.assertTrue("Bit pattern is expected to be NaN.", Float.isNaN(value));
+      Assert.assertEquals(
+          "All NaN representations should result in the same hash",
+          BucketUtil.hash(value),
+          BucketUtil.hash(canonicalNaN));
+    }
+  }
+
+  @Test
+  public void testDoubleNaN() {
+    double canonicalNaN = Double.longBitsToDouble(0x7ff8000000000000L);
+
+    // All bit patterns in the range 0x7ff0000000000001L to 0x7fffffffffffffffL
+    // and 0xfff0000000000001L to 0xffffffffffffffffL are considered NaNs.
+    double[] testNaNs = {
+      Double.NaN,
+      Double.longBitsToDouble(0x7ff0000000000001L),
+      Double.longBitsToDouble(0x7ff123456789abcdL),
+      Double.longBitsToDouble(0x7ffdcba987654321L),
+      Double.longBitsToDouble(0x7fffffffffffffffL),
+      Double.longBitsToDouble(0xfff0000000000001L),
+      Double.longBitsToDouble(0xfff123456789abcdL),
+      Double.longBitsToDouble(0xfffdcba987654321L),
+      Double.longBitsToDouble(0xffffffffffffffffL),
+    };
+
+    for (double value : testNaNs) {
+      Assert.assertTrue("Bit pattern is expected to be NaN.", Double.isNaN(value));
+      Assert.assertEquals(
+          "All NaN representations should result in the same hash",
+          BucketUtil.hash(value),
+          BucketUtil.hash(canonicalNaN));
+    }
   }
 
   @Test

--- a/format/spec.md
+++ b/format/spec.md
@@ -983,8 +983,8 @@ The types below are not currently valid for bucketing, and so are not hashed. Ho
 | Primitive type     | Hash specification                        | Test value                                 |
 |--------------------|-------------------------------------------|--------------------------------------------|
 | **`boolean`**      | `false: hashInt(0)`, `true: hashInt(1)`   | `true` ￫ `1392991556`                      |
-| **`float`**        | `hashDouble(double(v))`         [4]       | `1.0F` ￫ `-142385009`                      |
-| **`double`**       | `hashLong(doubleToLongBits(v))`           | `1.0D` ￫ `-142385009`                      |
+| **`float`**        | `hashLong(doubleToLongBits(double(v))` [4]| `1.0F` ￫ `-142385009`, `0.0F` ￫ `1669671676`, `-0.0F` ￫ `1669671676` |
+| **`double`**       | `hashLong(doubleToLongBits(v))`        [4]| `1.0D` ￫ `-142385009`, `0.0D` ￫ `1669671676`, `-0.0D` ￫ `1669671676` |
 
 Notes:
 
@@ -993,8 +993,7 @@ Notes:
 Hash results are not dependent on decimal scale, which is part of the type, not the data value.
 3. UUIDs are encoded using big endian. The test UUID for the example above is: `f79c3e09-677c-4bbd-a479-3f349cb785e7`. This UUID encoded as a byte array is:
 `F7 9C 3E 09 67 7C 4B BD A4 79 3F 34 9C B7 85 E7`
-4. Float hash values are the result of hashing the float cast to double to ensure that schema evolution does not change hash values if float types are promoted.
-
+4. `doubleToLongBits` must give the IEEE 754 compliant bit representation of the double value. All `NaN` bit patterns must be canonicalized to `0x7ff8000000000000L`. Negative zero (`-0.0`) must be canonicalized to positive zero (`0.0`). Float hash values are the result of hashing the float cast to double to ensure that schema evolution does not change hash values if float types are promoted.
 
 ## Appendix C: JSON serialization
 


### PR DESCRIPTION
This commit changes the hashing of float/double for negative zero (-0.0) to produce the same hash as for positive zero (0.0). This is needed because positive/ negative zero are considered equal according to ==, but have distinct bit patterns according to
Double#doubleToLongBits. Therefore, using these bit patterns directly would violate the assumption "x = y implies bucket(x) = bucket(y)". With this commit, the bit pattern for negative zero is replaced with the bit pattern for positive zero before hashing, to ensure both produce the same hash.

Double negative zero has the bit pattern 0x8000000000000000, (which matches the bit pattern of Long.MIN_VALUE), whereas the bit pattern for positive zero is 0x0000000000000000.