### PR TITLE
Struct fields should be provided to Schema constructor

### DIFF
--- a/python/pyiceberg/expressions/visitors.py
+++ b/python/pyiceberg/expressions/visitors.py
@@ -613,6 +613,7 @@ class _ManifestEvalVisitor(BoundBooleanExpressionVisitor[bool]):
 def manifest_evaluator(
     partition_spec: PartitionSpec, schema: Schema, partition_filter: BooleanExpression, case_sensitive: bool = True
 ) -> Callable[[ManifestFile], bool]:
-    partition_schema = Schema(*partition_spec.partition_type(schema))
+    partition_type = partition_spec.partition_type(schema)
+    partition_schema = Schema(*partition_type.fields)
     evaluator = _ManifestEvalVisitor(partition_schema, partition_filter, case_sensitive)
     return evaluator.eval


### PR DESCRIPTION
@Fokko I'm playing with the new Manifest evaluator from #5845.

I had to make the included change to get that to work.  I know this is early days for this code but it's useful functionality even now.