### PR TITLE
Flink: Add 'cache.expiration-interval-ms' option to FlinkCatalog

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -215,7 +215,8 @@ The following properties can be set globally and are not limited to a specific c
 * `catalog-type`: `hive` or `hadoop` for built-in catalogs, or left unset for custom catalog implementations using catalog-impl. (Optional)
 * `catalog-impl`: The fully-qualified class name of a custom catalog implementation. Must be set if `catalog-type` is unset. (Optional)
 * `property-version`: Version number to describe the property version. This property can be used for backwards compatibility in case the property format changes. The current property version is `1`. (Optional)
-* `cache-enabled`: Whether to enable catalog cache, default value is `true`
+* `cache-enabled`: Whether to enable catalog cache, default value is `true`. (Optional)
+* `cache.expiration-interval-ms`: How long catalog entries are locally cached, in milliseconds; value 0 will disable caching, negative values like `-1` will disable expiration. default value is `30000`. (Optional)
 
 ### Hive catalog
 

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -216,7 +216,7 @@ The following properties can be set globally and are not limited to a specific c
 * `catalog-impl`: The fully-qualified class name of a custom catalog implementation. Must be set if `catalog-type` is unset. (Optional)
 * `property-version`: Version number to describe the property version. This property can be used for backwards compatibility in case the property format changes. The current property version is `1`. (Optional)
 * `cache-enabled`: Whether to enable catalog cache, default value is `true`. (Optional)
-* `cache.expiration-interval-ms`: How long catalog entries are locally cached, in milliseconds; value 0 will disable caching, negative values like `-1` will disable expiration. default value is `30000`. (Optional)
+* `cache.expiration-interval-ms`: How long catalog entries are locally cached, in milliseconds; negative values like `-1` will disable expiration, value 0 is not allowed to set. default value is `-1`. (Optional)
 
 ### Hive catalog
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -102,14 +102,18 @@ public class FlinkCatalog extends AbstractCatalog {
       String defaultDatabase,
       Namespace baseNamespace,
       CatalogLoader catalogLoader,
-      boolean cacheEnabled) {
+      boolean cacheEnabled,
+      long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 
     Catalog originalCatalog = catalogLoader.loadCatalog();
-    icebergCatalog = cacheEnabled ? CachingCatalog.wrap(originalCatalog) : originalCatalog;
+    icebergCatalog =
+        cacheEnabled
+            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -155,9 +155,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
     Preconditions.checkArgument(
-            cacheExpirationIntervalMs != 0,
-            "%s is not allowed to be 0.",
-            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
+        cacheExpirationIntervalMs != 0,
+        "%s is not allowed to be 0.",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
     return new FlinkCatalog(
         name,

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -153,10 +153,11 @@ public class FlinkCatalogFactory implements CatalogFactory {
         PropertyUtil.propertyAsLong(
             properties,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
-            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
-    if (cacheExpirationIntervalMs == 0) {
-      cacheEnabled = false;
-    }
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
+    Preconditions.checkArgument(
+            cacheExpirationIntervalMs != 0,
+            "%s is not allowed to be 0.",
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
     return new FlinkCatalog(
         name,

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -145,10 +145,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
       baseNamespace = Namespace.of(properties.get(BASE_NAMESPACE).split("\\."));
     }
 
-    boolean cacheEnabled = CatalogProperties.CACHE_ENABLED_DEFAULT;
-    if (properties.containsKey(CatalogProperties.CACHE_ENABLED)) {
-      cacheEnabled = Boolean.parseBoolean(properties.get(CatalogProperties.CACHE_ENABLED));
-    }
+    boolean cacheEnabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -18,14 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
-import static org.apache.iceberg.flink.FlinkCatalogFactory.CACHE_ENABLED;
-
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -63,7 +62,7 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
       String catalogName, Namespace baseNamespace, FileFormat format, boolean cacheEnabled) {
     super(catalogName, baseNamespace);
     this.format = format;
-    config.put(CACHE_ENABLED, String.valueOf(cacheEnabled));
+    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -102,14 +102,18 @@ public class FlinkCatalog extends AbstractCatalog {
       String defaultDatabase,
       Namespace baseNamespace,
       CatalogLoader catalogLoader,
-      boolean cacheEnabled) {
+      boolean cacheEnabled,
+      long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 
     Catalog originalCatalog = catalogLoader.loadCatalog();
-    icebergCatalog = cacheEnabled ? CachingCatalog.wrap(originalCatalog) : originalCatalog;
+    icebergCatalog =
+        cacheEnabled
+            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -155,9 +155,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
     Preconditions.checkArgument(
-            cacheExpirationIntervalMs != 0,
-            "%s is not allowed to be 0.",
-            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
+        cacheExpirationIntervalMs != 0,
+        "%s is not allowed to be 0.",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
     return new FlinkCatalog(
         name,

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -153,10 +153,11 @@ public class FlinkCatalogFactory implements CatalogFactory {
         PropertyUtil.propertyAsLong(
             properties,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
-            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
-    if (cacheExpirationIntervalMs == 0) {
-      cacheEnabled = false;
-    }
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
+    Preconditions.checkArgument(
+            cacheExpirationIntervalMs != 0,
+            "%s is not allowed to be 0.",
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
     return new FlinkCatalog(
         name,

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -145,10 +145,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
       baseNamespace = Namespace.of(properties.get(BASE_NAMESPACE).split("\\."));
     }
 
-    boolean cacheEnabled = CatalogProperties.CACHE_ENABLED_DEFAULT;
-    if (properties.containsKey(CatalogProperties.CACHE_ENABLED)) {
-      cacheEnabled = Boolean.parseBoolean(properties.get(CatalogProperties.CACHE_ENABLED));
-    }
+    boolean cacheEnabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -18,14 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
-import static org.apache.iceberg.flink.FlinkCatalogFactory.CACHE_ENABLED;
-
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -63,7 +62,7 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
       String catalogName, Namespace baseNamespace, FileFormat format, boolean cacheEnabled) {
     super(catalogName, baseNamespace);
     this.format = format;
-    config.put(CACHE_ENABLED, String.valueOf(cacheEnabled));
+    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
   }
 
   @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -102,14 +102,18 @@ public class FlinkCatalog extends AbstractCatalog {
       String defaultDatabase,
       Namespace baseNamespace,
       CatalogLoader catalogLoader,
-      boolean cacheEnabled) {
+      boolean cacheEnabled,
+      long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 
     Catalog originalCatalog = catalogLoader.loadCatalog();
-    icebergCatalog = cacheEnabled ? CachingCatalog.wrap(originalCatalog) : originalCatalog;
+    icebergCatalog =
+        cacheEnabled
+            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -153,10 +153,11 @@ public class FlinkCatalogFactory implements CatalogFactory {
         PropertyUtil.propertyAsLong(
             properties,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
-            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
-    if (cacheExpirationIntervalMs == 0) {
-      cacheEnabled = false;
-    }
+            CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF);
+    Preconditions.checkArgument(
+        cacheExpirationIntervalMs != 0,
+        "%s is not allowed to be 0.",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
     return new FlinkCatalog(
         name,

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -145,10 +145,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
       baseNamespace = Namespace.of(properties.get(BASE_NAMESPACE).split("\\."));
     }
 
-    boolean cacheEnabled = CatalogProperties.CACHE_ENABLED_DEFAULT;
-    if (properties.containsKey(CatalogProperties.CACHE_ENABLED)) {
-      cacheEnabled = Boolean.parseBoolean(properties.get(CatalogProperties.CACHE_ENABLED));
-    }
+    boolean cacheEnabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -18,14 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
-import static org.apache.iceberg.flink.FlinkCatalogFactory.CACHE_ENABLED;
-
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -63,7 +62,7 @@ public class TestFlinkCatalogTablePartitions extends FlinkCatalogTestBase {
       String catalogName, Namespace baseNamespace, FileFormat format, boolean cacheEnabled) {
     super(catalogName, baseNamespace);
     this.format = format;
-    config.put(CACHE_ENABLED, String.valueOf(cacheEnabled));
+    config.put(CatalogProperties.CACHE_ENABLED, String.valueOf(cacheEnabled));
   }
 
   @Override


### PR DESCRIPTION
As what https://github.com/apache/iceberg/pull/3543 has introduced, 'cache.expiration-interval-ms' option allows user to configure caching policy.
But this parameter has not been added in FlinkCatalog yet, This pr is aiming to do that.