### PR TITLE
Spec: Clarify auth responses in the REST spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -506,10 +506,10 @@ paths:
 
         The response contains both configuration and table metadata. The configuration, if non-empty is used
         as additional configuration for the table that overrides catalog configuration. For example, this
-        configuration may change the FileIO implemented used for the table.
+        configuration may change the FileIO implementation to be used for the table.
 
 
-        The response also contains the table's full metadata.
+        The response also contains the table's full metadata, matching the table metadata JSON file.
 
 
         The catalog configuration may contain credentials that should be used for subsequent requests for the
@@ -2385,6 +2385,13 @@ components:
   securitySchemes:
     OAuth2:
       type: oauth2
+      description:
+        This scheme is used for OAuth2 authorization.
+
+
+        For unauthorized requests, services should return an appropriate 401 or
+        403 response. Implementations must not return altered success (200)
+        responses when a request is unauthenticated or unauthorized.
       flows:
         clientCredentials:
           tokenUrl: /v1/oauth/tokens


### PR DESCRIPTION
This is a minor clarification to the REST catalog spec. When a request is unauthenticated or unauthorized, the REST service must respond with a correct HTTP error code and must not return fake success responses. For example, if a request to load a table is unauthorized, the service cannot return fake table metadata to signal that the table exists but cannot be used.