### PR TITLE
Core: Remove unused toTaskGroupStream from TableScanUtil

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -187,17 +187,6 @@ public class TableScanUtil {
         combinedTasks -> new BaseScanTaskGroup<>(mergeTasks(combinedTasks)));
   }
 
-  private static <T extends ScanTask> Stream<ScanTaskGroup<T>> toTaskGroupStream(
-      Iterable<T> tasks, long splitSize, int lookback, Function<T, Long> weightFunc) {
-    CloseableIterable<ScanTaskGroup<T>> taskGroups =
-        CloseableIterable.transform(
-            CloseableIterable.combine(
-                new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFunc, true),
-                CloseableIterable.withNoopClose(tasks)),
-            combinedTasks -> new BaseScanTaskGroup<>(mergeTasks(combinedTasks)));
-    return StreamSupport.stream(taskGroups.spliterator(), false);
-  }
-
   @SuppressWarnings("unchecked")
   public static <T extends ScanTask> List<T> mergeTasks(List<T> tasks) {
     List<T> mergedTasks = Lists.newArrayList();

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.util;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseScanTaskGroup;
 import org.apache.iceberg.CombinedScanTask;


### PR DESCRIPTION
#2276 accidentally left an unused method `toTaskGroupStream` (which is replaced by `toTaskGroupIterable`). This removes it.