### PR TITLE
AWS: Use provided glue catalog id in defaultWarehouseLocation

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -261,6 +261,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     GetDatabaseResponse response =
         glue.getDatabase(
             GetDatabaseRequest.builder()
+                .catalogId(awsProperties.glueCatalogId())
                 .name(
                     IcebergToGlueConverter.getDatabaseName(
                         tableIdentifier, awsProperties.glueCatalogSkipNameValidation()))

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -148,12 +148,12 @@ public class TestGlueCatalog {
   public void testDefaultWarehouseLocationCustomCatalogId() {
     GlueCatalog catalogWithCustomCatalogId = new GlueCatalog();
     String catalogId = "myCatalogId";
-    ImmutableMap.Builder<String, String> catalogIdPropertiesBuilder =
-        ImmutableMap.<String, String>builder().put(AwsProperties.GLUE_CATALOG_ID, catalogId);
+    AwsProperties awsProperties = new AwsProperties();
+    awsProperties.setGlueCatalogId(catalogId);
     catalogWithCustomCatalogId.initialize(
         CATALOG_NAME,
         WAREHOUSE_PATH + "/",
-        new AwsProperties(catalogIdPropertiesBuilder.build()),
+        awsProperties,
         glue,
         LockManagers.defaultLockManager(),
         null,

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -167,7 +167,8 @@ public class TestGlueCatalog {
         .getDatabase(Mockito.any(GetDatabaseRequest.class));
     catalogWithCustomCatalogId.defaultWarehouseLocation(TableIdentifier.of("db", "table"));
     Mockito.verify(glue)
-        .getDatabase(Mockito.argThat((GetDatabaseRequest req) -> req.catalogId() == catalogId));
+        .getDatabase(
+            Mockito.argThat((GetDatabaseRequest req) -> req.catalogId().equals(catalogId)));
   }
 
   @Test


### PR DESCRIPTION
`defaultWarehouseLocation` call to `glue.getDatabase` did not set catalog id while building a request.  
This results in `software.amazon.awssdk.services.glue.model.EntityNotFoundException: Database my_database not found.` error when table is being created in another AWS account.

More details are in https://github.com/apache/iceberg/issues/6215  

@singhpk234 
If you can take a look, it would be appreciated.  
I did not add any tests for it since I saw that similar tests for other methods do not exist.