### PR TITLE
Python: Fix PyArrow Type conversion

### DIFF
--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -64,6 +64,7 @@ from pyiceberg.types import (
     DoubleType,
     FixedType,
     FloatType,
+    IcebergType,
     IntegerType,
     ListType,
     LongType,
@@ -387,6 +388,12 @@ def _(_: BinaryType) -> pa.DataType:
     return pa.binary()
 
 
+def _convert_scalar(value: Any, iceberg_type: IcebergType) -> pa.scalar:
+    if not isinstance(iceberg_type, PrimitiveType):
+        raise ValueError(f"Expected primitive type, got: {iceberg_type}")
+    return pa.scalar(value).cast(_iceberg_to_pyarrow_type(iceberg_type))
+
+
 class _ConvertToArrowExpression(BoundBooleanExpressionVisitor[pc.Expression]):
     def visit_in(self, term: BoundTerm[pc.Expression], literals: Set[Any]) -> pc.Expression:
         return pc.field(term.ref().field.name).isin(literals)
@@ -409,22 +416,22 @@ class _ConvertToArrowExpression(BoundBooleanExpressionVisitor[pc.Expression]):
         return pc.field(term.ref().field.name).is_valid()
 
     def visit_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) == literal.value
+        return pc.field(term.ref().field.name) == _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_not_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) != literal.value
+        return pc.field(term.ref().field.name) != _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_greater_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) >= literal.value
+        return pc.field(term.ref().field.name) >= _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_greater_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) > literal.value
+        return pc.field(term.ref().field.name) > _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_less_than(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) < literal.value
+        return pc.field(term.ref().field.name) < _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_less_than_or_equal(self, term: BoundTerm[Any], literal: Literal[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name) <= literal.value
+        return pc.field(term.ref().field.name) <= _convert_scalar(literal.value, term.ref().field.field_type)
 
     def visit_true(self) -> pc.Expression:
         return pc.scalar(True)

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -396,10 +396,12 @@ def _convert_scalar(value: Any, iceberg_type: IcebergType) -> pa.scalar:
 
 class _ConvertToArrowExpression(BoundBooleanExpressionVisitor[pc.Expression]):
     def visit_in(self, term: BoundTerm[pc.Expression], literals: Set[Any]) -> pc.Expression:
-        return pc.field(term.ref().field.name).isin(literals)
+        pyarrow_literals = pa.array(literals, type=_iceberg_to_pyarrow_type(term.ref().field.field_type))
+        return pc.field(term.ref().field.name).isin(pyarrow_literals)
 
     def visit_not_in(self, term: BoundTerm[pc.Expression], literals: Set[Any]) -> pc.Expression:
-        return ~pc.field(term.ref().field.name).isin(literals)
+        pyarrow_literals = pa.array(literals, type=_iceberg_to_pyarrow_type(term.ref().field.field_type))
+        return ~pc.field(term.ref().field.name).isin(pyarrow_literals)
 
     def visit_is_nan(self, term: BoundTerm[pc.Expression]) -> pc.Expression:
         ref = pc.field(term.ref().field.name)


### PR DESCRIPTION
It turns out that we need to cast the literal to the right type:

```
ArrowNotImplementedError: Function 'greater_equal' has no kernel matching input types (timestamp[us, tz=+00:00], int64)
```

After casting the scalar, it works perfectly. One awkward thing to note is that we don't have to do this for the `isin` predicate. Where this is done for us. Please check the Jupyter notebook:

![image](https://user-images.githubusercontent.com/1134248/205333551-ebf3a885-4b2a-4200-bb50-25c632d9babc.png)
