### PR TITLE
Update Schema - should check if field is optional/required

### DIFF
--- a/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/UnionByNameVisitor.java
@@ -156,7 +156,11 @@ public class UnionByNameVisitor extends SchemaWithPartnerVisitor<Integer, Boolea
 
   private void addColumn(int parentId, Types.NestedField field) {
     String parentName = partnerSchema.findColumnName(parentId);
-    api.addColumn(parentName, field.name(), field.type(), field.doc());
+    if (field.isOptional()) {
+      api.addColumn(parentName, field.name(), field.type(), field.doc());
+    } else {
+      api.addRequiredColumn(parentName, field.name(), field.type(), field.doc());
+    }
   }
 
   private void updateColumn(Types.NestedField field, Types.NestedField existingField) {

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUnionByFieldName.java
@@ -24,7 +24,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
@@ -588,8 +587,8 @@ public class TestSchemaUnionByFieldName {
     Schema newSchema = new Schema(required(1, "a1", BooleanType.get()));
     SchemaUpdate schemaUpdate = new SchemaUpdate(new Schema(), 0);
     Assertions.assertThatThrownBy(() -> schemaUpdate.unionByNameWith(newSchema).apply())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("Incompatible");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Incompatible");
   }
 
   @Test


### PR DESCRIPTION
Update schema currently does not check if the field is optional/required and adds all new fields as optional. This leads to incorrect schema evolution where a required filed gets added to a table schema as optional. 

With this change, a required field can only be added if 'allowIncompatibleChanges' is enabled. 