### PR TITLE
API: Fix ErrorProne warning around Immutable Enums

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.transforms;
 
+import com.google.errorprone.annotations.Immutable;
 import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundTransform;
@@ -35,6 +36,7 @@ enum Dates implements Transform<Integer, Integer> {
   MONTH(ChronoUnit.MONTHS, "month"),
   DAY(ChronoUnit.DAYS, "day");
 
+  @Immutable
   static class Apply implements SerializableFunction<Integer, Integer> {
     private final ChronoUnit granularity;
 

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.transforms;
 
+import com.google.errorprone.annotations.Immutable;
 import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundTransform;
@@ -36,6 +37,7 @@ enum Timestamps implements Transform<Long, Integer> {
   DAY(ChronoUnit.DAYS, "day"),
   HOUR(ChronoUnit.HOURS, "hour");
 
+  @Immutable
   static class Apply implements SerializableFunction<Long, Integer> {
     private final ChronoUnit granularity;
 
@@ -66,7 +68,7 @@ enum Timestamps implements Transform<Long, Integer> {
 
   private final ChronoUnit granularity;
   private final String name;
-  private final SerializableFunction<Long, Integer> apply;
+  private final Apply apply;
 
   Timestamps(ChronoUnit granularity, String name) {
     this.granularity = granularity;


### PR DESCRIPTION
This should fix the ErrorProne warning
```
> Task :iceberg-api:compileJava
/home/nastra/Development/workspace/iceberg/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java:69: warning: [ImmutableEnumChecker] enums should be immutable: 'Timestamps' has field 'apply' of type 'org.apache.iceberg.util.SerializableFunction<java.lang.Long,java.lang.Integer>', the declaration of type 'org.apache.iceberg.util.SerializableFunction<java.lang.Long,java.lang.Integer>' is not annotated with @com.google.errorprone.annotations.Immutable
  private final SerializableFunction<Long, Integer> apply;
                                                    ^
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
/home/nastra/Development/workspace/iceberg/api/src/main/java/org/apache/iceberg/transforms/Dates.java:66: warning: [ImmutableEnumChecker] enums should be immutable: 'Dates' has field 'apply' of type 'org.apache.iceberg.transforms.Dates.Apply', the declaration of type 'org.apache.iceberg.transforms.Dates.Apply' is not annotated with @com.google.errorprone.annotations.Immutable
  private final Apply apply;
                      ^
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
```