### PR TITLE
Parquet, Core: Fix collection of Parquet metrics when column names co…

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -39,12 +39,14 @@ public class MetricsUtil {
       return Maps.newHashMap();
     }
 
-    return createNanValueCounts(fieldMetrics, metricsConfig, TypeUtil.indexNameById(inputSchema.asStruct()));
+    return createNanValueCounts(
+        fieldMetrics, metricsConfig, TypeUtil.indexNameById(inputSchema.asStruct()));
   }
 
-
   public static Map<Integer, Long> createNanValueCounts(
-      Stream<FieldMetrics<?>> fieldMetrics, MetricsConfig metricsConfig, Map<Integer, String> idToColumn) {
+      Stream<FieldMetrics<?>> fieldMetrics,
+      MetricsConfig metricsConfig,
+      Map<Integer, String> idToColumn) {
     Preconditions.checkNotNull(metricsConfig, "metricsConfig is required");
 
     if (fieldMetrics == null || idToColumn == null || idToColumn.isEmpty()) {
@@ -52,7 +54,9 @@ public class MetricsUtil {
     }
 
     return fieldMetrics
-        .filter(metrics -> metricsMode(idToColumn, metricsConfig, metrics.id()) != MetricsModes.None.get())
+        .filter(
+            metrics ->
+                metricsMode(idToColumn, metricsConfig, metrics.id()) != MetricsModes.None.get())
         .collect(Collectors.toMap(FieldMetrics::id, FieldMetrics::nanValueCount));
   }
 
@@ -66,7 +70,8 @@ public class MetricsUtil {
     return metricsConfig.columnMode(columnName);
   }
 
-  public static MetricsModes.MetricsMode metricsMode(Map<Integer, String> idToColumn, MetricsConfig metricsConfig, int fieldId) {
+  public static MetricsModes.MetricsMode metricsMode(
+      Map<Integer, String> idToColumn, MetricsConfig metricsConfig, int fieldId) {
     Preconditions.checkNotNull(idToColumn, "inputSchema is required");
     Preconditions.checkNotNull(metricsConfig, "metricsConfig is required");
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -76,14 +76,18 @@ public class ParquetUtil {
   public static Metrics fileMetrics(
       InputFile file, MetricsConfig metricsConfig, NameMapping nameMapping) {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
-      return footerMetrics(reader.getFooter(), Stream.empty(), metricsConfig, nameMapping, Maps.newHashMap());
+      return footerMetrics(
+          reader.getFooter(), Stream.empty(), metricsConfig, nameMapping, Maps.newHashMap());
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
     }
   }
 
   public static Metrics footerMetrics(
-      ParquetMetadata metadata, Stream<FieldMetrics<?>> fieldMetrics, MetricsConfig metricsConfig, Map<Integer, String> idToColumn) {
+      ParquetMetadata metadata,
+      Stream<FieldMetrics<?>> fieldMetrics,
+      MetricsConfig metricsConfig,
+      Map<Integer, String> idToColumn) {
     return footerMetrics(metadata, fieldMetrics, metricsConfig, null, idToColumn);
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
@@ -60,7 +61,7 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
     Preconditions.checkState(footer != null, "Cannot produce metrics until closed");
     // Note: Metrics reported by this method do not contain a full set of available metrics.
     // Specifically, it lacks metrics not included in Parquet file's footer (e.g. NaN count)
-    return ParquetUtil.footerMetrics(footer, Stream.empty(), metricsConfig);
+    return ParquetUtil.footerMetrics(footer, Stream.empty(), metricsConfig, Maps.newHashMap());
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteAdapter.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
@@ -61,7 +60,7 @@ public class ParquetWriteAdapter<D> implements FileAppender<D> {
     Preconditions.checkState(footer != null, "Cannot produce metrics until closed");
     // Note: Metrics reported by this method do not contain a full set of available metrics.
     // Specifically, it lacks metrics not included in Parquet file's footer (e.g. NaN count)
-    return ParquetUtil.footerMetrics(footer, Stream.empty(), metricsConfig, Maps.newHashMap());
+    return ParquetUtil.footerMetrics(footer, Stream.empty(), metricsConfig, null);
   }
 
   @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.TypeUtil;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.column.ColumnWriteStore;
 import org.apache.parquet.column.ParquetProperties;
@@ -83,7 +82,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   private long nextCheckRecordCount = 10;
   private boolean closed;
   private ParquetFileWriter writer;
-  private Map<Integer, String> idToColumn;
+  private Schema schema;
 
   private static final String COLUMN_INDEX_TRUNCATE_LENGTH = "parquet.columnindex.truncate.length";
   private static final int DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH = 64;
@@ -112,7 +111,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
     this.writeMode = writeMode;
     this.output = output;
     this.conf = conf;
-    this.idToColumn = TypeUtil.indexNameById(schema.asStruct());
+    this.schema = schema;
 
     startRowGroup();
   }
@@ -147,8 +146,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   public Metrics metrics() {
     Preconditions.checkState(closed, "Cannot return metrics for unclosed writer");
     if (writer != null) {
-      return ParquetUtil.footerMetrics(
-          writer.getFooter(), model.metrics(), metricsConfig, idToColumn);
+      return ParquetUtil.footerMetrics(writer.getFooter(), model.metrics(), metricsConfig, schema);
     }
     return EMPTY_METRICS;
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -147,7 +147,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   public Metrics metrics() {
     Preconditions.checkState(closed, "Cannot return metrics for unclosed writer");
     if (writer != null) {
-      return ParquetUtil.footerMetrics(writer.getFooter(), model.metrics(), metricsConfig, idToColumn);
+      return ParquetUtil.footerMetrics(
+          writer.getFooter(), model.metrics(), metricsConfig, idToColumn);
     }
     return EMPTY_METRICS;
   }


### PR DESCRIPTION
…ntain special characters.

Iceberg escape special characters in field names when converting Schema to Parquet MessageType or Avro Schema: 
https://github.com/apache/iceberg/blob/7a247fdb44110363bd9e87d1ace91497fd72ba92/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java#L429-L434
so the MetricsMode obtained by the field name in the file schema might be wrong if the column name is an escaped one. ~~This pr updates MetricsConfig to use column id to track MetricsMode to solve this issue.~~
MetricsConfig#fromProperties is used in many places so cannot update it to use column id directly. Fix this by passing a parameter instead.