### PR TITLE
Spark: Add missing override

### DIFF
--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -79,6 +79,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
   private PartitionSpec unpartitionedSpec;
   private PartitionSpec partitionedSpec;
 
+  @Override
   protected abstract FileFormat fileFormat();
 
   @Setup


### PR DESCRIPTION
Saw this noise in the logs, and figured it would be nice to remove the noise