### PR TITLE
Python: Add expression evaluator

### DIFF
--- a/python/pyiceberg/avro/reader.py
+++ b/python/pyiceberg/avro/reader.py
@@ -42,8 +42,8 @@ from typing import (
 from uuid import UUID
 
 from pyiceberg.avro.decoder import BinaryDecoder
-from pyiceberg.files import StructProtocol
 from pyiceberg.schema import Schema, SchemaVisitor
+from pyiceberg.typedef import StructProtocol
 from pyiceberg.types import (
     BinaryType,
     BooleanType,

--- a/python/pyiceberg/expressions/__init__.py
+++ b/python/pyiceberg/expressions/__init__.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from functools import reduce
+from functools import cached_property, reduce
 from typing import (
     Any,
     Generic,
@@ -29,9 +29,8 @@ from typing import (
 )
 
 from pyiceberg.expressions.literals import Literal, literal
-from pyiceberg.files import StructProtocol
 from pyiceberg.schema import Accessor, Schema
-from pyiceberg.typedef import L
+from pyiceberg.typedef import L, StructProtocol
 from pyiceberg.types import DoubleType, FloatType, NestedField
 from pyiceberg.utils.singleton import Singleton
 
@@ -458,6 +457,10 @@ class BoundSetPredicate(BoundPredicate[L], ABC):
         # Since we don't know the type of BoundPredicate[L], we have to ignore this one
         super().__init__(term)  # type: ignore
         self.literals = _to_literal_set(literals)  # pylint: disable=W0621
+
+    @cached_property
+    def value_set(self) -> Set[L]:
+        return {lit.value for lit in self.literals}
 
     def __str__(self):
         # Sort to make it deterministic

--- a/python/pyiceberg/expressions/visitors.py
+++ b/python/pyiceberg/expressions/visitors.py
@@ -420,7 +420,9 @@ class _RewriteNotVisitor(BooleanExpressionVisitor[BooleanExpression]):
         return predicate
 
 
-def expression_evaluator(schema: Schema, unbound: BooleanExpression, case_sensitive=True) -> Callable[[StructProtocol], bool]:
+def expression_evaluator(
+    schema: Schema, unbound: BooleanExpression, case_sensitive: bool = True
+) -> Callable[[StructProtocol], bool]:
     return _ExpressionEvaluator(schema, unbound, case_sensitive).eval
 
 
@@ -428,10 +430,10 @@ class _ExpressionEvaluator(BoundBooleanExpressionVisitor[bool]):
     bound: BooleanExpression
     struct: StructProtocol
 
-    def __init__(self, schema: Schema, unbound: BooleanExpression, case_sensitive=True):
+    def __init__(self, schema: Schema, unbound: BooleanExpression, case_sensitive: bool = True):
         self.bound = bind(schema, unbound, case_sensitive)
 
-    def eval(self, struct: StructProtocol):
+    def eval(self, struct: StructProtocol) -> bool:
         self.struct = struct
         return visit(self.bound, self)
 

--- a/python/pyiceberg/expressions/visitors.py
+++ b/python/pyiceberg/expressions/visitors.py
@@ -53,6 +53,7 @@ from pyiceberg.expressions.literals import Literal
 from pyiceberg.manifest import ManifestFile, PartitionFieldSummary
 from pyiceberg.schema import Schema
 from pyiceberg.table import PartitionSpec
+from pyiceberg.typedef import StructProtocol
 from pyiceberg.types import (
     DoubleType,
     FloatType,
@@ -240,11 +241,11 @@ class BindVisitor(BooleanExpressionVisitor[BooleanExpression]):
 
 class BoundBooleanExpressionVisitor(BooleanExpressionVisitor[T], ABC):
     @abstractmethod
-    def visit_in(self, term: BoundTerm[L], literals: Set[Literal[L]]) -> T:
+    def visit_in(self, term: BoundTerm[L], literals: Set[L]) -> T:
         """Visit a bound In predicate"""
 
     @abstractmethod
-    def visit_not_in(self, term: BoundTerm[L], literals: Set[Literal[L]]) -> T:
+    def visit_not_in(self, term: BoundTerm[L], literals: Set[L]) -> T:
         """Visit a bound NotIn predicate"""
 
     @abstractmethod
@@ -331,12 +332,12 @@ def visit_bound_predicate(expr: BoundPredicate[L], _: BooleanExpressionVisitor[T
 
 @visit_bound_predicate.register(BoundIn)
 def _(expr: BoundIn[L], visitor: BoundBooleanExpressionVisitor[T]) -> T:
-    return visitor.visit_in(term=expr.term, literals=expr.literals)
+    return visitor.visit_in(term=expr.term, literals=expr.value_set)
 
 
 @visit_bound_predicate.register(BoundNotIn)
 def _(expr: BoundNotIn[L], visitor: BoundBooleanExpressionVisitor[T]) -> T:
-    return visitor.visit_not_in(term=expr.term, literals=expr.literals)
+    return visitor.visit_not_in(term=expr.term, literals=expr.value_set)
 
 
 @visit_bound_predicate.register(BoundIsNaN)
@@ -419,6 +420,75 @@ class _RewriteNotVisitor(BooleanExpressionVisitor[BooleanExpression]):
         return predicate
 
 
+def expression_evaluator(schema: Schema, unbound: BooleanExpression, case_sensitive=True) -> Callable[[StructProtocol], bool]:
+    return _ExpressionEvaluator(schema, unbound, case_sensitive).eval
+
+
+class _ExpressionEvaluator(BoundBooleanExpressionVisitor[bool]):
+    bound: BooleanExpression
+    struct: StructProtocol
+
+    def __init__(self, schema: Schema, unbound: BooleanExpression, case_sensitive=True):
+        self.bound = bind(schema, unbound, case_sensitive)
+
+    def eval(self, struct: StructProtocol):
+        self.struct = struct
+        return visit(self.bound, self)
+
+    def visit_in(self, term: BoundTerm[L], literals: Set[L]) -> bool:
+        return term.eval(self.struct) in literals
+
+    def visit_not_in(self, term: BoundTerm[L], literals: Set[L]) -> bool:
+        return term.eval(self.struct) not in literals
+
+    def visit_is_nan(self, term: BoundTerm[L]) -> bool:
+        val = term.eval(self.struct)
+        return val != val
+
+    def visit_not_nan(self, term: BoundTerm[L]) -> bool:
+        val = term.eval(self.struct)
+        return val == val
+
+    def visit_is_null(self, term: BoundTerm[L]) -> bool:
+        return term.eval(self.struct) is None
+
+    def visit_not_null(self, term: BoundTerm[L]) -> bool:
+        return term.eval(self.struct) is not None
+
+    def visit_equal(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) == literal.value
+
+    def visit_not_equal(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) != literal.value
+
+    def visit_greater_than_or_equal(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) >= literal.value
+
+    def visit_greater_than(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) > literal.value
+
+    def visit_less_than(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) < literal.value
+
+    def visit_less_than_or_equal(self, term: BoundTerm[L], literal: Literal[L]) -> bool:
+        return term.eval(self.struct) <= literal.value
+
+    def visit_true(self) -> bool:
+        return True
+
+    def visit_false(self) -> bool:
+        return False
+
+    def visit_not(self, child_result: bool) -> bool:
+        return not child_result
+
+    def visit_and(self, left_result: bool, right_result: bool) -> bool:
+        return left_result and right_result
+
+    def visit_or(self, left_result: bool, right_result: bool) -> bool:
+        return left_result or right_result
+
+
 ROWS_MIGHT_MATCH = True
 ROWS_CANNOT_MATCH = False
 IN_PREDICATE_LIMIT = 200
@@ -445,7 +515,7 @@ class _ManifestEvalVisitor(BoundBooleanExpressionVisitor[bool]):
         # No partition information
         return ROWS_MIGHT_MATCH
 
-    def visit_in(self, term: BoundTerm[L], literals: Set[Literal[L]]) -> bool:
+    def visit_in(self, term: BoundTerm[L], literals: Set[L]) -> bool:
         pos = term.ref().accessor.position
         field = self.partition_fields[pos]
 
@@ -457,17 +527,17 @@ class _ManifestEvalVisitor(BoundBooleanExpressionVisitor[bool]):
 
         lower = _from_byte_buffer(term.ref().field.field_type, field.lower_bound)
 
-        if all(lower > val.value for val in literals):
+        if all(lower > val for val in literals):
             return ROWS_CANNOT_MATCH
 
         if field.upper_bound is not None:
             upper = _from_byte_buffer(term.ref().field.field_type, field.upper_bound)
-            if all(upper < val.value for val in literals):
+            if all(upper < val for val in literals):
                 return ROWS_CANNOT_MATCH
 
         return ROWS_MIGHT_MATCH
 
-    def visit_not_in(self, term: BoundTerm[L], literals: Set[Literal[L]]) -> bool:
+    def visit_not_in(self, term: BoundTerm[L], literals: Set[L]) -> bool:
         # because the bounds are not necessarily a min or max value, this cannot be answered using
         # them. notIn(col, {X, ...}) with (X, Y) doesn't guarantee that X is a value in col.
         return ROWS_MIGHT_MATCH

--- a/python/pyiceberg/files.py
+++ b/python/pyiceberg/files.py
@@ -14,9 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from abc import abstractmethod
 from enum import Enum, auto
-from typing import Any, Protocol, runtime_checkable
 
 
 class FileContentType(Enum):
@@ -34,16 +32,3 @@ class FileFormat(Enum):
     PARQUET = auto()
     AVRO = auto()
     METADATA = auto()
-
-
-@runtime_checkable
-class StructProtocol(Protocol):  # pragma: no cover
-    """A generic protocol used by accessors to get and set at positions of an object"""
-
-    @abstractmethod
-    def get(self, pos: int) -> Any:
-        ...
-
-    @abstractmethod
-    def set(self, pos: int, value: Any) -> None:
-        ...

--- a/python/pyiceberg/schema.py
+++ b/python/pyiceberg/schema.py
@@ -35,7 +35,7 @@ from typing import (
 
 from pydantic import Field, PrivateAttr
 
-from pyiceberg.files import StructProtocol
+from pyiceberg.typedef import StructProtocol
 from pyiceberg.types import (
     IcebergType,
     ListType,

--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -14,13 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from abc import abstractmethod
 from decimal import Decimal
 from typing import (
     Any,
     Dict,
+    Protocol,
     Tuple,
     TypeVar,
     Union,
+    runtime_checkable,
 )
 from uuid import UUID
 
@@ -41,3 +44,16 @@ RecursiveDict = Dict[str, Union[str, "RecursiveDict"]]
 
 # Represents the literal value
 L = TypeVar("L", str, bool, int, float, bytes, UUID, Decimal, covariant=True)
+
+
+@runtime_checkable
+class StructProtocol(Protocol):  # pragma: no cover
+    """A generic protocol used by accessors to get and set at positions of an object"""
+
+    @abstractmethod
+    def get(self, pos: int) -> Any:
+        ...
+
+    @abstractmethod
+    def set(self, pos: int, value: Any) -> None:
+        ...

--- a/python/tests/expressions/test_evaluator.py
+++ b/python/tests/expressions/test_evaluator.py
@@ -1,0 +1,179 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, List
+
+from pyiceberg.expressions import (
+    AlwaysFalse,
+    AlwaysTrue,
+    And,
+    EqualTo,
+    GreaterThan,
+    GreaterThanOrEqual,
+    In,
+    IsNaN,
+    IsNull,
+    LessThan,
+    LessThanOrEqual,
+    Not,
+    NotEqualTo,
+    NotIn,
+    NotNaN,
+    NotNull,
+    Or,
+)
+from pyiceberg.expressions.visitors import expression_evaluator
+from pyiceberg.schema import Schema
+from pyiceberg.typedef import StructProtocol
+from pyiceberg.types import (
+    DoubleType,
+    LongType,
+    NestedField,
+    StringType,
+)
+
+
+class Record(StructProtocol):
+    data: List[Any]
+
+    def __init__(self, *values):
+        self.data = list(values)
+
+    def get(self, pos: int) -> Any:
+        return self.data[pos]
+
+    def set(self, pos: int, value: Any) -> None:
+        self.data[pos] = value
+
+
+SIMPLE_SCHEMA = Schema(
+    NestedField(id=1, name="id", field_type=LongType()), NestedField(id=2, name="data", field_type=StringType(), required=False)
+)
+
+FLOAT_SCHEMA = Schema(
+    NestedField(id=1, name="id", field_type=LongType()), NestedField(id=2, name="f", field_type=DoubleType(), required=False)
+)
+
+
+def test_true():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, AlwaysTrue())
+    assert evaluate(Record(1, "a"))
+
+
+def test_false():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, AlwaysFalse())
+    assert not evaluate(Record(1, "a"))
+
+
+def test_less_than():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, LessThan("id", 3))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+
+
+def test_less_than_or_equal():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, LessThanOrEqual("id", 3))
+    assert evaluate(Record(1, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
+
+
+def test_greater_than():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, GreaterThan("id", 3))
+    assert not evaluate(Record(1, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
+
+
+def test_greater_than_or_equal():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, GreaterThanOrEqual("id", 3))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
+
+
+def test_equal_to():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, EqualTo("id", 3))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
+
+
+def test_not_equal_to():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, NotEqualTo("id", 3))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
+
+
+def test_in():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, In("id", [1, 2, 3]))
+    assert evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+    assert not evaluate(Record(4, "a"))
+
+
+def test_not_in():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, NotIn("id", [1, 2, 3]))
+    assert not evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+    assert evaluate(Record(4, "a"))
+
+
+def test_is_null():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, IsNull("data"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, None))
+
+
+def test_not_null():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, NotNull("data"))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, None))
+
+
+def test_is_nan():
+    evaluate = expression_evaluator(FLOAT_SCHEMA, IsNaN("f"))
+    assert not evaluate(Record(2, 0.0))
+    assert not evaluate(Record(3, float("infinity")))
+    assert evaluate(Record(4, float("nan")))
+
+
+def test_not_nan():
+    evaluate = expression_evaluator(FLOAT_SCHEMA, NotNaN("f"))
+    assert evaluate(Record(2, 0.0))
+    assert evaluate(Record(3, float("infinity")))
+    assert not evaluate(Record(4, float("nan")))
+
+
+def test_not():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, Not(LessThan("id", 3)))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))
+
+
+def test_and():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, And(LessThan("id", 3), GreaterThan("id", 1)))
+    assert not evaluate(Record(1, "a"))
+    assert evaluate(Record(2, "a"))
+    assert not evaluate(Record(3, "a"))
+
+
+def test_or():
+    evaluate = expression_evaluator(SIMPLE_SCHEMA, Or(LessThan("id", 2), GreaterThan("id", 2)))
+    assert evaluate(Record(1, "a"))
+    assert not evaluate(Record(2, "a"))
+    assert evaluate(Record(3, "a"))

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -22,9 +22,8 @@ import pytest
 
 from pyiceberg import schema
 from pyiceberg.expressions import Accessor
-from pyiceberg.files import StructProtocol
 from pyiceberg.schema import Schema, build_position_accessors, prune_columns
-from pyiceberg.typedef import EMPTY_DICT
+from pyiceberg.typedef import EMPTY_DICT, StructProtocol
 from pyiceberg.types import (
     BooleanType,
     FloatType,


### PR DESCRIPTION
Implement an expression evaluator in Python. This is needed for pruning data files based on the partition tuple in a manifest file.

This also makes a few of other changes:
* Moves `StructProtocol` to `typedef`
* Adds a `value_set` to `BoundSetPredicate` for faster in and not in evaluation