### PR TITLE
AWS: Fix inconsistent behavior of naming S3 location between read and write operations by allowing only s3 bucket name

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
@@ -74,17 +74,14 @@ class S3URI {
     this.scheme = schemeSplit[0];
 
     String[] authoritySplit = schemeSplit[1].split(PATH_DELIM, 2);
-    ValidationException.check(
-        authoritySplit.length == 2, "Invalid S3 URI, cannot determine bucket: %s", location);
-    ValidationException.check(
-        !authoritySplit[1].trim().isEmpty(), "Invalid S3 URI, path is empty: %s", location);
+
     this.bucket =
         bucketToAccessPointMapping == null
             ? authoritySplit[0]
             : bucketToAccessPointMapping.getOrDefault(authoritySplit[0], authoritySplit[0]);
 
     // Strip query and fragment if they exist
-    String path = authoritySplit[1];
+    String path = authoritySplit.length > 1 ? authoritySplit[1] : "";
     path = path.split(QUERY_DELIM, -1)[0];
     path = path.split(FRAGMENT_DELIM, -1)[0];
     this.key = path;

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
@@ -50,15 +50,6 @@ public class TestS3URI {
   }
 
   @Test
-  public void testEmptyPath() {
-    AssertHelpers.assertThrows(
-        "Should not allow missing object key",
-        ValidationException.class,
-        "Invalid S3 URI, path is empty",
-        () -> new S3URI("https://bucket/"));
-  }
-
-  @Test
   public void testMissingScheme() {
     AssertHelpers.assertThrows(
         "Should not allow missing scheme",
@@ -68,12 +59,13 @@ public class TestS3URI {
   }
 
   @Test
-  public void testMissingBucket() {
-    AssertHelpers.assertThrows(
-        "Should not allow missing bucket",
-        ValidationException.class,
-        "Invalid S3 URI, cannot determine bucket",
-        () -> new S3URI("https://bucket"));
+  public void testOnlyBucketNameLocation() {
+    String p1 = "s3://bucket";
+    S3URI url1 = new S3URI(p1);
+
+    assertEquals("bucket", url1.bucket());
+    assertEquals("", url1.key());
+    assertEquals(p1, url1.toString());
   }
 
   @Test


### PR DESCRIPTION
### Fix
Enable users to run read-queries when specifying only S3 bucket name as its Iceberg table location.

### Issue
Current S3URI ValidationChecker doesn't allow users to specify only bucket name such as `s3://bucket/` or `s3://bucket`.

However, we can specify an only bucket name when creating an Iceberg table. 

For example, if you run the following DDL with Spark, your table location is specified as `s3://bucket`

```
CREATE TABLE catalog.db.table(id int, data string)
USING iceberg
LOCATION 's3://bucket'
```

(If you don't specify `LOCATION`, Spark creates a table under `s3://<warehouse_path>/db.db/table/` by default.)

And you can also run `INSERT INTO` query for this. Through this operation, S3URI handles manifest list, files and metadata json in metadata directory. However, `SELECT` query needs to access its table location. Therefore, when the query access the location that only has bucket name such as `s3://bucket`, S3URI validation fails with `org.apache.iceberg.exceptions.ValidationException : Invalid S3 URI, path is empty: s3://bucket`.

This also happens if you create a table with Athena. When Athena creates a table with only bucket name location, it fails with `ValidationException`. 

I understand there's another way to fix this, that is not allowed using only bucket name. However, I made this choice (supporting only bucket name) because I believe some users want to create an Iceberg table at direct bucket.


### Simply actual Spark test (Spark 3.3 is used)

```scala
import java.util.UUID.{randomUUID => uuid}
import java.sql.Timestamp
import scala.collection.JavaConverters._

import org.apache.spark.{SparkContext, SparkConf}
import org.apache.spark.sql.Row
import org.apache.spark.sql.SparkSession
import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}

object IcebergSparkApp {
    def main(sysArgs: Array[String]) {
        val database = "db"
        val table = "s3url_validation_fix"
        val catalog: String = "catalog"
        val resourceName = s"$catalog.$database.$table"
        val warehouse = "s3://bucket/path"
        println(s"Resource: $resourceName")

        val spark = SparkSession.builder()
                            .config(s"spark.sql.catalog.$catalog", "org.apache.iceberg.spark.SparkCatalog")
                            .config(s"spark.sql.catalog.$catalog.warehouse", warehouse)
                            .config(s"spark.sql.catalog.$catalog.catalog-impl", "org.apache.iceberg.aws.glue.GlueCatalog")
                            .config(s"spark.sql.catalog.$catalog.io-impl", "org.apache.iceberg.aws.s3.S3FileIO")
                            .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
                            .getOrCreate()

        val qCreate = s"""
        CREATE TABLE $resourceName(id int, data string)
        USING iceberg
        LOCATION 's3://bucket'
        """
        
        println(s"Creating a table: $qCreate")
        spark.sql(qCreate)

        println("Running INSERT query")
        spark.sql(s"INSERT INTO $resourceName VALUES(1, 'a')")
        
        println("Running SELECT query")
        spark.sql(s"SELECT * FROM $resourceName").show(false)
    }
}

/* Output
Resource: catalog.db.s3url_validation_fix
Creating a table: 
        CREATE TABLE catalog.db.s3url_validation_fix(id int, data string)
        USING iceberg
        LOCATION 's3://bucket'

Running INSERT query
Running SELECT query
+---+----+
|id |data|
+---+----+
|1  |a   |
+---+----+
*/

```

Iceberg table in Glue Data Catalog (AWS environment was used):

```
aws glue get-table --database-name db --name s3url_validation_fix
{
    "Table": {
        "Name": "s3url_validation_fix",
        "DatabaseName": "db",
        "CreateTime": 1670080197.0,
        "UpdateTime": 1670080210.0,
        "Retention": 0,
        "StorageDescriptor": {
            "Columns": [
                {
                    "Name": "id",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.current": "true",
                        "iceberg.field.id": "1",
                        "iceberg.field.optional": "true"
                    }
                },
                {
                    "Name": "data",
                    "Type": "string",
                    "Parameters": {
                        "iceberg.field.current": "true",
                        "iceberg.field.id": "2",
                        "iceberg.field.optional": "true"
                    }
                }
            ],
            "Location": "s3://bucket",
            "AdditionalLocations": [],
            "Compressed": false,
            "NumberOfBuckets": 0,
            "SortColumns": [],
            "StoredAsSubDirectories": false
        },
        "TableType": "EXTERNAL_TABLE",
        "Parameters": {
            "metadata_location": "s3://bucket/metadata/00001-622af8bc-e984-46bd-8e55-6183b0406a59.metadata.json",
            "previous_metadata_location": "s3://bucket/metadata/00000-87a008c6-fcab-44c8-8592-a244a3b0489e.metadata.json",
            "table_type": "ICEBERG"
        },
        "CreatedBy": "*********",
        "IsRegisteredWithLakeFormation": false,
        "CatalogId": "0123456789012",
        "VersionId": "1"
    }
}
```

### Test result
```Starting Gradle Daemon...
Gradle Daemon started in 1 s 830 ms

> Task :iceberg-core:processResources NO-SOURCE
> Task :iceberg-common:processResources NO-SOURCE
> Task :iceberg-aws:processResources NO-SOURCE
> Task :iceberg-api:processResources NO-SOURCE
> Task :iceberg-aws:processTestResources NO-SOURCE
> Task :iceberg-bundled-guava:compileJava UP-TO-DATE
> Task :iceberg-bundled-guava:processResources NO-SOURCE
> Task :iceberg-bundled-guava:classes UP-TO-DATE
> Task :iceberg-bundled-guava:compileTestJava NO-SOURCE
> Task :iceberg-bundled-guava:processTestResources NO-SOURCE
> Task :iceberg-bundled-guava:testClasses UP-TO-DATE
> Task :iceberg-bundled-guava:shadowJar UP-TO-DATE
> Task :iceberg-common:compileJava UP-TO-DATE
> Task :iceberg-common:classes UP-TO-DATE
> Task :iceberg-api:compileJava UP-TO-DATE
> Task :iceberg-api:classes UP-TO-DATE
> Task :generateGitProperties
> Task :buildInfo
> Task :iceberg-common:jar UP-TO-DATE
> Task :iceberg-api:compileTestJava UP-TO-DATE
> Task :iceberg-api:jar UP-TO-DATE
> Task :iceberg-api:processTestResources
> Task :iceberg-api:testClasses
> Task :iceberg-api:testJar
Encountered duplicate path "iceberg-build.properties" during copy operation configured with DuplicatesStrategy.WARN
> Task :iceberg-core:compileJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
> Task :iceberg-core:classes
> Task :iceberg-core:jar
> Task :iceberg-aws:compileJava UP-TO-DATE
> Task :iceberg-aws:classes UP-TO-DATE
> Task :iceberg-aws:compileTestJava UP-TO-DATE
> Task :iceberg-aws:testClasses UP-TO-DATE
> Task :iceberg-aws:test
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Successfully dropped table db1.t1 from Glue
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Dropped table: db1.t1
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Created namespace: db
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - created rename destination table db.x_renamed
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Successfully dropped table db.t from Glue
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Dropped table: db.t
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Successfully renamed table from db.t to db.x_renamed
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Successfully dropped table db1.t1 from Glue
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Dropped table: db1.t1
[Test worker] INFO org.apache.iceberg.aws.glue.GlueCatalog - Dropped namespace: db1
log4j:WARN No appenders could be found for logger (org.jboss.logging).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Starting GradleWorkerMain on bcd074755ade with PID 25085 (started by tomtan in /Users/tomtan/iceberg/aws)
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - No active profile set, falling back to default profiles: default
[Test worker] INFO org.eclipse.jetty.util.log - Logging initialized @10477ms to org.eclipse.jetty.util.log.Slf4jLog
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory - Server initialized with port: 0
[Test worker] INFO org.eclipse.jetty.server.Server - jetty-9.4.19.v20190610; built: 2019-06-10T16:30:51.723Z; git: afcf563148970e98786327af5e07c261fda175d3; jvm 1.8.0_341-b10
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring embedded WebApplicationContext
[Test worker] INFO org.springframework.web.context.ContextLoader - Root WebApplicationContext: initialization completed in 3192 ms
[Test worker] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
[Test worker] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
[Test worker] INFO org.eclipse.jetty.server.session - node0 Scavenging every 660000ms
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.s.b.w.e.j.JettyEmbeddedWebAppContext@16e4db59{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.8196807160261207123.0/],AVAILABLE}
[Test worker] INFO org.eclipse.jetty.server.Server - Started @11563ms
[Test worker] INFO com.adobe.testing.s3mock.FileStoreController - Creating initial buckets: []
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Initializing ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver - Exposing 2 endpoint(s) beneath base path '/actuator'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring DispatcherServlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Completed initialization in 17 ms
[Test worker] INFO org.eclipse.jetty.util.ssl.SslContextFactory - x509=X509@729a9c3d(selfsigned,h=[],w=[]) for Server@574327ed[provider=null,keyStore=jar:file:/Users/tomtan/.gradle/caches/modules-2/files-2.1/com.adobe.testing/s3mock/2.1.28/b94ddf8460857edaff4f6b6b918ec9759c3b26df/s3mock-2.1.28.jar!/s3mock.jks,trustStore=null]
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@19924f15{SSL,[ssl, http/1.1]}{0.0.0.0:56927}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@280d6a20{HTTP/1.1,[http/1.1]}{0.0.0.0:56928}
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyWebServer - Jetty started on port(s) 56927 (ssl, http/1.1), 56928 (http/1.1) with context path '/'
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Started GradleWorkerMain in 7.411 seconds (JVM running for 14.115)
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN org.apache.iceberg.aws.s3.S3FileIO - Failed to delete object at path s3://bucket/path/to/file.txt
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.apache.iceberg.CatalogUtil - Loading custom FileIO implementation: org.apache.iceberg.aws.s3.S3FileIO
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.apache.iceberg.CatalogUtil - Loading custom FileIO implementation: org.apache.iceberg.aws.s3.S3FileIO
[Test worker] INFO org.apache.iceberg.BaseMetastoreCatalog - Table properties set at catalog level through catalog properties: {}
[Test worker] INFO org.apache.iceberg.BaseMetastoreCatalog - Table properties enforced at catalog level through catalog properties: {}
[Test worker] INFO org.apache.iceberg.BaseMetastoreTableOperations - Successfully committed to table table_name in 90 ms
[Test worker] INFO org.apache.iceberg.BaseMetastoreTableOperations - Refreshing table metadata from new version: s3://bucket/warehouse/table_name/metadata/00000-08bb2449-5d0b-4157-8b00-7963874fe4e7.metadata.json
[Test worker] INFO org.apache.iceberg.BaseMetastoreTableOperations - Refreshing table metadata from new version: s3://bucket/warehouse/table_name/metadata/00000-08bb2449-5d0b-4157-8b00-7963874fe4e7.metadata.json
[qtp1155566202-18] INFO com.adobe.testing.s3mock.util.S3MockExceptionHandler - Responding with status 404: The specified key does not exist.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[qtp1155566202-55] INFO com.adobe.testing.s3mock.util.S3MockExceptionHandler - Responding with status 404: The specified key does not exist.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Finalizer] WARN org.apache.iceberg.aws.s3.S3InputStream - Unclosed input stream created by:
	org.apache.iceberg.aws.s3.S3InputStream.<init>(S3InputStream.java:73)
	org.apache.iceberg.aws.s3.S3InputFile.newStream(S3InputFile.java:83)
	org.apache.iceberg.aws.s3.TestS3FileIO.lambda$testReadMissingLocation$4(TestS3FileIO.java:272)
	org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:63)
	org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:892)
	org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1366)
	org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1210)
	org.apache.iceberg.AssertHelpers.assertThrows(AssertHelpers.java:45)
	org.apache.iceberg.aws.s3.TestS3FileIO.testReadMissingLocation(TestS3FileIO.java:268)
	sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	java.lang.reflect.Method.invoke(Method.java:498)
	org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:55)
	org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	com.adobe.testing.s3mock.junit4.S3MockRule$1.evaluate(S3MockRule.java:66)
	org.junit.rules.RunRules.evaluate(RunRules.java:20)
	org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:100)
	org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:107)
	org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:41)
	org.mockito.junit.MockitoJUnitRunner.run(MockitoJUnitRunner.java:163)
	org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:108)
	org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:57)
	org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:39)
	org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	java.lang.reflect.Method.invoke(Method.java:498)
	org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Shutting down ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@19924f15{SSL,[ssl, http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@280d6a20{HTTP/1.1,[http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.session - node0 Stopped scavenging
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Destroying Spring FrameworkServlet 'dispatcherServlet'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Stopped o.s.b.w.e.j.JettyEmbeddedWebAppContext@16e4db59{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.8196807160261207123.0/],UNAVAILABLE}
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Starting GradleWorkerMain on bcd074755ade with PID 25085 (started by tomtan in /Users/tomtan/iceberg/aws)
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - No active profile set, falling back to default profiles: default
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory - Server initialized with port: 0
[Test worker] INFO org.eclipse.jetty.server.Server - jetty-9.4.19.v20190610; built: 2019-06-10T16:30:51.723Z; git: afcf563148970e98786327af5e07c261fda175d3; jvm 1.8.0_341-b10
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring embedded WebApplicationContext
[Test worker] INFO org.springframework.web.context.ContextLoader - Root WebApplicationContext: initialization completed in 1254 ms
[Test worker] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
[Test worker] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
[Test worker] INFO org.eclipse.jetty.server.session - node0 Scavenging every 600000ms
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.s.b.w.e.j.JettyEmbeddedWebAppContext@17994ef8{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.199468788830389320.0/],AVAILABLE}
[Test worker] INFO org.eclipse.jetty.server.Server - Started @50108ms
[Test worker] INFO com.adobe.testing.s3mock.FileStoreController - Creating initial buckets: []
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Initializing ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver - Exposing 2 endpoint(s) beneath base path '/actuator'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring DispatcherServlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Completed initialization in 9 ms
[Test worker] INFO org.eclipse.jetty.util.ssl.SslContextFactory - x509=X509@5fa78e0a(selfsigned,h=[],w=[]) for Server@69f1887c[provider=null,keyStore=jar:file:/Users/tomtan/.gradle/caches/modules-2/files-2.1/com.adobe.testing/s3mock/2.1.28/b94ddf8460857edaff4f6b6b918ec9759c3b26df/s3mock-2.1.28.jar!/s3mock.jks,trustStore=null]
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@de1b4dd{SSL,[ssl, http/1.1]}{0.0.0.0:57316}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@329ba591{HTTP/1.1,[http/1.1]}{0.0.0.0:57317}
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyWebServer - Jetty started on port(s) 57316 (ssl, http/1.1), 57317 (http/1.1) with context path '/'
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Started GradleWorkerMain in 2.44 seconds (JVM running for 50.831)
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[qtp1415595306-447] WARN org.eclipse.jetty.server.HttpChannel - /bucket/path/to/read.dat java.io.IOException: Close org.eclipse.jetty.server.HttpConnection$SendCallback@4d543119[PROCESSING][i=null,cb=org.eclipse.jetty.server.HttpChannel$SendCallback@39a6d359] in state PROCESSING
[qtp1415595306-460] WARN org.eclipse.jetty.server.HttpChannel - /bucket/path/to/read.dat java.io.IOException: Close org.eclipse.jetty.server.HttpConnection$SendCallback@5db5faf7[PROCESSING][i=null,cb=org.eclipse.jetty.server.HttpChannel$SendCallback@18b77f25] in state PROCESSING
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Shutting down ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@de1b4dd{SSL,[ssl, http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@329ba591{HTTP/1.1,[http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.session - node0 Stopped scavenging
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Destroying Spring FrameworkServlet 'dispatcherServlet'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Stopped o.s.b.w.e.j.JettyEmbeddedWebAppContext@17994ef8{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.199468788830389320.0/],UNAVAILABLE}
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Starting GradleWorkerMain on bcd074755ade with PID 25085 (started by tomtan in /Users/tomtan/iceberg/aws)
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - No active profile set, falling back to default profiles: default
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory - Server initialized with port: 0
[Test worker] INFO org.eclipse.jetty.server.Server - jetty-9.4.19.v20190610; built: 2019-06-10T16:30:51.723Z; git: afcf563148970e98786327af5e07c261fda175d3; jvm 1.8.0_341-b10
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring embedded WebApplicationContext
[Test worker] INFO org.springframework.web.context.ContextLoader - Root WebApplicationContext: initialization completed in 674 ms
[Test worker] INFO org.eclipse.jetty.server.session - DefaultSessionIdManager workerName=node0
[Test worker] INFO org.eclipse.jetty.server.session - No SessionScavenger set, using defaults
[Test worker] INFO org.eclipse.jetty.server.session - node0 Scavenging every 660000ms
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Started o.s.b.w.e.j.JettyEmbeddedWebAppContext@40fa9db2{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.4353685860397921428.0/],AVAILABLE}
[Test worker] INFO org.eclipse.jetty.server.Server - Started @53363ms
[Test worker] INFO com.adobe.testing.s3mock.FileStoreController - Creating initial buckets: []
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Initializing ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver - Exposing 2 endpoint(s) beneath base path '/actuator'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Initializing Spring DispatcherServlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Initializing Servlet 'dispatcherServlet'
[Test worker] INFO org.springframework.web.servlet.DispatcherServlet - Completed initialization in 1 ms
[Test worker] INFO org.eclipse.jetty.util.ssl.SslContextFactory - x509=X509@308b8e8f(selfsigned,h=[],w=[]) for Server@1faa627c[provider=null,keyStore=jar:file:/Users/tomtan/.gradle/caches/modules-2/files-2.1/com.adobe.testing/s3mock/2.1.28/b94ddf8460857edaff4f6b6b918ec9759c3b26df/s3mock-2.1.28.jar!/s3mock.jks,trustStore=null]
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@52f93a84{SSL,[ssl, http/1.1]}{0.0.0.0:57327}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Started ServerConnector@71f164d6{HTTP/1.1,[http/1.1]}{0.0.0.0:57328}
[Test worker] INFO org.springframework.boot.web.embedded.jetty.JettyWebServer - Jetty started on port(s) 57327 (ssl, http/1.1), 57328 (http/1.1) with context path '/'
[Test worker] INFO worker.org.gradle.process.internal.worker.GradleWorkerMain - Started GradleWorkerMain in 1.407 seconds (JVM running for 53.861)
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[iceberg-s3fileio-upload-4] ERROR org.apache.iceberg.aws.s3.S3OutputStream - Failed to upload part: UploadPartRequest(Bucket=test-bucket, ContentLength=5242880, Key=data/db090e62-e5bc-4961-ac1c-413102cfc81b.dat, PartNumber=1, UploadId=21f9c248-059f-4d17-a73a-383e570b532b)
java.util.concurrent.CompletionException: java.lang.RuntimeException: mock uploadPart failure
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1606)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: mock uploadPart failure
	at software.amazon.awssdk.services.s3.S3Client.uploadPart(S3Client.java:19661)
	at org.apache.iceberg.aws.s3.S3OutputStream.lambda$uploadParts$2(S3OutputStream.java:323)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	... 3 more
[iceberg-s3fileio-upload-2] ERROR org.apache.iceberg.aws.s3.S3OutputStream - Failed to upload part: UploadPartRequest(Bucket=test-bucket, ContentLength=5242880, Key=data/db090e62-e5bc-4961-ac1c-413102cfc81b.dat, PartNumber=2, UploadId=21f9c248-059f-4d17-a73a-383e570b532b)
java.util.concurrent.CompletionException: java.lang.RuntimeException: mock uploadPart failure
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:273)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:280)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1606)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.RuntimeException: mock uploadPart failure
	at software.amazon.awssdk.services.s3.S3Client.uploadPart(S3Client.java:19661)
	at org.apache.iceberg.aws.s3.S3OutputStream.lambda$uploadParts$2(S3OutputStream.java:323)
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1604)
	... 3 more
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.apache.iceberg.aws.s3.S3OutputStream - Staging directory does not exist, trying to create one: /tmp/newStagingDirectory
[Test worker] INFO org.apache.iceberg.aws.s3.S3OutputStream - Successfully created staging directory: /tmp/newStagingDirectory
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] ERROR org.apache.iceberg.aws.s3.S3OutputStream - Failed to complete multipart upload request: CompleteMultipartUploadRequest(Bucket=test-bucket, Key=data/4ab40f3e-f78e-44d0-971b-85305ba41ae0.dat, MultipartUpload=CompletedMultipartUpload(Parts=[CompletedPart(ETag="f4ce2eef33b39bc0bca206386365d4e6", PartNumber=1), CompletedPart(ETag="121bcc977d9859c4cdaf9f86b1e88975", PartNumber=2)]), UploadId=38cdb871-6a03-4d4b-9673-f40aa10de278)
java.lang.RuntimeException: mock completeMultipartUpload failure
	at software.amazon.awssdk.services.s3.S3Client.completeMultipartUpload(S3Client.java:574)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:402)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:212)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:189)
	at org.apache.iceberg.aws.s3.S3OutputStream.completeMultiPartUpload(S3OutputStream.java:383)
	at org.apache.iceberg.aws.s3.S3OutputStream.completeUploads(S3OutputStream.java:441)
	at org.apache.iceberg.aws.s3.S3OutputStream.close(S3OutputStream.java:269)
	at org.apache.iceberg.aws.s3.TestS3OutputStream.$closeResource(TestS3OutputStream.java:305)
	at org.apache.iceberg.aws.s3.TestS3OutputStream.lambda$testAbortMultipart$1(TestS3OutputStream.java:154)
	at org.assertj.core.api.ThrowableAssert.catchThrowable(ThrowableAssert.java:63)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowable(AssertionsForClassTypes.java:892)
	at org.assertj.core.api.Assertions.catchThrowable(Assertions.java:1366)
	at org.assertj.core.api.Assertions.assertThatThrownBy(Assertions.java:1210)
	at org.apache.iceberg.aws.s3.TestS3OutputStream.testAbortMultipart(TestS3OutputStream.java:149)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:55)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at com.adobe.testing.s3mock.junit4.S3MockRule$1.evaluate(S3MockRule.java:66)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:100)
	at org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:107)
	at org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:41)
	at org.mockito.junit.MockitoJUnitRunner.run(MockitoJUnitRunner.java:163)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:108)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:57)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:39)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:52)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:176)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60)
	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113)
	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] WARN software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient - SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
[Test worker] INFO org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor - Shutting down ExecutorService 'applicationTaskExecutor'
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@52f93a84{SSL,[ssl, http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.AbstractConnector - Stopped ServerConnector@71f164d6{HTTP/1.1,[http/1.1]}{0.0.0.0:0}
[Test worker] INFO org.eclipse.jetty.server.session - node0 Stopped scavenging
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler.application - Destroying Spring FrameworkServlet 'dispatcherServlet'
[Test worker] INFO org.eclipse.jetty.server.handler.ContextHandler - Stopped o.s.b.w.e.j.JettyEmbeddedWebAppContext@40fa9db2{application,/,[file:///private/var/folders/m2/5yss1dvs3fd6bbsc4kym4j_m0000gr/T/jetty-docbase.4353685860397921428.0/],UNAVAILABLE}
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings
BUILD SUCCESSFUL in 2m 19s
15 actionable tasks: 6 executed, 9 up-to-date
23:43:58: Execution finished 'test'.

```