### PR TITLE
Python: Fix rough edges around literals

### DIFF
--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -83,7 +83,7 @@ def timestamp_to_micros(timestamp_str: str) -> int:
         return datetime_to_micros(datetime.fromisoformat(timestamp_str))
     if ISO_TIMESTAMPTZ.fullmatch(timestamp_str):
         # When we can match a timestamp without a zone, we can give a more specific error
-        raise ValueError(f"Timezone provided, but not expected: {timestamp_str}")
+        raise ValueError(f"Zone offset provided, but not expected: {timestamp_str}")
     raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
 
 
@@ -93,7 +93,7 @@ def timestamptz_to_micros(timestamptz_str: str) -> int:
         return datetime_to_micros(datetime.fromisoformat(timestamptz_str))
     if ISO_TIMESTAMP.fullmatch(timestamptz_str):
         # When we can match a timestamp without a zone, we can give a more specific error
-        raise ValueError(f"Missing timezone: {timestamptz_str} (must be ISO-8601)")
+        raise ValueError(f"Missing zone offset: {timestamptz_str} (must be ISO-8601)")
     raise ValueError(f"Invalid timestamp with zone: {timestamptz_str} (must be ISO-8601)")
 
 

--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -81,6 +81,9 @@ def timestamp_to_micros(timestamp_str: str) -> int:
     """Converts an ISO-9601 formatted timestamp without zone to microseconds from 1970-01-01T00:00:00.000000"""
     if ISO_TIMESTAMP.fullmatch(timestamp_str):
         return datetime_to_micros(datetime.fromisoformat(timestamp_str))
+    if ISO_TIMESTAMPTZ.fullmatch(timestamp_str):
+        # When we can match a timestamp without a zone, we can give a more specific error
+        raise ValueError(f"Timezone provided, but not expected: {timestamp_str}")
     raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
 
 
@@ -88,6 +91,9 @@ def timestamptz_to_micros(timestamptz_str: str) -> int:
     """Converts an ISO-8601 formatted timestamp with zone to microseconds from 1970-01-01T00:00:00.000000+00:00"""
     if ISO_TIMESTAMPTZ.fullmatch(timestamptz_str):
         return datetime_to_micros(datetime.fromisoformat(timestamptz_str))
+    if ISO_TIMESTAMP.fullmatch(timestamptz_str):
+        # When we can match a timestamp without a zone, we can give a more specific error
+        raise ValueError(f"Missing timezone: {timestamptz_str} (must be ISO-8601)")
     raise ValueError(f"Invalid timestamp with zone: {timestamptz_str} (must be ISO-8601)")
 
 

--- a/python/tests/expressions/test_literals.py
+++ b/python/tests/expressions/test_literals.py
@@ -322,7 +322,7 @@ def test_timestamp_with_zone_without_zone_in_literal():
     timestamp_str = literal("2017-08-18T14:21:01.919234")
     with pytest.raises(ValueError) as e:
         _ = timestamp_str.to(timestamp_str.to(TimestamptzType()))
-    assert "Missing timezone: 2017-08-18T14:21:01.919234 (must be ISO-8601)" in str(e.value)
+    assert "Missing zone offset: 2017-08-18T14:21:01.919234 (must be ISO-8601)" in str(e.value)
 
 
 def test_invalid_timestamp_in_literal():
@@ -336,7 +336,7 @@ def test_timestamp_without_zone_with_zone_in_literal():
     timestamp_str = literal("2017-08-18T14:21:01.919234+07:00")
     with pytest.raises(ValueError) as e:
         _ = timestamp_str.to(TimestampType())
-    assert "Timezone provided, but not expected: 2017-08-18T14:21:01.919234+07:00" in str(e.value)
+    assert "Zone offset provided, but not expected: 2017-08-18T14:21:01.919234+07:00" in str(e.value)
 
 
 def test_invalid_timestamp_with_zone_in_literal():


### PR DESCRIPTION
From https://github.com/apache/iceberg/pull/6141, for follow-up:

> Fix types returned by to when AboveMax/BelowMin are returned

Fixed

- Add tests for binding with invalid conversions

Added some tests to cover the last few uncovered lines:

```
poetry run coverage report -m --fail-under=90
Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
...
pyiceberg/expressions/literals.py            331      0   100%
```
 
- Update binding to rewrite expressions when AboveMax and BelowMin are returned

First thing after https://github.com/apache/iceberg/pull/6139 has been merged

- Check whether we need AboveMax/BelowMin for longs, since Python uses arbitrary precision numbers

Do you mean when you run Python on a 32bit computer? This will reduce the precision.

- Improve some of the error messages

Went over all of them 👍🏻 