### PR TITLE
Flink: support split discovery throttling for streaming read

### DIFF
--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -28,6 +28,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
+import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -71,6 +72,7 @@ public class GuavaClasses {
     Splitter.class.getName();
     Throwables.class.getName();
     BiMap.class.getName();
+    EvictingQueue.class.getName();
     FluentIterable.class.getName();
     ImmutableBiMap.class.getName();
     ImmutableList.class.getName();

--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -28,7 +28,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
 import com.google.common.collect.BiMap;
-import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
@@ -72,7 +71,6 @@ public class GuavaClasses {
     Splitter.class.getName();
     Throwables.class.getName();
     BiMap.class.getName();
-    EvictingQueue.class.getName();
     FluentIterable.class.getName();
     ImmutableBiMap.class.getName();
     ImmutableList.class.getName();

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -187,8 +187,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
     } else {
       List<IcebergSourceSplit> splits = planSplitsForBatch(planningThreadName());
       assigner.onDiscoveredSplits(splits);
-      return new StaticIcebergEnumerator(
-          enumContext, assigner, lazyTable(), scanContext, enumState);
+      return new StaticIcebergEnumerator(enumContext, assigner);
     }
   }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -98,7 +98,8 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
 
   @Override
   public IcebergEnumeratorState snapshotState(long checkpointId) {
-    return new IcebergEnumeratorState(enumeratorPosition.get(), assigner.state());
+    return new IcebergEnumeratorState(
+        enumeratorPosition.get(), assigner.state(), enumerationHistory.snapshot());
   }
 
   /** This method is executed in an IO thread pool. */

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.enumerator;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -34,6 +35,11 @@ import org.slf4j.LoggerFactory;
 public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
 
   private static final Logger LOG = LoggerFactory.getLogger(ContinuousIcebergEnumerator.class);
+  /**
+   * This is hardcoded, as {@link ScanContext#maxPlanningSnapshotCount()} could be the knob to
+   * control the total number of snapshots worth of splits tracked by assigner.
+   */
+  private static final int ENUMERATION_SPLIT_COUNT_HISTORY_SIZE = 3;
 
   private final SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext;
   private final SplitAssigner assigner;
@@ -45,6 +51,9 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
    * this as the starting position.
    */
   private final AtomicReference<IcebergEnumeratorPosition> enumeratorPosition;
+
+  /** Track enumeration result history for split discovery throttling. */
+  private final EnumerationHistory enumerationHistory;
 
   public ContinuousIcebergEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
@@ -59,6 +68,8 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
     this.scanContext = scanContext;
     this.splitPlanner = splitPlanner;
     this.enumeratorPosition = new AtomicReference<>();
+    this.enumerationHistory = new EnumerationHistory(ENUMERATION_SPLIT_COUNT_HISTORY_SIZE);
+
     if (enumState != null) {
       this.enumeratorPosition.set(enumState.lastEnumeratedPosition());
     }
@@ -92,7 +103,19 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
 
   /** This method is executed in an IO thread pool. */
   private ContinuousEnumerationResult discoverSplits() {
-    return splitPlanner.planSplits(enumeratorPosition.get());
+    int pendingSplitCountFromAssigner = assigner.pendingSplitCount();
+    if (enumerationHistory.shouldPauseSplitDiscovery(pendingSplitCountFromAssigner)) {
+      // If the assigner already has many pending splits, it is better to pause split discovery.
+      // Otherwise, eagerly discovering more splits will just increase assigner memory footprint
+      // and enumerator checkpoint state size.
+      LOG.info(
+          "Pause split discovery as the assigner already has too many pending splits: {}",
+          pendingSplitCountFromAssigner);
+      return new ContinuousEnumerationResult(
+          Collections.emptyList(), enumeratorPosition.get(), enumeratorPosition.get());
+    } else {
+      return splitPlanner.planSplits(enumeratorPosition.get());
+    }
   }
 
   /** This method is executed in a single coordinator thread. */
@@ -100,13 +123,10 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
     if (error == null) {
       if (!Objects.equals(result.fromPosition(), enumeratorPosition.get())) {
         // Multiple discoverSplits() may be triggered with the same starting snapshot to the I/O
-        // thread pool.
-        // E.g., the splitDiscoveryInterval is very short (like 10 ms in some unit tests) or the
-        // thread
-        // pool is busy and multiple discovery actions are executed concurrently. Discovery result
-        // should
-        // only be accepted if the starting position matches the enumerator position (like
-        // compare-and-swap).
+        // thread pool. E.g., the splitDiscoveryInterval is very short (like 10 ms in some unit
+        // tests) or the thread pool is busy and multiple discovery actions are executed
+        // concurrently. Discovery result should only be accepted if the starting position
+        // matches the enumerator position (like compare-and-swap).
         LOG.info(
             "Skip {} discovered splits because the scan starting position doesn't match "
                 + "the current enumerator position: enumerator position = {}, scan starting position = {}",
@@ -114,12 +134,21 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
             enumeratorPosition.get(),
             result.fromPosition());
       } else {
-        assigner.onDiscoveredSplits(result.splits());
-        LOG.info(
-            "Added {} splits discovered between ({}, {}] to the assigner",
-            result.splits().size(),
-            result.fromPosition(),
-            result.toPosition());
+        // Sometimes, enumeration may yield no splits for a few reasons.
+        // - upstream paused or delayed streaming writes to the Iceberg table.
+        // - enumeration frequency is higher than the upstream write frequency.
+        if (!result.splits().isEmpty()) {
+          assigner.onDiscoveredSplits(result.splits());
+          // EnumerationHistory makes throttling decision on split discovery
+          // based on the total number of splits discovered in the last a few cycles.
+          // Only update enumeration history when there are some discovered splits.
+          enumerationHistory.add(result.splits().size());
+          LOG.info(
+              "Added {} splits discovered between ({}, {}] to the assigner",
+              result.splits().size(),
+              result.fromPosition(),
+              result.toPosition());
+        }
         // update the enumerator position even if there is no split discovered
         // or the toPosition is empty (e.g. for empty table).
         enumeratorPosition.set(result.toPosition());

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -148,6 +148,11 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
               result.splits().size(),
               result.fromPosition(),
               result.toPosition());
+        } else {
+          LOG.info(
+              "No new splits discovered between ({}, {}]",
+              result.fromPosition(),
+              result.toPosition());
         }
         // update the enumerator position even if there is no split discovered
         // or the toPosition is empty (e.g. for empty table).

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -95,7 +95,6 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     }
   }
 
-  /** Discover incremental changes between {@code lastPosition} and current table snapshot */
   private ContinuousEnumerationResult discoverIncrementalSplits(
       IcebergEnumeratorPosition lastPosition) {
     Snapshot currentSnapshot = table.currentSnapshot();

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.flink.source.FlinkSplitPlanner;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
@@ -78,6 +79,22 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     }
   }
 
+  private Snapshot toSnapshotInclusive(
+      Long lastConsumedSnapshotId, Snapshot currentSnapshot, int maxPlanningSnapshotCount) {
+    // snapshots are in reverse order (latest snapshot first)
+    List<Snapshot> snapshots =
+        Lists.newArrayList(
+            SnapshotUtil.ancestorsBetween(
+                table, currentSnapshot.snapshotId(), lastConsumedSnapshotId));
+    if (snapshots.size() <= maxPlanningSnapshotCount) {
+      return currentSnapshot;
+    } else {
+      // Because snapshots are in reverse order of commit history, this index returns
+      // the max allowed number of snapshots from the lastConsumedSnapshotId.
+      return snapshots.get(snapshots.size() - maxPlanningSnapshotCount);
+    }
+  }
+
   /** Discover incremental changes between {@code lastPosition} and current table snapshot */
   private ContinuousEnumerationResult discoverIncrementalSplits(
       IcebergEnumeratorPosition lastPosition) {
@@ -94,12 +111,16 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
       LOG.info("Current table snapshot is already enumerated: {}", currentSnapshot.snapshotId());
       return new ContinuousEnumerationResult(Collections.emptyList(), lastPosition, lastPosition);
     } else {
+      Long lastConsumedSnapshotId = lastPosition != null ? lastPosition.snapshotId() : null;
+      Snapshot toSnapshotInclusive =
+          toSnapshotInclusive(
+              lastConsumedSnapshotId, currentSnapshot, scanContext.maxPlanningSnapshotCount());
       IcebergEnumeratorPosition newPosition =
           IcebergEnumeratorPosition.of(
-              currentSnapshot.snapshotId(), currentSnapshot.timestampMillis());
+              toSnapshotInclusive.snapshotId(), toSnapshotInclusive.timestampMillis());
       ScanContext incrementalScan =
           scanContext.copyWithAppendsBetween(
-              lastPosition.snapshotId(), currentSnapshot.snapshotId());
+              lastPosition.snapshotId(), toSnapshotInclusive.snapshotId());
       List<IcebergSourceSplit> splits =
           FlinkSplitPlanner.planIcebergSourceSplits(table, incrementalScan, workerPool);
       LOG.info(

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/EnumerationHistory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/EnumerationHistory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.iceberg.relocated.com.google.common.collect.EvictingQueue;
+
+/**
+ * This enumeration history is used for split discovery throttling. It wraps Guava {@link
+ * EvictingQueue} to provide thread safety.
+ */
+@ThreadSafe
+class EnumerationHistory {
+
+  // EvictingQueue is not thread safe.
+  private final EvictingQueue<Integer> enumerationSplitCountHistory;
+
+  EnumerationHistory(int maxHistorySize) {
+    this.enumerationSplitCountHistory = EvictingQueue.create(maxHistorySize);
+  }
+
+  /** Add the split count from the last enumeration result. */
+  synchronized void add(int splitCount) {
+    enumerationSplitCountHistory.add(splitCount);
+  }
+
+  /** @return true if split discovery should pause because assigner has too many splits already. */
+  synchronized boolean shouldPauseSplitDiscovery(int pendingSplitCountFromAssigner) {
+    if (enumerationSplitCountHistory.remainingCapacity() > 0) {
+      // only check throttling when full history is obtained.
+      return false;
+    } else {
+      // if ScanContext#maxPlanningSnapshotCount() is 5, each split enumeration can
+      // discovery splits up to 6 snapshots. if maxHistorySize is 3, the max number of
+      // splits tracked in assigner shouldn't be more than 15 snapshots worth of splits.
+      // Split discovery pauses when reaching that threshold.
+      int totalSplitCountFromRecentDiscovery =
+          enumerationSplitCountHistory.stream().reduce(0, Integer::sum);
+      return pendingSplitCountFromAssigner >= totalSplitCountFromRecentDiscovery;
+    }
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorState.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorState.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.flink.source.enumerator;
 import java.io.Serializable;
 import java.util.Collection;
 import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 
 /** Enumerator state for checkpointing */
+@Internal
 public class IcebergEnumeratorState implements Serializable {
   @Nullable private final IcebergEnumeratorPosition lastEnumeratedPosition;
   private final Collection<IcebergSourceSplitState> pendingSplits;
+  private int[] enumerationSplitCountHistory;
 
   public IcebergEnumeratorState(Collection<IcebergSourceSplitState> pendingSplits) {
     this(null, pendingSplits);
@@ -35,8 +38,16 @@ public class IcebergEnumeratorState implements Serializable {
   public IcebergEnumeratorState(
       @Nullable IcebergEnumeratorPosition lastEnumeratedPosition,
       Collection<IcebergSourceSplitState> pendingSplits) {
+    this(lastEnumeratedPosition, pendingSplits, new int[0]);
+  }
+
+  public IcebergEnumeratorState(
+      @Nullable IcebergEnumeratorPosition lastEnumeratedPosition,
+      Collection<IcebergSourceSplitState> pendingSplits,
+      int[] enumerationSplitCountHistory) {
     this.lastEnumeratedPosition = lastEnumeratedPosition;
     this.pendingSplits = pendingSplits;
+    this.enumerationSplitCountHistory = enumerationSplitCountHistory;
   }
 
   @Nullable
@@ -46,5 +57,9 @@ public class IcebergEnumeratorState implements Serializable {
 
   public Collection<IcebergSourceSplitState> pendingSplits() {
     return pendingSplits;
+  }
+
+  public int[] enumerationSplitCountHistory() {
+    return enumerationSplitCountHistory;
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorStateSerializer.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorStateSerializer.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.enumerator;
 import java.io.IOException;
 import java.util.Collection;
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -37,7 +38,7 @@ public class IcebergEnumeratorStateSerializer
   public static final IcebergEnumeratorStateSerializer INSTANCE =
       new IcebergEnumeratorStateSerializer();
 
-  private static final int VERSION = 1;
+  private static final int VERSION = 2;
 
   private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
       ThreadLocal.withInitial(() -> new DataOutputSerializer(1024));
@@ -54,7 +55,7 @@ public class IcebergEnumeratorStateSerializer
 
   @Override
   public byte[] serialize(IcebergEnumeratorState enumState) throws IOException {
-    return serializeV1(enumState);
+    return serializeV2(enumState);
   }
 
   @Override
@@ -62,39 +63,73 @@ public class IcebergEnumeratorStateSerializer
     switch (version) {
       case 1:
         return deserializeV1(serialized);
+      case 2:
+        return deserializeV2(serialized);
       default:
         throw new IOException("Unknown version: " + version);
     }
   }
 
-  private byte[] serializeV1(IcebergEnumeratorState enumState) throws IOException {
+  @VisibleForTesting
+  byte[] serializeV1(IcebergEnumeratorState enumState) throws IOException {
     DataOutputSerializer out = SERIALIZER_CACHE.get();
-
-    out.writeBoolean(enumState.lastEnumeratedPosition() != null);
-    if (enumState.lastEnumeratedPosition() != null) {
-      out.writeInt(positionSerializer.getVersion());
-      byte[] positionBytes = positionSerializer.serialize(enumState.lastEnumeratedPosition());
-      out.writeInt(positionBytes.length);
-      out.write(positionBytes);
-    }
-
-    out.writeInt(splitSerializer.getVersion());
-    out.writeInt(enumState.pendingSplits().size());
-    for (IcebergSourceSplitState splitState : enumState.pendingSplits()) {
-      byte[] splitBytes = splitSerializer.serialize(splitState.split());
-      out.writeInt(splitBytes.length);
-      out.write(splitBytes);
-      out.writeUTF(splitState.status().name());
-    }
-
+    serializeEnumeratorPosition(out, enumState.lastEnumeratedPosition(), positionSerializer);
+    serializePendingSplits(out, enumState.pendingSplits(), splitSerializer);
     byte[] result = out.getCopyOfBuffer();
     out.clear();
     return result;
   }
 
-  private IcebergEnumeratorState deserializeV1(byte[] serialized) throws IOException {
+  @VisibleForTesting
+  IcebergEnumeratorState deserializeV1(byte[] serialized) throws IOException {
     DataInputDeserializer in = new DataInputDeserializer(serialized);
+    IcebergEnumeratorPosition enumeratorPosition =
+        deserializeEnumeratorPosition(in, positionSerializer);
+    Collection<IcebergSourceSplitState> pendingSplits =
+        deserializePendingSplits(in, splitSerializer);
+    return new IcebergEnumeratorState(enumeratorPosition, pendingSplits);
+  }
 
+  @VisibleForTesting
+  byte[] serializeV2(IcebergEnumeratorState enumState) throws IOException {
+    DataOutputSerializer out = SERIALIZER_CACHE.get();
+    serializeEnumeratorPosition(out, enumState.lastEnumeratedPosition(), positionSerializer);
+    serializePendingSplits(out, enumState.pendingSplits(), splitSerializer);
+    serializeEnumerationSplitCountHistory(out, enumState.enumerationSplitCountHistory());
+    byte[] result = out.getCopyOfBuffer();
+    out.clear();
+    return result;
+  }
+
+  @VisibleForTesting
+  IcebergEnumeratorState deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer in = new DataInputDeserializer(serialized);
+    IcebergEnumeratorPosition enumeratorPosition =
+        deserializeEnumeratorPosition(in, positionSerializer);
+    Collection<IcebergSourceSplitState> pendingSplits =
+        deserializePendingSplits(in, splitSerializer);
+    int[] enumerationSplitCountHistory = deserializeEnumerationSplitCountHistory(in);
+    return new IcebergEnumeratorState(
+        enumeratorPosition, pendingSplits, enumerationSplitCountHistory);
+  }
+
+  private static void serializeEnumeratorPosition(
+      DataOutputSerializer out,
+      IcebergEnumeratorPosition enumeratorPosition,
+      IcebergEnumeratorPositionSerializer positionSerializer)
+      throws IOException {
+    out.writeBoolean(enumeratorPosition != null);
+    if (enumeratorPosition != null) {
+      out.writeInt(positionSerializer.getVersion());
+      byte[] positionBytes = positionSerializer.serialize(enumeratorPosition);
+      out.writeInt(positionBytes.length);
+      out.write(positionBytes);
+    }
+  }
+
+  private static IcebergEnumeratorPosition deserializeEnumeratorPosition(
+      DataInputDeserializer in, IcebergEnumeratorPositionSerializer positionSerializer)
+      throws IOException {
     IcebergEnumeratorPosition enumeratorPosition = null;
     if (in.readBoolean()) {
       int version = in.readInt();
@@ -102,7 +137,26 @@ public class IcebergEnumeratorStateSerializer
       in.read(positionBytes);
       enumeratorPosition = positionSerializer.deserialize(version, positionBytes);
     }
+    return enumeratorPosition;
+  }
 
+  private static void serializePendingSplits(
+      DataOutputSerializer out,
+      Collection<IcebergSourceSplitState> pendingSplits,
+      IcebergSourceSplitSerializer splitSerializer)
+      throws IOException {
+    out.writeInt(splitSerializer.getVersion());
+    out.writeInt(pendingSplits.size());
+    for (IcebergSourceSplitState splitState : pendingSplits) {
+      byte[] splitBytes = splitSerializer.serialize(splitState.split());
+      out.writeInt(splitBytes.length);
+      out.write(splitBytes);
+      out.writeUTF(splitState.status().name());
+    }
+  }
+
+  private static Collection<IcebergSourceSplitState> deserializePendingSplits(
+      DataInputDeserializer in, IcebergSourceSplitSerializer splitSerializer) throws IOException {
     int splitSerializerVersion = in.readInt();
     int splitCount = in.readInt();
     Collection<IcebergSourceSplitState> pendingSplits = Lists.newArrayListWithCapacity(splitCount);
@@ -114,6 +168,29 @@ public class IcebergEnumeratorStateSerializer
       pendingSplits.add(
           new IcebergSourceSplitState(split, IcebergSourceSplitStatus.valueOf(statusName)));
     }
-    return new IcebergEnumeratorState(enumeratorPosition, pendingSplits);
+    return pendingSplits;
+  }
+
+  private static void serializeEnumerationSplitCountHistory(
+      DataOutputSerializer out, int[] enumerationSplitCountHistory) throws IOException {
+    out.writeInt(enumerationSplitCountHistory.length);
+    if (enumerationSplitCountHistory.length > 0) {
+      for (int i = 0; i < enumerationSplitCountHistory.length; ++i) {
+        out.writeInt(enumerationSplitCountHistory[i]);
+      }
+    }
+  }
+
+  private static int[] deserializeEnumerationSplitCountHistory(DataInputDeserializer in)
+      throws IOException {
+    int historySize = in.readInt();
+    int[] history = new int[historySize];
+    if (historySize > 0) {
+      for (int i = 0; i < historySize; ++i) {
+        history[i] = in.readInt();
+      }
+    }
+
+    return history;
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/StaticIcebergEnumerator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/StaticIcebergEnumerator.java
@@ -18,11 +18,8 @@
  */
 package org.apache.iceberg.flink.source.enumerator;
 
-import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.iceberg.Table;
-import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.assigner.SplitAssigner;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 
@@ -30,19 +27,11 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 @Internal
 public class StaticIcebergEnumerator extends AbstractIcebergEnumerator {
   private final SplitAssigner assigner;
-  private final Table table;
-  private final ScanContext scanContext;
 
   public StaticIcebergEnumerator(
-      SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
-      SplitAssigner assigner,
-      Table table,
-      ScanContext scanContext,
-      @Nullable IcebergEnumeratorState enumState) {
+      SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext, SplitAssigner assigner) {
     super(enumeratorContext, assigner);
     this.assigner = assigner;
-    this.table = table;
-    this.scanContext = scanContext;
   }
 
   @Override
@@ -57,6 +46,6 @@ public class StaticIcebergEnumerator extends AbstractIcebergEnumerator {
 
   @Override
   public IcebergEnumeratorState snapshotState(long checkpointId) {
-    return new IcebergEnumeratorState(null, assigner.state());
+    return new IcebergEnumeratorState(null, assigner.state(), new int[0]);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestEnumerationHistory.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestEnumerationHistory.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestEnumerationHistory {
+  private static final int MAX_HISTORY_SIZE = 3;
+  private static final int FEW_PENDING_SPLITS = 2;
+  private static final int TOO_MANY_PENDING_SPLITS = 100;
+
+  @Test
+  public void testEmptyHistory() {
+    EnumerationHistory history = new EnumerationHistory(MAX_HISTORY_SIZE);
+    int[] expectedHistorySnapshot = new int[0];
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  @Test
+  public void testNotFullHistory() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    int[] expectedHistorySnapshot = {1, 2};
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  @Test
+  public void testExactFullHistory() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    history.add(3);
+    int[] expectedHistorySnapshot = {1, 2, 3};
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  @Test
+  public void testOneMoreThanFullHistory() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    history.add(3);
+    history.add(4);
+    int[] expectedHistorySnapshot = {2, 3, 4};
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  @Test
+  public void testTwoMoreThanFullHistory() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    history.add(3);
+    history.add(4);
+    history.add(5);
+    int[] expectedHistorySnapshot = {3, 4, 5};
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  @Test
+  public void testThreeMoreThanFullHistory() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    history.add(3);
+    history.add(4);
+    history.add(5);
+    history.add(6);
+    int[] expectedHistorySnapshot = {4, 5, 6};
+    testHistory(history, expectedHistorySnapshot);
+  }
+
+  private void testHistory(EnumerationHistory history, int[] expectedHistorySnapshot) {
+    Assert.assertFalse(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS));
+    if (history.hasFullHistory()) {
+      // throttle because pending split count is more than the sum of enumeration history
+      Assert.assertTrue(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+    } else {
+      // skipped throttling check because there is not enough history
+      Assert.assertFalse(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+    }
+
+    int[] historySnapshot = history.snapshot();
+    Assert.assertArrayEquals(expectedHistorySnapshot, historySnapshot);
+
+    EnumerationHistory restoredHistory = new EnumerationHistory(MAX_HISTORY_SIZE);
+    restoredHistory.restore(historySnapshot);
+
+    Assert.assertFalse(history.shouldPauseSplitDiscovery(FEW_PENDING_SPLITS));
+    if (history.hasFullHistory()) {
+      // throttle because pending split count is more than the sum of enumeration history
+      Assert.assertTrue(history.shouldPauseSplitDiscovery(TOO_MANY_PENDING_SPLITS));
+    } else {
+      // skipped throttling check because there is not enough history
+      Assert.assertFalse(history.shouldPauseSplitDiscovery(30));
+    }
+  }
+
+  @Test
+  public void testRestoreDifferentSize() {
+    EnumerationHistory history = new EnumerationHistory(3);
+    history.add(1);
+    history.add(2);
+    history.add(3);
+    int[] historySnapshot = history.snapshot();
+
+    EnumerationHistory smallerHistory = new EnumerationHistory(2);
+    smallerHistory.restore(historySnapshot);
+    int[] expectedRestoredHistorySnapshot = {2, 3};
+    Assert.assertArrayEquals(expectedRestoredHistorySnapshot, smallerHistory.snapshot());
+
+    EnumerationHistory largerHisotry = new EnumerationHistory(4);
+    largerHisotry.restore(historySnapshot);
+    Assert.assertArrayEquals(historySnapshot, largerHisotry.snapshot());
+  }
+}


### PR DESCRIPTION
there are two scenarios why throttling is desirable for streaming read.
1) large backlog. E.g., started the streaming job from earliest snapshot
2) intentionally delayed consumption. E.g., if we have a stream join job reading from two Iceberg tables. First table has more real-time data and second table has typically delayed data (e.g. 24 hours). It would be great to delay the consumption for the second table by 24 hours for event time alignment. This way, we can reduce the join window in Flink state. With delayed consumption, it doesn't make sense to discovery all 24 hours of splits and hold them in enumerator memory.