### PR TITLE
Python-legacy: Pin flake8

### DIFF
--- a/python_legacy/tox.ini
+++ b/python_legacy/tox.ini
@@ -50,7 +50,7 @@ basepython = python3
 skip_install = true
 deps =
     flake8==5.0.4
-    flake8-import-order>=0.9
+    flake8-import-order==0.18.1
     flake8-bugbear==22.6.22
 commands =
     flake8 iceberg setup.py tests

--- a/python_legacy/tox.ini
+++ b/python_legacy/tox.ini
@@ -49,7 +49,7 @@ commands =
 basepython = python3
 skip_install = true
 deps =
-    flake8>=3.8.4
+    flake8==5.0.4
     flake8-import-order>=0.9
     flake8-bugbear==22.6.22
 commands =


### PR DESCRIPTION
Flake8 6.0.0 has been released, and this breaks the build.