### PR TITLE
Python: Move FileIO initialization to the catalog

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -29,6 +29,7 @@ from typing import (
 )
 
 from pyiceberg.exceptions import NotInstalledError
+from pyiceberg.io import FileIO, load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.table.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionSpec
@@ -161,6 +162,9 @@ class Catalog(ABC):
     def __init__(self, name: str, **properties: str):
         self.name = name
         self.properties = properties
+
+    def _load_file_io(self, properties: Properties = EMPTY_DICT) -> FileIO:
+        return load_file_io({**self.properties, **properties})
 
     @abstractmethod
     def create_table(

--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -259,7 +259,7 @@ class HiveCatalog(Catalog):
             identifier=(table.dbName, table.tableName),
             metadata=metadata,
             metadata_location=metadata_location,
-            catalog_properties=self.properties,
+            io=self._load_file_io(metadata.properties),
         )
 
     def _write_metadata(self, metadata: TableMetadata, io: FileIO, metadata_path: str):

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -368,8 +368,7 @@ class RestCatalog(Catalog):
             identifier=(self.name,) + self.identifier_to_tuple(identifier),
             metadata_location=table_response.metadata_location,
             metadata=table_response.metadata,
-            catalog_properties=self.properties,
-            config=table_response.config,
+            io=self._load_file_io({**table_response.metadata.properties, **table_response.config}),
         )
 
     def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
@@ -399,8 +398,7 @@ class RestCatalog(Catalog):
             identifier=(self.name,) + identifier_tuple if self.name else identifier_tuple,
             metadata_location=table_response.metadata_location,
             metadata=table_response.metadata,
-            catalog_properties=self.properties,
-            config=table_response.config,
+            io=self._load_file_io({**table_response.metadata.properties, **table_response.config}),
         )
 
     def drop_table(self, identifier: Union[str, Identifier], purge_requested: bool = False) -> None:

--- a/python/pyiceberg/io/__init__.py
+++ b/python/pyiceberg/io/__init__.py
@@ -281,7 +281,7 @@ def _infer_file_io_from_schema(path: str, properties: Properties) -> Optional[Fi
     return None
 
 
-def load_file_io(properties: Properties, location: Optional[str] = None) -> FileIO:
+def load_file_io(properties: Properties = EMPTY_DICT, location: Optional[str] = None) -> FileIO:
     # First look for the py-io-impl property to directly load the class
     if io_impl := properties.get(PY_IO_IMPL):
         if file_io := _import_file_io(io_impl, properties):

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import (
     Any,
     Dict,
@@ -28,7 +27,7 @@ from typing import (
 from pydantic import Field
 
 from pyiceberg.expressions import AlwaysTrue, And, BooleanExpression
-from pyiceberg.io import FileIO, load_file_io
+from pyiceberg.io import FileIO
 from pyiceberg.schema import Schema
 from pyiceberg.table.metadata import TableMetadata
 from pyiceberg.table.partitioning import PartitionSpec
@@ -41,22 +40,13 @@ class Table:
     identifier: Identifier = Field()
     metadata: TableMetadata = Field()
     metadata_location: str = Field()
-    catalog_properties: Properties
-    config: Properties
+    io: FileIO
 
-    def __init__(
-        self,
-        identifier: Identifier,
-        metadata: TableMetadata,
-        metadata_location: str,
-        catalog_properties: Properties = EMPTY_DICT,
-        config: Properties = EMPTY_DICT,
-    ):
+    def __init__(self, identifier: Identifier, metadata: TableMetadata, metadata_location: str, io: FileIO):
         self.identifier = identifier
         self.metadata = metadata
         self.metadata_location = metadata_location
-        self.catalog_properties = catalog_properties
-        self.config = config
+        self.io = io
 
     def refresh(self):
         """Refresh the current table metadata"""
@@ -137,10 +127,6 @@ class Table:
     def history(self) -> List[SnapshotLogEntry]:
         """Get the snapshot history of this table."""
         return self.metadata.snapshot_log
-
-    @cached_property
-    def io(self) -> FileIO:
-        return load_file_io({**self.catalog_properties, **self.metadata.properties, **self.config})
 
     def __eq__(self, other: Any) -> bool:
         return (

--- a/python/tests/catalog/test_base.py
+++ b/python/tests/catalog/test_base.py
@@ -38,6 +38,7 @@ from pyiceberg.exceptions import (
     NoSuchTableError,
     TableAlreadyExistsError,
 )
+from pyiceberg.io import load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.table.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
@@ -81,6 +82,7 @@ class InMemoryCatalog(Catalog):
                 identifier=identifier,
                 metadata=EXAMPLE_TABLE_METADATA_V1,
                 metadata_location=f's3://warehouse/{"/".join(identifier)}/metadata/metadata.json',
+                io=load_file_io(),
             )
             self.__tables[identifier] = table
             return table
@@ -115,7 +117,10 @@ class InMemoryCatalog(Catalog):
             self.__namespaces[to_namespace] = {}
 
         self.__tables[to_identifier] = Table(
-            identifier=to_identifier, metadata=table.metadata, metadata_location=table.metadata_location
+            identifier=to_identifier,
+            metadata=table.metadata,
+            metadata_location=table.metadata_location,
+            io=load_file_io(),
         )
         return self.__tables[to_identifier]
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -30,6 +30,7 @@ from pyiceberg.exceptions import (
     OAuthError,
     TableAlreadyExistsError,
 )
+from pyiceberg.io import load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table.metadata import TableMetadataV1
 from pyiceberg.table.partitioning import PartitionField, PartitionSpec
@@ -439,7 +440,7 @@ def test_load_table_200(rest_mock: Mocker):
             ),
             partition_spec=[],
         ),
-        config={"client.factory": "io.tabular.iceberg.catalog.TabularAwsClientFactory", "region": "us-west-2"},
+        io=load_file_io(),
     )
     assert actual == expected
 
@@ -594,6 +595,7 @@ def test_create_table_200(rest_mock: Mocker, table_schema_simple: Schema):
             ),
             partition_spec=[],
         ),
+        io=load_file_io(),
     )
 
 

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -28,6 +28,7 @@ from click.testing import CliRunner
 from pyiceberg.catalog import Catalog, PropertiesUpdateSummary
 from pyiceberg.cli.console import run
 from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchTableError
+from pyiceberg.io import load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 from pyiceberg.table.metadata import TableMetadataV2
@@ -51,6 +52,7 @@ class MockCatalog(Catalog):
             identifier=Catalog.identifier_to_tuple(identifier),
             metadata_location="s3://tmp/",
             metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2),
+            io=load_file_io(),
         )
 
     def load_table(self, identifier: Union[str, Identifier]) -> Table:
@@ -60,6 +62,7 @@ class MockCatalog(Catalog):
                 identifier=tuple_identifier,
                 metadata_location="s3://tmp/",
                 metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2),
+                io=load_file_io(),
             )
         else:
             raise NoSuchTableError(f"Table does not exist: {'.'.join(tuple_identifier)}")
@@ -78,7 +81,10 @@ class MockCatalog(Catalog):
         tuple_identifier = Catalog.identifier_to_tuple(from_identifier)
         if tuple_identifier == ("default", "foo"):
             return Table(
-                identifier=tuple_identifier, metadata_location="s3://tmp/", metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2)
+                identifier=tuple_identifier,
+                metadata_location="s3://tmp/",
+                metadata=TableMetadataV2(**EXAMPLE_TABLE_METADATA_V2),
+                io=load_file_io(),
             )
         else:
             raise NoSuchTableError(f"Table does not exist: {from_identifier}")

--- a/python/tests/table/test_init.py
+++ b/python/tests/table/test_init.py
@@ -25,6 +25,7 @@ from pyiceberg.expressions import (
     EqualTo,
     In,
 )
+from pyiceberg.io import load_file_io
 from pyiceberg.schema import Schema
 from pyiceberg.table import PartitionSpec, Table
 from pyiceberg.table.metadata import TableMetadataV2
@@ -52,6 +53,7 @@ def table(example_table_metadata_v2: Dict[str, Any]) -> Table:
         identifier=("database", "table"),
         metadata=table_metadata,
         metadata_location=f"{table_metadata.location}/uuid.metadata.json",
+        io=load_file_io(),
     )
 
 


### PR DESCRIPTION
Follow up on: https://github.com/apache/iceberg/pull/6161#discussion_r1018547445

Another option is to move it to the constructor of the Table and not store the properties.