### PR TITLE
API: Override `equals` and `hashCode` methods for primitive types

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Type.java
+++ b/api/src/main/java/org/apache/iceberg/types/Type.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.iceberg.StructLike;
 
 public interface Type extends Serializable {
@@ -111,6 +112,23 @@ public interface Type extends Serializable {
 
     Object writeReplace() throws ObjectStreamException {
       return new PrimitiveHolder(toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      } else if (!(o instanceof PrimitiveType)) {
+        return false;
+      }
+
+      PrimitiveType that = (PrimitiveType) o;
+      return typeId() == that.typeId();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(PrimitiveType.class, typeId());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -332,10 +332,10 @@ public class TypeUtil {
 
     switch (from.typeId()) {
       case INTEGER:
-        return to == Types.LongType.get();
+        return to.typeId() == Type.TypeID.LONG;
 
       case FLOAT:
-        return to == Types.DoubleType.get();
+        return to.typeId() == Type.TypeID.DOUBLE;
 
       case DECIMAL:
         Types.DecimalType fromDecimal = (Types.DecimalType) from;


### PR DESCRIPTION
Deserialization of POJOs in Flink will call the default parameterless constructor to generate a new instance.

However, `Comparators` uses the `PrimitiveType` instance as the key of `Map`:
https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/types/Comparators.java#L33-L47

We need to override `equals` and `hashCode` methods for primitive types, otherwise, exception will occur after serializing `Schema`:

```
java.lang.UnsupportedOperationException: Cannot determine comparator for type: int
	at org.apache.iceberg.types.Comparators.forType(Comparators.java:71)
	at org.apache.iceberg.types.Comparators.internal(Comparators.java:77)
	at org.apache.iceberg.types.Comparators.access$300(Comparators.java:31)
	at org.apache.iceberg.types.Comparators$StructLikeComparator.lambda$new$0(Comparators.java:109)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:4747)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:4755)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:550)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:517)
	at org.apache.iceberg.types.Comparators$StructLikeComparator.<init>(Comparators.java:112)
	at org.apache.iceberg.types.Comparators$StructLikeComparator.<init>(Comparators.java:102)
	at org.apache.iceberg.types.Comparators.forType(Comparators.java:53)
	at org.apache.iceberg.util.StructLikeWrapper.<init>(StructLikeWrapper.java:43)
	at org.apache.iceberg.util.StructLikeWrapper.forType(StructLikeWrapper.java:34)
	at org.apache.iceberg.util.StructLikeMap.put(StructLikeMap.java:87)
	at org.apache.iceberg.util.StructLikeMap.put(StructLikeMap.java:32)
	at org.apache.iceberg.io.BaseTaskWriter$BaseEqualityDeltaWriter.write(BaseTaskWriter.java:125)
	at org.apache.iceberg.flink.sink.BaseDeltaTaskWriter.write(BaseDeltaTaskWriter.java:79)
	at org.apache.iceberg.flink.sink.BaseDeltaTaskWriter.write(BaseDeltaTaskWriter.java:39)
```