### PR TITLE
Python: Make invalid Literal conversions explicit

### DIFF
--- a/python/tests/expressions/test_literals.py
+++ b/python/tests/expressions/test_literals.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+# pylint:disable=eval-used
+
 import datetime
 import uuid
 from decimal import Decimal
@@ -21,15 +23,17 @@ from decimal import Decimal
 import pytest
 
 from pyiceberg.expressions.literals import (
-    AboveMax,
-    BelowMin,
     BinaryLiteral,
     BooleanLiteral,
     DateLiteral,
     DecimalLiteral,
     DoubleLiteral,
     FixedLiteral,
+    FloatAboveMax,
+    FloatBelowMin,
     FloatLiteral,
+    IntAboveMax,
+    IntBelowMin,
     LongLiteral,
     StringLiteral,
     TimeLiteral,
@@ -52,8 +56,6 @@ from pyiceberg.types import (
     TimeType,
     UUIDType,
 )
-
-# Base
 
 
 def test_literal_from_none_error():
@@ -147,11 +149,11 @@ def test_long_to_integer_within_bound():
 def test_long_to_integer_outside_bound():
     big_lit = literal(IntegerType.max + 1).to(LongType())
     above_max_lit = big_lit.to(IntegerType())
-    assert above_max_lit == AboveMax()
+    assert above_max_lit == IntAboveMax()
 
     small_lit = literal(IntegerType.min - 1).to(LongType())
     below_min_lit = small_lit.to(IntegerType())
-    assert below_min_lit == BelowMin()
+    assert below_min_lit == IntBelowMin()
 
 
 def test_long_to_float_conversion():
@@ -218,11 +220,11 @@ def test_double_to_float_within_bound():
 def test_double_to_float_outside_bound():
     big_lit = literal(FloatType.max + 1.0e37).to(DoubleType())
     above_max_lit = big_lit.to(FloatType())
-    assert above_max_lit == AboveMax()
+    assert above_max_lit == FloatAboveMax()
 
     small_lit = literal(FloatType.min - 1.0e37).to(DoubleType())
     below_min_lit = small_lit.to(FloatType())
-    assert below_min_lit == BelowMin()
+    assert below_min_lit == FloatBelowMin()
 
 
 @pytest.mark.parametrize(
@@ -239,9 +241,15 @@ def test_decimal_to_decimal_conversion():
 
     assert lit.value.as_tuple() == lit.to(DecimalType(9, 2)).value.as_tuple()
     assert lit.value.as_tuple() == lit.to(DecimalType(11, 2)).value.as_tuple()
-    assert lit.to(DecimalType(9, 0)) is None
-    assert lit.to(DecimalType(9, 1)) is None
-    assert lit.to(DecimalType(9, 3)) is None
+    with pytest.raises(ValueError) as e:
+        _ = lit.to(DecimalType(9, 0))
+    assert "Could not convert 34.11 into a decimal(9, 0)" in str(e.value)
+    with pytest.raises(ValueError) as e:
+        _ = lit.to(DecimalType(9, 1))
+    assert "Could not convert 34.11 into a decimal(9, 1)" in str(e.value)
+    with pytest.raises(ValueError) as e:
+        _ = lit.to(DecimalType(9, 3))
+    assert "Could not convert 34.11 into a decimal(9, 3)" in str(e.value)
 
 
 def test_timestamp_to_date():
@@ -251,14 +259,14 @@ def test_timestamp_to_date():
     assert date_lit.value == 0
 
 
-# STRING
-
-
 def test_string_literal():
     sqrt2 = literal("1.414").to(StringType())
     pi = literal("3.141").to(StringType())
     pi_string_lit = StringLiteral("3.141")
     pi_double_lit = literal(3.141).to(DoubleType())
+
+    assert literal("3.141").to(IntegerType()) == literal(3)
+    assert literal("3.141").to(LongType()) == literal(3)
 
     assert sqrt2 != pi
     assert pi != pi_double_lit
@@ -312,12 +320,16 @@ def test_string_to_timestamp_literal():
 
 def test_timestamp_with_zone_without_zone_in_literal():
     timestamp_str = literal("2017-08-18T14:21:01.919234")
-    assert timestamp_str.to(TimestamptzType()) is None
+    with pytest.raises(ValueError) as e:
+        _ = timestamp_str.to(timestamp_str.to(TimestamptzType()))
+    assert "Invalid timestamp with zone: 2017-08-18T14:21:01.919234 (must be ISO-8601)" in str(e.value)
 
 
 def test_timestamp_without_zone_with_zone_in_literal():
     timestamp_str = literal("2017-08-18T14:21:01.919234+07:00")
-    assert timestamp_str.to(TimestampType()) is None
+    with pytest.raises(ValueError) as e:
+        _ = timestamp_str.to(TimestampType())
+    assert "Could not convert 2017-08-18T14:21:01.919234+07:00 into a timestamp" in str(e.value)
 
 
 def test_string_to_uuid_literal():
@@ -431,12 +443,18 @@ def test_binary_to_fixed():
     fixed_lit = lit.to(FixedType(3))
     assert fixed_lit is not None
     assert lit.value == fixed_lit.value
-    assert lit.to(FixedType(4)) is None
+
+    with pytest.raises(TypeError) as e:
+        _ = lit.to(FixedType(4))
+    assert "Cannot convert BinaryLiteral into fixed[4], different length: 4 <> 3" in str(e.value)
 
 
 def test_binary_to_smaller_fixed_none():
     lit = literal(bytearray([0x00, 0x01, 0x02]))
-    assert lit.to(FixedType(2)) is None
+
+    with pytest.raises(TypeError) as e:
+        _ = lit.to(FixedType(2))
+    assert "Cannot convert BinaryLiteral into fixed[2], different length: 2 <> 3" in str(e.value)
 
 
 def test_fixed_to_binary():
@@ -448,35 +466,61 @@ def test_fixed_to_binary():
 
 def test_fixed_to_smaller_fixed_none():
     lit = literal(bytearray([0x00, 0x01, 0x02])).to(FixedType(3))
-    assert lit.to(FixedType(2)) is None
-
-
-def test_above_max():
-    a = AboveMax()
-    # singleton
-    assert a == AboveMax()
-    assert str(a) == "AboveMax"
-    assert repr(a) == "AboveMax()"
     with pytest.raises(ValueError) as e:
-        a.value()
-    assert "AboveMax has no value" in str(e.value)
+        lit.to(lit.to(FixedType(2)))
+    assert "Could not convert b'\\x00\\x01\\x02' into a fixed[2]" in str(e.value)
+
+
+def test_above_max_float():
+    a = FloatAboveMax()
+    # singleton
+    assert a == FloatAboveMax()
+    assert str(a) == "FloatAboveMax"
+    assert repr(a) == "FloatAboveMax()"
+    assert a.value == FloatType.max
+    assert a == eval(repr(a))
     with pytest.raises(TypeError) as e:
         a.to(IntegerType())
-    assert "Cannot change the type of AboveMax" in str(e.value)
+    assert "Cannot change the type of FloatAboveMax" in str(e.value)
 
 
-def test_below_min():
-    b = BelowMin()
+def test_below_min_float():
+    b = FloatBelowMin()
     # singleton
-    assert b == BelowMin()
-    assert str(b) == "BelowMin"
-    assert repr(b) == "BelowMin()"
-    with pytest.raises(ValueError) as e:
-        b.value()
-    assert "BelowMin has no value" in str(e.value)
+    assert b == FloatBelowMin()
+    assert str(b) == "FloatBelowMin"
+    assert repr(b) == "FloatBelowMin()"
+    assert b == eval(repr(b))
+    assert b.value == FloatType.min
     with pytest.raises(TypeError) as e:
         b.to(IntegerType())
-    assert "Cannot change the type of BelowMin" in str(e.value)
+    assert "Cannot change the type of FloatBelowMin" in str(e.value)
+
+
+def test_above_max_int():
+    a = IntAboveMax()
+    # singleton
+    assert a == IntAboveMax()
+    assert str(a) == "IntAboveMax"
+    assert repr(a) == "IntAboveMax()"
+    assert a.value == IntegerType.max
+    assert a == eval(repr(a))
+    with pytest.raises(TypeError) as e:
+        a.to(IntegerType())
+    assert "Cannot change the type of IntAboveMax" in str(e.value)
+
+
+def test_below_min_int():
+    b = IntBelowMin()
+    # singleton
+    assert b == IntBelowMin()
+    assert str(b) == "IntBelowMin"
+    assert repr(b) == "IntBelowMin()"
+    assert b == eval(repr(b))
+    assert b.value == IntegerType.min
+    with pytest.raises(TypeError) as e:
+        b.to(IntegerType())
+    assert "Cannot change the type of IntBelowMin" in str(e.value)
 
 
 def test_invalid_boolean_conversions():
@@ -531,7 +575,8 @@ def test_invalid_long_conversions():
     ],
 )
 def test_invalid_float_conversions(lit, test_type):
-    assert lit.to(test_type) is None
+    with pytest.raises(TypeError):
+        _ = lit.to(test_type)
 
 
 @pytest.mark.parametrize("lit", [literal("2017-08-18").to(DateType())])
@@ -597,6 +642,13 @@ def test_invalid_timestamp_conversions():
     )
 
 
+def test_invalid_decimal_conversion_scale():
+    lit = literal(Decimal("34.11"))
+    with pytest.raises(ValueError) as e:
+        lit.to(DecimalType(9, 4))
+    assert "Could not convert 34.11 into a decimal(9, 4)" in str(e.value)
+
+
 def test_invalid_decimal_conversions():
     assert_invalid_conversions(
         literal(Decimal("34.11")),
@@ -610,7 +662,6 @@ def test_invalid_decimal_conversions():
             TimeType(),
             TimestampType(),
             TimestamptzType(),
-            DecimalType(9, 4),
             StringType(),
             UUIDType(),
             FixedType(1),
@@ -622,7 +673,7 @@ def test_invalid_decimal_conversions():
 def test_invalid_string_conversions():
     assert_invalid_conversions(
         literal("abc"),
-        [BooleanType(), IntegerType(), LongType(), FloatType(), DoubleType(), FixedType(1), BinaryType()],
+        [BooleanType(), FloatType(), DoubleType(), FixedType(1), BinaryType()],
     )
 
 
@@ -689,4 +740,5 @@ def test_invalid_binary_conversions():
 
 def assert_invalid_conversions(lit, types=None):
     for type_var in types:
-        assert lit.to(type_var) is None
+        with pytest.raises(TypeError):
+            _ = lit.to(type_var)


### PR DESCRIPTION
Currently, we silently turn Literals into `None` if we can't convert them, instead I prefer to raise an exception. This can cause silent bugs like: `EqualTo(Reference("id"), StringLiteral("123a"))` will turn into a `IsNull` predicate since `123a` cannot be casted to a `Long` (assuming that the `id` column is a Long). 

This PR also:
- Adds support for casting a `StringLiteral` to a `LongLiteral`
- Also fixed the return types. The type checker couldn't work with it, so it was silently ignored. Now it works again by adding the annotations. The main `to` in the superclass returns a literal, therefore `AboveMax` and `BelowMin` also need to be literal. We can also turn this into a `Union[Literal, AboveMin, AboveMax]`.

~~Blocked on https://github.com/apache/iceberg/pull/6140~~