### PR TITLE
Core: Re-add and deprecate HMS_TABLE_OWNER to TableProperties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -359,4 +359,7 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  /** @deprecated will be removed in 1.3.0, use the HMS_TABLE_OWNER constant from HiveCatalog */
+  @Deprecated public static final String HMS_TABLE_OWNER = "hive.metastore.table.owner";
 }


### PR DESCRIPTION
This table property was shipped with [1.1.0](https://github.com/apache/iceberg/blob/apache-iceberg-1.1.0/core/src/main/java/org/apache/iceberg/TableProperties.java#L363) and then removed by https://github.com/apache/iceberg/pull/6045 before we configured RevAPI to compare against 1.1.0 in #6275

CI is currently failing on `master` with:
```
    * Just this break:
        ./gradlew :iceberg-core:revapiAcceptBreak --justification "{why this break is ok}" \
          --code "java.field.removedWithConstant" \
          --old "field org.apache.iceberg.TableProperties.HMS_TABLE_OWNER"
    * All breaks in this project:
        ./gradlew :iceberg-core:revapiAcceptAllBreaks --justification "{why this break is ok}"
    * All breaks in all projects:
        ./gradlew revapiAcceptAllBreaks --justification "{why this break is ok}"
  ----------------------------------------------------------------------------------------------------
```
/cc @szehon-ho @haizhou-zhao 