### PR TITLE
Replace ImmutableMap.Builder.build() with buildOrThrow()

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -44,7 +44,7 @@ public class Comparators {
           .put(Types.StringType.get(), Comparators.charSequences())
           .put(Types.UUIDType.get(), Comparator.naturalOrder())
           .put(Types.BinaryType.get(), Comparators.unsignedBytes())
-          .build();
+          .buildOrThrow();
 
   public static Comparator<StructLike> forType(Types.StructType struct) {
     return new StructLikeComparator(struct);

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -51,7 +51,7 @@ public class Types {
           .put(StringType.get().toString(), StringType.get())
           .put(UUIDType.get().toString(), UUIDType.get())
           .put(BinaryType.get().toString(), BinaryType.get())
-          .build();
+          .buildOrThrow();
 
   private static final Pattern FIXED = Pattern.compile("fixed\\[(\\d+)\\]");
   private static final Pattern DECIMAL = Pattern.compile("decimal\\((\\d+),\\s+(\\d+)\\)");

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -94,7 +94,7 @@ public class TestInclusiveMetricsEvaluator {
               .put(12, 50L)
               .put(13, 50L)
               .put(14, 50L)
-              .build(),
+              .buildOrThrow(),
           // null value counts
           ImmutableMap.<Integer, Long>builder()
               .put(4, 50L)
@@ -104,7 +104,7 @@ public class TestInclusiveMetricsEvaluator {
               .put(11, 0L)
               .put(12, 1L)
               .put(14, 0L)
-              .build(),
+              .buildOrThrow(),
           // nan value counts
           ImmutableMap.of(
               7, 50L,

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
@@ -58,7 +58,7 @@ public class TestMetricsEvaluatorsNaNHandling {
               .put(3, 10L)
               .put(4, 10L)
               .put(5, 10L)
-              .build(),
+              .buildOrThrow(),
           // null value counts
           ImmutableMap.<Integer, Long>builder()
               .put(1, 0L)
@@ -66,23 +66,23 @@ public class TestMetricsEvaluatorsNaNHandling {
               .put(3, 0L)
               .put(4, 0L)
               .put(5, 0L)
-              .build(),
+              .buildOrThrow(),
           // nan value counts
-          ImmutableMap.<Integer, Long>builder().put(1, 10L).put(4, 10L).put(5, 5L).build(),
+          ImmutableMap.<Integer, Long>builder().put(1, 10L).put(4, 10L).put(5, 5L).buildOrThrow(),
           // lower bounds
           ImmutableMap.<Integer, ByteBuffer>builder()
               .put(1, toByteBuffer(Types.DoubleType.get(), Double.NaN))
               .put(2, toByteBuffer(Types.DoubleType.get(), 7D))
               .put(3, toByteBuffer(Types.FloatType.get(), Float.NaN))
               .put(5, toByteBuffer(Types.FloatType.get(), 7F))
-              .build(),
+              .buildOrThrow(),
           // upper bounds
           ImmutableMap.<Integer, ByteBuffer>builder()
               .put(1, toByteBuffer(Types.DoubleType.get(), Double.NaN))
               .put(2, toByteBuffer(Types.DoubleType.get(), Double.NaN))
               .put(3, toByteBuffer(Types.FloatType.get(), Float.NaN))
               .put(5, toByteBuffer(Types.FloatType.get(), 22F))
-              .build());
+              .buildOrThrow());
 
   private static final Set<BiFunction<String, Number, Expression>> LESS_THAN_EXPRESSIONS =
       ImmutableSet.of(Expressions::lessThan, Expressions::lessThanOrEqual);

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -88,7 +88,7 @@ public class TestStrictMetricsEvaluator {
               .put(12, 50L)
               .put(13, 50L)
               .put(14, 50L)
-              .build(),
+              .buildOrThrow(),
           // null value counts
           ImmutableMap.<Integer, Long>builder()
               .put(4, 50L)
@@ -97,7 +97,7 @@ public class TestStrictMetricsEvaluator {
               .put(11, 50L)
               .put(12, 0L)
               .put(13, 1L)
-              .build(),
+              .buildOrThrow(),
           // nan value counts
           ImmutableMap.of(
               8, 50L,

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -125,7 +125,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
         builder.put(AwsProperties.CLIENT_FACTORY, LakeFormationAwsClientFactory.class.getName());
       }
 
-      this.catalogProperties = builder.build();
+      this.catalogProperties = builder.buildOrThrow();
       awsClientFactory = AwsClientFactories.from(catalogProperties);
       Preconditions.checkArgument(
           awsClientFactory instanceof LakeFormationAwsClientFactory,
@@ -232,7 +232,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
           lockManager,
           catalogName,
           awsProperties,
-          tableSpecificCatalogPropertiesBuilder.build(),
+          tableSpecificCatalogPropertiesBuilder.buildOrThrow(),
           hadoopConf,
           tableIdentifier);
     }

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -126,7 +126,7 @@ public class MetadataUpdateParser {
           .put(MetadataUpdate.SetProperties.class, SET_PROPERTIES)
           .put(MetadataUpdate.RemoveProperties.class, REMOVE_PROPERTIES)
           .put(MetadataUpdate.SetLocation.class, SET_LOCATION)
-          .build();
+          .buildOrThrow();
 
   public static String toJson(MetadataUpdate metadataUpdate) {
     return toJson(metadataUpdate, false);

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -270,7 +270,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
           ImmutableMap.<String, String>builder()
               .putAll(metadata)
               .put(NAMESPACE_EXISTS_PROPERTY, "true")
-              .build();
+              .buildOrThrow();
     }
 
     insertProperties(namespace, createMetadata);
@@ -539,7 +539,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
             catalogName,
             namespaceName);
 
-    return ImmutableMap.<String, String>builder().putAll(entries).build();
+    return ImmutableMap.<String, String>builder().putAll(entries).buildOrThrow();
   }
 
   private boolean insertProperties(Namespace namespace, Map<String, String> properties) {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java
@@ -79,7 +79,7 @@ public class UpdateRequirementParser {
               ASSERT_LAST_ASSIGNED_PARTITION_ID)
           .put(UpdateRequirement.AssertDefaultSpecID.class, ASSERT_DEFAULT_SPEC_ID)
           .put(UpdateRequirement.AssertDefaultSortOrderID.class, ASSERT_DEFAULT_SORT_ORDER_ID)
-          .build();
+          .buildOrThrow();
 
   public static String toJson(UpdateRequirement updateRequirement) {
     return toJson(updateRequirement, false);

--- a/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
@@ -242,7 +242,7 @@ public class TestManifestCaching {
         ImmutableMap.<String, String>builder()
             .putAll(catalogProperties)
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.newFolder().getAbsolutePath())
-            .build());
+            .buildOrThrow());
     return hadoopCatalog;
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -198,7 +198,7 @@ public class HadoopTableTestBase {
         ImmutableMap.<String, String>builder()
             .putAll(catalogProperties)
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.newFolder().getAbsolutePath())
-            .build());
+            .buildOrThrow());
     return hadoopCatalog;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -77,7 +77,7 @@ public class RESTCatalogAdapter implements RESTClient {
           .put(CommitFailedException.class, 409)
           .put(UnprocessableEntityException.class, 422)
           .put(CommitStateUnknownException.class, 500)
-          .build();
+          .buildOrThrow();
 
   private final Catalog catalog;
   private final SupportsNamespaces asNamespaceCatalog;

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
@@ -60,7 +60,7 @@ public class FlinkFilters {
           .put(BuiltInFunctionDefinitions.OR, Operation.OR)
           .put(BuiltInFunctionDefinitions.NOT, Operation.NOT)
           .put(BuiltInFunctionDefinitions.LIKE, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   /**
    * Convert flink expression to iceberg expression.

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -259,7 +259,7 @@ public abstract class TestFlinkScan {
             ImmutableMap.<String, String>builder()
                 .put("start-snapshot-id", Long.toString(snapshotId1))
                 .put("end-snapshot-id", Long.toString(snapshotId3))
-                .build()),
+                .buildOrThrow()),
         expected2,
         TestFixtures.SCHEMA);
   }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
@@ -60,7 +60,7 @@ public class FlinkFilters {
           .put(BuiltInFunctionDefinitions.OR, Operation.OR)
           .put(BuiltInFunctionDefinitions.NOT, Operation.NOT)
           .put(BuiltInFunctionDefinitions.LIKE, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   /**
    * Convert flink expression to iceberg expression.

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -259,7 +259,7 @@ public abstract class TestFlinkScan {
             ImmutableMap.<String, String>builder()
                 .put("start-snapshot-id", Long.toString(snapshotId1))
                 .put("end-snapshot-id", Long.toString(snapshotId3))
-                .build()),
+                .buildOrThrow()),
         expected2,
         TestFixtures.SCHEMA);
   }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
@@ -60,7 +60,7 @@ public class FlinkFilters {
           .put(BuiltInFunctionDefinitions.OR, Operation.OR)
           .put(BuiltInFunctionDefinitions.NOT, Operation.NOT)
           .put(BuiltInFunctionDefinitions.LIKE, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   /**
    * Convert flink expression to iceberg expression.

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -259,7 +259,7 @@ public abstract class TestFlinkScan {
             ImmutableMap.<String, String>builder()
                 .put("start-snapshot-id", Long.toString(snapshotId1))
                 .put("end-snapshot-id", Long.toString(snapshotId3))
-                .build()),
+                .buildOrThrow()),
         expected2,
         TestFixtures.SCHEMA);
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -337,7 +337,10 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     // remove the trailing slash of the URI
     hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
     ImmutableMap newMeta =
-        ImmutableMap.<String, String>builder().putAll(meta).put("location", hiveLocalDir).build();
+        ImmutableMap.<String, String>builder()
+            .putAll(meta)
+            .put("location", hiveLocalDir)
+            .buildOrThrow();
     Namespace namespace2 = Namespace.of("haveLocation");
 
     catalog.createNamespace(namespace2, newMeta);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -144,7 +144,7 @@ public abstract class BaseTestIceberg {
     if (null != hash) {
       options.put("ref.hash", hash);
     }
-    newCatalog.initialize("nessie", options.build());
+    newCatalog.initialize("nessie", options.buildOrThrow());
     return newCatalog;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteSupport.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriteSupport.java
@@ -44,7 +44,7 @@ class ParquetWriteSupport<T> extends WriteSupport<T> {
         ImmutableMap.<String, String>builder()
             .putAll(keyValueMetadata)
             .putAll(wrappedContext.getExtraMetaData())
-            .build();
+            .buildOrThrow();
     return new WriteContext(type, metadata);
   }
 

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -271,5 +271,5 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -236,5 +236,5 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -76,7 +76,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   public static Expression convert(Filter filter) {
     // avoid using a chain of if instanceof statements by mapping to the expression enum.

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -271,5 +271,5 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -236,5 +236,5 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -84,7 +84,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
     Expression expression = Expressions.alwaysTrue();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -271,5 +271,5 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -236,5 +236,5 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -94,7 +94,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
     Expression expression = Expressions.alwaysTrue();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithReordering.java
@@ -271,5 +271,5 @@ public class PruneColumnsWithReordering extends TypeUtil.CustomOrderSchemaVisito
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -236,5 +236,5 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, StringType.class)
           .put(TypeID.FIXED, BinaryType.class)
           .put(TypeID.BINARY, BinaryType.class)
-          .build();
+          .buildOrThrow();
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkAggregates.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkAggregates.java
@@ -39,7 +39,7 @@ public class SparkAggregates {
           .put(CountStar.class, Operation.COUNT_STAR)
           .put(Max.class, Operation.MAX)
           .put(Min.class, Operation.MIN)
-          .build();
+          .buildOrThrow();
 
   public static Expression convert(AggregateFunc aggregate) {
     Operation op = AGGREGATES.get(aggregate.getClass());

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -94,7 +94,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
     Expression expression = Expressions.alwaysTrue();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -86,7 +86,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
-          .build();
+          .buildOrThrow();
 
   private SparkV2Filters() {}
 


### PR DESCRIPTION
Starting from guava 31.1,  `ImmutableMap.Builder.build()` is discouraged to use and will soon be deprecated.

Please see https://github.com/google/guava/commit/4bbe12c4e031b6c18074f933e444fa20a371d633

Replacing `ImmutableMap.Builder.build()` with `ImmutableMap.Builder.buildOrThrow()`