### PR TITLE
REST: Assign metadata UUID on create transaction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -41,7 +41,7 @@ public interface MetadataUpdate extends Serializable {
 
     @Override
     public void applyTo(TableMetadata.Builder metadataBuilder) {
-      throw new UnsupportedOperationException("Not implemented");
+      metadataBuilder.assignUUID(uuid);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -915,6 +915,17 @@ public class TableMetadata implements Serializable {
       return this;
     }
 
+    public Builder assignUUID(String newUuid) {
+      Preconditions.checkArgument(newUuid != null, "Cannot set uuid to null");
+
+      if (!newUuid.equals(uuid)) {
+        this.uuid = newUuid;
+        changes.add(new MetadataUpdate.AssignUUID(uuid));
+      }
+
+      return this;
+    }
+
     public Builder upgradeFormatVersion(int newFormatVersion) {
       Preconditions.checkArgument(
           newFormatVersion <= SUPPORTED_TABLE_FORMAT_VERSION,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -691,6 +691,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   private static List<MetadataUpdate> createChanges(TableMetadata meta) {
     ImmutableList.Builder<MetadataUpdate> changes = ImmutableList.builder();
 
+    changes.add(new MetadataUpdate.AssignUUID(meta.uuid()));
     changes.add(new MetadataUpdate.UpgradeFormatVersion(meta.formatVersion()));
 
     Schema schema = meta.schema();


### PR DESCRIPTION
This PR adds assigning the metadata UUID to the metadata change list for create table transactions when using the REST catalog. Currently the metadata UUID isn't being passed, which could lead to an inconsistent UUID when writing the data versus committing the metadata.