### PR TITLE
Flink: Fix tests creating catalog after FLINK-29677

### DIFF
--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -60,11 +60,13 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
 
   @Before
   public void before() {
+    pushCatalog();
     sql("CREATE CATALOG %s WITH %s", catalogName, toWithClause(config));
   }
 
   @After
   public void clean() {
+    popCatalog();
     sql("DROP CATALOG IF EXISTS %s", catalogName);
   }
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -60,14 +60,12 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
 
   @Before
   public void before() {
-    pushCatalog();
     sql("CREATE CATALOG %s WITH %s", catalogName, toWithClause(config));
   }
 
   @After
   public void clean() {
-    popCatalog();
-    sql("DROP CATALOG IF EXISTS %s", catalogName);
+    dropCatalog(catalogName, true);
   }
 
   @Parameterized.Parameters(name = "catalogName = {0} baseNamespace = {1}")

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -52,6 +52,8 @@ public abstract class FlinkTestBase extends TestBaseUtils {
 
   private volatile TableEnvironment tEnv = null;
 
+  private String oldCatalog;
+
   @BeforeClass
   public static void startMetastore() {
     FlinkTestBase.metastore = new TestHiveMetastore();
@@ -112,5 +114,13 @@ public abstract class FlinkTestBase extends TestBaseUtils {
         .isNotNull()
         .as(message)
         .containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  protected void pushCatalog() {
+    oldCatalog = sql("SHOW CURRENT CATALOG").get(0).getField(0).toString();
+  }
+
+  protected void popCatalog() {
+    sql("USE CATALOG %s", oldCatalog);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -82,6 +82,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
 
   @Before
   public void before() {
+    pushCatalog();
     sql(
         "CREATE CATALOG %s WITH ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         CATALOG_NAME, warehouse);
@@ -99,6 +100,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void clean() {
     sql("DROP TABLE IF EXISTS %s", TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", DATABASE_NAME);
+    popCatalog();
     sql("DROP CATALOG IF EXISTS %s", CATALOG_NAME);
     BoundedTableFactory.clearDataSets();
   }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -82,7 +82,6 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
 
   @Before
   public void before() {
-    pushCatalog();
     sql(
         "CREATE CATALOG %s WITH ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         CATALOG_NAME, warehouse);
@@ -100,8 +99,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void clean() {
     sql("DROP TABLE IF EXISTS %s", TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", DATABASE_NAME);
-    popCatalog();
-    sql("DROP CATALOG IF EXISTS %s", CATALOG_NAME);
+    dropCatalog(CATALOG_NAME, true);
     BoundedTableFactory.clearDataSets();
   }
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
@@ -78,6 +78,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
 
   private void checkSQLQuery(Map<String, String> catalogProperties, File warehouseDir)
       throws IOException {
+    pushCatalog();
     sql(
         "CREATE CATALOG test_catalog WITH %s",
         FlinkCatalogTestBase.toWithClause(catalogProperties));
@@ -100,6 +101,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
 
     sql("DROP TABLE test_table");
     sql("DROP DATABASE test_db");
+    popCatalog();
     sql("DROP CATALOG test_catalog");
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
@@ -78,7 +78,6 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
 
   private void checkSQLQuery(Map<String, String> catalogProperties, File warehouseDir)
       throws IOException {
-    pushCatalog();
     sql(
         "CREATE CATALOG test_catalog WITH %s",
         FlinkCatalogTestBase.toWithClause(catalogProperties));
@@ -101,7 +100,6 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
 
     sql("DROP TABLE test_table");
     sql("DROP DATABASE test_db");
-    popCatalog();
-    sql("DROP CATALOG test_catalog");
+    dropCatalog("test_catalog", false);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
@@ -76,7 +76,6 @@ public class TestFlinkTableSource extends FlinkTestBase {
 
   @Before
   public void before() {
-    pushCatalog();
     sql(
         "CREATE CATALOG %s WITH ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         CATALOG_NAME, warehouse);
@@ -98,8 +97,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void clean() {
     sql("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", DATABASE_NAME);
-    popCatalog();
-    sql("DROP CATALOG IF EXISTS %s", CATALOG_NAME);
+    dropCatalog(CATALOG_NAME, true);
   }
 
   @Test

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
@@ -76,6 +76,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
 
   @Before
   public void before() {
+    pushCatalog();
     sql(
         "CREATE CATALOG %s WITH ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
         CATALOG_NAME, warehouse);
@@ -97,6 +98,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
   public void clean() {
     sql("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, TABLE_NAME);
     sql("DROP DATABASE IF EXISTS %s", DATABASE_NAME);
+    popCatalog();
     sql("DROP CATALOG IF EXISTS %s", CATALOG_NAME);
   }
 


### PR DESCRIPTION
FLINK-29677 add a check, so the currently used `Catalog` could not be dropped.
FLINK-29677 will land in Flink 1.16.1, and 1.17.0 and when we start to use it we need to update some of our tests.

This PR creates a method `pushCatalog` to store the current catalog, and `popCatalog` to restore this old catalog. This should be used to restore the original catalog before dropping the one used in the tests.