### PR TITLE
Python: Add initial TableScan implementation

### DIFF
--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -403,7 +403,7 @@ class HiveCatalog(Catalog):
             raise NoSuchTableError(f"Table does not exist: {from_table_name}") from e
         except InvalidOperationException as e:
             raise NoSuchNamespaceError(f"Database does not exists: {to_database_name}") from e
-        return Table()
+        return self.load_table(to_identifier)
 
     def create_namespace(self, namespace: Union[str, Identifier], properties: Properties = EMPTY_DICT) -> None:
         """Create a namespace in the catalog.

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -186,7 +186,12 @@ class JsonOutput(Output):
         self._out([".".join(identifier) for identifier in identifiers])
 
     def describe_table(self, table: Table) -> None:
-        print(table.json())
+        print(
+            f"""{
+        "identifier": "{".".join(table.identifier)}",
+        "metadata": {table.metadata.json()},
+        "metadata_location\": "{table.metadata_location}"}"""
+        )
 
     def describe_properties(self, properties: Properties) -> None:
         self._out(properties)

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -47,7 +47,11 @@ class MockCatalog(Catalog):
         sort_order: SortOrder = UNSORTED_SORT_ORDER,
         properties: Properties = EMPTY_DICT,
     ) -> Table:
-        return Table(identifier=identifier, metadata_location="s3://tmp/", metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2))
+        return Table(
+            identifier=Catalog.identifier_to_tuple(identifier),
+            metadata_location="s3://tmp/",
+            metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2),
+        )
 
     def load_table(self, identifier: Union[str, Identifier]) -> Table:
         tuple_identifier = Catalog.identifier_to_tuple(identifier)


### PR DESCRIPTION
This adds an implementation of `TableScan` that is an alternative to the one in #6069. This doesn't implement `plan_files`, it is just to demonstrate a possible scan API.

This scan API works like the Java scan API, but also allows passing scan options when creating an initial scan. Both of these are supported:

```python
scan = table.scan(
    row_filter=In("id", [5, 6, 7]),
    selected_fields=("id", "data"),
    snapshot_id=1234567890
  )
# OR
scan = table.scan() \
    .filter_rows(In("id", [5, 6, 7])) \
    .select("id", "data") \
    .use_snapshot(1234567890)
```

I think this is a reasonable way to get more pythonic (by passing optional arguments) and also mostly match the API and behavior in the JVM implementation.