### PR TITLE
Core: Fix check is delete file and data file overlap

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -271,7 +271,8 @@ class DeleteFileIndex {
     T deleteUpper = Conversions.fromByteBuffer(type, deleteUpperBuf);
 
     return !((comparator.compare(deleteLower, dataLower) <= 0
-        && comparator.compare(deleteUpper, dataLower) <= 0) || ((comparator.compare(deleteLower, dataUpper) >= 0
+            && comparator.compare(deleteUpper, dataLower) <= 0)
+        || ((comparator.compare(deleteLower, dataUpper) >= 0
             && comparator.compare(deleteUpper, dataUpper) >= 0)));
   }
 

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -270,9 +270,9 @@ class DeleteFileIndex {
     T deleteLower = Conversions.fromByteBuffer(type, deleteLowerBuf);
     T deleteUpper = Conversions.fromByteBuffer(type, deleteUpperBuf);
 
-    return (comparator.compare(deleteLower, dataLower) <= 0
-        && comparator.compare(deleteUpper, dataLower) >= 0) || ((comparator.compare(deleteLower, dataUpper) <= 0
-            && comparator.compare(deleteUpper, dataUpper) >= 0));
+    return !((comparator.compare(deleteLower, dataLower) <= 0
+        && comparator.compare(deleteUpper, dataLower) <= 0) || ((comparator.compare(deleteLower, dataUpper) >= 0
+            && comparator.compare(deleteUpper, dataUpper) >= 0)));
   }
 
   private static boolean allNonNull(Map<Integer, Long> nullValueCounts, Types.NestedField field) {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -270,8 +270,9 @@ class DeleteFileIndex {
     T deleteLower = Conversions.fromByteBuffer(type, deleteLowerBuf);
     T deleteUpper = Conversions.fromByteBuffer(type, deleteUpperBuf);
 
-    return comparator.compare(deleteLower, dataUpper) <= 0
-        && comparator.compare(dataLower, deleteUpper) <= 0;
+    return (comparator.compare(deleteLower, dataLower) <= 0
+        && comparator.compare(deleteUpper, dataLower) >= 0) || ((comparator.compare(deleteLower, dataUpper) <= 0
+            && comparator.compare(deleteUpper, dataUpper) >= 0));
   }
 
   private static boolean allNonNull(Map<Integer, Long> nullValueCounts, Types.NestedField field) {


### PR DESCRIPTION
Just `deleteLower` and `deleteUpper` less than `dataLower ` is true or `deleteLower` and `deleteUpper` greater than `dataUpper` is true mean there is no overlap between the delete-file and data-file.