### PR TITLE
Python: Disallow Any generics

### DIFF
--- a/python/pyiceberg/avro/reader.py
+++ b/python/pyiceberg/avro/reader.py
@@ -34,6 +34,7 @@ from functools import singledispatch
 from typing import (
     Any,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -67,7 +68,7 @@ from pyiceberg.types import (
 from pyiceberg.utils.singleton import Singleton
 
 
-def _skip_map_array(decoder: BinaryDecoder, skip_entry: Callable) -> None:
+def _skip_map_array(decoder: BinaryDecoder, skip_entry: Callable[[], None]) -> None:
     """Skips over an array or map
 
     Both the array and map are encoded similar, and we can re-use
@@ -294,7 +295,7 @@ class StructReader(Reader):
 class ListReader(Reader):
     element: Reader
 
-    def read(self, decoder: BinaryDecoder) -> list:
+    def read(self, decoder: BinaryDecoder) -> List[Any]:
         read_items = []
         block_count = decoder.read_int()
         while block_count != 0:
@@ -315,7 +316,7 @@ class MapReader(Reader):
     key: Reader
     value: Reader
 
-    def read(self, decoder: BinaryDecoder) -> dict:
+    def read(self, decoder: BinaryDecoder) -> Dict[Any, Any]:
         read_items = {}
         block_count = decoder.read_int()
         while block_count != 0:

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -172,7 +172,7 @@ class OAuthErrorResponse(IcebergBaseModel):
 class RestCatalog(Catalog):
     uri: str
     session: Session
-    properties: dict
+    properties: Properties
 
     def __init__(
         self,
@@ -198,9 +198,9 @@ class RestCatalog(Catalog):
         self.session = Session()
         # Sets the client side and server side SSL cert verification, if provided as properties.
         if ssl_config := self.properties.get(SSL):
-            if ssl_ca_bundle := ssl_config.get(CA_BUNDLE):
+            if ssl_ca_bundle := ssl_config.get(CA_BUNDLE):  # type: ignore
                 self.session.verify = ssl_ca_bundle
-            if ssl_client := ssl_config.get(CLIENT):
+            if ssl_client := ssl_config.get(CLIENT):  # type: ignore
                 if all(k in ssl_client for k in (CERT, KEY)):
                     self.session.cert = (ssl_client[CERT], ssl_client[KEY])
                 elif ssl_client_cert := ssl_client.get(CERT):

--- a/python/pyiceberg/expressions/__init__.py
+++ b/python/pyiceberg/expressions/__init__.py
@@ -127,11 +127,11 @@ class BoundReference(BoundTerm[L]):
         return self
 
 
-class UnboundTerm(Term, Unbound, ABC):
+class UnboundTerm(Term[Any], Unbound, ABC):
     """Represents an unbound term."""
 
     @abstractmethod
-    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundTerm:
+    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundTerm[Any]:
         ...
 
 
@@ -171,10 +171,10 @@ class Reference(UnboundTerm):
         """
         field = schema.find_field(name_or_id=self.name, case_sensitive=case_sensitive)
         accessor = schema.accessor_for_field(field.field_id)
-        return self.as_bound(field=field, accessor=accessor)
+        return self.as_bound(field=field, accessor=accessor)  # type: ignore
 
     @property
-    def as_bound(self) -> Type[BoundReference]:
+    def as_bound(self) -> Type[BoundReference[L]]:
         return BoundReference[L]
 
 
@@ -317,17 +317,17 @@ class UnboundPredicate(Generic[L], Unbound, BooleanExpression, ABC):
         return self.term == other.term if isinstance(other, UnboundPredicate) else False
 
     @abstractmethod
-    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundPredicate:
+    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundPredicate[L]:
         ...
 
     @property
     @abstractmethod
-    def as_bound(self) -> Type[BoundPredicate]:
+    def as_bound(self) -> Type[BoundPredicate[L]]:
         ...
 
 
 class UnaryPredicate(UnboundPredicate[Any], ABC):
-    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate:
+    def bind(self, schema: Schema, case_sensitive: bool = True) -> BoundUnaryPredicate[Any]:
         bound_term = self.term.bind(schema, case_sensitive)
         return self.as_bound(bound_term)
 
@@ -361,7 +361,7 @@ class BoundNotNull(BoundUnaryPredicate[L]):
             return AlwaysTrue()
         return super().__new__(cls)
 
-    def __invert__(self) -> BoundIsNull:
+    def __invert__(self) -> BoundIsNull[L]:
         return BoundIsNull(self.term)
 
 
@@ -622,7 +622,7 @@ class BoundLessThanOrEqual(BoundLiteralPredicate[L]):
 
 
 class EqualTo(LiteralPredicate[L]):
-    def __invert__(self) -> NotEqualTo:
+    def __invert__(self) -> NotEqualTo[L]:
         return NotEqualTo[L](self.term, self.literal)
 
     @property

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -72,7 +72,7 @@ class Literal(Generic[L], ABC):
 
     @singledispatchmethod
     @abstractmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal[L]:
         ...  # pragma: no cover
 
     def __repr__(self) -> str:
@@ -194,7 +194,7 @@ class BooleanLiteral(Literal[bool]):
         super().__init__(value, bool)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal[bool]:  # type: ignore
         raise TypeError(f"Cannot convert BooleanLiteral into {type_var}")
 
     @to.register(BooleanType)
@@ -207,7 +207,7 @@ class LongLiteral(Literal[int]):
         super().__init__(value, int)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert LongLiteral into {type_var}")
 
     @to.register(LongType)
@@ -274,7 +274,7 @@ class FloatLiteral(Literal[float]):
         return self._value32 >= other
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert FloatLiteral into {type_var}")
 
     @to.register(FloatType)
@@ -295,7 +295,7 @@ class DoubleLiteral(Literal[float]):
         super().__init__(value, float)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert DoubleLiteral into {type_var}")
 
     @to.register(DoubleType)
@@ -320,7 +320,7 @@ class DateLiteral(Literal[int]):
         super().__init__(value, int)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert DateLiteral into {type_var}")
 
     @to.register(DateType)
@@ -333,7 +333,7 @@ class TimeLiteral(Literal[int]):
         super().__init__(value, int)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert TimeLiteral into {type_var}")
 
     @to.register(TimeType)
@@ -346,7 +346,7 @@ class TimestampLiteral(Literal[int]):
         super().__init__(value, int)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert TimestampLiteral into {type_var}")
 
     @to.register(TimestampType)
@@ -363,7 +363,7 @@ class DecimalLiteral(Literal[Decimal]):
         super().__init__(value, Decimal)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert DecimalLiteral into {type_var}")
 
     @to.register(DecimalType)
@@ -378,7 +378,7 @@ class StringLiteral(Literal[str]):
         super().__init__(value, str)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert StringLiteral into {type_var}")
 
     @to.register(StringType)
@@ -450,7 +450,7 @@ class UUIDLiteral(Literal[UUID]):
         super().__init__(value, UUID)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert UUIDLiteral into {type_var}")
 
     @to.register(UUIDType)
@@ -463,7 +463,7 @@ class FixedLiteral(Literal[bytes]):
         super().__init__(value, bytes)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert FixedLiteral into {type_var}")
 
     @to.register(FixedType)
@@ -485,7 +485,7 @@ class BinaryLiteral(Literal[bytes]):
         super().__init__(value, bytes)
 
     @singledispatchmethod
-    def to(self, type_var: IcebergType) -> Literal:
+    def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError(f"Cannot convert BinaryLiteral into {type_var}")
 
     @to.register(BinaryType)

--- a/python/pyiceberg/expressions/visitors.py
+++ b/python/pyiceberg/expressions/visitors.py
@@ -17,6 +17,7 @@
 from abc import ABC, abstractmethod
 from functools import singledispatch
 from typing import (
+    Any,
     Callable,
     Generic,
     List,
@@ -165,7 +166,7 @@ def _(obj: And, visitor: BooleanExpressionVisitor[T]) -> T:
 
 
 @visit.register(UnboundPredicate)
-def _(obj: UnboundPredicate, visitor: BooleanExpressionVisitor[T]) -> T:
+def _(obj: UnboundPredicate[Any], visitor: BooleanExpressionVisitor[T]) -> T:
     """Visit an unbound boolean expression with a concrete BooleanExpressionVisitor"""
     return visitor.visit_unbound_predicate(predicate=obj)
 

--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -74,7 +74,7 @@ def _s3(properties: Properties) -> AbstractFileSystem:
         "aws_session_token": properties.get("s3.session-token"),
     }
     config_kwargs = {}
-    register_events: Dict[str, Callable] = {}
+    register_events: Dict[str, Callable[[Properties], None]] = {}
 
     if signer := properties.get("s3.signer"):
         logger.info("Loading signer %s", signer)
@@ -194,7 +194,7 @@ class FsspecFileIO(FileIO):
     def __init__(self, properties: Properties):
         self._scheme_to_fs = {}
         self._scheme_to_fs.update(SCHEME_TO_FS)
-        self.get_fs: Callable = lru_cache(self._get_fs)
+        self.get_fs: Callable[[str], AbstractFileSystem] = lru_cache(self._get_fs)
         super().__init__(properties=properties)
 
     def new_input(self, location: str) -> FsspecInputFile:

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -198,7 +198,7 @@ class PyArrowFile(InputFile, OutputFile):
 
 class PyArrowFileIO(FileIO):
     def __init__(self, properties: Properties = EMPTY_DICT):
-        self.get_fs: Callable = lru_cache(self._get_fs)
+        self.get_fs: Callable[[str], FileSystem] = lru_cache(self._get_fs)
         super().__init__(properties=properties)
 
     @staticmethod

--- a/python/pyiceberg/manifest.py
+++ b/python/pyiceberg/manifest.py
@@ -187,7 +187,7 @@ def _(list_type: ListType, values: List[Any]) -> Any:
 
 
 @_convert_pos_to_dict.register
-def _(map_type: MapType, values: Dict) -> Dict:
+def _(map_type: MapType, values: Dict[Any, Any]) -> Dict[Any, Any]:
     """In the case of a map, we both traverse over the key and value to handle complex types"""
     return (
         {
@@ -200,5 +200,5 @@ def _(map_type: MapType, values: Dict) -> Dict:
 
 
 @_convert_pos_to_dict.register
-def _(primitive: PrimitiveType, value: Any) -> Any:  # pylint: disable=unused-argument
+def _(_: PrimitiveType, value: Any) -> Any:
     return value

--- a/python/pyiceberg/schema.py
+++ b/python/pyiceberg/schema.py
@@ -746,7 +746,7 @@ def assign_fresh_schema_ids(schema: Schema) -> Schema:
 class _SetFreshIDs(PreOrderSchemaVisitor[IcebergType]):
     """Traverses the schema and assigns monotonically increasing ids"""
 
-    counter: itertools.count
+    counter: itertools.count  # type: ignore
     reserved_ids: Dict[int, int]
 
     def __init__(self, start: int = 1) -> None:

--- a/python/pyiceberg/table/metadata.py
+++ b/python/pyiceberg/table/metadata.py
@@ -381,7 +381,7 @@ class TableMetadataUtil:
     # TableMetadata = Annotated[TableMetadata, Field(alias="format-version", discriminator="format-version")]
 
     @staticmethod
-    def parse_obj(data: dict) -> TableMetadata:
+    def parse_obj(data: Dict[str, Any]) -> TableMetadata:
         if "format-version" not in data:
             raise ValidationError(f"Missing format-version in TableMetadata: {data}")
 

--- a/python/pyiceberg/table/partitioning.py
+++ b/python/pyiceberg/table/partitioning.py
@@ -48,14 +48,14 @@ class PartitionField(IcebergBaseModel):
 
     source_id: int = Field(alias="source-id")
     field_id: int = Field(alias="field-id")
-    transform: Transform = Field()
+    transform: Transform[Any, Any] = Field()
     name: str = Field()
 
     def __init__(
         self,
         source_id: Optional[int] = None,
         field_id: Optional[int] = None,
-        transform: Optional[Transform] = None,
+        transform: Optional[Transform[Any, Any]] = None,
         name: Optional[str] = None,
         **data: Any,
     ):

--- a/python/pyiceberg/table/sorting.py
+++ b/python/pyiceberg/table/sorting.py
@@ -69,7 +69,7 @@ class SortField(IcebergBaseModel):
     def __init__(
         self,
         source_id: Optional[int] = None,
-        transform: Optional[Union[Transform, Callable[[IcebergType], Transform]]] = None,
+        transform: Optional[Union[Transform[Any, Any], Callable[[IcebergType], Transform[Any, Any]]]] = None,
         direction: Optional[SortDirection] = None,
         null_order: Optional[NullOrder] = None,
         **data: Any,
@@ -92,7 +92,7 @@ class SortField(IcebergBaseModel):
         return values
 
     source_id: int = Field(alias="source-id")
-    transform: Transform = Field()
+    transform: Transform[Any, Any] = Field()
     direction: SortDirection = Field()
     null_order: NullOrder = Field(alias="null-order")
 

--- a/python/pyiceberg/transforms.py
+++ b/python/pyiceberg/transforms.py
@@ -243,7 +243,7 @@ class TimeTransform(Transform[S, int], Singleton):
     def granularity(self) -> TimeResolution:
         ...
 
-    def satisfies_order_of(self, other: Transform) -> bool:
+    def satisfies_order_of(self, other: Transform[S, T]) -> bool:
         return self.granularity <= other.granularity if hasattr(other, "granularity") else False
 
     def result_type(self, source: IcebergType) -> IcebergType:
@@ -258,7 +258,7 @@ class TimeTransform(Transform[S, int], Singleton):
         return True
 
 
-class YearTransform(TimeTransform):
+class YearTransform(TimeTransform[S]):
     """Transforms a datetime value into a year value.
 
     Example:
@@ -304,7 +304,7 @@ class YearTransform(TimeTransform):
         return "YearTransform()"
 
 
-class MonthTransform(TimeTransform):
+class MonthTransform(TimeTransform[S]):
     """Transforms a datetime value into a month value.
 
     Example:
@@ -350,7 +350,7 @@ class MonthTransform(TimeTransform):
         return "MonthTransform()"
 
 
-class DayTransform(TimeTransform):
+class DayTransform(TimeTransform[S]):
     """Transforms a datetime value into a day value.
 
     Example:
@@ -399,7 +399,7 @@ class DayTransform(TimeTransform):
         return "DayTransform()"
 
 
-class HourTransform(TimeTransform):
+class HourTransform(TimeTransform[S]):
     """Transforms a datetime value into a hour value.
 
     Example:
@@ -467,7 +467,7 @@ class IdentityTransform(Transform[S, S]):
     def preserves_order(self) -> bool:
         return True
 
-    def satisfies_order_of(self, other: Transform) -> bool:
+    def satisfies_order_of(self, other: Transform[S, T]) -> bool:
         """ordering by value is the same as long as the other preserves order"""
         return other.preserves_order
 
@@ -537,7 +537,7 @@ class TruncateTransform(Transform[S, S]):
 
         return lambda v: truncate_func(v) if v else None
 
-    def satisfies_order_of(self, other: Transform) -> bool:
+    def satisfies_order_of(self, other: Transform[S, T]) -> bool:
         if self == other:
             return True
         elif (
@@ -601,7 +601,7 @@ def _(_type: IcebergType, value: int) -> str:
     return datetime.to_human_timestamptz(value)
 
 
-class UnknownTransform(Transform):
+class UnknownTransform(Transform[S, T]):
     """A transform that represents when an unknown transform is provided
     Args:
       source_type (IcebergType): An Iceberg `Type`
@@ -630,7 +630,7 @@ class UnknownTransform(Transform):
         return f"UnknownTransform(transform={repr(self._transform)})"
 
 
-class VoidTransform(Transform, Singleton):
+class VoidTransform(Transform[S, None], Singleton):
     """A transform that always returns None"""
 
     __root__ = "void"

--- a/python/pyiceberg/utils/bin_packing.py
+++ b/python/pyiceberg/utils/bin_packing.py
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
+
 from typing import (
     Callable,
     Generic,
@@ -43,9 +45,9 @@ class Bin(Generic[T]):
         self.items.append(item)
 
 
-class PackingIterator:
+class PackingIterator(Generic[T]):
 
-    bins: List[Bin]
+    bins: List[Bin[T]]
 
     def __init__(
         self,
@@ -62,7 +64,7 @@ class PackingIterator:
         self.largest_bin_first = largest_bin_first
         self.bins = []
 
-    def __iter__(self) -> "PackingIterator":
+    def __iter__(self) -> PackingIterator[T]:
         return self
 
     def __next__(self) -> List[T]:
@@ -88,13 +90,13 @@ class PackingIterator:
 
         return self.remove_bin().items
 
-    def find_bin(self, weight: int) -> Optional[Bin]:
+    def find_bin(self, weight: int) -> Optional[Bin[T]]:
         for bin_ in self.bins:
             if bin_.can_add(weight):
                 return bin_
         return None
 
-    def remove_bin(self) -> Bin:
+    def remove_bin(self) -> Bin[T]:
         if self.largest_bin_first:
             bin_ = max(self.bins, key=lambda b: b.weight())
             self.bins.remove(bin_)

--- a/python/pyiceberg/utils/deprecated.py
+++ b/python/pyiceberg/utils/deprecated.py
@@ -27,7 +27,7 @@ def deprecated(deprecated_in: str, removed_in: str, help_message: Optional[str] 
     if help_message is not None:
         help_message = f" {help_message}."
 
-    def decorator(func: Callable):
+    def decorator(func: Callable):  # type: ignore
         @functools.wraps(func)
         def new_func(*args, **kwargs):
             warnings.simplefilter("always", DeprecationWarning)  # turn off filter

--- a/python/pyiceberg/utils/parsing.py
+++ b/python/pyiceberg/utils/parsing.py
@@ -21,7 +21,7 @@ from re import Pattern
 class ParseNumberFromBrackets:
     """Extracts the size from a string in the form of prefix[22]"""
 
-    regex: Pattern
+    regex: Pattern  # type: ignore
     prefix: str
 
     def __init__(self, prefix: str):

--- a/python/pyiceberg/utils/schema_conversion.py
+++ b/python/pyiceberg/utils/schema_conversion.py
@@ -118,7 +118,9 @@ class AvroSchemaConversion:
         """
         return Schema(*[self._convert_field(field) for field in avro_schema["fields"]], schema_id=1)
 
-    def _resolve_union(self, type_union: Union[Dict, List, str]) -> Tuple[Union[str, Dict[str, Any]], bool]:
+    def _resolve_union(
+        self, type_union: Union[Dict[str, str], List[Union[str, Dict[str, str]]], str]
+    ) -> Tuple[Union[str, Dict[str, Any]], bool]:
         """
         Converts Unions into their type and resolves if the field is required
 
@@ -141,7 +143,7 @@ class AvroSchemaConversion:
         Raises:
             TypeError: In the case non-optional union types are encountered
         """
-        avro_types: Union[Dict, List]
+        avro_types: Union[Dict[str, str], List[Union[Dict[str, str], str]]]
         if isinstance(type_union, str):
             # It is a primitive and required
             return type_union, True

--- a/python/pyiceberg/utils/singleton.py
+++ b/python/pyiceberg/utils/singleton.py
@@ -39,7 +39,7 @@ def _convert_to_hashable_type(element: Any) -> Any:
 
 
 class Singleton:
-    _instances: ClassVar[Dict] = {}
+    _instances: ClassVar[Dict] = {}  # type: ignore
 
     def __new__(cls, *args, **kwargs):
         key = (cls, tuple(args), _convert_to_hashable_type(kwargs))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -113,6 +113,7 @@ namespace_packages = false
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
+disallow_any_generics = true
 
 [[tool.mypy.overrides]]
 module = "pyarrow.*"

--- a/python/tests/expressions/test_expressions.py
+++ b/python/tests/expressions/test_expressions.py
@@ -18,6 +18,7 @@
 
 import uuid
 from decimal import Decimal
+from typing import Any
 
 import pytest
 from typing_extensions import assert_type
@@ -619,7 +620,7 @@ def accessor() -> Accessor:
 
 
 @pytest.fixture
-def term(field: NestedField, accessor: Accessor) -> BoundReference:
+def term(field: NestedField, accessor: Accessor) -> BoundReference[Any]:
     return BoundReference(
         field=field,
         accessor=accessor,
@@ -688,14 +689,14 @@ def test_bound_reference_field_property():
     assert bound_ref.field == NestedField(field_id=1, name="foo", field_type=StringType(), required=False)
 
 
-def test_bound_is_null(term: BoundReference) -> None:
+def test_bound_is_null(term: BoundReference[Any]) -> None:
     bound_is_null = BoundIsNull(term)
     assert str(bound_is_null) == f"BoundIsNull(term={str(term)})"
     assert repr(bound_is_null) == f"BoundIsNull(term={repr(term)})"
     assert bound_is_null == eval(repr(bound_is_null))
 
 
-def test_bound_is_not_null(term: BoundReference) -> None:
+def test_bound_is_not_null(term: BoundReference[Any]) -> None:
     bound_not_null = BoundNotNull(term)
     assert str(bound_not_null) == f"BoundNotNull(term={str(term)})"
     assert repr(bound_not_null) == f"BoundNotNull(term={repr(term)})"
@@ -758,14 +759,14 @@ def test_not_nan() -> None:
     assert not_nan == eval(repr(not_nan))
 
 
-def test_bound_in(term: BoundReference) -> None:
+def test_bound_in(term: BoundReference[Any]) -> None:
     bound_in = BoundIn(term, {literal("a"), literal("b"), literal("c")})
     assert str(bound_in) == f"BoundIn({str(term)}, {{a, b, c}})"
     assert repr(bound_in) == f"BoundIn({repr(term)}, {{literal('a'), literal('b'), literal('c')}})"
     assert bound_in == eval(repr(bound_in))
 
 
-def test_bound_not_in(term: BoundReference) -> None:
+def test_bound_not_in(term: BoundReference[Any]) -> None:
     bound_not_in = BoundNotIn(term, {literal("a"), literal("b"), literal("c")})
     assert str(bound_not_in) == f"BoundNotIn({str(term)}, {{a, b, c}})"
     assert repr(bound_not_in) == f"BoundNotIn({repr(term)}, {{literal('a'), literal('b'), literal('c')}})"
@@ -788,42 +789,42 @@ def test_not_in() -> None:
     assert not_in == eval(repr(not_in))
 
 
-def test_bound_equal_to(term: BoundReference) -> None:
+def test_bound_equal_to(term: BoundReference[Any]) -> None:
     bound_equal_to = BoundEqualTo(term, literal("a"))
     assert str(bound_equal_to) == f"BoundEqualTo(term={str(term)}, literal=literal('a'))"
     assert repr(bound_equal_to) == f"BoundEqualTo(term={repr(term)}, literal=literal('a'))"
     assert bound_equal_to == eval(repr(bound_equal_to))
 
 
-def test_bound_not_equal_to(term: BoundReference) -> None:
+def test_bound_not_equal_to(term: BoundReference[Any]) -> None:
     bound_not_equal_to = BoundNotEqualTo(term, literal("a"))
     assert str(bound_not_equal_to) == f"BoundNotEqualTo(term={str(term)}, literal=literal('a'))"
     assert repr(bound_not_equal_to) == f"BoundNotEqualTo(term={repr(term)}, literal=literal('a'))"
     assert bound_not_equal_to == eval(repr(bound_not_equal_to))
 
 
-def test_bound_greater_than_or_equal_to(term: BoundReference) -> None:
+def test_bound_greater_than_or_equal_to(term: BoundReference[Any]) -> None:
     bound_greater_than_or_equal_to = BoundGreaterThanOrEqual(term, literal("a"))
     assert str(bound_greater_than_or_equal_to) == f"BoundGreaterThanOrEqual(term={str(term)}, literal=literal('a'))"
     assert repr(bound_greater_than_or_equal_to) == f"BoundGreaterThanOrEqual(term={repr(term)}, literal=literal('a'))"
     assert bound_greater_than_or_equal_to == eval(repr(bound_greater_than_or_equal_to))
 
 
-def test_bound_greater_than(term: BoundReference) -> None:
+def test_bound_greater_than(term: BoundReference[Any]) -> None:
     bound_greater_than = BoundGreaterThan(term, literal("a"))
     assert str(bound_greater_than) == f"BoundGreaterThan(term={str(term)}, literal=literal('a'))"
     assert repr(bound_greater_than) == f"BoundGreaterThan(term={repr(term)}, literal=literal('a'))"
     assert bound_greater_than == eval(repr(bound_greater_than))
 
 
-def test_bound_less_than(term: BoundReference) -> None:
+def test_bound_less_than(term: BoundReference[Any]) -> None:
     bound_less_than = BoundLessThan(term, literal("a"))
     assert str(bound_less_than) == f"BoundLessThan(term={str(term)}, literal=literal('a'))"
     assert repr(bound_less_than) == f"BoundLessThan(term={repr(term)}, literal=literal('a'))"
     assert bound_less_than == eval(repr(bound_less_than))
 
 
-def test_bound_less_than_or_equal(term: BoundReference) -> None:
+def test_bound_less_than_or_equal(term: BoundReference[Any]) -> None:
     bound_less_than_or_equal = BoundLessThanOrEqual(term, literal("a"))
     assert str(bound_less_than_or_equal) == f"BoundLessThanOrEqual(term={str(term)}, literal=literal('a'))"
     assert repr(bound_less_than_or_equal) == f"BoundLessThanOrEqual(term={repr(term)}, literal=literal('a'))"

--- a/python/tests/expressions/test_visitors.py
+++ b/python/tests/expressions/test_visitors.py
@@ -38,6 +38,7 @@ from pyiceberg.expressions import (
     BoundNotIn,
     BoundNotNaN,
     BoundNotNull,
+    BoundPredicate,
     BoundReference,
     BoundTerm,
     EqualTo,
@@ -55,6 +56,7 @@ from pyiceberg.expressions import (
     NotNull,
     Or,
     Reference,
+    UnboundPredicate,
 )
 from pyiceberg.expressions.literals import Literal, literal
 from pyiceberg.expressions.visitors import (
@@ -102,7 +104,7 @@ class ExpressionB(BooleanExpression, Singleton):
         return "testexprb"
 
 
-class ExampleVisitor(BooleanExpressionVisitor[List]):
+class ExampleVisitor(BooleanExpressionVisitor[List[str]]):
     """A test implementation of a BooleanExpressionVisitor
 
     As this visitor visits each node, it appends an element to a `visit_history` list. This enables testing that a given expression is
@@ -110,131 +112,137 @@ class ExampleVisitor(BooleanExpressionVisitor[List]):
     """
 
     def __init__(self):
-        self.visit_history: List = []
+        self.visit_history: List[str] = []
 
-    def visit_true(self) -> List:
+    def visit_true(self) -> List[str]:
         self.visit_history.append("TRUE")
         return self.visit_history
 
-    def visit_false(self) -> List:
+    def visit_false(self) -> List[str]:
         self.visit_history.append("FALSE")
         return self.visit_history
 
-    def visit_not(self, child_result: List) -> List:
+    def visit_not(self, child_result: List[str]) -> List[str]:
         self.visit_history.append("NOT")
         return self.visit_history
 
-    def visit_and(self, left_result: List, right_result: List) -> List:
+    def visit_and(self, left_result: List[str], right_result: List[str]) -> List[str]:
         self.visit_history.append("AND")
         return self.visit_history
 
-    def visit_or(self, left_result: List, right_result: List) -> List:
+    def visit_or(self, left_result: List[str], right_result: List[str]) -> List[str]:
         self.visit_history.append("OR")
         return self.visit_history
 
-    def visit_unbound_predicate(self, predicate) -> List:
+    def visit_unbound_predicate(self, predicate: UnboundPredicate[Any]) -> List[str]:
         self.visit_history.append("UNBOUND PREDICATE")
         return self.visit_history
 
-    def visit_bound_predicate(self, predicate) -> List:
+    def visit_bound_predicate(self, predicate: BoundPredicate[Any]) -> List[str]:
         self.visit_history.append("BOUND PREDICATE")
         return self.visit_history
 
-    def visit_test_expression_a(self) -> List:
+    def visit_test_expression_a(self) -> List[str]:
         self.visit_history.append("ExpressionA")
         return self.visit_history
 
-    def visit_test_expression_b(self) -> List:
+    def visit_test_expression_b(self) -> List[str]:
         self.visit_history.append("ExpressionB")
         return self.visit_history
 
 
 @visit.register(ExpressionA)
-def _(obj: ExpressionA, visitor: ExampleVisitor) -> List:
+def _(obj: ExpressionA, visitor: ExampleVisitor) -> List[str]:
     """Visit a ExpressionA with a BooleanExpressionVisitor"""
     return visitor.visit_test_expression_a()
 
 
 @visit.register(ExpressionB)
-def _(obj: ExpressionB, visitor: ExampleVisitor) -> List:
+def _(obj: ExpressionB, visitor: ExampleVisitor) -> List[str]:
     """Visit a ExpressionB with a BooleanExpressionVisitor"""
     return visitor.visit_test_expression_b()
 
 
-class FooBoundBooleanExpressionVisitor(BoundBooleanExpressionVisitor[List]):
+class FooBoundBooleanExpressionVisitor(BoundBooleanExpressionVisitor[List[str]]):
     """A test implementation of a BoundBooleanExpressionVisitor
     As this visitor visits each node, it appends an element to a `visit_history` list. This enables testing that a given bound expression is
     visited in an expected order by the `visit` method.
     """
 
     def __init__(self):
-        self.visit_history: List = []
+        self.visit_history: List[str] = []
 
-    def visit_in(self, term: BoundTerm, literals: Set) -> List:
+    def visit_in(self, term: BoundTerm[Any], literals: Set[Any]) -> List[str]:
         self.visit_history.append("IN")
         return self.visit_history
 
-    def visit_not_in(self, term: BoundTerm, literals: Set) -> List:
+    def visit_not_in(self, term: BoundTerm[Any], literals: Set[Any]) -> List[str]:
         self.visit_history.append("NOT_IN")
         return self.visit_history
 
-    def visit_is_nan(self, term: BoundTerm) -> List:
+    def visit_is_nan(self, term: BoundTerm[Any]) -> List[str]:
         self.visit_history.append("IS_NAN")
         return self.visit_history
 
-    def visit_not_nan(self, term: BoundTerm) -> List:
+    def visit_not_nan(self, term: BoundTerm[Any]) -> List[str]:
         self.visit_history.append("NOT_NAN")
         return self.visit_history
 
-    def visit_is_null(self, term: BoundTerm) -> List:
+    def visit_is_null(self, term: BoundTerm[Any]) -> List[str]:
         self.visit_history.append("IS_NULL")
         return self.visit_history
 
-    def visit_not_null(self, term: BoundTerm) -> List:
+    def visit_not_null(self, term: BoundTerm[Any]) -> List[str]:
         self.visit_history.append("NOT_NULL")
         return self.visit_history
 
-    def visit_equal(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("EQUAL")
         return self.visit_history
 
-    def visit_not_equal(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_not_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("NOT_EQUAL")
         return self.visit_history
 
-    def visit_greater_than_or_equal(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_greater_than_or_equal(
+        self, term: BoundTerm[Any], literal: Literal[Any]
+    ) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("GREATER_THAN_OR_EQUAL")
         return self.visit_history
 
-    def visit_greater_than(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_greater_than(
+        self, term: BoundTerm[Any], literal: Literal[Any]
+    ) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("GREATER_THAN")
         return self.visit_history
 
-    def visit_less_than(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_less_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("LESS_THAN")
         return self.visit_history
 
-    def visit_less_than_or_equal(self, term: BoundTerm, literal: Literal) -> List:  # pylint: disable=redefined-outer-name
+    def visit_less_than_or_equal(
+        self, term: BoundTerm[Any], literal: Literal[Any]
+    ) -> List[str]:  # pylint: disable=redefined-outer-name
         self.visit_history.append("LESS_THAN_OR_EQUAL")
         return self.visit_history
 
-    def visit_true(self) -> List:
+    def visit_true(self) -> List[str]:
         self.visit_history.append("TRUE")
         return self.visit_history
 
-    def visit_false(self) -> List:
+    def visit_false(self) -> List[str]:
         self.visit_history.append("FALSE")
         return self.visit_history
 
-    def visit_not(self, child_result: List) -> List:
+    def visit_not(self, child_result: List[str]) -> List[str]:
         self.visit_history.append("NOT")
         return self.visit_history
 
-    def visit_and(self, left_result: List, right_result: List) -> List:
+    def visit_and(self, left_result: List[str], right_result: List[str]) -> List[str]:
         self.visit_history.append("AND")
         return self.visit_history
 
-    def visit_or(self, left_result: List, right_result: List) -> List:
+    def visit_or(self, left_result: List[str], right_result: List[str]) -> List[str]:
         self.visit_history.append("OR")
         return self.visit_history
 

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -17,6 +17,7 @@
 # pylint: disable=eval-used,protected-access
 from datetime import date
 from decimal import Decimal
+from typing import Any
 from uuid import UUID
 
 import mmh3 as mmh3
@@ -392,7 +393,7 @@ def test_void_transform():
 
 
 class TestType(IcebergBaseModel):
-    __root__: Transform
+    __root__: Transform[Any, Any]
 
 
 def test_bucket_transform_serialize():


### PR DESCRIPTION
Mypy allows us to warn when a type is missing:
`List`, should be `List[str]`

This way we don't accidentally forget any type (which happens to me all the time :). I just ignored, added `Any` to most of the current violations, and also fixed some of them.