### PR TITLE
Python: Skip in the case of AboveMax and BelowMin

### DIFF
--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -134,12 +134,25 @@ def literal(value: L) -> Literal[L]:
         raise TypeError(f"Invalid literal value: {repr(value)}")
 
 
-class FloatAboveMax(Literal[float], Singleton):
+class AboveMax(Literal[L]):
+    ...
+
+
+class BelowMin(Literal[L]):
+    ...
+
+
+class FloatAboveMax(AboveMax[float], Singleton):
     def __init__(self):
         super().__init__(FloatType.max, float)
 
+    @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of FloatAboveMax")
+
+    @to.register(FloatType)
+    def _(self, _: FloatType) -> Literal[float]:
+        return self
 
     def __repr__(self) -> str:
         return "FloatAboveMax()"
@@ -148,12 +161,17 @@ class FloatAboveMax(Literal[float], Singleton):
         return "FloatAboveMax"
 
 
-class FloatBelowMin(Literal[float], Singleton):
+class FloatBelowMin(BelowMin[float], Singleton):
     def __init__(self):
         super().__init__(FloatType.min, float)
 
+    @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of FloatBelowMin")
+
+    @to.register(FloatType)
+    def _(self, _: FloatType) -> Literal[float]:
+        return self
 
     def __repr__(self) -> str:
         return "FloatBelowMin()"
@@ -162,12 +180,17 @@ class FloatBelowMin(Literal[float], Singleton):
         return "FloatBelowMin"
 
 
-class IntAboveMax(Literal[int]):
+class IntAboveMax(AboveMax[int], Singleton):
     def __init__(self):
         super().__init__(IntegerType.max, int)
 
+    @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of IntAboveMax")
+
+    @to.register(IntegerType)
+    def _(self, _: IntegerType) -> Literal[int]:
+        return self
 
     def __repr__(self) -> str:
         return "IntAboveMax()"
@@ -176,12 +199,17 @@ class IntAboveMax(Literal[int]):
         return "IntAboveMax"
 
 
-class IntBelowMin(Literal[int]):
+class IntBelowMin(BelowMin[int], Singleton):
     def __init__(self):
         super().__init__(IntegerType.min, int)
 
+    @singledispatchmethod
     def to(self, type_var: IcebergType) -> Literal:  # type: ignore
         raise TypeError("Cannot change the type of IntBelowMin")
+
+    @to.register(IntegerType)
+    def _(self, _: IntegerType) -> Literal[int]:
+        return self
 
     def __repr__(self) -> str:
         return "IntBelowMin()"

--- a/python/tests/expressions/test_expressions.py
+++ b/python/tests/expressions/test_expressions.py
@@ -56,7 +56,14 @@ from pyiceberg.expressions import (
     Or,
     Reference,
 )
-from pyiceberg.expressions.literals import literal
+from pyiceberg.expressions.literals import (
+    FloatAboveMax,
+    FloatBelowMin,
+    IntAboveMax,
+    IntBelowMin,
+    Literal,
+    literal,
+)
 from pyiceberg.expressions.visitors import _from_byte_buffer
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.types import (
@@ -913,6 +920,96 @@ def test_string_argument_unbound_literal():
 
 def test_string_argument_unbound_set():
     assert In("a", {"b", "c"}) == In(Reference("a"), {"b", "c"})
+
+
+@pytest.fixture
+def int_schema() -> Schema:
+    return Schema(NestedField(field_id=1, name="a", field_type=IntegerType(), required=False))
+
+
+@pytest.fixture
+def above_int_max() -> Literal[int]:
+    return IntAboveMax()
+
+
+@pytest.fixture
+def below_int_min() -> Literal[int]:
+    return IntBelowMin()
+
+
+def test_above_int_bounds_equal_to(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert EqualTo("a", above_int_max).bind(int_schema) is AlwaysFalse()
+    assert EqualTo("a", below_int_min).bind(int_schema) is AlwaysFalse()
+
+
+def test_above_int_bounds_not_equal_to(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert NotEqualTo("a", above_int_max).bind(int_schema) is AlwaysTrue()
+    assert NotEqualTo("a", below_int_min).bind(int_schema) is AlwaysTrue()
+
+
+def test_above_int_bounds_less_than(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert LessThan("a", above_int_max).bind(int_schema) is AlwaysTrue()
+    assert LessThan("a", below_int_min).bind(int_schema) is AlwaysFalse()
+
+
+def test_above_int_bounds_less_than_or_equal(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert LessThanOrEqual("a", above_int_max).bind(int_schema) is AlwaysTrue()
+    assert LessThanOrEqual("a", below_int_min).bind(int_schema) is AlwaysFalse()
+
+
+def test_above_int_bounds_greater_than(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert GreaterThan("a", above_int_max).bind(int_schema) is AlwaysFalse()
+    assert GreaterThan("a", below_int_min).bind(int_schema) is AlwaysTrue()
+
+
+def test_above_int_bounds_greater_than_or_equal(int_schema: Schema, above_int_max, below_int_min) -> None:
+    assert GreaterThanOrEqual("a", above_int_max).bind(int_schema) is AlwaysFalse()
+    assert GreaterThanOrEqual("a", below_int_min).bind(int_schema) is AlwaysTrue()
+
+
+@pytest.fixture
+def float_schema() -> Schema:
+    return Schema(NestedField(field_id=1, name="a", field_type=FloatType(), required=False))
+
+
+@pytest.fixture
+def above_float_max() -> Literal[float]:
+    return FloatAboveMax()
+
+
+@pytest.fixture
+def below_float_min() -> Literal[float]:
+    return FloatBelowMin()
+
+
+def test_above_float_bounds_equal_to(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert EqualTo("a", above_float_max).bind(float_schema) is AlwaysFalse()
+    assert EqualTo("a", below_float_min).bind(float_schema) is AlwaysFalse()
+
+
+def test_above_float_bounds_not_equal_to(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert NotEqualTo("a", above_float_max).bind(float_schema) is AlwaysTrue()
+    assert NotEqualTo("a", below_float_min).bind(float_schema) is AlwaysTrue()
+
+
+def test_above_float_bounds_less_than(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert LessThan("a", above_float_max).bind(float_schema) is AlwaysTrue()
+    assert LessThan("a", below_float_min).bind(float_schema) is AlwaysFalse()
+
+
+def test_above_float_bounds_less_than_or_equal(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert LessThanOrEqual("a", above_float_max).bind(float_schema) is AlwaysTrue()
+    assert LessThanOrEqual("a", below_float_min).bind(float_schema) is AlwaysFalse()
+
+
+def test_above_float_bounds_greater_than(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert GreaterThan("a", above_float_max).bind(float_schema) is AlwaysFalse()
+    assert GreaterThan("a", below_float_min).bind(float_schema) is AlwaysTrue()
+
+
+def test_above_float_bounds_greater_than_or_equal(float_schema: Schema, above_float_max, below_float_min) -> None:
+    assert GreaterThanOrEqual("a", above_float_max).bind(float_schema) is AlwaysFalse()
+    assert GreaterThanOrEqual("a", below_float_min).bind(float_schema) is AlwaysTrue()
 
 
 #   __  __      ___

--- a/python/tests/expressions/test_expressions.py
+++ b/python/tests/expressions/test_expressions.py
@@ -56,14 +56,7 @@ from pyiceberg.expressions import (
     Or,
     Reference,
 )
-from pyiceberg.expressions.literals import (
-    FloatAboveMax,
-    FloatBelowMin,
-    IntAboveMax,
-    IntBelowMin,
-    Literal,
-    literal,
-)
+from pyiceberg.expressions.literals import Literal, literal
 from pyiceberg.expressions.visitors import _from_byte_buffer
 from pyiceberg.schema import Accessor, Schema
 from pyiceberg.types import (
@@ -71,6 +64,7 @@ from pyiceberg.types import (
     FloatType,
     IntegerType,
     ListType,
+    LongType,
     NestedField,
     StringType,
 )
@@ -929,12 +923,12 @@ def int_schema() -> Schema:
 
 @pytest.fixture
 def above_int_max() -> Literal[int]:
-    return IntAboveMax()
+    return literal(IntegerType.max + 1)
 
 
 @pytest.fixture
 def below_int_min() -> Literal[int]:
-    return IntBelowMin()
+    return literal(IntegerType.min - 1)
 
 
 def test_above_int_bounds_equal_to(int_schema: Schema, above_int_max, below_int_min) -> None:
@@ -974,12 +968,12 @@ def float_schema() -> Schema:
 
 @pytest.fixture
 def above_float_max() -> Literal[float]:
-    return FloatAboveMax()
+    return literal(FloatType.max * 2)
 
 
 @pytest.fixture
 def below_float_min() -> Literal[float]:
-    return FloatBelowMin()
+    return literal(FloatType.min * 2)
 
 
 def test_above_float_bounds_equal_to(float_schema: Schema, above_float_max, below_float_min) -> None:
@@ -1010,6 +1004,51 @@ def test_above_float_bounds_greater_than(float_schema: Schema, above_float_max, 
 def test_above_float_bounds_greater_than_or_equal(float_schema: Schema, above_float_max, below_float_min) -> None:
     assert GreaterThanOrEqual("a", above_float_max).bind(float_schema) is AlwaysFalse()
     assert GreaterThanOrEqual("a", below_float_min).bind(float_schema) is AlwaysTrue()
+
+
+@pytest.fixture
+def long_schema() -> Schema:
+    return Schema(NestedField(field_id=1, name="a", field_type=LongType(), required=False))
+
+
+@pytest.fixture
+def above_long_max() -> Literal[float]:
+    return literal(LongType.max + 1)
+
+
+@pytest.fixture
+def below_long_min() -> Literal[float]:
+    return literal(LongType.min - 1)
+
+
+def test_above_long_bounds_equal_to(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert EqualTo("a", above_long_max).bind(long_schema) is AlwaysFalse()
+    assert EqualTo("a", below_long_min).bind(long_schema) is AlwaysFalse()
+
+
+def test_above_long_bounds_not_equal_to(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert NotEqualTo("a", above_long_max).bind(long_schema) is AlwaysTrue()
+    assert NotEqualTo("a", below_long_min).bind(long_schema) is AlwaysTrue()
+
+
+def test_above_long_bounds_less_than(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert LessThan("a", above_long_max).bind(long_schema) is AlwaysTrue()
+    assert LessThan("a", below_long_min).bind(long_schema) is AlwaysFalse()
+
+
+def test_above_long_bounds_less_than_or_equal(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert LessThanOrEqual("a", above_long_max).bind(long_schema) is AlwaysTrue()
+    assert LessThanOrEqual("a", below_long_min).bind(long_schema) is AlwaysFalse()
+
+
+def test_above_long_bounds_greater_than(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert GreaterThan("a", above_long_max).bind(long_schema) is AlwaysFalse()
+    assert GreaterThan("a", below_long_min).bind(long_schema) is AlwaysTrue()
+
+
+def test_above_long_bounds_greater_than_or_equal(long_schema: Schema, above_long_max, below_long_min) -> None:
+    assert GreaterThanOrEqual("a", above_long_max).bind(long_schema) is AlwaysFalse()
+    assert GreaterThanOrEqual("a", below_long_min).bind(long_schema) is AlwaysTrue()
 
 
 #   __  __      ___

--- a/python/tests/expressions/test_literals.py
+++ b/python/tests/expressions/test_literals.py
@@ -492,9 +492,7 @@ def test_above_max_float():
     assert repr(a) == "FloatAboveMax()"
     assert a.value == FloatType.max
     assert a == eval(repr(a))
-    with pytest.raises(TypeError) as e:
-        a.to(IntegerType())
-    assert "Cannot change the type of FloatAboveMax" in str(e.value)
+    assert a.to(FloatType()) == FloatAboveMax()
 
 
 def test_below_min_float():
@@ -505,9 +503,7 @@ def test_below_min_float():
     assert repr(b) == "FloatBelowMin()"
     assert b == eval(repr(b))
     assert b.value == FloatType.min
-    with pytest.raises(TypeError) as e:
-        b.to(IntegerType())
-    assert "Cannot change the type of FloatBelowMin" in str(e.value)
+    assert b.to(FloatType()) == FloatBelowMin()
 
 
 def test_above_max_int():
@@ -518,9 +514,7 @@ def test_above_max_int():
     assert repr(a) == "IntAboveMax()"
     assert a.value == IntegerType.max
     assert a == eval(repr(a))
-    with pytest.raises(TypeError) as e:
-        a.to(IntegerType())
-    assert "Cannot change the type of IntAboveMax" in str(e.value)
+    assert a.to(IntegerType()) == IntAboveMax()
 
 
 def test_below_min_int():
@@ -530,10 +524,7 @@ def test_below_min_int():
     assert str(b) == "IntBelowMin"
     assert repr(b) == "IntBelowMin()"
     assert b == eval(repr(b))
-    assert b.value == IntegerType.min
-    with pytest.raises(TypeError) as e:
-        b.to(IntegerType())
-    assert "Cannot change the type of IntBelowMin" in str(e.value)
+    assert b.to(IntegerType()) == IntBelowMin()
 
 
 def test_invalid_boolean_conversions():


### PR DESCRIPTION
When we have an expression `EqualTo('a', IntegerType.max + 1)`, that will result in an `AboveMax` literal. This means that the value cannot be in the values because it is out of bounds.

We can use this information in the optimizer to skip the files where this is the case.

Closes #6203 