### PR TITLE
Build: Let revapi compare against 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ subprojects {
     revapi {
       oldGroup = project.group
       oldName = project.name
-      oldVersion = "1.0.0"
+      oldVersion = "1.1.0"
     }
   }
 


### PR DESCRIPTION
We should merge this once 1.1.0 has been released