### PR TITLE
Python: Projection

### DIFF
--- a/python/pyiceberg/expressions/__init__.py
+++ b/python/pyiceberg/expressions/__init__.py
@@ -309,8 +309,8 @@ class BoundPredicate(Generic[L], Bound, BooleanExpression, ABC):
             return self.term == other.term
         return False
 
-    @abstractmethod
     @property
+    @abstractmethod
     def as_unbound(self) -> Type[UnboundPredicate]:
         ...
 
@@ -352,8 +352,8 @@ class BoundUnaryPredicate(BoundPredicate[L], ABC):
     def __repr__(self) -> str:
         return f"{str(self.__class__.__name__)}(term={repr(self.term)})"
 
-    @abstractmethod
     @property
+    @abstractmethod
     def as_unbound(self) -> Type[UnaryPredicate]:
         ...
 
@@ -499,8 +499,8 @@ class BoundSetPredicate(BoundPredicate[L], ABC):
     def __eq__(self, other: Any) -> bool:
         return self.term == other.term and self.literals == other.literals if isinstance(other, BoundSetPredicate) else False
 
-    @abstractmethod
     @property
+    @abstractmethod
     def as_unbound(self) -> Type[SetPredicate]:
         ...
 
@@ -632,8 +632,8 @@ class BoundLiteralPredicate(BoundPredicate[L], ABC):
     def __repr__(self) -> str:
         return f"{str(self.__class__.__name__)}(term={repr(self.term)}, literal={repr(self.literal)})"
 
-    @abstractmethod
     @property
+    @abstractmethod
     def as_unbound(self) -> Type[LiteralPredicate]:
         ...
 

--- a/python/pyiceberg/expressions/__init__.py
+++ b/python/pyiceberg/expressions/__init__.py
@@ -25,9 +25,6 @@ from typing import (
     Iterable,
     Set,
     Type,
-    Tuple,
-    Type,
-    TypeVar,
     Union,
 )
 

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -23,6 +23,10 @@ from __future__ import annotations
 
 import struct
 from abc import ABC, abstractmethod
+<<<<<<< HEAD
+=======
+from datetime import date, datetime
+>>>>>>> e3c82ef77 (Fix the transformers)
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatchmethod
 from typing import Any, Generic, Type
@@ -56,6 +60,11 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.datetime import (
     date_str_to_days,
+<<<<<<< HEAD
+=======
+    date_to_days,
+    datetime_to_micros,
+>>>>>>> e3c82ef77 (Fix the transformers)
     micros_to_days,
     time_to_micros,
     timestamp_to_micros,
@@ -169,9 +178,21 @@ class FloatBelowMin(Literal[float], Singleton):
         return "FloatBelowMin"
 
 
+<<<<<<< HEAD
 class IntAboveMax(Literal[int]):
     def __init__(self):
         super().__init__(IntegerType.max, int)
+=======
+@literal.register(datetime)
+def _(value: datetime) -> TimestampLiteral:
+    return TimestampLiteral(datetime_to_micros(value))
+
+
+class AboveMax(Singleton):
+    @property
+    def value(self):
+        raise ValueError("AboveMax has no value")
+>>>>>>> e3c82ef77 (Fix the transformers)
 
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of IntAboveMax")

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -333,6 +333,12 @@ class DateLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
 
+    def increment(self) -> TimeLiteral:
+        return TimeLiteral(self.value + 1)
+
+    def decrement(self) -> TimeLiteral:
+        return TimeLiteral(self.value - 1)
+
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:
         raise TypeError(f"Cannot convert DateLiteral into {type_var}")
@@ -346,6 +352,12 @@ class TimeLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
 
+    def increment(self) -> TimeLiteral:
+        return TimeLiteral(self.value + 1)
+
+    def decrement(self) -> TimeLiteral:
+        return TimeLiteral(self.value - 1)
+
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:
         raise TypeError(f"Cannot convert TimeLiteral into {type_var}")
@@ -358,6 +370,12 @@ class TimeLiteral(Literal[int]):
 class TimestampLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
+
+    def increment(self) -> TimeLiteral:
+        return TimeLiteral(self.value + 1)
+
+    def decrement(self) -> TimeLiteral:
+        return TimeLiteral(self.value - 1)
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -25,12 +25,7 @@ import struct
 from abc import ABC, abstractmethod
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatchmethod
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Type,
-)
+from typing import Any, Generic, Type
 from uuid import UUID
 
 from pyiceberg.typedef import L
@@ -215,10 +210,10 @@ class LongLiteral(Literal[int]):
     def to(self, type_var: IcebergType) -> Literal:
         raise TypeError(f"Cannot convert LongLiteral into {type_var}")
 
-    def increment(self) -> LongLiteral:
+    def increment(self) -> Literal[int]:
         return LongLiteral(self.value + 1)
 
-    def decrement(self) -> LongLiteral:
+    def decrement(self) -> Literal[int]:
         return LongLiteral(self.value - 1)
 
     @to.register(LongType)
@@ -330,11 +325,11 @@ class DateLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
 
-    def increment(self) -> TimeLiteral:
-        return TimeLiteral(self.value + 1)
+    def increment(self) -> Literal[int]:
+        return DateLiteral(self.value + 1)
 
-    def decrement(self) -> TimeLiteral:
-        return TimeLiteral(self.value - 1)
+    def decrement(self) -> Literal[int]:
+        return DateLiteral(self.value - 1)
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:
@@ -349,12 +344,6 @@ class TimeLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
 
-    def increment(self) -> TimeLiteral:
-        return TimeLiteral(self.value + 1)
-
-    def decrement(self) -> TimeLiteral:
-        return TimeLiteral(self.value - 1)
-
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:
         raise TypeError(f"Cannot convert TimeLiteral into {type_var}")
@@ -368,11 +357,11 @@ class TimestampLiteral(Literal[int]):
     def __init__(self, value: int):
         super().__init__(value, int)
 
-    def increment(self) -> TimeLiteral:
-        return TimeLiteral(self.value + 1)
+    def increment(self) -> Literal[int]:
+        return TimestampLiteral(self.value + 1)
 
-    def decrement(self) -> TimeLiteral:
-        return TimeLiteral(self.value - 1)
+    def decrement(self) -> Literal[int]:
+        return TimestampLiteral(self.value - 1)
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:
@@ -391,10 +380,10 @@ class DecimalLiteral(Literal[Decimal]):
     def __init__(self, value: Decimal):
         super().__init__(value, Decimal)
 
-    def increment(self) -> DecimalLiteral:
+    def increment(self) -> Literal[Decimal]:
         return DecimalLiteral(self.value + 1)
 
-    def decrement(self) -> DecimalLiteral:
+    def decrement(self) -> Literal[Decimal]:
         return DecimalLiteral(self.value - 1)
 
     @singledispatchmethod
@@ -535,8 +524,3 @@ class BinaryLiteral(Literal[bytes]):
             raise TypeError(
                 f"Cannot convert BinaryLiteral into {type_var}, different length: {len(type_var)} <> {len(self.value)}"
             )
-
-
-def _transform_literal(func: Callable[[L], L], lit: Literal[L]) -> Literal[L]:
-    """Small helper to upwrap the value from the literal, and wrap it again"""
-    return literal(func(lit.value))

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -23,20 +23,13 @@ from __future__ import annotations
 
 import struct
 from abc import ABC, abstractmethod
-<<<<<<< HEAD
-=======
-from datetime import date, datetime
->>>>>>> e3c82ef77 (Fix the transformers)
 from decimal import ROUND_HALF_UP, Decimal
 from functools import singledispatchmethod
-from typing import Any, Generic, Type
-from functools import singledispatch, singledispatchmethod
 from typing import (
+    Any,
     Callable,
     Generic,
-    Optional,
-    TypeVar,
-    Union,
+    Type,
 )
 from uuid import UUID
 
@@ -60,11 +53,6 @@ from pyiceberg.types import (
 )
 from pyiceberg.utils.datetime import (
     date_str_to_days,
-<<<<<<< HEAD
-=======
-    date_to_days,
-    datetime_to_micros,
->>>>>>> e3c82ef77 (Fix the transformers)
     micros_to_days,
     time_to_micros,
     timestamp_to_micros,
@@ -178,21 +166,9 @@ class FloatBelowMin(Literal[float], Singleton):
         return "FloatBelowMin"
 
 
-<<<<<<< HEAD
 class IntAboveMax(Literal[int]):
     def __init__(self):
         super().__init__(IntegerType.max, int)
-=======
-@literal.register(datetime)
-def _(value: datetime) -> TimestampLiteral:
-    return TimestampLiteral(datetime_to_micros(value))
-
-
-class AboveMax(Singleton):
-    @property
-    def value(self):
-        raise ValueError("AboveMax has no value")
->>>>>>> e3c82ef77 (Fix the transformers)
 
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of IntAboveMax")

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -381,10 +381,12 @@ class DecimalLiteral(Literal[Decimal]):
         super().__init__(value, Decimal)
 
     def increment(self) -> Literal[Decimal]:
-        return DecimalLiteral(self.value + 1)
+        inc_value = 1 / (10 ** abs(self.value.as_tuple().exponent))
+        return DecimalLiteral(self.value + Decimal(str(inc_value)))
 
     def decrement(self) -> Literal[Decimal]:
-        return DecimalLiteral(self.value - 1)
+        inc_value = 1 / (10 ** abs(self.value.as_tuple().exponent))
+        return DecimalLiteral(self.value - Decimal(str(inc_value)))
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -53,6 +53,7 @@ from pyiceberg.utils.datetime import (
     timestamp_to_micros,
     timestamptz_to_micros,
 )
+from pyiceberg.utils.decimal import decimal_to_unscaled, unscaled_to_decimal
 from pyiceberg.utils.singleton import Singleton
 
 
@@ -381,12 +382,14 @@ class DecimalLiteral(Literal[Decimal]):
         super().__init__(value, Decimal)
 
     def increment(self) -> Literal[Decimal]:
-        inc_value = 1 / (10 ** abs(self.value.as_tuple().exponent))
-        return DecimalLiteral(self.value + Decimal(str(inc_value)))
+        original_scale = abs(self.value.as_tuple().exponent)
+        unscaled = decimal_to_unscaled(self.value)
+        return DecimalLiteral(unscaled_to_decimal(unscaled + 1, original_scale))
 
     def decrement(self) -> Literal[Decimal]:
-        inc_value = 1 / (10 ** abs(self.value.as_tuple().exponent))
-        return DecimalLiteral(self.value - Decimal(str(inc_value)))
+        original_scale = abs(self.value.as_tuple().exponent)
+        unscaled = decimal_to_unscaled(self.value)
+        return DecimalLiteral(unscaled_to_decimal(unscaled - 1, original_scale))
 
     @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:

--- a/python/pyiceberg/transforms.py
+++ b/python/pyiceberg/transforms.py
@@ -61,6 +61,7 @@ from pyiceberg.expressions.literals import (
     TimestampLiteral,
     _transform_literal,
 )
+from pyiceberg.typedef import L
 from pyiceberg.types import (
     BinaryType,
     DateType,
@@ -151,7 +152,7 @@ class Transform(IcebergBaseModel, ABC, Generic[S, T]):
         ...
 
     @abstractmethod
-    def project(self, name: str, pred: BoundPredicate) -> Optional[UnboundPredicate]:
+    def project(self, name: str, pred: BoundPredicate[L]) -> Optional[UnboundPredicate]:
         ...
 
     @property
@@ -829,11 +830,11 @@ def _transform_set(name: str, pred: BoundSetPredicate, func: Callable[[Optional[
         raise ValueError(f"Unknown BoundSetPredicate: {pred}")
 
 
-class BoundTransform(BoundTerm[T]):
+class BoundTransform(BoundTerm[Any]):
     """A transform expression"""
 
     transform: Transform
 
-    def __init__(self, term: BoundTerm[T], transform: Transform):
+    def __init__(self, term: BoundTerm, transform: Transform):
         self.term = term
         self.transform = transform

--- a/python/pyiceberg/transforms.py
+++ b/python/pyiceberg/transforms.py
@@ -815,9 +815,7 @@ def _remove_transform(partition_name: str, pred: BoundPredicate[L]):
         raise ValueError(f"Cannot replace transform in unknown predicate: {pred}")
 
 
-def _set_apply_transform(
-    name: str, pred: BoundSetPredicate[L], transform: Callable[[L], L]
-) -> UnboundPredicate[Any]:
+def _set_apply_transform(name: str, pred: BoundSetPredicate[L], transform: Callable[[L], L]) -> UnboundPredicate[Any]:
     literals = pred.literals
     if isinstance(pred, BoundSetPredicate):
         return pred.as_unbound(Reference(name), {_transform_literal(transform, literal) for literal in literals})

--- a/python/pyiceberg/transforms.py
+++ b/python/pyiceberg/transforms.py
@@ -765,7 +765,7 @@ M = TypeVar("M")
 
 
 def _truncate_number(
-    name: str, pred: BoundLiteralPredicate, func: Callable[[Optional[M]], Optional[M]]
+    name: str, pred: BoundLiteralPredicate, transform: Callable[[Optional[M]], Optional[M]]
 ) -> Optional[UnboundPredicate]:
     boundary = pred.literal
 
@@ -773,15 +773,15 @@ def _truncate_number(
         raise ValueError(f"Expected a numeric literal, got: {type(boundary)}")
 
     if isinstance(pred, BoundLessThan):
-        return LessThanOrEqual(Reference(name), _transform_literal(func, boundary.decrement()))
+        return LessThanOrEqual(Reference(name), _transform_literal(transform, boundary.decrement()))
     elif isinstance(pred, BoundLessThanOrEqual):
-        return LessThanOrEqual(Reference(name), _transform_literal(func, boundary))
+        return LessThanOrEqual(Reference(name), _transform_literal(transform, boundary))
     elif isinstance(pred, BoundGreaterThan):
-        return GreaterThanOrEqual(Reference(name), _transform_literal(func, boundary.increment()))
+        return GreaterThanOrEqual(Reference(name), _transform_literal(transform, boundary.increment()))
     elif isinstance(pred, BoundGreaterThanOrEqual):
-        return GreaterThanOrEqual(Reference(name), _transform_literal(func, boundary))
+        return GreaterThanOrEqual(Reference(name), _transform_literal(transform, boundary))
     elif isinstance(pred, BoundEqualTo):
-        return EqualTo(Reference(name), _transform_literal(func, boundary))
+        return EqualTo(Reference(name), _transform_literal(transform, boundary))
     else:
         return None
 

--- a/python/pyiceberg/transforms.py
+++ b/python/pyiceberg/transforms.py
@@ -761,11 +761,8 @@ class VoidTransform(Transform, Singleton):
         return "VoidTransform()"
 
 
-M = TypeVar("M")
-
-
 def _truncate_number(
-    name: str, pred: BoundLiteralPredicate, transform: Callable[[Optional[M]], Optional[M]]
+    name: str, pred: BoundLiteralPredicate[L], transform: Callable[[Optional[L]], Optional[L]]
 ) -> Optional[UnboundPredicate]:
     boundary = pred.literal
 
@@ -773,11 +770,11 @@ def _truncate_number(
         raise ValueError(f"Expected a numeric literal, got: {type(boundary)}")
 
     if isinstance(pred, BoundLessThan):
-        return LessThanOrEqual(Reference(name), _transform_literal(transform, boundary.decrement()))
+        return LessThanOrEqual(Reference(name), _transform_literal(transform, boundary.decrement()))  # type: ignore
     elif isinstance(pred, BoundLessThanOrEqual):
         return LessThanOrEqual(Reference(name), _transform_literal(transform, boundary))
     elif isinstance(pred, BoundGreaterThan):
-        return GreaterThanOrEqual(Reference(name), _transform_literal(transform, boundary.increment()))
+        return GreaterThanOrEqual(Reference(name), _transform_literal(transform, boundary.increment()))  # type: ignore
     elif isinstance(pred, BoundGreaterThanOrEqual):
         return GreaterThanOrEqual(Reference(name), _transform_literal(transform, boundary))
     elif isinstance(pred, BoundEqualTo):
@@ -787,7 +784,7 @@ def _truncate_number(
 
 
 def _truncate_array(
-    name: str, pred: BoundLiteralPredicate, transform: Callable[[Optional[M]], Optional[M]]
+    name: str, pred: BoundLiteralPredicate[L], transform: Callable[[Optional[L]], Optional[L]]
 ) -> Optional[UnboundPredicate]:
     boundary = pred.literal
 
@@ -820,7 +817,7 @@ def _remove_transform(partition_name: str, pred: BoundPredicate):
 
 
 def _set_apply_transform(
-    name: str, pred: BoundSetPredicate[L], transform: Callable[[Optional[M]], Optional[M]]
+    name: str, pred: BoundSetPredicate[L], transform: Callable[[Optional[L]], Optional[L]]
 ) -> UnboundPredicate:
     literals = pred.literals
     if isinstance(pred, BoundSetPredicate):

--- a/python/tests/expressions/test_literals.py
+++ b/python/tests/expressions/test_literals.py
@@ -805,6 +805,24 @@ def test_string_to_decimal_type_invalid_value():
     assert "Could not convert 18.15 into a decimal(10, 0), scales differ 0 <> 2" in str(e.value)
 
 
+def test_decimal_literal_increment():
+    dec = DecimalLiteral(Decimal("10.123"))
+    # Twice to check that we don't mutate the value
+    assert dec.increment() == DecimalLiteral(Decimal("10.124"))
+    assert dec.increment() == DecimalLiteral(Decimal("10.124"))
+    # To check that the scale is still the same
+    assert dec.increment().value.as_tuple() == Decimal("10.124").as_tuple()
+
+
+def test_decimal_literal_dencrement():
+    dec = DecimalLiteral(Decimal("10.123"))
+    # Twice to check that we don't mutate the value
+    assert dec.decrement() == DecimalLiteral(Decimal("10.122"))
+    assert dec.decrement() == DecimalLiteral(Decimal("10.122"))
+    # To check that the scale is still the same
+    assert dec.decrement().value.as_tuple() == Decimal("10.122").as_tuple()
+
+
 #   __  __      ___
 #  |  \/  |_  _| _ \_  _
 #  | |\/| | || |  _/ || |

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -844,7 +844,7 @@ def test_projection_truncate_decimal_literal_eq(bound_reference_decimal: BoundRe
 def test_projection_truncate_decimal_literal_gt(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThan(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=Decimal("20.24"))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("19.26"))
 
 
 def test_projection_truncate_decimal_literal_gte(bound_reference_decimal: BoundReference) -> None:
@@ -874,7 +874,7 @@ def test_projection_truncate_long_literal_eq(bound_reference_long: BoundReferenc
 def test_projection_truncate_long_literal_gt(bound_reference_long: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThan(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=Decimal("20.24"))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("19.26"))
 
 
 def test_projection_truncate_long_literal_gte(bound_reference_long: BoundReference) -> None:

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -865,27 +865,27 @@ def test_projection_truncate_decimal_in(bound_reference_decimal: BoundReference)
     )
 
 
-def test_projection_truncate_long_literal_eq(bound_reference_long: BoundReference) -> None:
+def test_projection_truncate_long_literal_eq(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
-        "name", BoundEqualTo(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
+        "name", BoundEqualTo(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
     ) == EqualTo(term="name", literal=Decimal("19.24"))
 
 
-def test_projection_truncate_long_literal_gt(bound_reference_long: BoundReference) -> None:
+def test_projection_truncate_long_literal_gt(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
-        "name", BoundGreaterThan(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
+        "name", BoundGreaterThan(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
     ) == GreaterThanOrEqual(term="name", literal=Decimal("19.26"))
 
 
-def test_projection_truncate_long_literal_gte(bound_reference_long: BoundReference) -> None:
+def test_projection_truncate_long_literal_gte(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
-        "name", BoundGreaterThanOrEqual(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
+        "name", BoundGreaterThanOrEqual(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
     ) == GreaterThanOrEqual(term="name", literal=Decimal("19.24"))
 
 
-def test_projection_truncate_long_in(bound_reference_long: BoundReference) -> None:
+def test_projection_truncate_long_in(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
-        "name", BoundIn(term=bound_reference_long, literals={DecimalLiteral(Decimal(19.25)), DecimalLiteral(Decimal(18.15))})
+        "name", BoundIn(term=bound_reference_decimal, literals={DecimalLiteral(Decimal(19.25)), DecimalLiteral(Decimal(18.15))})
     ) == In(
         term="name",
         literals={

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -715,31 +715,44 @@ def test_projection_hour_unary(bound_reference_timestamp) -> None:
     assert HourTransform().project("name", BoundNotNull(term=bound_reference_timestamp)) == NotNull(term="name")
 
 
+TIMESTAMP_EXAMPLE = 1667696874000000  # Sun Nov 06 2022 01:07:54
+HOUR_IN_MICROSECONDS = 60 * 60 * 1000 * 1000
+
+
 def test_projection_hour_literal(bound_reference_timestamp) -> None:
     assert HourTransform().project(
-        "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(1667696874000))
-    ) == EqualTo(term="name", literal=463)
+        "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(TIMESTAMP_EXAMPLE))
+    ) == EqualTo(term="name", literal=463249)
 
 
 def test_projection_hour_set_same_hour(bound_reference_timestamp) -> None:
     assert HourTransform().project(
         "name",
-        BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1667696874000)}),
-    ) == EqualTo(term="name", literal=463)
+        BoundIn(
+            term=bound_reference_timestamp,
+            literals={TimestampLiteral(TIMESTAMP_EXAMPLE + 1), TimestampLiteral(TIMESTAMP_EXAMPLE)},
+        ),
+    ) == EqualTo(term="name", literal=463249)
 
 
 def test_projection_hour_set_in(bound_reference_timestamp) -> None:
     assert HourTransform().project(
         "name",
-        BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1567696874000)}),
-    ) == In(term="name", literals={435, 463})
+        BoundIn(
+            term=bound_reference_timestamp,
+            literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)},
+        ),
+    ) == In(term="name", literals={463249, 463250})
 
 
 def test_projection_hour_set_not_in(bound_reference_timestamp) -> None:
     assert (
         HourTransform().project(
             "name",
-            BoundNotIn(term=bound_reference_timestamp, literals={TimestampLiteral(1567696874), TimestampLiteral(1667696874)}),
+            BoundNotIn(
+                term=bound_reference_timestamp,
+                literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)},
+            ),
         )
         is None
     )
@@ -751,27 +764,33 @@ def test_projection_identity_unary(bound_reference_timestamp) -> None:
 
 def test_projection_identity_literal(bound_reference_timestamp) -> None:
     assert IdentityTransform().project(
-        "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(1667696874000))
+        "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(TIMESTAMP_EXAMPLE))
     ) == EqualTo(
-        term="name", literal=TimestampLiteral(1667696874000)  # type: ignore
+        term="name", literal=TimestampLiteral(TIMESTAMP_EXAMPLE)  # type: ignore
     )
 
 
 def test_projection_identity_set_in(bound_reference_timestamp) -> None:
     assert IdentityTransform().project(
         "name",
-        BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1567696874000)}),
+        BoundIn(
+            term=bound_reference_timestamp,
+            literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)},
+        ),
     ) == In(
-        term="name", literals={TimestampLiteral(1567696874000), TimestampLiteral(1667696874001)}  # type: ignore
+        term="name", literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)}  # type: ignore
     )
 
 
 def test_projection_identity_set_not_in(bound_reference_timestamp) -> None:
     assert IdentityTransform().project(
         "name",
-        BoundNotIn(term=bound_reference_timestamp, literals={TimestampLiteral(1567696874), TimestampLiteral(1667696874)}),
+        BoundNotIn(
+            term=bound_reference_timestamp,
+            literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)},
+        ),
     ) == NotIn(
-        term="name", literals={TimestampLiteral(1567696874), TimestampLiteral(1667696874)}  # type: ignore
+        term="name", literals={TimestampLiteral(TIMESTAMP_EXAMPLE + HOUR_IN_MICROSECONDS), TimestampLiteral(TIMESTAMP_EXAMPLE)}  # type: ignore
     )
 
 

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -571,20 +571,20 @@ def test_projection_bucket_unary(bound_reference_str: BoundReference) -> None:
 
 def test_projection_bucket_literal(bound_reference_str: BoundReference) -> None:
     assert BucketTransform(2).project("name", BoundEqualTo(term=bound_reference_str, literal=literal("data"))) == EqualTo(
-        term="name", literal=literal(1)
+        term="name", literal=1
     )
 
 
 def test_projection_bucket_set_same_bucket(bound_reference_str: BoundReference) -> None:
     assert BucketTransform(2).project(
         "name", BoundIn(term=bound_reference_str, literals={literal("hello"), literal("world")})
-    ) == EqualTo(term="name", literal=literal(1))
+    ) == EqualTo(term="name", literal=1)
 
 
 def test_projection_bucket_set_in(bound_reference_str: BoundReference) -> None:
     assert BucketTransform(3).project(
         "name", BoundIn(term=bound_reference_str, literals={literal("hello"), literal("world")})
-    ) == In(term="name", literals={literal(1), literal(2)})
+    ) == In(term="name", literals={1, 2})
 
 
 def test_projection_bucket_set_not_in(bound_reference_str: BoundReference) -> None:
@@ -600,20 +600,20 @@ def test_projection_year_unary(bound_reference_date: BoundReference) -> None:
 
 def test_projection_year_literal(bound_reference_date: BoundReference) -> None:
     assert YearTransform().project("name", BoundEqualTo(term=bound_reference_date, literal=DateLiteral(1925))) == EqualTo(
-        term="name", literal=literal(5)
+        term="name", literal=5
     )
 
 
 def test_projection_year_set_same_year(bound_reference_date: BoundReference) -> None:
     assert YearTransform().project(
         "name", BoundIn(term=bound_reference_date, literals={DateLiteral(1925), DateLiteral(1926)})
-    ) == EqualTo(term="name", literal=literal(5))
+    ) == EqualTo(term="name", literal=5)
 
 
 def test_projection_year_set_in(bound_reference_date: BoundReference) -> None:
     assert YearTransform().project(
         "name", BoundIn(term=bound_reference_date, literals={DateLiteral(1925), DateLiteral(2925)})
-    ) == In(term="name", literals={literal(8), literal(5)})
+    ) == In(term="name", literals={8, 5})
 
 
 def test_projection_year_set_not_in(bound_reference_date: BoundReference) -> None:
@@ -629,20 +629,20 @@ def test_projection_month_unary(bound_reference_date: BoundReference) -> None:
 
 def test_projection_month_literal(bound_reference_date: BoundReference) -> None:
     assert MonthTransform().project("name", BoundEqualTo(term=bound_reference_date, literal=DateLiteral(1925))) == EqualTo(
-        term="name", literal=literal(63)
+        term="name", literal=63
     )
 
 
 def test_projection_month_set_same_month(bound_reference_date: BoundReference) -> None:
     assert MonthTransform().project(
         "name", BoundIn(term=bound_reference_date, literals={DateLiteral(1925), DateLiteral(1926)})
-    ) == EqualTo(term="name", literal=literal(63))
+    ) == EqualTo(term="name", literal=63)
 
 
 def test_projection_month_set_in(bound_reference_date: BoundReference) -> None:
     assert MonthTransform().project(
         "name", BoundIn(term=bound_reference_date, literals={DateLiteral(1925), DateLiteral(2925)})
-    ) == In(term="name", literals={literal(96), literal(63)})
+    ) == In(term="name", literals={96, 63})
 
 
 def test_projection_day_month_not_in(bound_reference_date: BoundReference) -> None:
@@ -659,21 +659,21 @@ def test_projection_day_unary(bound_reference_timestamp) -> None:
 def test_projection_day_literal(bound_reference_timestamp) -> None:
     assert DayTransform().project(
         "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(1667696874000))
-    ) == EqualTo(term="name", literal=literal(19))
+    ) == EqualTo(term="name", literal=19)
 
 
 def test_projection_day_set_same_day(bound_reference_timestamp) -> None:
     assert DayTransform().project(
         "name",
         BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1667696874000)}),
-    ) == EqualTo(term="name", literal=literal(19))
+    ) == EqualTo(term="name", literal=19)
 
 
 def test_projection_day_set_in(bound_reference_timestamp) -> None:
     assert DayTransform().project(
         "name",
         BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1567696874000)}),
-    ) == In(term="name", literals={literal(18), literal(19)})
+    ) == In(term="name", literals={18, 19})
 
 
 def test_projection_day_set_not_in(bound_reference_timestamp) -> None:
@@ -687,27 +687,27 @@ def test_projection_day_set_not_in(bound_reference_timestamp) -> None:
 
 
 def test_projection_day_human(bound_reference_date: BoundReference) -> None:
-    date_literal = literal(date(2018, 1, 1))
+    date_literal = DateLiteral(17532)
     assert DayTransform().project("dt", BoundEqualTo(term=bound_reference_date, literal=date_literal)) == EqualTo(
-        term="dt", literal=literal(17532)
+        term="dt", literal=17532
     )  # == 2018, 1, 1
 
     assert DayTransform().project("dt", BoundLessThanOrEqual(term=bound_reference_date, literal=date_literal)) == LessThanOrEqual(
-        term="dt", literal=literal(17532)
+        term="dt", literal=17532
     )  # <= 2018, 1, 1
 
     assert DayTransform().project("dt", BoundLessThan(term=bound_reference_date, literal=date_literal)) == LessThanOrEqual(
-        term="dt", literal=literal(17531)
+        term="dt", literal=17531
     )  # <= 2017, 12, 31
 
     assert DayTransform().project(
         "dt", BoundGreaterThanOrEqual(term=bound_reference_date, literal=date_literal)
     ) == GreaterThanOrEqual(
-        term="dt", literal=literal(17532)
+        term="dt", literal=17532
     )  # >= 2018, 1, 1
 
     assert DayTransform().project("dt", BoundGreaterThan(term=bound_reference_date, literal=date_literal)) == GreaterThanOrEqual(
-        term="dt", literal=literal(17533)
+        term="dt", literal=17533
     )  # >= 2018, 1, 2
 
 
@@ -718,21 +718,21 @@ def test_projection_hour_unary(bound_reference_timestamp) -> None:
 def test_projection_hour_literal(bound_reference_timestamp) -> None:
     assert HourTransform().project(
         "name", BoundEqualTo(term=bound_reference_timestamp, literal=TimestampLiteral(1667696874000))
-    ) == EqualTo(term="name", literal=literal(463))
+    ) == EqualTo(term="name", literal=463)
 
 
 def test_projection_hour_set_same_hour(bound_reference_timestamp) -> None:
     assert HourTransform().project(
         "name",
         BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1667696874000)}),
-    ) == EqualTo(term="name", literal=literal(463))
+    ) == EqualTo(term="name", literal=463)
 
 
 def test_projection_hour_set_in(bound_reference_timestamp) -> None:
     assert HourTransform().project(
         "name",
         BoundIn(term=bound_reference_timestamp, literals={TimestampLiteral(1667696874001), TimestampLiteral(1567696874000)}),
-    ) == In(term="name", literals={literal(435), literal(463)})
+    ) == In(term="name", literals={435, 463})
 
 
 def test_projection_hour_set_not_in(bound_reference_timestamp) -> None:
@@ -819,19 +819,19 @@ def test_projection_truncate_string_set_not_in(bound_reference_str: BoundReferen
 def test_projection_truncate_decimal_literal_eq(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundEqualTo(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
-    ) == EqualTo(term="name", literal=literal(Decimal("19.24")))
+    ) == EqualTo(term="name", literal=Decimal("19.24"))
 
 
 def test_projection_truncate_decimal_literal_gt(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThan(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=literal(Decimal("20.24")))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("20.24"))
 
 
 def test_projection_truncate_decimal_literal_gte(bound_reference_decimal: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThanOrEqual(term=bound_reference_decimal, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=literal(Decimal("19.24")))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("19.24"))
 
 
 def test_projection_truncate_decimal_in(bound_reference_decimal: BoundReference) -> None:
@@ -840,8 +840,8 @@ def test_projection_truncate_decimal_in(bound_reference_decimal: BoundReference)
     ) == In(
         term="name",
         literals={
-            literal(Decimal("19.24")),
-            DecimalLiteral(Decimal("18.14999999999999857891452847979962825775146484374")),
+            Decimal("19.24"),
+            Decimal("18.14999999999999857891452847979962825775146484374"),
         },
     )
 
@@ -849,19 +849,19 @@ def test_projection_truncate_decimal_in(bound_reference_decimal: BoundReference)
 def test_projection_truncate_long_literal_eq(bound_reference_long: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundEqualTo(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
-    ) == EqualTo(term="name", literal=literal(Decimal("19.24")))
+    ) == EqualTo(term="name", literal=Decimal("19.24"))
 
 
 def test_projection_truncate_long_literal_gt(bound_reference_long: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThan(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=literal(Decimal("20.24")))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("20.24"))
 
 
 def test_projection_truncate_long_literal_gte(bound_reference_long: BoundReference) -> None:
     assert TruncateTransform(2).project(
         "name", BoundGreaterThanOrEqual(term=bound_reference_long, literal=DecimalLiteral(Decimal(19.25)))
-    ) == GreaterThanOrEqual(term="name", literal=literal(Decimal("19.24")))
+    ) == GreaterThanOrEqual(term="name", literal=Decimal("19.24"))
 
 
 def test_projection_truncate_long_in(bound_reference_long: BoundReference) -> None:
@@ -870,7 +870,7 @@ def test_projection_truncate_long_in(bound_reference_long: BoundReference) -> No
     ) == In(
         term="name",
         literals={
-            literal(Decimal("19.24")),
-            DecimalLiteral(Decimal("18.14999999999999857891452847979962825775146484374")),
+            Decimal("19.24"),
+            Decimal("18.14999999999999857891452847979962825775146484374"),
         },
     )


### PR DESCRIPTION
- Adds projection for each of the transforms
- Removes the dataclasses from the expressions. I noticed that the IDE didn't like the way we were using the dataclasses in a hierarchical structure: 
![image](https://user-images.githubusercontent.com/1134248/200150958-3634a40c-a530-424c-956d-94b843bb5cb9.png)
It complaints about unexpected arguments. Also, noticed that mypy was struggling with it. I've removed the dataclasses and added the abstract classes. I've implemented the `__eq__` and `__repr__` where required. Also removed some inconsistencies along the way (`In` was expecting a tuple, and `BoundIn` a set).

More tests still to be added