### PR TITLE
API, Core: Add groupingKey to ScanTaskGroup

### DIFF
--- a/api/src/main/java/org/apache/iceberg/BaseScanTaskGroup.java
+++ b/api/src/main/java/org/apache/iceberg/BaseScanTaskGroup.java
@@ -26,12 +26,23 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class BaseScanTaskGroup<T extends ScanTask> implements ScanTaskGroup<T> {
+  private final StructLike groupingKey;
   private final Object[] tasks;
   private transient volatile List<T> taskList;
 
-  public BaseScanTaskGroup(Collection<T> tasks) {
+  public BaseScanTaskGroup(StructLike groupingKey, Collection<T> tasks) {
     Preconditions.checkNotNull(tasks, "tasks cannot be null");
+    this.groupingKey = groupingKey;
     this.tasks = tasks.toArray();
+  }
+
+  public BaseScanTaskGroup(Collection<T> tasks) {
+    this(EmptyStructLike.get(), tasks);
+  }
+
+  @Override
+  public StructLike groupingKey() {
+    return groupingKey;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/EmptyStructLike.java
+++ b/api/src/main/java/org/apache/iceberg/EmptyStructLike.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+
+class EmptyStructLike implements StructLike, Serializable {
+
+  private static final EmptyStructLike INSTANCE = new EmptyStructLike();
+
+  private EmptyStructLike() {}
+
+  static EmptyStructLike get() {
+    return INSTANCE;
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    throw new UnsupportedOperationException("Can't retrieve values from an empty struct");
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    throw new UnsupportedOperationException("Can't modify an empty struct");
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    return other != null && getClass() == other.getClass();
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    return "StructLike{}";
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
+++ b/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
@@ -29,14 +29,13 @@ public interface ScanTaskGroup<T extends ScanTask> extends ScanTask {
   /**
    * Returns a grouping key for this task group.
    *
-   * <p>Tasks may produce records that belong to a specific group of data (e.g. partition). It may
-   * be beneficial to preserve that grouping while combining tasks into groups if query engines can
-   * leverage that information to avoid shuffles. Grouping keys indicate how data is split between
-   * different task groups. The grouping key type is determined at planning time and is identical
-   * across all task groups produced by a scan.
+   * <p>A grouping key is a set of values that are common amongst all rows produced by the tasks in
+   * this task group. The values may be the result of transforming the underlying data. For example,
+   * a grouping key can consist of a bucket ordinal computed by applying a bucket transform to a
+   * column of the underlying rows. The grouping key type is determined at planning time and is
+   * identical across all task groups produced by a scan.
    *
-   * <p>All records produced by tasks in this group are guaranteed to have the reported grouping
-   * key. Implementations should return an empty struct if the data grouping is random or unknown.
+   * <p>Implementations should return an empty struct if the data grouping is random or unknown.
    *
    * @return a grouping key for this task group
    */

--- a/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
+++ b/api/src/main/java/org/apache/iceberg/ScanTaskGroup.java
@@ -26,6 +26,24 @@ import java.util.Collection;
  * @param <T> the type of scan tasks
  */
 public interface ScanTaskGroup<T extends ScanTask> extends ScanTask {
+  /**
+   * Returns a grouping key for this task group.
+   *
+   * <p>Tasks may produce records that belong to a specific group of data (e.g. partition). It may
+   * be beneficial to preserve that grouping while combining tasks into groups if query engines can
+   * leverage that information to avoid shuffles. Grouping keys indicate how data is split between
+   * different task groups. The grouping key type is determined at planning time and is identical
+   * across all task groups produced by a scan.
+   *
+   * <p>All records produced by tasks in this group are guaranteed to have the reported grouping
+   * key. Implementations should return an empty struct if the data grouping is random or unknown.
+   *
+   * @return a grouping key for this task group
+   */
+  default StructLike groupingKey() {
+    return EmptyStructLike.get();
+  }
+
   /** Returns scan tasks in this group. */
   Collection<T> tasks();
 

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-class PartitionData
+public class PartitionData
     implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
 
   static Schema partitionDataSchema(Types.StructType partitionType) {
@@ -57,7 +57,7 @@ class PartitionData
     this.schema = schema;
   }
 
-  PartitionData(Types.StructType partitionType) {
+  public PartitionData(Types.StructType partitionType) {
     for (Types.NestedField field : partitionType.fields()) {
       Preconditions.checkArgument(
           field.type().isPrimitiveType(),

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -28,11 +28,13 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MergeableScanTask;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.SplittableScanTask;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
@@ -140,7 +142,7 @@ public class TableScanUtil {
       long splitSize,
       int lookback,
       long openFileCost,
-      Types.StructType projectedPartitionType) {
+      Types.StructType groupingKeyType) {
 
     Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative or 0): %s", splitSize);
     Preconditions.checkArgument(
@@ -151,38 +153,68 @@ public class TableScanUtil {
     Function<T, Long> weightFunc =
         task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
 
-    Map<Integer, StructProjection> projectionsBySpec = Maps.newHashMap();
+    Map<Integer, StructProjection> groupingKeyProjectionsBySpec = Maps.newHashMap();
 
-    // Group tasks by their partition values
-    StructLikeMap<List<T>> tasksByPartition = StructLikeMap.create(projectedPartitionType);
+    // group tasks by grouping keys derived from their partition tuples
+    StructLikeMap<List<T>> tasksByGroupingKey = StructLikeMap.create(groupingKeyType);
 
     for (T task : tasks) {
       PartitionSpec spec = task.spec();
-      StructProjection projectedStruct =
-          projectionsBySpec.computeIfAbsent(
+      StructProjection groupingKeyProjection =
+          groupingKeyProjectionsBySpec.computeIfAbsent(
               spec.specId(),
-              specId -> StructProjection.create(spec.partitionType(), projectedPartitionType));
-      List<T> taskList =
-          tasksByPartition.computeIfAbsent(
-              projectedStruct.copyFor(task.partition()), k -> Lists.newArrayList());
+              specId -> StructProjection.create(spec.partitionType(), groupingKeyType));
+      List<T> groupingKeyTasks =
+          tasksByGroupingKey.computeIfAbsent(
+              projectGroupingKey(groupingKeyProjection, groupingKeyType, task),
+              groupingKey -> Lists.newArrayList());
       if (task instanceof SplittableScanTask<?>) {
-        ((SplittableScanTask<? extends T>) task).split(splitSize).forEach(taskList::add);
+        ((SplittableScanTask<? extends T>) task).split(splitSize).forEach(groupingKeyTasks::add);
       } else {
-        taskList.add(task);
+        groupingKeyTasks.add(task);
       }
     }
 
-    // Now apply task combining within each partition
-    return FluentIterable.from(tasksByPartition.values())
-        .transformAndConcat(ts -> toTaskGroupIterable(ts, splitSize, lookback, weightFunc))
-        .toList();
+    List<ScanTaskGroup<T>> taskGroups = Lists.newArrayList();
+
+    for (Map.Entry<StructLike, List<T>> entry : tasksByGroupingKey.entrySet()) {
+      StructLike groupingKey = entry.getKey();
+      List<T> groupingKeyTasks = entry.getValue();
+      Iterables.addAll(
+          taskGroups,
+          toTaskGroupIterable(groupingKey, groupingKeyTasks, splitSize, lookback, weightFunc));
+    }
+
+    return taskGroups;
+  }
+
+  private static StructLike projectGroupingKey(
+      StructProjection groupingKeyProjection,
+      Types.StructType groupingKeyType,
+      PartitionScanTask task) {
+
+    PartitionData groupingKey = new PartitionData(groupingKeyType);
+
+    groupingKeyProjection.wrap(task.partition());
+
+    for (int pos = 0; pos < groupingKeyProjection.size(); pos++) {
+      Class<?> javaClass = groupingKey.getType(pos).typeId().javaClass();
+      groupingKey.set(pos, groupingKeyProjection.get(pos, javaClass));
+    }
+
+    return groupingKey;
   }
 
   private static <T extends ScanTask> Iterable<ScanTaskGroup<T>> toTaskGroupIterable(
-      Iterable<T> tasks, long splitSize, int lookback, Function<T, Long> weightFunc) {
+      StructLike groupingKey,
+      Iterable<T> tasks,
+      long splitSize,
+      int lookback,
+      Function<T, Long> weightFunc) {
+
     return Iterables.transform(
         new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFunc, true),
-        combinedTasks -> new BaseScanTaskGroup<>(mergeTasks(combinedTasks)));
+        combinedTasks -> new BaseScanTaskGroup<>(groupingKey, mergeTasks(combinedTasks)));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
This PR adds `groupingKey` to `ScanTaskGroup` so that we can later report it to query engines.