### PR TITLE
Added FileIO Support for ORC Reader and Writers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSInputStream;
 import org.apache.iceberg.io.DelegatingInputStream;
 import org.apache.iceberg.io.DelegatingOutputStream;
 import org.apache.iceberg.io.PositionOutputStream;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This class is based on Parquet's HadoopStreams.
  */
-class HadoopStreams {
+public class HadoopStreams {
 
   private HadoopStreams() {}
 
@@ -188,6 +189,50 @@ class HadoopStreams {
             Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
         LOG.warn("Unclosed output stream created by:\n\t{}", trace);
       }
+    }
+  }
+
+  public static class WrappedSeekableInputStream extends FSInputStream
+      implements DelegatingInputStream {
+    private final SeekableInputStream inputStream;
+
+    public WrappedSeekableInputStream(SeekableInputStream inputStream) {
+      this.inputStream = inputStream;
+    }
+
+    @Override
+    public void seek(long pos) throws IOException {
+      inputStream.seek(pos);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return inputStream.getPos();
+    }
+
+    @Override
+    public boolean seekToNewSource(long targetPos) throws IOException {
+      throw new UnsupportedOperationException("seekToNewSource not supported");
+    }
+
+    @Override
+    public int read() throws IOException {
+      return inputStream.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return inputStream.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      inputStream.close();
+    }
+
+    @Override
+    public InputStream getDelegate() {
+      return inputStream;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -67,6 +67,16 @@ public class HadoopStreams {
   }
 
   /**
+   * Wraps a {@link SeekableInputStream} in a {@link FSDataOutputStream} implementation for readers.
+   *
+   * @param stream a SeekableInputStream
+   * @return a FSDataOutputStream
+   */
+  public static FSInputStream wrap(SeekableInputStream stream) {
+    return new WrappedSeekableInputStream(stream);
+  }
+
+  /**
    * SeekableInputStream implementation for FSDataInputStream that implements ByteBufferReadable in
    * Hadoop 2.
    */
@@ -192,11 +202,11 @@ public class HadoopStreams {
     }
   }
 
-  public static class WrappedSeekableInputStream extends FSInputStream
+  private static class WrappedSeekableInputStream extends FSInputStream
       implements DelegatingInputStream {
     private final SeekableInputStream inputStream;
 
-    public WrappedSeekableInputStream(SeekableInputStream inputStream) {
+    private WrappedSeekableInputStream(SeekableInputStream inputStream) {
       this.inputStream = inputStream;
     }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
@@ -34,7 +34,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class FileIOFSUtil {
+class FileIOFSUtil {
   private FileIOFSUtil() {}
 
   private static class NullFileSystem extends FileSystem {

--- a/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.iceberg.hadoop.HadoopStreams;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class FileIOFSUtil {
+  private FileIOFSUtil() {}
+
+  private static class NullFileSystem extends FileSystem {
+
+    @Override
+    public URI getUri() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FSDataInputStream open(Path f) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path f,
+        FsPermission permission,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FSDataOutputStream append(Path f, int bufferSize, Progressable progress)
+        throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean delete(Path f, boolean recursive) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path f) throws FileNotFoundException, IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setWorkingDirectory(Path new_dir) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path f) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  static class InputFileSystem extends NullFileSystem {
+    private final InputFile inputFile;
+    private final Path inputPath;
+
+    InputFileSystem(InputFile inputFile) {
+      this.inputFile = inputFile;
+      this.inputPath = new Path(inputFile.location());
+    }
+
+    @Override
+    public FSDataInputStream open(Path f) throws IOException {
+      Preconditions.checkArgument(
+          f.equals(inputPath), String.format("Input %s does not equal expected %s", f, inputPath));
+      return new FSDataInputStream(
+          new HadoopStreams.WrappedSeekableInputStream(inputFile.newStream()));
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+      return open(f);
+    }
+  }
+
+  static class OutputFileSystem extends NullFileSystem {
+    private final OutputFile outputFile;
+    private final Path outPath;
+
+    OutputFileSystem(OutputFile outputFile) {
+      this.outputFile = outputFile;
+      this.outPath = new Path(outputFile.location());
+    }
+
+    @Override
+    public FSDataOutputStream create(Path f, boolean overwrite) throws IOException {
+      Preconditions.checkArgument(
+          f.equals(outPath), String.format("Input %s does not equal expected %s", f, outPath));
+      OutputStream outputStream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
+      return new FSDataOutputStream(outputStream, null);
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path f,
+        FsPermission permission,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress)
+        throws IOException {
+      return create(f, overwrite);
+    }
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/FileIOFSUtil.java
@@ -122,8 +122,7 @@ public class FileIOFSUtil {
     public FSDataInputStream open(Path f) throws IOException {
       Preconditions.checkArgument(
           f.equals(inputPath), String.format("Input %s does not equal expected %s", f, inputPath));
-      return new FSDataInputStream(
-          new HadoopStreams.WrappedSeekableInputStream(inputFile.newStream()));
+      return new FSDataInputStream(HadoopStreams.wrap(inputFile.newStream()));
     }
 
     @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -88,12 +88,9 @@ import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
 public class ORC {
-  private static final Logger LOG = LoggerFactory.getLogger(ORC.class);
 
   /** @deprecated use {@link TableProperties#ORC_WRITE_BATCH_SIZE} instead */
   @Deprecated private static final String VECTOR_ROW_BATCH_SIZE = "iceberg.orc.vectorbatch.size";

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -779,15 +779,6 @@ public class ORC {
     }
   }
 
-  @Deprecated
-  static Reader newFileReader(String location, ReaderOptions readerOptions) {
-    try {
-      return OrcFile.createReader(new Path(location), readerOptions);
-    } catch (IOException ioe) {
-      throw new RuntimeIOException(ioe, "Failed to open file: %s", location);
-    }
-  }
-
   static Reader newFileReader(InputFile file, Configuration config) {
     ReaderOptions readerOptions = OrcFile.readerOptions(config).useUTCTimestamp(true);
     if (file instanceof HadoopInputFile) {

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -38,13 +38,9 @@ import static org.apache.iceberg.TableProperties.ORC_STRIPE_SIZE_BYTES_DEFAULT;
 import static org.apache.iceberg.TableProperties.ORC_WRITE_BATCH_SIZE;
 import static org.apache.iceberg.TableProperties.ORC_WRITE_BATCH_SIZE_DEFAULT;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -54,14 +50,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FSInputStream;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.util.Progressable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
@@ -85,9 +74,7 @@ import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.mapping.NameMapping;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ArrayUtil;
@@ -101,7 +88,6 @@ import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -796,6 +782,7 @@ public class ORC {
     }
   }
 
+  @Deprecated
   static Reader newFileReader(String location, ReaderOptions readerOptions) {
     try {
       return OrcFile.createReader(new Path(location), readerOptions);
@@ -809,9 +796,16 @@ public class ORC {
     if (file instanceof HadoopInputFile) {
       readerOptions.filesystem(((HadoopInputFile) file).getFileSystem());
     } else {
-      readerOptions.filesystem(new InputFileSystem(file)).maxLength(file.getLength());
+      // In case of any other InputFile we wrap the InputFile with InputFileSystem that only
+      // supports the creation of an InputStream. To prevent a file status call to determine the
+      // length we supply the length as input
+      readerOptions.filesystem(new FileIOFSUtil.InputFileSystem(file)).maxLength(file.getLength());
     }
-    return newFileReader(file.location(), readerOptions);
+    try {
+      return OrcFile.createReader(new Path(file.location()), readerOptions);
+    } catch (IOException ioe) {
+      throw new RuntimeIOException(ioe, "Failed to open file: %s", file.location());
+    }
   }
 
   static Writer newFileWriter(
@@ -819,7 +813,7 @@ public class ORC {
     if (file instanceof HadoopOutputFile) {
       options.fileSystem(((HadoopOutputFile) file).getFileSystem());
     } else {
-      options.fileSystem(new OutputFileSystem(file));
+      options.fileSystem(new FileIOFSUtil.OutputFileSystem(file));
     }
     final Path locPath = new Path(file.location());
     final Writer writer;
@@ -833,185 +827,5 @@ public class ORC {
     metadata.forEach((key, value) -> writer.addUserMetadata(key, ByteBuffer.wrap(value)));
 
     return writer;
-  }
-
-  private static class WrappedSeekableInputStream extends FSInputStream {
-    private final SeekableInputStream inputStream;
-    private boolean closed;
-    private final StackTraceElement[] createStack;
-
-    private WrappedSeekableInputStream(SeekableInputStream inputStream) {
-      this.inputStream = inputStream;
-      this.createStack = Thread.currentThread().getStackTrace();
-      this.closed = false;
-    }
-
-    @Override
-    public void seek(long pos) throws IOException {
-      inputStream.seek(pos);
-    }
-
-    @Override
-    public long getPos() throws IOException {
-      return inputStream.getPos();
-    }
-
-    @Override
-    public boolean seekToNewSource(long targetPos) throws IOException {
-      throw new UnsupportedOperationException("seekToNewSource not supported");
-    }
-
-    @Override
-    public int read() throws IOException {
-      return inputStream.read();
-    }
-
-    @Override
-    public int read(@NotNull byte[] b, int off, int len) throws IOException {
-      return inputStream.read(b, off, len);
-    }
-
-    @Override
-    public void close() throws IOException {
-      inputStream.close();
-      closed = true;
-    }
-
-    @SuppressWarnings("checkstyle:NoFinalizer")
-    @Override
-    protected void finalize() throws Throwable {
-      super.finalize();
-      if (!closed) {
-        close(); // releasing resources is more important than printing the warning
-        String trace =
-            Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
-        LOG.warn("Unclosed input stream created by:\n\t{}", trace);
-      }
-    }
-  }
-
-  private static class NullFileSystem extends FileSystem {
-
-    @Override
-    public URI getUri() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FSDataInputStream open(Path f) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FSDataOutputStream create(
-        Path f,
-        FsPermission permission,
-        boolean overwrite,
-        int bufferSize,
-        short replication,
-        long blockSize,
-        Progressable progress)
-        throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FSDataOutputStream append(Path f, int bufferSize, Progressable progress)
-        throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean rename(Path src, Path dst) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean delete(Path f, boolean recursive) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FileStatus[] listStatus(Path f) throws FileNotFoundException, IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setWorkingDirectory(Path new_dir) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Path getWorkingDirectory() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public FileStatus getFileStatus(Path f) throws IOException {
-      throw new UnsupportedOperationException();
-    }
-  }
-
-  static class InputFileSystem extends NullFileSystem {
-    private final InputFile inputFile;
-    private final Path inputPath;
-
-    InputFileSystem(InputFile inputFile) {
-      this.inputFile = inputFile;
-      this.inputPath = new Path(inputFile.location());
-    }
-
-    @Override
-    public FSDataInputStream open(Path f) throws IOException {
-      return open(f, 0);
-    }
-
-    @Override
-    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
-      Preconditions.checkArgument(
-          f.equals(inputPath), String.format("Input %s does not equal expected %s", f, inputPath));
-      return new FSDataInputStream(new WrappedSeekableInputStream(inputFile.newStream()));
-    }
-  }
-
-  static class OutputFileSystem extends NullFileSystem {
-    private final OutputFile outputFile;
-    private final Path outPath;
-
-    OutputFileSystem(OutputFile outputFile) {
-      this.outputFile = outputFile;
-      this.outPath = new Path(outputFile.location());
-    }
-
-    @Override
-    public FSDataOutputStream create(Path f) throws IOException {
-      return create(f, null, true, 0, (short) 0, 0, null);
-    }
-
-    @Override
-    public FSDataOutputStream create(
-        Path f,
-        FsPermission permission,
-        boolean overwrite,
-        int bufferSize,
-        short replication,
-        long blockSize,
-        Progressable progress)
-        throws IOException {
-      Preconditions.checkArgument(
-          f.equals(outPath), String.format("Input %s does not equal expected %s", f, outPath));
-      OutputStream outputStream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
-      return new FSDataOutputStream(outputStream, null);
-    }
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -20,13 +20,11 @@ package org.apache.iceberg.orc;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
@@ -88,8 +86,7 @@ class OrcFileAppender<D> implements FileAppender<D> {
       options.fileSystem(((HadoopOutputFile) file).getFileSystem());
     }
     options.setSchema(orcSchema);
-    this.writer = newOrcWriter(file, options, metadata);
-
+    this.writer = ORC.newFileWriter(file, options, metadata);
     this.valueWriter = newOrcRowWriter(schema, orcSchema, createWriterFunc);
   }
 
@@ -168,22 +165,6 @@ class OrcFileAppender<D> implements FileAppender<D> {
         this.isClosed = true;
       }
     }
-  }
-
-  private static Writer newOrcWriter(
-      OutputFile file, OrcFile.WriterOptions options, Map<String, byte[]> metadata) {
-    final Path locPath = new Path(file.location());
-    final Writer writer;
-
-    try {
-      writer = OrcFile.createWriter(locPath, options);
-    } catch (IOException ioe) {
-      throw new RuntimeIOException(ioe, "Can't create file %s", locPath);
-    }
-
-    metadata.forEach((key, value) -> writer.addUserMetadata(key, ByteBuffer.wrap(value)));
-
-    return writer;
   }
 
   @SuppressWarnings("unchecked")

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.orc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,6 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestORCFileIOProxies {
@@ -45,12 +45,13 @@ public class TestORCFileIOProxies {
     assertNotNull(is);
 
     // Cannot use the filesystem for any other operation
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> ifs.getFileStatus(new Path(localFile.location())));
+    Assertions.assertThatThrownBy(() -> ifs.getFileStatus(new Path(localFile.location())))
+        .isInstanceOf(UnsupportedOperationException.class);
 
     // Cannot use the filesystem for any other path
-    assertThrows(IllegalArgumentException.class, () -> ifs.open(new Path("/tmp/dummy")));
+    Assertions.assertThatThrownBy(() -> ifs.open(new Path("/tmp/dummy")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Input /tmp/dummy does not equal expected");
   }
 
   @Test
@@ -66,10 +67,12 @@ public class TestORCFileIOProxies {
       os.write('C');
     }
     // No other operation is supported
-    assertThrows(
-        UnsupportedOperationException.class, () -> ofs.open(new Path(outputFile.location())));
+    Assertions.assertThatThrownBy(() -> ofs.open(new Path(outputFile.location())))
+        .isInstanceOf(UnsupportedOperationException.class);
     // No other path is supported
-    assertThrows(IllegalArgumentException.class, () -> ofs.create(new Path("/tmp/dummy")));
+    Assertions.assertThatThrownBy(() -> ofs.create(new Path("/tmp/dummy")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Input /tmp/dummy does not equal expected");
 
     FileSystem ifs = new ORC.InputFileSystem(outputFile.toInputFile());
     try (InputStream is = ifs.open(new Path(outputFile.location()))) {

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.junit.Test;
+
+public class TestORCFileIOProxies {
+  @Test
+  public void testInputFileSystem() throws IOException {
+    File inputFile = File.createTempFile("read", ".orc");
+    inputFile.deleteOnExit();
+
+    InputFile localFile = Files.localInput(inputFile);
+    ORC.InputFileSystem ifs = new ORC.InputFileSystem(localFile);
+    InputStream is = ifs.open(new Path(localFile.location()));
+    assertNotNull(is);
+
+    // Cannot use the filesystem for any other operation
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> ifs.getFileStatus(new Path(localFile.location())));
+
+    // Cannot use the filesystem for any other path
+    assertThrows(IllegalArgumentException.class, () -> ifs.open(new Path("/tmp/dummy")));
+  }
+
+  @Test
+  public void testOutputFileSystem() throws IOException {
+    File localFile = File.createTempFile("write", ".orc");
+    localFile.deleteOnExit();
+
+    OutputFile outputFile = Files.localOutput(localFile);
+    FileSystem ofs = new ORC.OutputFileSystem(outputFile);
+    try (OutputStream os = ofs.create(new Path(outputFile.location()))) {
+      os.write('O');
+      os.write('R');
+      os.write('C');
+    }
+    // No other operation is supported
+    assertThrows(
+        UnsupportedOperationException.class, () -> ofs.open(new Path(outputFile.location())));
+    // No other path is supported
+    assertThrows(IllegalArgumentException.class, () -> ofs.create(new Path("/tmp/dummy")));
+
+    FileSystem ifs = new ORC.InputFileSystem(outputFile.toInputFile());
+    try (InputStream is = ifs.open(new Path(outputFile.location()))) {
+      assertEquals('O', is.read());
+      assertEquals('R', is.read());
+      assertEquals('C', is.read());
+      assertEquals(-1, is.read());
+    }
+  }
+}

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCFileIOProxies.java
@@ -40,7 +40,7 @@ public class TestORCFileIOProxies {
     inputFile.deleteOnExit();
 
     InputFile localFile = Files.localInput(inputFile);
-    ORC.InputFileSystem ifs = new ORC.InputFileSystem(localFile);
+    FileIOFSUtil.InputFileSystem ifs = new FileIOFSUtil.InputFileSystem(localFile);
     InputStream is = ifs.open(new Path(localFile.location()));
     assertNotNull(is);
 
@@ -60,7 +60,7 @@ public class TestORCFileIOProxies {
     localFile.deleteOnExit();
 
     OutputFile outputFile = Files.localOutput(localFile);
-    FileSystem ofs = new ORC.OutputFileSystem(outputFile);
+    FileSystem ofs = new FileIOFSUtil.OutputFileSystem(outputFile);
     try (OutputStream os = ofs.create(new Path(outputFile.location()))) {
       os.write('O');
       os.write('R');
@@ -74,7 +74,7 @@ public class TestORCFileIOProxies {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("Input /tmp/dummy does not equal expected");
 
-    FileSystem ifs = new ORC.InputFileSystem(outputFile.toInputFile());
+    FileSystem ifs = new FileIOFSUtil.InputFileSystem(outputFile.toInputFile());
     try (InputStream is = ifs.open(new Path(outputFile.location()))) {
       assertEquals('O', is.read());
       assertEquals('R', is.read());

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
@@ -48,11 +48,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.OrcFile;
 import org.apache.orc.StripeInformation;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
 
 public class TestOrcDataWriter {
@@ -137,23 +137,14 @@ public class TestOrcDataWriter {
   }
 
   @Test
-  public void testNoSupportForDummyScheme() throws IOException {
-    ProxyOutputFile outFile = new ProxyOutputFile(Files.localOutput(temp.newFile()));
-    Assertions.assertThrows(
-        RuntimeIOException.class,
-        () -> HadoopOutputFile.fromPath(new Path(outFile.location()), new Configuration()),
-        "No FileSystem for scheme \"dummy\"");
-  }
-
-  @Test
   public void testUsingFileIO() throws IOException {
     // Show that FileSystem access is not possible for the file we are supplying as the scheme
     // dummy is not handled
     ProxyOutputFile outFile = new ProxyOutputFile(Files.localOutput(temp.newFile()));
-    Assertions.assertThrows(
-        RuntimeIOException.class,
-        () -> HadoopOutputFile.fromPath(new Path(outFile.location()), new Configuration()),
-        "No FileSystem for scheme \"dummy\"");
+    Assertions.assertThatThrownBy(
+            () -> HadoopOutputFile.fromPath(new Path(outFile.location()), new Configuration()))
+        .isInstanceOf(RuntimeIOException.class)
+        .hasMessageStartingWith("Failed to get file system for path: dummy");
 
     // We are creating the proxy
     SortOrder sortOrder = SortOrder.builderFor(SCHEMA).withOrderId(10).asc("id").build();

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
@@ -34,8 +35,6 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.orc.GenericOrcReader;
 import org.apache.iceberg.data.orc.GenericOrcWriter;
-import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.hadoop.HadoopOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.InputFile;
@@ -144,9 +143,9 @@ public class TestOrcDataWriter {
     // use a scheme `dummy` that is not handled.
     ProxyOutputFile outFile = new ProxyOutputFile(Files.localOutput(temp.newFile()));
     Assertions.assertThatThrownBy(
-            () -> HadoopOutputFile.fromPath(new Path(outFile.location()), new Configuration()))
-        .isInstanceOf(RuntimeIOException.class)
-        .hasMessageStartingWith("Failed to get file system for path: dummy");
+            () -> new Path(outFile.location()).getFileSystem(new Configuration()))
+        .isInstanceOf(UnsupportedFileSystemException.class)
+        .hasMessageStartingWith("No FileSystem for scheme \"dummy\"");
 
     // Given that FileIO is now handled there is no determination of FileSystem based on scheme
     // but instead operations are handled by the InputFileSystem and OutputFileSystem that wrap


### PR DESCRIPTION
## What?
This adds support for FileIO with Apache ORC by wrapping InputFile and OutputFile into a consumable FileSystem objects.

## Why?
In the absence of this ORC is not able to leverage the benefits of better FileIO such as S3FileIO compared to S3AFileSystem

## Tested?
New unit tests have been added to ensure the use of FileIO in ORC Readers and Writers
