### PR TITLE
Infra: Add 1.1.0 to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "1.0.0 (latest release)"
+        - "1.1.0 (latest release)"
+        - "1.0.0"
         - "0.14.1"
         - "0.14.0"
         - "0.13.1"


### PR DESCRIPTION
As 1.1.0 release is pushed to maven central, 
https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/1.1.0/

Also dependabots / renovate bots started raising version bump PR.  https://github.com/projectnessie/nessie/pull/5582