### PR TITLE
Python: Use pythonic `len()` built-in instead of `length` property

### DIFF
--- a/python/pyiceberg/avro/reader.py
+++ b/python/pyiceberg/avro/reader.py
@@ -216,13 +216,16 @@ class UUIDReader(Reader):
 
 @dataclass(frozen=True)
 class FixedReader(Reader):
-    length: int = dataclassfield()
+    _len: int = dataclassfield()
 
     def read(self, decoder: BinaryDecoder) -> bytes:
-        return decoder.read(self.length)
+        return decoder.read(len(self))
 
     def skip(self, decoder: BinaryDecoder) -> None:
-        decoder.skip(self.length)
+        decoder.skip(len(self))
+
+    def __len__(self):
+        return self._len
 
 
 class BinaryReader(Reader):
@@ -364,7 +367,7 @@ def primitive_reader(primitive: PrimitiveType) -> Reader:
 
 @primitive_reader.register
 def _(primitive: FixedType) -> Reader:
-    return FixedReader(primitive.length)
+    return FixedReader(len(primitive))
 
 
 @primitive_reader.register

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -456,7 +456,7 @@ class FixedLiteral(Literal[bytes]):
 
     @to.register(FixedType)
     def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
-        if len(self.value) == type_var.length:
+        if len(self.value) == len(type_var):
             return self
         else:
             return None
@@ -480,7 +480,7 @@ class BinaryLiteral(Literal[bytes]):
 
     @to.register(FixedType)
     def _(self, type_var: FixedType) -> Optional[Literal[bytes]]:
-        if type_var.length == len(self.value):
+        if len(type_var) == len(self.value):
             return FixedLiteral(self.value)
         else:
             return None

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -304,7 +304,7 @@ def _iceberg_to_pyarrow_type(primitive: PrimitiveType) -> pa.DataType:
 
 @_iceberg_to_pyarrow_type.register
 def _(primitive: FixedType) -> pa.DataType:
-    return pa.binary(primitive.length)
+    return pa.binary(len(primitive))
 
 
 @_iceberg_to_pyarrow_type.register

--- a/python/pyiceberg/types.py
+++ b/python/pyiceberg/types.py
@@ -126,7 +126,7 @@ class FixedType(PrimitiveType):
     """
 
     __root__: str = Field()
-    _length: int = PrivateAttr()
+    _len: int = PrivateAttr()
 
     @staticmethod
     def parse(str_repr: str) -> "FixedType":
@@ -134,14 +134,13 @@ class FixedType(PrimitiveType):
 
     def __init__(self, length: int):
         super().__init__(__root__=f"fixed[{length}]")
-        self._length = length
+        self._len = length
 
-    @property
-    def length(self) -> int:
-        return self._length
+    def __len__(self) -> int:
+        return self._len
 
     def __repr__(self) -> str:
-        return f"FixedType(length={self._length})"
+        return f"FixedType(length={self._len})"
 
 
 class DecimalType(PrimitiveType):

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -100,7 +100,7 @@ def test_is_primitive(input_type, result):
 
 def test_fixed_type():
     type_var = FixedType(length=5)
-    assert type_var.length == 5
+    assert len(type_var) == 5
     assert str(type_var) == "fixed[5]"
     assert repr(type_var) == "FixedType(length=5)"
     assert str(type_var) == str(eval(repr(type_var)))
@@ -401,7 +401,7 @@ def test_deserialization_fixed():
 
     inner = fixed.__root__
     assert isinstance(inner, FixedType)
-    assert inner.length == 22
+    assert len(inner) == 22
 
 
 def test_str_fixed():


### PR DESCRIPTION
* Replaces `.length` property with the pythonic `__len__` method on `FixedReader` and `FixedType` to enable use of `len()` built-in.