### PR TITLE
AWS: Re-tag files when renaming tables in GlueCatalog

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -756,7 +756,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
                 }
                 updateFilesTag(io, pathsToUpdated, "data", false, oldTags, newTags);
               }
-              // TODO: handle delete manifests
             });
   }
 


### PR DESCRIPTION
Follows PR #4402 . 
As mentioned in https://github.com/apache/iceberg/pull/4402#issuecomment-1261096282:
In `GlueCatalog`, if `s3.write.table-name-tag-enabled` and `s3.write.namespace-name-tag-enabled` are enabled, all the files related to the table will be tagged with the table name and the namespace name. We need to update these tags when we rename the table.

This PR add S3 tag updates for `renameTable` operation in `GlueCatalog`