### PR TITLE
Python: Add warning on projection by name

### DIFF
--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import cached_property
@@ -335,6 +336,10 @@ class DataScan(TableScan["DataScan"]):
 
     def to_arrow(self):
         from pyiceberg.io.pyarrow import PyArrowFileIO
+
+        warnings.warn(
+            "Projection is currently done by name instead of Field ID, this can lead to incorrect results in some cases."
+        )
 
         fs = None
         if isinstance(self.table.io, PyArrowFileIO):


### PR DESCRIPTION
```python
➜  python git:(master) ✗ python3
Python 3.10.8 (main, Oct 13 2022, 09:48:40) [Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyiceberg.catalog import load_catalog
>>>
>>> catalog = load_catalog('local')
>>>
>>> table = catalog.load_table(('nyc', 'taxis'))
>>>
>>> table.scan().to_arrow()
/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/table/__init__.py:340: UserWarning: Projection is currently done by name instead of column ID, this can lead to incorrect results in some cases.
```