### PR TITLE
Docs: Remove parent-version-id from the view spec example

### DIFF
--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -149,7 +149,6 @@ The metadata directory contains View Version Metadata files. The text after '=>'
   },
   "versions" : [ { => Last few versions of the view.
     "version-id" : 1,
-    "parent-version-id" : -1,
     "timestamp-ms" : 1573518431292,
     "summary" : {
       "operation" : "create", => View operation that caused this metadata to be created
@@ -201,7 +200,6 @@ The Iceberg / view library creates a new metadata JSON file every time the view 
   },
   "versions" : [ {
     "version-id" : 1,
-    "parent-version-id" : -1,
     "timestamp-ms" : 1573518431292,
     "summary" : {
       "operation" : "create",
@@ -218,7 +216,6 @@ The Iceberg / view library creates a new metadata JSON file every time the view 
     "properties" : { }
   }, {
     "version-id" : 2,
-    "parent-version-id" : 1, => Version 2 was created on top of version 1, making parent-version-id 1
     "timestamp-ms" : 1573518440265,
     "summary" : {
       "operation" : "replace", => The ‘replace’ operation caused this latest version creation


### PR DESCRIPTION
`parent-version-id` is not mentioned in the spec but the example has the field. 
The latest API implementation also doesn't have it(https://github.com/apache/iceberg/pull/4925)
So, removing it from the examples. 