### PR TITLE
Core: Rename HMS_TABLE_OWNER to follow naming convention

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -360,5 +360,5 @@ public class TableProperties {
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
 
-  public static final String HMS_TABLE_OWNER = "hms_table_owner";
+  public static final String HMS_TABLE_OWNER = "hive.metastore.table.owner";
 }


### PR DESCRIPTION
I introduced this property in #5763, however, I learned since that its value doesn't follow the naming conventions for a table property. Fortunately the change hasn't been released yet so we can safely change this property before we release 1.1.0. and won't hurt backward compatibility.