### PR TITLE
Spark-3.3: Use table sort order with sort strategy when user has not specified

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -183,11 +183,10 @@ class RewriteDataFilesProcedure extends BaseProcedure {
                 .flatMap(zOrder -> zOrder.refs().stream().map(NamedReference::name))
                 .toArray(String[]::new);
         return action.zOrder(columnNames);
-      } else {
-        if (sortOrderFields.isEmpty()) {
-          return action.sort();
-        }
+      } else if (!sortOrderFields.isEmpty()) {
         return action.sort(buildSortOrder(sortOrderFields, schema));
+      } else {
+        return action.sort();
       }
     }
     if (strategy.equalsIgnoreCase("binpack")) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -184,6 +184,9 @@ class RewriteDataFilesProcedure extends BaseProcedure {
                 .toArray(String[]::new);
         return action.zOrder(columnNames);
       } else {
+        if (sortOrderFields.isEmpty()) {
+          return action.sort();
+        }
         return action.sort(buildSortOrder(sortOrderFields, schema));
       }
     }


### PR DESCRIPTION
For `RewriteDataFilesProcedure`, when the table has been created with a default sort order, there should be no need for the user to again specify the same sort order for the sort strategy during re-write. Currently, it fails with `Cannot set strategy sort order: unsorted` error for this scenario.

This particular scenario works with rewrite spark action now also and used to work with `RewriteDataFilesProcedure` too (In 0.13.0 release). 
But while introducing `Zorder` with re-write procedure, a strict check has been introduced which caused this particular scenario to fail.  This would have not happened if we had a test case to catch it. Fixed it now and added the test case. 