### PR TITLE
Core: Sync client/server properties in REST catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -749,11 +749,15 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   private static ConfigResponse fetchConfig(
       RESTClient client, Map<String, String> headers, Map<String, String> properties) {
     // send the client's warehouse location to the service to keep in sync
-    // this is needed for cases where the warehouse is configured client side, but may be used on the server side,
-    // like the Hive Metastore, where both client and service hive-site.xml may have a warehouse location.
+    // this is needed for cases where the warehouse is configured client side, but may be used on
+    // the server side,
+    // like the Hive Metastore, where both client and service hive-site.xml may have a warehouse
+    // location.
     ImmutableMap.Builder<String, String> queryParams = ImmutableMap.builder();
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
-      queryParams.put(CatalogProperties.WAREHOUSE_LOCATION, properties.get(CatalogProperties.WAREHOUSE_LOCATION));
+      queryParams.put(
+          CatalogProperties.WAREHOUSE_LOCATION,
+          properties.get(CatalogProperties.WAREHOUSE_LOCATION));
     }
 
     ConfigResponse configResponse =

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -227,7 +227,12 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                   responseType,
                   ConfigResponse.builder()
                       .withDefaults(ImmutableMap.of(CatalogProperties.CLIENT_POOL_SIZE, "1"))
-                      .withOverrides(ImmutableMap.of(CatalogProperties.CACHE_ENABLED, "false"))
+                      .withOverrides(
+                          ImmutableMap.of(
+                              CatalogProperties.CACHE_ENABLED,
+                              "false",
+                              CatalogProperties.WAREHOUSE_LOCATION,
+                              queryParams.get(CatalogProperties.WAREHOUSE_LOCATION) + "warehouse"))
                       .build());
             }
             return super.get(path, queryParams, responseType, headers, errorHandler);
@@ -238,7 +243,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Map<String, String> initialConfig =
         ImmutableMap.of(
             CatalogProperties.URI, "http://localhost:8080",
-            CatalogProperties.CACHE_ENABLED, "true");
+            CatalogProperties.CACHE_ENABLED, "true",
+            CatalogProperties.WAREHOUSE_LOCATION, "s3://bucket/");
 
     restCat.setConf(new Configuration());
     restCat.initialize("prod", initialConfig);
@@ -252,6 +258,12 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         "Catalog after initialize should use the server's default properties if not specified",
         "1",
         restCat.properties().get(CatalogProperties.CLIENT_POOL_SIZE));
+
+    Assert.assertEquals(
+        "Catalog should return final warehouse location",
+        "s3://bucket/warehouse",
+        restCat.properties().get(CatalogProperties.WAREHOUSE_LOCATION));
+
     restCat.close();
   }
 


### PR DESCRIPTION
This PR adds query params to the REST config route that are used to sync configuration between the REST client and service.

Right now, this sends the only client catalog property that needs to be in sync between the client and service, the warehouse location. Iceberg catalogs allow setting the warehouse location as standard catalog config on the client. This introduces a problem when using those catalog implementations behind the REST API because the service doesn't know what the client's warehouse location was set to.

To keep the client config in sync, this sends the properties to the config route, where the service can choose how to handle the client config. In the tests, the service overrides the client's warehouse config to ensure the two are in sync.