### PR TITLE
Core: Use lower lengths for iceberg_namespace_properties / iceberg_tables in JdbcCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -72,9 +72,9 @@ final class JdbcUtil {
           + TABLE_NAME
           + " VARCHAR(255) NOT NULL,"
           + METADATA_LOCATION
-          + " VARCHAR(5500),"
+          + " VARCHAR(1000),"
           + PREVIOUS_METADATA_LOCATION
-          + " VARCHAR(5500),"
+          + " VARCHAR(1000),"
           + "PRIMARY KEY ("
           + CATALOG_NAME
           + ", "
@@ -185,9 +185,9 @@ final class JdbcUtil {
           + NAMESPACE_NAME
           + " VARCHAR(255) NOT NULL,"
           + NAMESPACE_PROPERTY_KEY
-          + " VARCHAR(5500),"
+          + " VARCHAR(255),"
           + NAMESPACE_PROPERTY_VALUE
-          + " VARCHAR(5500),"
+          + " VARCHAR(1000),"
           + "PRIMARY KEY ("
           + CATALOG_NAME
           + ", "


### PR DESCRIPTION
Users are running into issues when hooking up the `JdbcCatalog` with `MySql` or other Databases, which actually impose lower limits than [sqlite](https://www.sqlite.org/limits.html) (which we use for testing the `JdbcCatalog`.

fixes #6236 
fixes #5027
fixes #6332