### PR TITLE
Spark 3.3: Introduce the changelog iterator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ChangelogOperation.java
+++ b/api/src/main/java/org/apache/iceberg/ChangelogOperation.java
@@ -21,5 +21,7 @@ package org.apache.iceberg;
 /** An enum representing possible operations in a changelog. */
 public enum ChangelogOperation {
   INSERT,
-  DELETE
+  DELETE,
+  UPDATE_BEFORE,
+  UPDATE_AFTER
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -36,10 +36,10 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
  * <p>It removes the carry-over rows. Carry-over rows are the result of a removal and insertion of
  * the same row within an operation because of the copy-on-write mechanism. For example, given a
  * file which contains row1 (id=1, data='a') and row2 (id=2, data='b'). A copy-on-write delete of
- * row2 would require erasing this file and preserving row1 in a new file written with row1' which
- * is identical to row1. The change-log table would report this as (row1 deleted) and (row1'
- * inserted), since this row was not actually modified it is not an actual change in the table. The
- * iterator finds out the carry-over rows and removes them from the result.
+ * row2 would require erasing this file and preserving row1 in a new file. The change-log table
+ * would report this as (id=1, data='a', op='DELETE') and (id=1, data='a', op='INSERT'), despite it
+ * not being an actual change to the table. The iterator finds out the carry-over rows and removes
+ * them from the result.
  *
  * <p>The iterator marks the delete-row and insert-row to be the update-rows. For example, these two
  * rows
@@ -76,7 +76,7 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
   }
 
   /**
-   * Creates a new {@link ChangelogIterator} instance concatenated with the null-removal iterator.
+   * Creates an iterator for records of a changelog table.
    *
    * @param rowIterator the iterator of rows from a changelog table
    * @param changeTypeIndex the index of the change type column

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -129,10 +129,10 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
     return deletedRow.equals(insertedRow);
   }
 
-  private boolean updated(Row row) {
-    return row != null
-        && !row.getString(changeTypeIndex).equals(DELETE)
-        && !row.getString(changeTypeIndex).equals(INSERT);
+  private boolean updated(Row cachedRow) {
+    return cachedRow != null
+        && !cachedRow.getString(changeTypeIndex).equals(DELETE)
+        && !cachedRow.getString(changeTypeIndex).equals(INSERT);
   }
 
   private Row currentRow() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -80,7 +80,8 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
    *
    * @param rowIterator the iterator of rows from a changelog table
    * @param changeTypeIndex the index of the change type column
-   * @param identifierFieldIdx the indices of the identifier columns
+   * @param identifierFieldIdx the indices of the identifier columns, which determine if rows are
+   *     the same
    * @return a new {@link ChangelogIterator} instance concatenated with the null-removal iterator
    */
   public static Iterator<Row> iterator(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+
+public class ChangelogIterator implements Iterator<Row>, Serializable {
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+
+  private final Iterator<Row> rowIterator;
+  private final int changeTypeIndex;
+  private final List<Integer> partitionIdx;
+  private final boolean markUpdatedRows;
+
+  private Row cachedRow = null;
+
+  public ChangelogIterator(
+      Iterator<Row> rowIterator,
+      int changeTypeIndex,
+      List<Integer> partitionIdx,
+      boolean markUpdatedRows) {
+    this.rowIterator = rowIterator;
+    this.changeTypeIndex = changeTypeIndex;
+    this.partitionIdx = partitionIdx;
+    this.markUpdatedRows = markUpdatedRows;
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (cachedRow != null) {
+      return true;
+    }
+    return rowIterator.hasNext();
+  }
+
+  @Override
+  public Row next() {
+    // if there is a processed cached row, return it directly
+    if (cachedRow != null
+        && !cachedRow.getString(changeTypeIndex).equals(DELETE)
+        && !cachedRow.getString(changeTypeIndex).equals(INSERT)) {
+      Row row = cachedRow;
+      cachedRow = null;
+      return row;
+    }
+
+    Row currentRow = currentRow();
+
+    if (rowIterator.hasNext()) {
+      GenericRowWithSchema nextRow = (GenericRowWithSchema) rowIterator.next();
+
+      if (withinPartition(currentRow, nextRow)
+          && currentRow.getString(changeTypeIndex).equals(DELETE)
+          && nextRow.getString(changeTypeIndex).equals(INSERT)) {
+
+        GenericInternalRow deletedRow =
+            new GenericInternalRow(((GenericRowWithSchema) currentRow).values());
+        GenericInternalRow insertedRow = new GenericInternalRow(nextRow.values());
+
+        // set the change_type to the same value
+        deletedRow.update(changeTypeIndex, "");
+        insertedRow.update(changeTypeIndex, "");
+
+        if (deletedRow.equals(insertedRow)) {
+          // remove two carry-over rows
+          currentRow = null;
+          this.cachedRow = null;
+        } else if (markUpdatedRows) {
+          // mark the updated rows
+          deletedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_BEFORE.name());
+          currentRow = RowFactory.create(deletedRow.values());
+
+          insertedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_AFTER.name());
+          this.cachedRow = RowFactory.create(insertedRow.values());
+        } else {
+          this.cachedRow = nextRow;
+        }
+
+      } else {
+        this.cachedRow = nextRow;
+      }
+    }
+
+    return currentRow;
+  }
+
+  private Row currentRow() {
+    if (cachedRow != null) {
+      Row row = cachedRow;
+      cachedRow = null;
+      return row;
+    } else {
+      return rowIterator.next();
+    }
+  }
+
+  private boolean withinPartition(Row currentRow, Row nextRow) {
+    for (int i = 0; i < partitionIdx.size(); i++) {
+      int idx = partitionIdx.get(i);
+      if (!nextRow.get(idx).equals(currentRow.get(idx))) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -97,6 +97,9 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
           insertedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_AFTER.name());
           this.cachedRow = RowFactory.create(insertedRow.values());
         } else {
+          // recover the values of change type
+          deletedRow.update(changeTypeIndex, DELETE);
+          insertedRow.update(changeTypeIndex, INSERT);
           this.cachedRow = nextRow;
         }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -27,6 +27,31 @@ import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 
+/**
+ * An iterator that transforms rows within a single task.
+ *
+ * <p>It marks the carry-over rows to null to be filtered out later. Carry-over rows are unchanged
+ * rows in a snapshot but showed as delete-rows and insert-rows in a changelog table due to the
+ * copy-on-write(COW) mechanism. For example, there are row1 (id=1, data='a') and row2 (id=2,
+ * data='b') in a data file, if we only delete row2, the COW will copy row1 to a new data file and
+ * delete the whole old data file. The changelog table will have two delete-rows(row1 and row2), and
+ * one insert-row(row1). Row1 is a carry-over row.
+ *
+ * <p>The iterator marks the delete-row and insert-row to be the update-rows. For example, these two
+ * rows
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='DELETE')
+ *   <li>(id=1, data='b', op='INSERT')
+ * </ul>
+ *
+ * will be marked as update-rows:
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='UPDATE_BEFORE')
+ *   <li>(id=1, data='b', op='UPDATE_AFTER')
+ * </ul>
+ */
 public class ChangelogIterator implements Iterator<Row>, Serializable {
   private static final String DELETE = ChangelogOperation.DELETE.name();
   private static final String INSERT = ChangelogOperation.INSERT.name();
@@ -34,19 +59,14 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
   private final Iterator<Row> rowIterator;
   private final int changeTypeIndex;
   private final List<Integer> partitionIdx;
-  private final boolean markUpdatedRows;
 
   private Row cachedRow = null;
 
   public ChangelogIterator(
-      Iterator<Row> rowIterator,
-      int changeTypeIndex,
-      List<Integer> partitionIdx,
-      boolean markUpdatedRows) {
+      Iterator<Row> rowIterator, int changeTypeIndex, List<Integer> partitionIdx) {
     this.rowIterator = rowIterator;
     this.changeTypeIndex = changeTypeIndex;
     this.partitionIdx = partitionIdx;
-    this.markUpdatedRows = markUpdatedRows;
   }
 
   @Override
@@ -59,10 +79,8 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
 
   @Override
   public Row next() {
-    // if there is a processed cached row, return it directly
-    if (cachedRow != null
-        && !cachedRow.getString(changeTypeIndex).equals(DELETE)
-        && !cachedRow.getString(changeTypeIndex).equals(INSERT)) {
+    // if there is an updated cached row, return it directly
+    if (updated(cachedRow)) {
       Row row = cachedRow;
       cachedRow = null;
       return row;
@@ -72,43 +90,44 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
 
     if (rowIterator.hasNext()) {
       GenericRowWithSchema nextRow = (GenericRowWithSchema) rowIterator.next();
+      cachedRow = nextRow;
 
-      if (withinPartition(currentRow, nextRow)
-          && currentRow.getString(changeTypeIndex).equals(DELETE)
-          && nextRow.getString(changeTypeIndex).equals(INSERT)) {
+      if (updateOrCarryoverRecord(currentRow, nextRow)) {
+        Row[] rows = update((GenericRowWithSchema) currentRow, nextRow);
 
-        GenericInternalRow deletedRow =
-            new GenericInternalRow(((GenericRowWithSchema) currentRow).values());
-        GenericInternalRow insertedRow = new GenericInternalRow(nextRow.values());
-
-        // set the change_type to the same value
-        deletedRow.update(changeTypeIndex, "");
-        insertedRow.update(changeTypeIndex, "");
-
-        if (deletedRow.equals(insertedRow)) {
-          // remove two carry-over rows
-          currentRow = null;
-          this.cachedRow = null;
-        } else if (markUpdatedRows) {
-          // mark the updated rows
-          deletedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_BEFORE.name());
-          currentRow = RowFactory.create(deletedRow.values());
-
-          insertedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_AFTER.name());
-          this.cachedRow = RowFactory.create(insertedRow.values());
-        } else {
-          // recover the values of change type
-          deletedRow.update(changeTypeIndex, DELETE);
-          insertedRow.update(changeTypeIndex, INSERT);
-          this.cachedRow = nextRow;
-        }
-
-      } else {
-        this.cachedRow = nextRow;
+        currentRow = rows[0];
+        cachedRow = rows[1];
       }
     }
 
     return currentRow;
+  }
+
+  private Row[] update(GenericRowWithSchema currentRow, GenericRowWithSchema nextRow) {
+    GenericInternalRow deletedRow = new GenericInternalRow(currentRow.values());
+    GenericInternalRow insertedRow = new GenericInternalRow(nextRow.values());
+
+    // set the change_type to the same value
+    deletedRow.update(changeTypeIndex, "");
+    insertedRow.update(changeTypeIndex, "");
+
+    if (deletedRow.equals(insertedRow)) {
+      // set carry-over rows to null to be filtered out later
+      return new Row[] {null, null};
+    } else {
+      deletedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_BEFORE.name());
+      insertedRow.update(changeTypeIndex, ChangelogOperation.UPDATE_AFTER.name());
+
+      return new Row[] {
+        RowFactory.create(deletedRow.values()), RowFactory.create(insertedRow.values())
+      };
+    }
+  }
+
+  private boolean updated(Row row) {
+    return row != null
+        && !row.getString(changeTypeIndex).equals(DELETE)
+        && !row.getString(changeTypeIndex).equals(INSERT);
   }
 
   private Row currentRow() {
@@ -121,9 +140,14 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
     }
   }
 
+  private boolean updateOrCarryoverRecord(Row currentRow, Row nextRow) {
+    return withinPartition(currentRow, nextRow)
+        && currentRow.getString(changeTypeIndex).equals(DELETE)
+        && nextRow.getString(changeTypeIndex).equals(INSERT);
+  }
+
   private boolean withinPartition(Row currentRow, Row nextRow) {
-    for (int i = 0; i < partitionIdx.size(); i++) {
-      int idx = partitionIdx.get(i);
+    for (int idx : partitionIdx) {
       if (!nextRow.get(idx).equals(currentRow.get(idx))) {
         return false;
       }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -108,7 +108,7 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
 
     Row currentRow = currentRow();
 
-    if (rowIterator.hasNext()) {
+    if (currentRow.getString(changeTypeIndex).equals(DELETE) && rowIterator.hasNext()) {
       GenericRowWithSchema nextRow = (GenericRowWithSchema) rowIterator.next();
       cachedRow = nextRow;
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -148,10 +148,10 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
     return true;
   }
 
-  private boolean cachedUpdateRecord(Row cachedRow) {
-    return cachedRow != null
-        && !cachedRow.getString(changeTypeIndex).equals(DELETE)
-        && !cachedRow.getString(changeTypeIndex).equals(INSERT);
+  private boolean cachedUpdateRecord(Row cachedRecord) {
+    return cachedRecord != null
+        && !cachedRecord.getString(changeTypeIndex).equals(DELETE)
+        && !cachedRecord.getString(changeTypeIndex).equals(INSERT);
   }
 
   private Row currentRow() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -112,7 +112,7 @@ public class ChangelogIterator implements Iterator<Row>, Serializable {
     Row currentRow = currentRow();
 
     if (indicesForIdentifySameRow == null) {
-      generateIndicesForIdentifySameRow(currentRow);
+      indicesForIdentifySameRow = generateIndicesForIdentifySameRow(currentRow);
     }
 
     if (currentRow.getString(changeTypeIndex).equals(DELETE) && rowIterator.hasNext()) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -58,9 +56,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
-public abstract class SparkTestBase {
-
-  protected static final Object ANY = new Object();
+public abstract class SparkTestBase extends SparkTestHelperBase {
 
   protected static TestHiveMetastore metastore = null;
   protected static HiveConf hiveConf = null;
@@ -124,32 +120,6 @@ public abstract class SparkTestBase {
     return rowsToJava(rows);
   }
 
-  public static List<Object[]> rowsToJava(List<Row> rows) {
-    return rows.stream().map(SparkTestBase::toJava).collect(Collectors.toList());
-  }
-
-  private static Object[] toJava(Row row) {
-    return IntStream.range(0, row.size())
-        .mapToObj(
-            pos -> {
-              if (row.isNullAt(pos)) {
-                return null;
-              }
-
-              Object value = row.get(pos);
-              if (value instanceof Row) {
-                return toJava((Row) value);
-              } else if (value instanceof scala.collection.Seq) {
-                return row.getList(pos);
-              } else if (value instanceof scala.collection.Map) {
-                return row.getJavaMap(pos);
-              } else {
-                return value;
-              }
-            })
-        .toArray(Object[]::new);
-  }
-
   protected Object scalarSql(String query, Object... args) {
     List<Object[]> rows = sql(query, args);
     Assert.assertEquals("Scalar SQL should return one row", 1, rows.size());
@@ -160,39 +130,6 @@ public abstract class SparkTestBase {
 
   protected Object[] row(Object... values) {
     return values;
-  }
-
-  public static void assertEquals(
-      String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
-    Assert.assertEquals(
-        context + ": number of results should match", expectedRows.size(), actualRows.size());
-    for (int row = 0; row < expectedRows.size(); row += 1) {
-      Object[] expected = expectedRows.get(row);
-      Object[] actual = actualRows.get(row);
-      Assert.assertEquals("Number of columns should match", expected.length, actual.length);
-      for (int col = 0; col < actualRows.get(row).length; col += 1) {
-        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
-        assertEquals(newContext, expected, actual);
-      }
-    }
-  }
-
-  private static void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
-    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
-    for (int col = 0; col < actualRow.length; col += 1) {
-      Object expectedValue = expectedRow[col];
-      Object actualValue = actualRow[col];
-      if (expectedValue != null && expectedValue.getClass().isArray()) {
-        String newContext = String.format("%s (nested col %d)", context, col + 1);
-        if (expectedValue instanceof byte[]) {
-          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
-        } else {
-          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
-        }
-      } else if (expectedValue != ANY) {
-        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
-      }
-    }
   }
 
   protected static String dbPath(String dbName) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -124,11 +124,11 @@ public abstract class SparkTestBase {
     return rowsToJava(rows);
   }
 
-  protected List<Object[]> rowsToJava(List<Row> rows) {
-    return rows.stream().map(this::toJava).collect(Collectors.toList());
+  public static List<Object[]> rowsToJava(List<Row> rows) {
+    return rows.stream().map(SparkTestBase::toJava).collect(Collectors.toList());
   }
 
-  private Object[] toJava(Row row) {
+  private static Object[] toJava(Row row) {
     return IntStream.range(0, row.size())
         .mapToObj(
             pos -> {
@@ -162,7 +162,7 @@ public abstract class SparkTestBase {
     return values;
   }
 
-  protected void assertEquals(
+  public static void assertEquals(
       String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
     Assert.assertEquals(
         context + ": number of results should match", expectedRows.size(), actualRows.size());
@@ -177,7 +177,7 @@ public abstract class SparkTestBase {
     }
   }
 
-  private void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
+  private static void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
     Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
     for (int col = 0; col < actualRow.length; col += 1) {
       Object expectedValue = expectedRow[col];

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+
+public class SparkTestHelperBase {
+  protected static final Object ANY = new Object();
+
+  protected List<Object[]> rowsToJava(List<Row> rows) {
+    return rows.stream().map(this::toJava).collect(Collectors.toList());
+  }
+
+  private Object[] toJava(Row row) {
+    return IntStream.range(0, row.size())
+        .mapToObj(
+            pos -> {
+              if (row.isNullAt(pos)) {
+                return null;
+              }
+
+              Object value = row.get(pos);
+              if (value instanceof Row) {
+                return toJava((Row) value);
+              } else if (value instanceof scala.collection.Seq) {
+                return row.getList(pos);
+              } else if (value instanceof scala.collection.Map) {
+                return row.getJavaMap(pos);
+              } else {
+                return value;
+              }
+            })
+        .toArray(Object[]::new);
+  }
+
+  protected void assertEquals(
+      String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
+    Assert.assertEquals(
+        context + ": number of results should match", expectedRows.size(), actualRows.size());
+    for (int row = 0; row < expectedRows.size(); row += 1) {
+      Object[] expected = expectedRows.get(row);
+      Object[] actual = actualRows.get(row);
+      Assert.assertEquals("Number of columns should match", expected.length, actual.length);
+      for (int col = 0; col < actualRows.get(row).length; col += 1) {
+        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
+        assertEquals(newContext, expected, actual);
+      }
+    }
+  }
+
+  private void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
+    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
+    for (int col = 0; col < actualRow.length; col += 1) {
+      Object expectedValue = expectedRow[col];
+      Object actualValue = actualRow[col];
+      if (expectedValue != null && expectedValue.getClass().isArray()) {
+        String newContext = String.format("%s (nested col %d)", context, col + 1);
+        if (expectedValue instanceof byte[]) {
+          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+        } else {
+          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        }
+      } else if (expectedValue != ANY) {
+        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
+      }
+    }
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -131,16 +131,16 @@ public class TestChangelogIterator {
   public void testRowsWithNullValue() {
     final List<Row> rowsWithNull =
         Lists.newArrayList(
-            new GenericRowWithSchema(new Object[] {2, null, null, "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {3, null, null, "INSERT"}, null),
-            new GenericRowWithSchema(new Object[] {4, null, null, "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {4, null, null, "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {2, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {3, null, null, INSERT}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, INSERT}, null),
             // mixed null and non-null value in non-identifier columns
-            new GenericRowWithSchema(new Object[] {5, null, null, "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {5, null, "data", "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {5, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {5, null, "data", INSERT}, null),
             // mixed null and non-null value in identifier columns
-            new GenericRowWithSchema(new Object[] {6, null, null, "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {6, "name", null, "INSERT"}, null));
+            new GenericRowWithSchema(new Object[] {6, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {6, "name", null, INSERT}, null));
 
     Iterator<Row> iterator =
         ChangelogIterator.iterator(rowsWithNull.iterator(), 3, Lists.newArrayList(0, 1));
@@ -163,17 +163,17 @@ public class TestChangelogIterator {
     List<Row> rowsWithDuplication =
         Lists.newArrayList(
             // next two rows are identical
-            new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "data", DELETE}, null),
             // next two rows are identical
-            new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
-            new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", INSERT}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", INSERT}, null),
             // next two rows are identical
-            new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
-            new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", DELETE}, null),
             // next two rows are identical
-            new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null),
-            new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
+            new GenericRowWithSchema(new Object[] {4, "d", "data", INSERT}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", INSERT}, null));
 
     Iterator<Row> iterator =
         ChangelogIterator.iterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -29,14 +29,14 @@ import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestChangelogIterator {
+public class TestChangelogIterator extends SparkTestHelperBase {
   private static final String DELETE = ChangelogOperation.DELETE.name();
   private static final String INSERT = ChangelogOperation.INSERT.name();
   private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
   private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
 
   private final int changeTypeIndex = 3;
-  private final List<Integer> partitionIdx = Lists.newArrayList(0, 1);
+  private final List<Integer> identifierFieldIdx = Lists.newArrayList(0, 1);
 
   private enum RowType {
     DELETED,
@@ -69,9 +69,9 @@ public class TestChangelogIterator {
     }
 
     Iterator<Row> iterator =
-        ChangelogIterator.iterator(rows.iterator(), changeTypeIndex, partitionIdx);
+        ChangelogIterator.iterator(rows.iterator(), changeTypeIndex, identifierFieldIdx);
     List<Row> result = Lists.newArrayList(iterator);
-    SparkTestBase.assertEquals("Rows should match", expectedRows, SparkTestBase.rowsToJava(result));
+    assertEquals("Rows should match", expectedRows, rowsToJava(result));
   }
 
   private List<Row> toOriginalRows(RowType rowType, int order) {
@@ -146,7 +146,7 @@ public class TestChangelogIterator {
         ChangelogIterator.iterator(rowsWithNull.iterator(), 3, Lists.newArrayList(0, 1));
     List<Row> result = Lists.newArrayList(iterator);
 
-    SparkTestBase.assertEquals(
+    assertEquals(
         "Rows should match",
         Lists.newArrayList(
             new Object[] {2, null, null, DELETE},
@@ -155,7 +155,7 @@ public class TestChangelogIterator {
             new Object[] {5, null, "data", UPDATE_AFTER},
             new Object[] {6, null, null, DELETE},
             new Object[] {6, "name", null, INSERT}),
-        SparkTestBase.rowsToJava(result));
+        rowsToJava(result));
   }
 
   @Test
@@ -176,10 +176,11 @@ public class TestChangelogIterator {
             new GenericRowWithSchema(new Object[] {4, "d", "data", INSERT}, null));
 
     Iterator<Row> iterator =
-        ChangelogIterator.iterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx);
+        ChangelogIterator.iterator(
+            rowsWithDuplication.iterator(), changeTypeIndex, identifierFieldIdx);
     List<Row> result = Lists.newArrayList(iterator);
 
-    SparkTestBase.assertEquals(
+    assertEquals(
         "Duplicate rows should not be removed",
         Lists.newArrayList(
             new Object[] {1, "a", "data", DELETE},
@@ -188,6 +189,6 @@ public class TestChangelogIterator {
             new Object[] {1, "a", "new_data", INSERT},
             new Object[] {4, "d", "data", DELETE},
             new Object[] {4, "d", "data", INSERT}),
-        SparkTestBase.rowsToJava(result));
+        rowsToJava(result));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -116,13 +116,13 @@ public class TestChangelogIterator {
     }
   }
 
-  private void permute(List<RowType> arr, int k, List<Object[]> pm) {
-    for (int i = k; i < arr.size(); i++) {
-      Collections.swap(arr, i, k);
-      permute(arr, k + 1, pm);
-      Collections.swap(arr, k, i);
+  private void permute(List<RowType> arr, int start, List<Object[]> pm) {
+    for (int i = start; i < arr.size(); i++) {
+      Collections.swap(arr, i, start);
+      permute(arr, start + 1, pm);
+      Collections.swap(arr, start, i);
     }
-    if (k == arr.size() - 1) {
+    if (start == arr.size() - 1) {
       pm.add(arr.toArray());
     }
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -47,25 +47,25 @@ public class TestChangelogIterator extends SparkTestHelperBase {
 
   @Test
   public void testIterator() {
-    List<Object[]> pm = Lists.newArrayList();
-    // generate 24 permutations.
+    List<Object[]> permutations = Lists.newArrayList();
+    // generate 24 permutations
     permute(
         Arrays.asList(RowType.DELETED, RowType.INSERTED, RowType.CARRY_OVER, RowType.UPDATED),
         0,
-        pm);
-    Assert.assertEquals(24, pm.size());
+        permutations);
+    Assert.assertEquals(24, permutations.size());
 
-    for (Object[] item : pm) {
-      validate(item);
+    for (Object[] permutation : permutations) {
+      validate(permutation);
     }
   }
 
-  private void validate(Object[] item) {
+  private void validate(Object[] permutation) {
     List<Row> rows = Lists.newArrayList();
     List<Object[]> expectedRows = Lists.newArrayList();
-    for (int i = 0; i < item.length; i++) {
-      rows.addAll(toOriginalRows((RowType) item[i], i));
-      expectedRows.addAll(toExpectedRows((RowType) item[i], i));
+    for (int i = 0; i < permutation.length; i++) {
+      rows.addAll(toOriginalRows((RowType) permutation[i], i));
+      expectedRows.addAll(toExpectedRows((RowType) permutation[i], i));
     }
 
     Iterator<Row> iterator =
@@ -74,22 +74,22 @@ public class TestChangelogIterator extends SparkTestHelperBase {
     assertEquals("Rows should match", expectedRows, rowsToJava(result));
   }
 
-  private List<Row> toOriginalRows(RowType rowType, int order) {
+  private List<Row> toOriginalRows(RowType rowType, int index) {
     switch (rowType) {
       case DELETED:
         return Lists.newArrayList(
-            new GenericRowWithSchema(new Object[] {order, "b", "data", DELETE}, null));
+            new GenericRowWithSchema(new Object[] {index, "b", "data", DELETE}, null));
       case INSERTED:
         return Lists.newArrayList(
-            new GenericRowWithSchema(new Object[] {order, "c", "data", INSERT}, null));
+            new GenericRowWithSchema(new Object[] {index, "c", "data", INSERT}, null));
       case CARRY_OVER:
         return Lists.newArrayList(
-            new GenericRowWithSchema(new Object[] {order, "d", "data", DELETE}, null),
-            new GenericRowWithSchema(new Object[] {order, "d", "data", INSERT}, null));
+            new GenericRowWithSchema(new Object[] {index, "d", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {index, "d", "data", INSERT}, null));
       case UPDATED:
         return Lists.newArrayList(
-            new GenericRowWithSchema(new Object[] {order, "a", "data", DELETE}, null),
-            new GenericRowWithSchema(new Object[] {order, "a", "new_data", INSERT}, null));
+            new GenericRowWithSchema(new Object[] {index, "a", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {index, "a", "new_data", INSERT}, null));
       default:
         throw new IllegalArgumentException("Unknown row type: " + rowType);
     }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -48,7 +48,7 @@ public class TestChangelogIterator {
   @Test
   public void testUpdatedRows() {
     ChangelogIterator iterator =
-        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx, true);
+        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx);
 
     List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
     SparkTestBase.assertEquals(
@@ -56,21 +56,6 @@ public class TestChangelogIterator {
         Lists.newArrayList(
             new Object[] {1, "a", "data", UPDATE_BEFORE.name()},
             new Object[] {1, "a", "new_data", UPDATE_AFTER.name()},
-            new Object[] {2, "b", "data", "DELETE"},
-            new Object[] {3, "c", "data", "INSERT"}),
-        SparkTestBase.rowsToJava(result));
-  }
-
-  @Test
-  public void testNotMarkUpdatedRows() {
-    ChangelogIterator iterator =
-        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx, false);
-    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
-    SparkTestBase.assertEquals(
-        "Rows should match",
-        Lists.newArrayList(
-            new Object[] {1, "a", "data", "DELETE"},
-            new Object[] {1, "a", "new_data", "INSERT"},
             new Object[] {2, "b", "data", "DELETE"},
             new Object[] {3, "c", "data", "INSERT"}),
         SparkTestBase.rowsToJava(result));
@@ -94,7 +79,7 @@ public class TestChangelogIterator {
             new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
 
     ChangelogIterator iterator =
-        new ChangelogIterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx, true);
+        new ChangelogIterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx);
 
     List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
     SparkTestBase.assertEquals(

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -18,46 +18,143 @@
  */
 package org.apache.iceberg.spark;
 
-import static org.apache.iceberg.ChangelogOperation.DELETE;
-import static org.apache.iceberg.ChangelogOperation.INSERT;
-import static org.apache.iceberg.ChangelogOperation.UPDATE_AFTER;
-import static org.apache.iceberg.ChangelogOperation.UPDATE_BEFORE;
-
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.ChangelogOperation;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestChangelogIterator {
-  private final List<Row> rows =
-      Lists.newArrayList(
-          new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
-          new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
-          // next two rows belong to different partitions
-          new GenericRowWithSchema(new Object[] {2, "b", "data", "DELETE"}, null),
-          new GenericRowWithSchema(new Object[] {3, "c", "data", "INSERT"}, null),
-          new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
-          new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+  private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
+  private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
 
   private final int changeTypeIndex = 3;
   private final List<Integer> partitionIdx = Lists.newArrayList(0, 1);
 
-  @Test
-  public void testUpdatedRows() {
-    ChangelogIterator iterator =
-        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx);
+  private enum RowType {
+    DELETED,
+    INSERTED,
+    CARRY_OVER,
+    UPDATED
+  }
 
-    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
+  @Test
+  public void testIterator() {
+    List<Object[]> pm = Lists.newArrayList();
+    // generate 24 permutations.
+    permute(
+        Arrays.asList(RowType.DELETED, RowType.INSERTED, RowType.CARRY_OVER, RowType.UPDATED),
+        0,
+        pm);
+    Assert.assertEquals(24, pm.size());
+
+    for (Object[] item : pm) {
+      validate(item);
+    }
+  }
+
+  private void validate(Object[] item) {
+    List<Row> rows = Lists.newArrayList();
+    List<Object[]> expectedRows = Lists.newArrayList();
+    for (int i = 0; i < item.length; i++) {
+      rows.addAll(toOriginalRows((RowType) item[i], i));
+      expectedRows.addAll(toExpectedRows((RowType) item[i], i));
+    }
+
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(rows.iterator(), changeTypeIndex, partitionIdx);
+    List<Row> result = Lists.newArrayList(iterator);
+    SparkTestBase.assertEquals("Rows should match", expectedRows, SparkTestBase.rowsToJava(result));
+  }
+
+  private List<Row> toOriginalRows(RowType rowType, int order) {
+    switch (rowType) {
+      case DELETED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {order, "b", "data", DELETE}, null));
+      case INSERTED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {order, "c", "data", INSERT}, null));
+      case CARRY_OVER:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {order, "d", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {order, "d", "data", INSERT}, null));
+      case UPDATED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {order, "a", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {order, "a", "new_data", INSERT}, null));
+      default:
+        throw new IllegalArgumentException("Unknown row type: " + rowType);
+    }
+  }
+
+  private List<Object[]> toExpectedRows(RowType rowType, int order) {
+    switch (rowType) {
+      case DELETED:
+        List<Object[]> rows = Lists.newArrayList();
+        rows.add(new Object[] {order, "b", "data", DELETE});
+        return rows;
+      case INSERTED:
+        List<Object[]> insertedRows = Lists.newArrayList();
+        insertedRows.add(new Object[] {order, "c", "data", INSERT});
+        return insertedRows;
+      case CARRY_OVER:
+        return Lists.newArrayList();
+      case UPDATED:
+        return Lists.newArrayList(
+            new Object[] {order, "a", "data", UPDATE_BEFORE},
+            new Object[] {order, "a", "new_data", UPDATE_AFTER});
+      default:
+        throw new IllegalArgumentException("Unknown row type: " + rowType);
+    }
+  }
+
+  private void permute(List<RowType> arr, int k, List<Object[]> pm) {
+    for (int i = k; i < arr.size(); i++) {
+      Collections.swap(arr, i, k);
+      permute(arr, k + 1, pm);
+      Collections.swap(arr, k, i);
+    }
+    if (k == arr.size() - 1) {
+      pm.add(arr.toArray());
+    }
+  }
+
+  @Test
+  public void testRowsWithNullValue() {
+    final List<Row> rowsWithNull =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {2, null, null, "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {3, null, null, "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, "INSERT"}, null),
+            // mixed null and non-null value in non-identifier columns
+            new GenericRowWithSchema(new Object[] {5, null, null, "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {5, null, "data", "INSERT"}, null),
+            // mixed null and non-null value in identifier columns
+            new GenericRowWithSchema(new Object[] {6, null, null, "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {6, "name", null, "INSERT"}, null));
+
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(rowsWithNull.iterator(), 3, Lists.newArrayList(0, 1));
+    List<Row> result = Lists.newArrayList(iterator);
+
     SparkTestBase.assertEquals(
         "Rows should match",
         Lists.newArrayList(
-            new Object[] {1, "a", "data", UPDATE_BEFORE.name()},
-            new Object[] {1, "a", "new_data", UPDATE_AFTER.name()},
-            new Object[] {2, "b", "data", "DELETE"},
-            new Object[] {3, "c", "data", "INSERT"}),
+            new Object[] {2, null, null, DELETE},
+            new Object[] {3, null, null, INSERT},
+            new Object[] {5, null, null, UPDATE_BEFORE},
+            new Object[] {5, null, "data", UPDATE_AFTER},
+            new Object[] {6, null, null, DELETE},
+            new Object[] {6, "name", null, INSERT}),
         SparkTestBase.rowsToJava(result));
   }
 
@@ -78,19 +175,19 @@ public class TestChangelogIterator {
             new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null),
             new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
 
-    ChangelogIterator iterator =
-        new ChangelogIterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx);
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx);
+    List<Row> result = Lists.newArrayList(iterator);
 
-    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
     SparkTestBase.assertEquals(
         "Duplicate rows should not be removed",
         Lists.newArrayList(
-            new Object[] {1, "a", "data", DELETE.name()},
-            new Object[] {1, "a", "data", UPDATE_BEFORE.name()},
-            new Object[] {1, "a", "new_data", UPDATE_AFTER.name()},
-            new Object[] {1, "a", "new_data", INSERT.name()},
-            new Object[] {4, "d", "data", DELETE.name()},
-            new Object[] {4, "d", "data", INSERT.name()}),
+            new Object[] {1, "a", "data", DELETE},
+            new Object[] {1, "a", "data", UPDATE_BEFORE},
+            new Object[] {1, "a", "new_data", UPDATE_AFTER},
+            new Object[] {1, "a", "new_data", INSERT},
+            new Object[] {4, "d", "data", DELETE},
+            new Object[] {4, "d", "data", INSERT}),
         SparkTestBase.rowsToJava(result));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.apache.iceberg.ChangelogOperation.DELETE;
+import static org.apache.iceberg.ChangelogOperation.INSERT;
+import static org.apache.iceberg.ChangelogOperation.UPDATE_AFTER;
+import static org.apache.iceberg.ChangelogOperation.UPDATE_BEFORE;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.junit.Test;
+
+public class TestChangelogIterator {
+  private final List<Row> rows =
+      Lists.newArrayList(
+          new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
+          new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
+          // next two rows belong to different partitions
+          new GenericRowWithSchema(new Object[] {2, "b", "data", "DELETE"}, null),
+          new GenericRowWithSchema(new Object[] {3, "c", "data", "INSERT"}, null),
+          new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
+          new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
+
+  private final int changeTypeIndex = 3;
+  private final List<Integer> partitionIdx = Lists.newArrayList(0, 1);
+
+  @Test
+  public void testUpdatedRows() {
+    ChangelogIterator iterator =
+        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx, true);
+
+    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
+    SparkTestBase.assertEquals(
+        "Rows should match",
+        Lists.newArrayList(
+            new Object[] {1, "a", "data", UPDATE_BEFORE.name()},
+            new Object[] {1, "a", "new_data", UPDATE_AFTER.name()},
+            new Object[] {2, "b", "data", "DELETE"},
+            new Object[] {3, "c", "data", "INSERT"}),
+        SparkTestBase.rowsToJava(result));
+  }
+
+  @Test
+  public void testNotMarkUpdatedRows() {
+    ChangelogIterator iterator =
+        new ChangelogIterator(rows.iterator(), changeTypeIndex, partitionIdx, false);
+    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
+    SparkTestBase.assertEquals(
+        "Rows should match",
+        Lists.newArrayList(
+            new Object[] {1, "a", "data", "DELETE"},
+            new Object[] {1, "a", "new_data", "INSERT"},
+            new Object[] {2, "b", "data", "DELETE"},
+            new Object[] {3, "c", "data", "INSERT"}),
+        SparkTestBase.rowsToJava(result));
+  }
+
+  @Test
+  public void testUpdatedRowsWithDuplication() {
+    List<Row> rowsWithDuplication =
+        Lists.newArrayList(
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "data", "DELETE"}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", "INSERT"}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", "DELETE"}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", "INSERT"}, null));
+
+    ChangelogIterator iterator =
+        new ChangelogIterator(rowsWithDuplication.iterator(), changeTypeIndex, partitionIdx, true);
+
+    List<Row> result = Lists.newArrayList(Iterators.filter(iterator, Objects::nonNull));
+    SparkTestBase.assertEquals(
+        "Duplicate rows should not be removed",
+        Lists.newArrayList(
+            new Object[] {1, "a", "data", DELETE.name()},
+            new Object[] {1, "a", "data", UPDATE_BEFORE.name()},
+            new Object[] {1, "a", "new_data", UPDATE_AFTER.name()},
+            new Object[] {1, "a", "new_data", INSERT.name()},
+            new Object[] {4, "d", "data", DELETE.name()},
+            new Object[] {4, "d", "data", INSERT.name()}),
+        SparkTestBase.rowsToJava(result));
+  }
+}


### PR DESCRIPTION
Introduce an iterator to handle changelog rows within a task. It will be used by the changelog procedure #6012.
cc @aokolnychyi @RussellSpitzer @szehon-ho