### PR TITLE
Python: Use Types from Typing

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     rev: v3.0.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [ --py38-plus, --keep-runtime-typing ]
   - repo: https://github.com/pycqa/pylint
     rev: v2.15.3
     hooks:

--- a/python/CONTRIBUTING.md
+++ b/python/CONTRIBUTING.md
@@ -124,6 +124,12 @@ Which will warn:
 Call to load_something, deprecated in 0.1.0, will be removed in 0.2.0. Please use load_something_else() instead.
 ```
 
+## Type annotations
+
+For the type annotation we currently rely on the `Typing` package that comes with Python.
+
+Since we're supporting from Python 3.8 onwards, we can't use the [type hints from the standard collections](https://peps.python.org/pep-0585/).
+
 ## Third party libraries
 
 Since we expect PyIceberg to be integrated into the Python ecosystem, we want to be hesitant with the use of third party packages. Adding a lot of packages makes the library heavyweight, and causes incompatibilities with other projects if they use a different version of the library. Also, big libraries such as `s3fs`, `pyarrow`, `thrift` should be optional to avoid downloading everything, while not being sure if is actually being used.

--- a/python/pyiceberg/avro/codecs/__init__.py
+++ b/python/pyiceberg/avro/codecs/__init__.py
@@ -25,13 +25,15 @@ converting character sets (https://docs.python.org/3/library/codecs.html).
 """
 from __future__ import annotations
 
+from typing import Dict, Optional, Type
+
 from pyiceberg.avro.codecs.bzip2 import BZip2Codec
 from pyiceberg.avro.codecs.codec import Codec
 from pyiceberg.avro.codecs.deflate import DeflateCodec
 from pyiceberg.avro.codecs.snappy_codec import SnappyCodec
 from pyiceberg.avro.codecs.zstandard_codec import ZStandardCodec
 
-KNOWN_CODECS: dict[str, type[Codec] | None] = {
+KNOWN_CODECS: Dict[str, Optional[Type[Codec]]] = {
     "null": None,
     "bzip2": BZip2Codec,
     "snappy": SnappyCodec,

--- a/python/pyiceberg/avro/file.py
+++ b/python/pyiceberg/avro/file.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from io import SEEK_SET
+from typing import Optional, Type
 
 from pyiceberg.avro.codecs import KNOWN_CODECS, Codec
 from pyiceberg.avro.decoder import BinaryDecoder
@@ -65,7 +66,7 @@ class AvroFileHeader:
     meta: dict[str, str]
     sync: bytes
 
-    def compression_codec(self) -> type[Codec] | None:
+    def compression_codec(self) -> Optional[Type[Codec]]:
         """Get the file's compression codec algorithm from the file's metadata.
 
         In the case of a null codec, we return a None indicating that we
@@ -108,7 +109,7 @@ class Block:
 
 class AvroFile:
     input_file: InputFile
-    read_schema: Schema | None
+    read_schema: Optional[Schema]
     input_stream: InputStream
     header: AvroFileHeader
     schema: Schema
@@ -116,9 +117,9 @@ class AvroFile:
     reader: StructReader
 
     decoder: BinaryDecoder
-    block: Block | None = None
+    block: Optional[Block] = None
 
-    def __init__(self, input_file: InputFile, read_schema: Schema | None = None) -> None:
+    def __init__(self, input_file: InputFile, read_schema: Optional[Schema] = None) -> None:
         self.input_file = input_file
         self.read_schema = read_schema
 

--- a/python/pyiceberg/utils/schema_conversion.py
+++ b/python/pyiceberg/utils/schema_conversion.py
@@ -18,7 +18,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import (
+    Any,
+    Dict,
+    List,
+    Tuple,
+    Union,
+)
 
 from pyiceberg.schema import Schema
 from pyiceberg.types import (
@@ -112,7 +118,7 @@ class AvroSchemaConversion:
         """
         return Schema(*[self._convert_field(field) for field in avro_schema["fields"]], schema_id=1)
 
-    def _resolve_union(self, type_union: dict | list | str) -> tuple[str | dict[str, Any], bool]:
+    def _resolve_union(self, type_union: Union[Dict, List, str]) -> Tuple[Union[str, Dict[str, Any]], bool]:
         """
         Converts Unions into their type and resolves if the field is required
 
@@ -135,7 +141,7 @@ class AvroSchemaConversion:
         Raises:
             TypeError: In the case non-optional union types are encountered
         """
-        avro_types: dict | list
+        avro_types: Union[Dict, List]
         if isinstance(type_union, str):
             # It is a primitive and required
             return type_union, True
@@ -161,7 +167,7 @@ class AvroSchemaConversion:
         # Filter the null value and return the type
         return list(filter(lambda t: t != "null", avro_types))[0], False
 
-    def _convert_schema(self, avro_type: str | dict[str, Any]) -> IcebergType:
+    def _convert_schema(self, avro_type: Union[str, Dict[str, Any]]) -> IcebergType:
         """
         Resolves the Avro type
 


### PR DESCRIPTION
Instead of using the runtime types that are available using the futures import (in Python 3.8):

```python
from __future__ import annotations
```

I prefer to use the types from Typing:

- I think `Optional[str]` is easier to read than `str | None`.
- Not all types are available, so we have to import from Types anyway (typevar, Callable, etc)

PyUpgrade was rewriting the [imports automatically](https://github.com/asottile/pyupgrade#pep-585-typing-rewrites), so we ended up with a mix, but I think it is better to stay consistent. I've disabled this on PyUpgrade.