### PR TITLE
Change SingleBufferInputStream .read signature to match super-method.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
@@ -64,7 +64,7 @@ class SingleBufferInputStream extends ByteBufferInputStream {
   }
 
   @Override
-  public int read(byte[] bytes, int offset, int len) throws IOException {
+  public int read(byte[] bytes, int off, int len) throws IOException {
     if (len == 0) {
       return 0;
     }
@@ -75,7 +75,7 @@ class SingleBufferInputStream extends ByteBufferInputStream {
     }
 
     int bytesToRead = Math.min(buffer.remaining(), len);
-    buffer.get(bytes, offset, bytesToRead);
+    buffer.get(bytes, off, bytesToRead);
 
     return bytesToRead;
   }


### PR DESCRIPTION
**What does this PR do?**
Changes the variable name `offset` to `off` in the `SingleBufferInputStream` function.

**Why are these changes needed?**
When running `./gradlew build` with `sourceCompatibility = '11'` and `targetCompatibility = '11'` instead of `1.8`, the build is blocked by a `ConsistentOverrides` error:

```
iceberg/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java:67: error: [ConsistentOverrides] Method overrides should have variable names consistent with the super-method when there are multiple parameters with the same type to avoid incorrectly binding values to variables.
  public int read(byte[] bytes, int offset, int len) throws IOException {
             ^
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
  Did you mean 'public int read(byte[] bytes, int off, int len) throws IOException {'?
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
```

`SingleBufferInputStream` overrides superclass `InputStream`, where the equivalent method is:

`public int read(byte[] b, int off, int len) throws IOException`

and changing it to match the super-method fixes the error.

**How were these changes tested?**
* `./gradlew build` succeeds on `sourceCompatibility = '11'` and `targetCompatibility = '11'`.
* `./gradlew build` succeeds on `sourceCompatibility = '1.8'` and `targetCompatibility = '1.8'`.
* Pass CI checks.