### PR TITLE
Make sure S3 stream opened by ReadConf ctor is closed

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -46,7 +46,7 @@ import org.apache.parquet.schema.MessageType;
  *
  * @param <T> type of value to read
  */
-class ReadConf<T> {
+class ReadConf<T> implements AutoCloseable {
   private final ParquetFileReader reader;
   private final InputFile file;
   private final ParquetReadOptions options;
@@ -256,5 +256,12 @@ class ReadConf<T> {
       }
     }
     return listBuilder.build();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (reader != null) {
+      reader.close();
+    }
   }
 }


### PR DESCRIPTION
What the title says. This is what currently is seen: 

```2022-12-03 10:25:11.154  WARN 5408 --- [      Finalizer] o.a.i.a.s.S3InputStream                  : Unclosed input stream created by:
        org.apache.iceberg.aws.s3.S3InputStream.<init>(S3InputStream.java:60)
        org.apache.iceberg.aws.s3.S3InputFile.newStream(S3InputFile.java:48)
        org.apache.iceberg.parquet.ParquetIO$ParquetInputFile.newStream(ParquetIO.java:183)
        org.apache.iceberg.bdp.shaded.org.apache.parquet.hadoop.ParquetFileReader.<init>(ParquetFileReader.java:802)
        org.apache.iceberg.bdp.shaded.org.apache.parquet.hadoop.ParquetFileReader.open(ParquetFileReader.java:667)
        org.apache.iceberg.parquet.ReadConf.newReader(ReadConf.java:218)
        org.apache.iceberg.parquet.ReadConf.<init>(ReadConf.java:74)
        org.apache.iceberg.parquet.ParquetReader.init(ParquetReader.java:66)
        org.apache.iceberg.parquet.ParquetReader.iterator(ParquetReader.java:77)
        org.apache.iceberg.data.TableScanIterable$ScanIterator.hasNext(TableScanIterable.java:200)```