### PR TITLE
Python: CI poetry cache

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -43,9 +43,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install poetry
+      run: pip install poetry
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
+        cache: poetry
+        cache-dependency-path: |
+          ./python/poetry.lock
     - name: Install
       working-directory: ./python
       run: make install


### PR DESCRIPTION
The `setup-python@v4` action supports caching for poetry lock files as shown over here: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages