### PR TITLE
Spark 3.3: Time range query of changelog tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -150,7 +150,7 @@ public class SnapshotUtil {
 
   /**
    * Traverses the history of the table's current snapshot and finds the first snapshot committed
-   * after the given time.
+   * after the given time(inclusive).
    *
    * @param table a table
    * @param timestampMillis a timestamp in milliseconds

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -149,7 +149,7 @@ public class SnapshotUtil {
   }
 
   /**
-   * Finds the oldest snapshot that was committed either at or after a given time.
+   * Finds the oldest snapshot of a table that was committed either at or after a given time.
    *
    * @param table a table
    * @param timestampMillis a timestamp in milliseconds

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -149,8 +149,7 @@ public class SnapshotUtil {
   }
 
   /**
-   * Traverses the history of the table's current snapshot and finds the first snapshot committed
-   * after the given time(inclusive).
+   * Finds the oldest snapshot that was committed either at or after a given time.
    *
    * @param table a table
    * @param timestampMillis a timestamp in milliseconds

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -137,7 +137,7 @@ public class TestChangelogTable extends SparkExtensionsTestBase {
         ImmutableList.of(
             row(2, "b", "DELETE", 0, snap3.snapshotId()),
             row(-2, "b", "INSERT", 0, snap3.snapshotId())),
-        changelogRecords(snap2.timestampMillis() + 1, snap3.timestampMillis()));
+        changelogRecords(rightAfterSnap2, snap3.timestampMillis()));
 
     assertEquals(
         "Should have expected changed rows from snapshot 2 and 3",

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -228,4 +228,12 @@ public class SparkReadConf {
         .defaultValue(Long.MIN_VALUE)
         .parse();
   }
+
+  public Long startTimestamp() {
+    return confParser.longConf().option(SparkReadOptions.START_TIMESTAMP).parseOptional();
+  }
+
+  public Long endTimestamp() {
+    return confParser.longConf().option(SparkReadOptions.END_TIMESTAMP).parseOptional();
+  }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -32,6 +32,12 @@ public class SparkReadOptions {
   // End snapshot ID used in incremental scans (inclusive)
   public static final String END_SNAPSHOT_ID = "end-snapshot-id";
 
+  // Start timestamp used in multi-snapshot scans (exclusive)
+  public static final String START_TIMESTAMP = "start-timestamp";
+
+  // End timestamp used in multi-snapshot scans (inclusive)
+  public static final String END_TIMESTAMP = "end-timestamp";
+
   // A timestamp in milliseconds; the snapshot used will be the snapshot current at this time.
   public static final String AS_OF_TIMESTAMP = "as-of-timestamp";
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -214,11 +214,24 @@ public class SparkScanBuilder
         SparkReadOptions.END_SNAPSHOT_ID,
         SparkReadOptions.START_SNAPSHOT_ID);
 
+    checkInvalidOptions();
+
     if (startSnapshotId != null) {
       return buildIncrementalAppendScan(startSnapshotId, endSnapshotId);
     } else {
       return buildBatchScan(snapshotId, asOfTimestamp, branch, tag);
     }
+  }
+
+  private void checkInvalidOptions() {
+    Long startTimestamp = readConf.startTimestamp();
+    Long endTimestamp = readConf.endTimestamp();
+    Preconditions.checkArgument(
+        startTimestamp != null || endTimestamp != null,
+        "Cannot set %s or %s for incremental scans and batch scan. They are only valid for "
+            + "changelog scans.",
+        SparkReadOptions.START_TIMESTAMP,
+        SparkReadOptions.END_TIMESTAMP);
   }
 
   private Scan buildBatchScan(Long snapshotId, Long asOfTimestamp, String branch, String tag) {
@@ -291,13 +304,13 @@ public class SparkScanBuilder
 
     Preconditions.checkArgument(
         !(startSnapshotId != null && startTimestamp != null),
-        "Cannot set neither %s nor %s for changelogs",
+        "Cannot set both %s and %s for changelogs",
         SparkReadOptions.START_SNAPSHOT_ID,
         SparkReadOptions.START_TIMESTAMP);
 
     Preconditions.checkArgument(
         !(endSnapshotId != null && endTimestamp != null),
-        "Cannot set neither %s nor %s for changelogs",
+        "Cannot set both %s and %s for changelogs",
         SparkReadOptions.END_SNAPSHOT_ID,
         SparkReadOptions.END_TIMESTAMP);
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -356,7 +356,11 @@ public class SparkScanBuilder
         startTimestamp,
         table.name());
 
-    return oldestSnapshotAfter.parentId();
+    if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
+      return oldestSnapshotAfter.snapshotId();
+    } else {
+      return oldestSnapshotAfter.parentId();
+    }
   }
 
   public Scan buildMergeOnReadScan() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -214,16 +214,6 @@ public class SparkScanBuilder
         SparkReadOptions.END_SNAPSHOT_ID,
         SparkReadOptions.START_SNAPSHOT_ID);
 
-    checkInvalidOptions();
-
-    if (startSnapshotId != null) {
-      return buildIncrementalAppendScan(startSnapshotId, endSnapshotId);
-    } else {
-      return buildBatchScan(snapshotId, asOfTimestamp, branch, tag);
-    }
-  }
-
-  private void checkInvalidOptions() {
     Long startTimestamp = readConf.startTimestamp();
     Long endTimestamp = readConf.endTimestamp();
     Preconditions.checkArgument(
@@ -232,6 +222,12 @@ public class SparkScanBuilder
             + "changelog scans.",
         SparkReadOptions.START_TIMESTAMP,
         SparkReadOptions.END_TIMESTAMP);
+
+    if (startSnapshotId != null) {
+      return buildIncrementalAppendScan(startSnapshotId, endSnapshotId);
+    } else {
+      return buildBatchScan(snapshotId, asOfTimestamp, branch, tag);
+    }
   }
 
   private Scan buildBatchScan(Long snapshotId, Long asOfTimestamp, String branch, String tag) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -227,7 +227,7 @@ public class SparkScanBuilder
     Long startTimestamp = readConf.startTimestamp();
     Long endTimestamp = readConf.endTimestamp();
     Preconditions.checkArgument(
-        startTimestamp != null || endTimestamp != null,
+        startTimestamp == null && endTimestamp == null,
         "Cannot set %s or %s for incremental scans and batch scan. They are only valid for "
             + "changelog scans.",
         SparkReadOptions.START_TIMESTAMP,


### PR DESCRIPTION
Per discussion in #6012, I create this PR to support time range query for changelog table. 
cc @aokolnychyi @RussellSpitzer @szehon-ho @rdblue 