### PR TITLE
Python: Pin mypy in Python Legacy

### DIFF
--- a/python_legacy/tox.ini
+++ b/python_legacy/tox.ini
@@ -59,7 +59,7 @@ commands =
 basepython = python3
 skip_install = true
 deps =
-    mypy
+    mypy==0.982
     types-pytz
     types-python-dateutil
 commands =


### PR DESCRIPTION
The CI is failing because a new version of mypy has been released yesterday: https://pypi.org/project/mypy/0.982/