### PR TITLE
Core: Add test + clarify behavior of write.metadata.delete-after-commit.enabled flag

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -416,6 +416,10 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     if (deleteAfterCommit) {
       Set<TableMetadata.MetadataLogEntry> removedPreviousMetadataFiles =
           Sets.newHashSet(base.previousFiles());
+      // TableMetadata#addPreviousFile builds up the metadata log and uses
+      // TableProperties.METADATA_PREVIOUS_VERSIONS_MAX to determine how many files should stay in
+      // the log, thus we don't include metadata.previousFiles() for deletion - everything else can
+      // be removed
       removedPreviousMetadataFiles.removeAll(metadata.previousFiles());
       Tasks.foreach(removedPreviousMetadataFiles)
           .noRetry()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.delete.distribution-mode     | hash               | Defines distribution of write delete data          |
 | write.wap.enabled                  | false              | Enables write-audit-publish writes |
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
-| write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
+| write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest **tracked** version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
 | write.spark.fanout.enabled         | false              | Enables the fanout writer in Spark that does not require data to be clustered; uses more memory |
 | write.object-storage.enabled       | false              | Enables the object storage location provider that adds a hash component to file paths |

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -76,10 +76,14 @@ Old metadata files are kept for history by default. Tables with frequent commits
 
 To automatically clean metadata files, set `write.metadata.delete-after-commit.enabled=true` in table properties. This will keep some metadata files (up to `write.metadata.previous-versions-max`) and will delete the oldest metadata file after each new one is created.
 
-| Property                                     | Description                                                  |
-| -------------------------------------------- | ------------------------------------------------------------ |
-| `write.metadata.delete-after-commit.enabled` | Whether to delete old metadata files after each table commit |
-| `write.metadata.previous-versions-max`       | The number of old metadata files to keep                     |
+| Property                                     | Description                                                              |
+| -------------------------------------------- |--------------------------------------------------------------------------|
+| `write.metadata.delete-after-commit.enabled` | Whether to delete old **tracked** metadata files after each table commit |
+| `write.metadata.previous-versions-max`       | The number of old metadata files to keep                                 |
+
+Note that this will only delete metadata files that are **tracked** in the metadata log and will not delete orphaned metadata files.
+Example: With `write.metadata.delete-after-commit.enabled=false` and `write.metadata.previous-versions-max=10`, one will have 10 tracked metadata files and 90 orphaned metadata files after 100 commits.
+Configuring `write.metadata.delete-after-commit.enabled=true` and `write.metadata.previous-versions-max=20` will not automatically delete metadata files. Tracked metadata files would be deleted again when reaching `write.metadata.previous-versions-max=20`.
 
 See [table write properties](../configuration/#write-properties) for more details.
 


### PR DESCRIPTION
The issue came up in a [slack discussion](https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1668714478198079?thread_ts=1668645354.671479&cid=C025PH0G1D4) and also in https://github.com/apache/iceberg/issues/6105.