### PR TITLE
Python: Fix Avro scan performance in PyArrow

### DIFF
--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -53,7 +53,10 @@ class BinaryDecoder:
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
         read_bytes = self._input_stream.read(n)
-        if len(read_bytes) != n:
+        read_len = len(read_bytes)
+        if read_len <= 0:
+            raise EOFError
+        elif read_len != n:
             raise ValueError(f"Read {len(read_bytes)} bytes, expected {n} bytes")
         return read_bytes
 

--- a/python/pyiceberg/avro/file.py
+++ b/python/pyiceberg/avro/file.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from io import SEEK_SET
+from io import SEEK_SET, BufferedReader
 from typing import Optional, Type
 
 from pyiceberg.avro.codecs import KNOWN_CODECS, Codec
@@ -131,7 +131,7 @@ class AvroFile:
         Returns:
             A generator returning the AvroStructs
         """
-        self.input_stream = self.input_file.open()
+        self.input_stream = BufferedReader(self.input_file.open())
         self.decoder = BinaryDecoder(self.input_stream)
         self.header = self._read_header()
         self.schema = self.header.get_schema()

--- a/python/pyiceberg/avro/file.py
+++ b/python/pyiceberg/avro/file.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from io import SEEK_SET, BufferedReader
-from typing import Optional, Type
+from typing import Optional, Type, cast
 
 from pyiceberg.avro.codecs import KNOWN_CODECS, Codec
 from pyiceberg.avro.decoder import BinaryDecoder
@@ -113,7 +113,6 @@ class AvroFile:
     input_stream: InputStream
     header: AvroFileHeader
     schema: Schema
-    file_length: int
     reader: StructReader
 
     decoder: BinaryDecoder
@@ -135,11 +134,10 @@ class AvroFile:
         self.decoder = BinaryDecoder(self.input_stream)
         self.header = self._read_header()
         self.schema = self.header.get_schema()
-        self.file_length = len(self.input_file)
         if not self.read_schema:
             self.reader = visit(self.schema, ConstructReader())
         else:
-            self.reader = resolve(self.schema, self.read_schema)
+            self.reader = cast(StructReader, resolve(self.schema, self.read_schema))
 
         return self
 
@@ -155,8 +153,6 @@ class AvroFile:
             sync_marker = self.decoder.read(SYNC_SIZE)
             if sync_marker != self.header.sync:
                 raise ValueError(f"Expected sync bytes {self.header.sync!r}, but got {sync_marker!r}")
-            if self.is_EOF():
-                raise StopIteration
         block_records = self.decoder.read_int()
 
         block_bytes_len = self.decoder.read_int()
@@ -173,7 +169,10 @@ class AvroFile:
         if self.block and self.block.has_next():
             return next(self.block)
 
-        new_block = self._read_block()
+        try:
+            new_block = self._read_block()
+        except EOFError as exc:
+            raise StopIteration from exc
 
         if new_block > 0:
             return self.__next__()
@@ -184,6 +183,3 @@ class AvroFile:
         reader = visit(META_SCHEMA, ConstructReader())
         _header = reader.read(self.decoder)
         return AvroFileHeader(magic=_header.get(0), meta=_header.get(1), sync=_header.get(2))
-
-    def is_EOF(self) -> bool:
-        return self.input_stream.tell() == self.file_length


### PR DESCRIPTION
This improves Avro scan performance when using PyArrowFileIO by about 10x by ensuring that scans are buffered and updating EOF handling. I was testing scan planning and found that S3 planning took about 130 seconds. Buffering the input stream and avoiding the `len(input_file)` call gets the planning time for the same query to 13 seconds.

The main problem was that the stream provided by PyArrow was not buffered, so nearly every read operation was causing another request to S3.

A second issue was that the call to get the file length was expensive, so this also updates the decoder to throw `EOFException` rather than checking file length. This improved the performance by about 1 second in my test.