### PR TITLE
Fix typo in unused python iceberg paramter

### DIFF
--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -153,7 +153,7 @@ PROP_PREVIOUS_METADATA_LOCATION = "previous_metadata_location"
 def _construct_parameters(metadata_location: str, previous_metadata_location: Optional[str] = None) -> Dict[str, Any]:
     properties = {PROP_EXTERNAL: "TRUE", PROP_TABLE_TYPE: "ICEBERG", PROP_METADATA_LOCATION: metadata_location}
     if previous_metadata_location:
-        properties[previous_metadata_location] = previous_metadata_location
+        properties[PROP_PREVIOUS_METADATA_LOCATION] = previous_metadata_location
 
     return properties
 


### PR DESCRIPTION
I happened to notice this typo, which seems obviously wrong. The code isn't yet exercised anywhere so it's not a big deal but figured I might as well fix it.