### PR TITLE
Flink: Port #6049 to Flink 1.14 to add Sink options of compression properties

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -93,6 +93,66 @@ public class FlinkWriteConf {
         .parse();
   }
 
+  public String parquetCompressionCodec() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_CODEC.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_CODEC)
+        .tableProperty(TableProperties.PARQUET_COMPRESSION)
+        .defaultValue(TableProperties.PARQUET_COMPRESSION_DEFAULT)
+        .parse();
+  }
+
+  public String parquetCompressionLevel() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_LEVEL.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_LEVEL)
+        .tableProperty(TableProperties.PARQUET_COMPRESSION_LEVEL)
+        .defaultValue(TableProperties.PARQUET_COMPRESSION_LEVEL_DEFAULT)
+        .parseOptional();
+  }
+
+  public String avroCompressionCodec() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_CODEC.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_CODEC)
+        .tableProperty(TableProperties.AVRO_COMPRESSION)
+        .defaultValue(TableProperties.AVRO_COMPRESSION_DEFAULT)
+        .parse();
+  }
+
+  public String avroCompressionLevel() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_LEVEL.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_LEVEL)
+        .tableProperty(TableProperties.AVRO_COMPRESSION_LEVEL)
+        .defaultValue(TableProperties.AVRO_COMPRESSION_LEVEL_DEFAULT)
+        .parseOptional();
+  }
+
+  public String orcCompressionCodec() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_CODEC.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_CODEC)
+        .tableProperty(TableProperties.ORC_COMPRESSION)
+        .defaultValue(TableProperties.ORC_COMPRESSION_DEFAULT)
+        .parse();
+  }
+
+  public String orcCompressionStrategy() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.COMPRESSION_STRATEGY.key())
+        .flinkConfig(FlinkWriteOptions.COMPRESSION_STRATEGY)
+        .tableProperty(TableProperties.ORC_COMPRESSION_STRATEGY)
+        .defaultValue(TableProperties.ORC_COMPRESSION_STRATEGY_DEFAULT)
+        .parse();
+  }
+
   public DistributionMode distributionMode() {
     String modeName =
         confParser

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -34,6 +34,18 @@ public class FlinkWriteOptions {
   public static final ConfigOption<Long> TARGET_FILE_SIZE_BYTES =
       ConfigOptions.key("target-file-size-bytes").longType().noDefaultValue();
 
+  // Overrides this table's write.<FILE_FORMAT>.compression-codec
+  public static final ConfigOption<String> COMPRESSION_CODEC =
+      ConfigOptions.key("compression-codec").stringType().noDefaultValue();
+
+  // Overrides this table's write.<FILE_FORMAT>.compression-level
+  public static final ConfigOption<String> COMPRESSION_LEVEL =
+      ConfigOptions.key("compression-level").stringType().noDefaultValue();
+
+  // Overrides this table's write.<FILE_FORMAT>.compression-strategy
+  public static final ConfigOption<String> COMPRESSION_STRATEGY =
+      ConfigOptions.key("compression-strategy").stringType().noDefaultValue();
+
   // Overrides this table's write.upsert.enabled
   public static final ConfigOption<Boolean> WRITE_UPSERT_ENABLED =
       ConfigOptions.key("upsert-enabled").booleanType().noDefaultValue();

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -57,6 +58,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
       RowType flinkSchema,
       long targetFileSizeBytes,
       FileFormat format,
+      Map<String, String> writeProperties,
       List<Integer> equalityFieldIds,
       boolean upsert) {
     this.table = table;
@@ -70,8 +72,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     this.upsert = upsert;
 
     if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
-      this.appenderFactory =
-          new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec);
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, writeProperties, spec);
     } else if (upsert) {
       // In upsert mode, only the new row is emitted using INSERT row kind. Therefore, any column of
       // the inserted row
@@ -82,7 +83,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
           new FlinkAppenderFactory(
               schema,
               flinkSchema,
-              table.properties(),
+              writeProperties,
               spec,
               ArrayUtil.toIntArray(equalityFieldIds),
               TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds)),
@@ -92,7 +93,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
           new FlinkAppenderFactory(
               schema,
               flinkSchema,
-              table.properties(),
+              writeProperties,
               spec,
               ArrayUtil.toIntArray(equalityFieldIds),
               schema,

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -77,7 +77,13 @@ public class RowDataRewriter {
     RowType flinkSchema = FlinkSchemaUtil.convert(table.schema());
     this.taskWriterFactory =
         new RowDataTaskWriterFactory(
-            SerializableTable.copyOf(table), flinkSchema, Long.MAX_VALUE, format, null, false);
+            SerializableTable.copyOf(table),
+            flinkSchema,
+            Long.MAX_VALUE,
+            format,
+            table.properties(),
+            null,
+            false);
   }
 
   public List<DataFile> rewriteDataForTasks(

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.common.DynFields;
+import org.apache.iceberg.flink.FlinkWriteConf;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.io.BaseTaskWriter;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestCompressionSettings {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  private Table table;
+
+  private final Map<String, String> initProperties;
+
+  @Parameterized.Parameters(name = "tableProperties = {0}")
+  public static Object[] parameters() {
+    return new Object[] {
+      ImmutableMap.of(),
+      ImmutableMap.of(
+          TableProperties.AVRO_COMPRESSION,
+          "zstd",
+          TableProperties.AVRO_COMPRESSION_LEVEL,
+          "3",
+          TableProperties.PARQUET_COMPRESSION,
+          "zstd",
+          TableProperties.PARQUET_COMPRESSION_LEVEL,
+          "3",
+          TableProperties.ORC_COMPRESSION,
+          "zstd",
+          TableProperties.ORC_COMPRESSION_STRATEGY,
+          "compression")
+    };
+  }
+
+  public TestCompressionSettings(Map<String, String> initProperties) {
+    this.initProperties = initProperties;
+  }
+
+  @Before
+  public void before() throws IOException {
+    File folder = tempFolder.newFolder();
+    table = SimpleDataUtil.createTable(folder.getAbsolutePath(), initProperties, false);
+  }
+
+  @Test
+  public void testCompressionAvro() throws Exception {
+    // No override provided
+    Map<String, String> resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(FlinkWriteOptions.WRITE_FORMAT.key(), "AVRO"));
+
+    if (initProperties.get(TableProperties.AVRO_COMPRESSION) == null) {
+      Assert.assertEquals(
+          TableProperties.AVRO_COMPRESSION_DEFAULT,
+          resultProperties.get(TableProperties.AVRO_COMPRESSION));
+      Assert.assertEquals(
+          TableProperties.AVRO_COMPRESSION_LEVEL_DEFAULT,
+          resultProperties.get(TableProperties.AVRO_COMPRESSION_LEVEL));
+    } else {
+      Assert.assertEquals(
+          initProperties.get(TableProperties.AVRO_COMPRESSION),
+          resultProperties.get(TableProperties.AVRO_COMPRESSION));
+      Assert.assertEquals(
+          initProperties.get(TableProperties.AVRO_COMPRESSION_LEVEL),
+          resultProperties.get(TableProperties.AVRO_COMPRESSION_LEVEL));
+    }
+
+    // Override compression to snappy and some random level
+    resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(
+                FlinkWriteOptions.WRITE_FORMAT.key(),
+                "AVRO",
+                FlinkWriteOptions.COMPRESSION_CODEC.key(),
+                "snappy",
+                FlinkWriteOptions.COMPRESSION_LEVEL.key(),
+                "6"));
+
+    Assert.assertEquals("snappy", resultProperties.get(TableProperties.AVRO_COMPRESSION));
+    Assert.assertEquals("6", resultProperties.get(TableProperties.AVRO_COMPRESSION_LEVEL));
+  }
+
+  @Test
+  public void testCompressionParquet() throws Exception {
+    // No override provided
+    Map<String, String> resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(FlinkWriteOptions.WRITE_FORMAT.key(), "PARQUET"));
+
+    if (initProperties.get(TableProperties.PARQUET_COMPRESSION) == null) {
+      Assert.assertEquals(
+          TableProperties.PARQUET_COMPRESSION_DEFAULT,
+          resultProperties.get(TableProperties.PARQUET_COMPRESSION));
+      Assert.assertEquals(
+          TableProperties.PARQUET_COMPRESSION_LEVEL_DEFAULT,
+          resultProperties.get(TableProperties.PARQUET_COMPRESSION_LEVEL));
+    } else {
+      Assert.assertEquals(
+          initProperties.get(TableProperties.PARQUET_COMPRESSION),
+          resultProperties.get(TableProperties.PARQUET_COMPRESSION));
+      Assert.assertEquals(
+          initProperties.get(TableProperties.PARQUET_COMPRESSION_LEVEL),
+          resultProperties.get(TableProperties.PARQUET_COMPRESSION_LEVEL));
+    }
+
+    // Override compression to snappy and some random level
+    resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(
+                FlinkWriteOptions.WRITE_FORMAT.key(),
+                "PARQUET",
+                FlinkWriteOptions.COMPRESSION_CODEC.key(),
+                "snappy",
+                FlinkWriteOptions.COMPRESSION_LEVEL.key(),
+                "6"));
+
+    Assert.assertEquals("snappy", resultProperties.get(TableProperties.PARQUET_COMPRESSION));
+    Assert.assertEquals("6", resultProperties.get(TableProperties.PARQUET_COMPRESSION_LEVEL));
+  }
+
+  @Test
+  public void testCompressionOrc() throws Exception {
+    // No override provided
+    Map<String, String> resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(FlinkWriteOptions.WRITE_FORMAT.key(), "ORC"));
+
+    if (initProperties.get(TableProperties.ORC_COMPRESSION) == null) {
+      Assert.assertEquals(
+          TableProperties.ORC_COMPRESSION_DEFAULT,
+          resultProperties.get(TableProperties.ORC_COMPRESSION));
+      Assert.assertEquals(
+          TableProperties.ORC_COMPRESSION_STRATEGY_DEFAULT,
+          resultProperties.get(TableProperties.ORC_COMPRESSION_STRATEGY));
+    } else {
+      Assert.assertEquals(
+          initProperties.get(TableProperties.ORC_COMPRESSION),
+          resultProperties.get(TableProperties.ORC_COMPRESSION));
+      Assert.assertEquals(
+          initProperties.get(TableProperties.ORC_COMPRESSION_STRATEGY),
+          resultProperties.get(TableProperties.ORC_COMPRESSION_STRATEGY));
+    }
+
+    // Override compression to snappy and a different strategy
+    resultProperties =
+        appenderProperties(
+            table,
+            SimpleDataUtil.FLINK_SCHEMA,
+            ImmutableMap.of(
+                FlinkWriteOptions.WRITE_FORMAT.key(),
+                "ORC",
+                FlinkWriteOptions.COMPRESSION_CODEC.key(),
+                "snappy",
+                FlinkWriteOptions.COMPRESSION_STRATEGY.key(),
+                "speed"));
+
+    Assert.assertEquals("snappy", resultProperties.get(TableProperties.ORC_COMPRESSION));
+    Assert.assertEquals("speed", resultProperties.get(TableProperties.ORC_COMPRESSION_STRATEGY));
+  }
+
+  private static OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
+      Table icebergTable, TableSchema flinkSchema, Map<String, String> override) throws Exception {
+    RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
+    FlinkWriteConf flinkWriteConfig =
+        new FlinkWriteConf(
+            icebergTable, override, new org.apache.flink.configuration.Configuration());
+
+    IcebergStreamWriter<RowData> streamWriter =
+        FlinkSink.createStreamWriter(icebergTable, flinkWriteConfig, flinkRowType, null);
+    OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
+        new OneInputStreamOperatorTestHarness<>(streamWriter, 1, 1, 0);
+
+    harness.setup();
+    harness.open();
+
+    return harness;
+  }
+
+  private static Map<String, String> appenderProperties(
+      Table table, TableSchema schema, Map<String, String> override) throws Exception {
+    try (OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness =
+        createIcebergStreamWriter(table, schema, override)) {
+      testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 1);
+
+      testHarness.prepareSnapshotPreBarrier(1L);
+      DynFields.BoundField<IcebergStreamWriter> operatorField =
+          DynFields.builder()
+              .hiddenImpl(testHarness.getOperatorFactory().getClass(), "operator")
+              .build(testHarness.getOperatorFactory());
+      DynFields.BoundField<TaskWriter> writerField =
+          DynFields.builder()
+              .hiddenImpl(IcebergStreamWriter.class, "writer")
+              .build(operatorField.get());
+      DynFields.BoundField<FlinkAppenderFactory> appenderField =
+          DynFields.builder()
+              .hiddenImpl(BaseTaskWriter.class, "appenderFactory")
+              .build(writerField.get());
+      DynFields.BoundField<Map<String, String>> propsField =
+          DynFields.builder()
+              .hiddenImpl(FlinkAppenderFactory.class, "props")
+              .build(appenderField.get());
+      return propsField.get();
+    }
+  }
+}

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -345,6 +345,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
         FlinkSchemaUtil.convert(table.schema()),
         128 * 1024 * 1024,
         format,
+        table.properties(),
         equalityFieldIds,
         false);
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -237,6 +237,7 @@ public class TestTaskWriters {
             (RowType) SimpleDataUtil.FLINK_SCHEMA.toRowDataType().getLogicalType(),
             targetFileSize,
             format,
+            table.properties(),
             null,
             false);
     taskWriterFactory.initialize(1, 1);

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestProjectMetaColumn.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestProjectMetaColumn.java
@@ -176,6 +176,7 @@ public class TestProjectMetaColumn {
             SimpleDataUtil.ROW_TYPE,
             TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
             format,
+            table.properties(),
             equalityFieldIds,
             upsert);
 


### PR DESCRIPTION
Flink: Port #6049 to Flink 1.14 in order to add Sink options of compression properties.
These codes has been included in Flink 1.16 since #6092.
