### PR TITLE
Docs: Remove redundant configuration from spark docs

### DIFF
--- a/docs/spark-getting-started.md
+++ b/docs/spark-getting-started.md
@@ -52,13 +52,11 @@ If you want to include Iceberg in your Spark installation, add the [`iceberg-spa
 
 Iceberg comes with [catalogs](../spark-configuration#catalogs) that enable SQL commands to manage tables and load them by name. Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
 
-This command creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog:
+This command creates a path-based catalog named `local` for tables under `$PWD/warehouse` :
 
 ```sh
 spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:{{% icebergVersion %}}\
     --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
-    --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
-    --conf spark.sql.catalog.spark_catalog.type=hive \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.local.type=hadoop \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse


### PR DESCRIPTION
The section description mentions that we are creating a catalog called `local`, but it also includes redundant configuration for `spark_catalog` of type hive. Also, hive URI is not mentioned for that hive catalog configuration. 
So, it is a dummy configuration which confuses the users.  Hence, removing it. 

P.S: This is on the getting started front page. So, please verify once more before merging. 
I did verify and all the examples worked for me without this configuration too.