### PR TITLE
API: Ignore case when comparing truncate

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -46,7 +46,7 @@ public class Transforms {
       int parsedWidth = Integer.parseInt(widthMatcher.group(2));
       if (name.equalsIgnoreCase("truncate")) {
         return Truncate.get(parsedWidth);
-      } else if (name.equals("bucket")) {
+      } else if (name.equalsIgnoreCase("bucket")) {
         return Bucket.get(parsedWidth);
       }
     }
@@ -75,7 +75,7 @@ public class Transforms {
       int parsedWidth = Integer.parseInt(widthMatcher.group(2));
       if (name.equalsIgnoreCase("truncate")) {
         return (Transform<?, ?>) Truncate.get(type, parsedWidth);
-      } else if (name.equals("bucket")) {
+      } else if (name.equalsIgnoreCase("bucket")) {
         return (Transform<?, ?>) Bucket.get(type, parsedWidth);
       }
     }


### PR DESCRIPTION
I noticed this is the only transform that does a case-sensitive equal. Looks like this is a copy-paste error