### PR TITLE
Gradle build: keep Scala compiler alive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,12 @@ subprojects {
       exceptionFormat "full"
     }
   }
+
+  plugins.withType(ScalaPlugin.class) {
+    tasks.withType(ScalaCompile.class) {
+      scalaCompileOptions.keepAliveMode.set(KeepAliveMode.DAEMON)
+    }
+  }
 }
 
 project(':iceberg-bundled-guava') {


### PR DESCRIPTION
Default behavior is one compiler instance per "session", this change updates it to keep the compiler alive with the Gradle daemon. (This uses a new feature from Gradle 7.6.)