### PR TITLE
Extract Flink package version programmatically for EnvironmentContext…

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -70,6 +70,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -120,7 +121,7 @@ public class FlinkCatalog extends AbstractCatalog {
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
     EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, "1.14");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.util;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+public class FlinkPackage {
+  /** Choose {@link DataStream} class because it is one of the core Flink API. */
+  private static final String VERSION = DataStream.class.getPackage().getImplementationVersion();
+
+  private FlinkPackage() {}
+
+  /** @return Flink version string like x.y.z */
+  public static String version() {
+    return VERSION;
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -70,6 +70,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -120,7 +121,7 @@ public class FlinkCatalog extends AbstractCatalog {
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
     EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, "1.15");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.util;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+public class FlinkPackage {
+  /** Choose {@link DataStream} class because it is one of the core Flink API. */
+  private static final String VERSION = DataStream.class.getPackage().getImplementationVersion();
+
+  private FlinkPackage() {}
+
+  /** @return Flink version string like x.y.z */
+  public static String version() {
+    return VERSION;
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -70,6 +70,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -120,7 +121,7 @@ public class FlinkCatalog extends AbstractCatalog {
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
     EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, "1.16");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
   }
 
   @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.util;
+
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+public class FlinkPackage {
+  /** Choose {@link DataStream} class because it is one of the core Flink API. */
+  private static final String VERSION = DataStream.class.getPackage().getImplementationVersion();
+
+  private FlinkPackage() {}
+
+  /** @return Flink version string like x.y.z */
+  public static String version() {
+    return VERSION;
+  }
+}


### PR DESCRIPTION
… engine-version

This is to address hard-coded Flink version from PR #6184. Hard-code value can be very tricky to detect and fix when we copy the 1.16 module to 1.17 module in the future.
