### PR TITLE
Core: Remove TableOperations from metadata tables.

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -349,6 +349,10 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.SnapshotProducer<ThisT>::validate(org.apache.iceberg.TableMetadata)\
         \ @ org.apache.iceberg.StreamingDelete"
       justification: "Removing deprecations for 1.2.0"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method org.apache.iceberg.Table org.apache.iceberg.BaseMetadataTable::table()"
+      new: "method org.apache.iceberg.BaseTable org.apache.iceberg.BaseMetadataTable::table()"
+      justification: "Returning more specific subclass"
     org.apache.iceberg:iceberg-orc:
     - code: "java.method.removed"
       old: "method org.apache.iceberg.orc.ORC.WriteBuilder org.apache.iceberg.orc.ORC.WriteBuilder::config(java.lang.String,\

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -29,17 +29,17 @@ import org.apache.iceberg.io.CloseableIterable;
  */
 public class AllDataFilesTable extends BaseFilesTable {
 
-  AllDataFilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".all_data_files");
+  AllDataFilesTable(Table table) {
+    this(table, table.name() + ".all_data_files");
   }
 
-  AllDataFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  AllDataFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(operations(), table(), schema());
+    return new AllDataFilesTableScan(table(), schema());
   }
 
   @Override
@@ -49,24 +49,22 @@ public class AllDataFilesTable extends BaseFilesTable {
 
   public static class AllDataFilesTableScan extends BaseAllFilesTableScan {
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.ALL_DATA_FILES);
+    AllDataFilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.ALL_DATA_FILES);
     }
 
-    private AllDataFilesTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ALL_DATA_FILES, context);
+    private AllDataFilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ALL_DATA_FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new AllDataFilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return reachableManifests(snapshot -> snapshot.dataManifests(tableOps().io()));
+      return reachableManifests(snapshot -> snapshot.dataManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDeleteFilesTable.java
@@ -29,17 +29,17 @@ import org.apache.iceberg.io.CloseableIterable;
  */
 public class AllDeleteFilesTable extends BaseFilesTable {
 
-  AllDeleteFilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".all_delete_files");
+  AllDeleteFilesTable(Table table) {
+    this(table, table.name() + ".all_delete_files");
   }
 
-  AllDeleteFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  AllDeleteFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllDeleteFilesTableScan(operations(), table(), schema());
+    return new AllDeleteFilesTableScan(table(), schema());
   }
 
   @Override
@@ -49,24 +49,22 @@ public class AllDeleteFilesTable extends BaseFilesTable {
 
   public static class AllDeleteFilesTableScan extends BaseAllFilesTableScan {
 
-    AllDeleteFilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES);
+    AllDeleteFilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.ALL_DELETE_FILES);
     }
 
-    private AllDeleteFilesTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ALL_DELETE_FILES, context);
+    private AllDeleteFilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ALL_DELETE_FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDeleteFilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new AllDeleteFilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return reachableManifests(snapshot -> snapshot.deleteManifests(tableOps().io()));
+      return reachableManifests(snapshot -> snapshot.deleteManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -29,17 +29,17 @@ import org.apache.iceberg.io.CloseableIterable;
  */
 public class AllEntriesTable extends BaseEntriesTable {
 
-  AllEntriesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".all_entries");
+  AllEntriesTable(Table table) {
+    this(table, table.name() + ".all_entries");
   }
 
-  AllEntriesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  AllEntriesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new Scan(operations(), table(), schema());
+    return new Scan(table(), schema());
   }
 
   @Override
@@ -49,24 +49,23 @@ public class AllEntriesTable extends BaseEntriesTable {
 
   private static class Scan extends BaseAllMetadataTableScan {
 
-    Scan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.ALL_ENTRIES);
+    Scan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.ALL_ENTRIES);
     }
 
-    private Scan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ALL_ENTRIES, context);
+    private Scan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ALL_ENTRIES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new Scan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new Scan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<FileScanTask> doPlanFiles() {
       CloseableIterable<ManifestFile> manifests =
-          reachableManifests(snapshot -> snapshot.allManifests(tableOps().io()));
+          reachableManifests(snapshot -> snapshot.allManifests(table().io()));
       return BaseEntriesTable.planFiles(table(), manifests, tableSchema(), schema(), context());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/AllFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllFilesTable.java
@@ -29,17 +29,17 @@ import org.apache.iceberg.io.CloseableIterable;
  */
 public class AllFilesTable extends BaseFilesTable {
 
-  AllFilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".all_files");
+  AllFilesTable(Table table) {
+    this(table, table.name() + ".all_files");
   }
 
-  AllFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  AllFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllFilesTableScan(operations(), table(), schema());
+    return new AllFilesTableScan(table(), schema());
   }
 
   @Override
@@ -49,24 +49,22 @@ public class AllFilesTable extends BaseFilesTable {
 
   public static class AllFilesTableScan extends BaseAllFilesTableScan {
 
-    AllFilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.ALL_FILES);
+    AllFilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.ALL_FILES);
     }
 
-    private AllFilesTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ALL_FILES, context);
+    private AllFilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ALL_FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllFilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new AllFilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return reachableManifests(snapshot -> snapshot.allManifests(tableOps().io()));
+      return reachableManifests(snapshot -> snapshot.allManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -77,17 +77,17 @@ public class AllManifestsTable extends BaseMetadataTable {
                       Types.NestedField.optional(13, "upper_bound", Types.StringType.get())))),
           REF_SNAPSHOT_ID);
 
-  AllManifestsTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".all_manifests");
+  AllManifestsTable(Table table) {
+    this(table, table.name() + ".all_manifests");
   }
 
-  AllManifestsTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  AllManifestsTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA);
+    return new AllManifestsTableScan(table(), MANIFEST_FILE_SCHEMA);
   }
 
   @Override
@@ -102,19 +102,17 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   public static class AllManifestsTableScan extends BaseAllMetadataTableScan {
 
-    AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema, MetadataTableType.ALL_MANIFESTS);
+    AllManifestsTableScan(Table table, Schema fileSchema) {
+      super(table, fileSchema, MetadataTableType.ALL_MANIFESTS);
     }
 
-    private AllManifestsTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ALL_MANIFESTS, context);
+    private AllManifestsTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ALL_MANIFESTS, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllManifestsTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new AllManifestsTableScan(table, schema, context);
     }
 
     @Override
@@ -137,7 +135,8 @@ public class AllManifestsTable extends BaseMetadataTable {
                       io, schema(), specs, snap.manifestListLocation(), filter, snap.snapshotId());
                 } else {
                   return StaticDataTask.of(
-                      io.newInputFile(tableOps().current().metadataFileLocation()),
+                      io.newInputFile(
+                          ((BaseTable) table()).operations().current().metadataFileLocation()),
                       MANIFEST_FILE_SCHEMA,
                       schema(),
                       snap.allManifests(io),

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -34,18 +34,13 @@ import org.slf4j.LoggerFactory;
 abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
   private static final Logger LOG = LoggerFactory.getLogger(BaseAllMetadataTableScan.class);
 
-  BaseAllMetadataTableScan(
-      TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
-    super(ops, table, schema, tableType);
+  BaseAllMetadataTableScan(Table table, Schema schema, MetadataTableType tableType) {
+    super(table, schema, tableType);
   }
 
   BaseAllMetadataTableScan(
-      TableOperations ops,
-      Table table,
-      Schema schema,
-      MetadataTableType tableType,
-      TableScanContext context) {
-    super(ops, table, schema, tableType, context);
+      Table table, Schema schema, MetadataTableType tableType, TableScanContext context) {
+    super(table, schema, tableType, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -39,8 +39,8 @@ import org.apache.iceberg.util.StructProjection;
 /** Base class logic for entries metadata tables */
 abstract class BaseEntriesTable extends BaseMetadataTable {
 
-  BaseEntriesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  BaseEntriesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -40,8 +40,8 @@ import org.apache.iceberg.types.Types.StructType;
 /** Base class logic for files metadata tables */
 abstract class BaseFilesTable extends BaseMetadataTable {
 
-  BaseFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  BaseFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
@@ -94,18 +94,13 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
   abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
 
-    protected BaseFilesTableScan(
-        TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
-      super(ops, table, schema, tableType);
+    protected BaseFilesTableScan(Table table, Schema schema, MetadataTableType tableType) {
+      super(table, schema, tableType);
     }
 
     protected BaseFilesTableScan(
-        TableOperations ops,
-        Table table,
-        Schema schema,
-        MetadataTableType tableType,
-        TableScanContext context) {
-      super(ops, table, schema, tableType, context);
+        Table table, Schema schema, MetadataTableType tableType, TableScanContext context) {
+      super(table, schema, tableType, context);
     }
 
     /** Returns an iterable of manifest files to explore for this files metadata table scan */
@@ -119,18 +114,13 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
   abstract static class BaseAllFilesTableScan extends BaseAllMetadataTableScan {
 
-    protected BaseAllFilesTableScan(
-        TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
-      super(ops, table, schema, tableType);
+    protected BaseAllFilesTableScan(Table table, Schema schema, MetadataTableType tableType) {
+      super(table, schema, tableType);
     }
 
     protected BaseAllFilesTableScan(
-        TableOperations ops,
-        Table table,
-        Schema schema,
-        MetadataTableType tableType,
-        TableScanContext context) {
-      super(ops, table, schema, tableType, context);
+        Table table, Schema schema, MetadataTableType tableType, TableScanContext context) {
+      super(table, schema, tableType, context);
     }
 
     /** Returns an iterable of manifest files to explore for this all files metadata table scan */

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
@@ -32,19 +32,14 @@ class BaseIncrementalAppendScan
     extends BaseIncrementalScan<IncrementalAppendScan, FileScanTask, CombinedScanTask>
     implements IncrementalAppendScan {
 
-  BaseIncrementalAppendScan(TableOperations ops, Table table) {
-    this(ops, table, table.schema(), new TableScanContext());
-  }
-
-  BaseIncrementalAppendScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
+  BaseIncrementalAppendScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
   }
 
   @Override
   protected IncrementalAppendScan newRefinedScan(
-      TableOperations newOps, Table newTable, Schema newSchema, TableScanContext newContext) {
-    return new BaseIncrementalAppendScan(newOps, newTable, newSchema, newContext);
+      Table newTable, Schema newSchema, TableScanContext newContext) {
+    return new BaseIncrementalAppendScan(newTable, newSchema, newContext);
   }
 
   @Override
@@ -79,7 +74,7 @@ class BaseIncrementalAppendScan
             .toSet();
 
     ManifestGroup manifestGroup =
-        new ManifestGroup(tableOps().io(), manifests)
+        new ManifestGroup(table().io(), manifests)
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
             .filterData(filter())
@@ -87,7 +82,7 @@ class BaseIncrementalAppendScan
                 manifestEntry ->
                     snapshotIds.contains(manifestEntry.snapshotId())
                         && manifestEntry.status() == ManifestEntry.Status.ADDED)
-            .specsById(tableOps().current().specsById())
+            .specsById(table().specs())
             .ignoreDeleted();
 
     if (context().ignoreResiduals()) {

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -38,19 +38,18 @@ class BaseIncrementalChangelogScan
         IncrementalChangelogScan, ChangelogScanTask, ScanTaskGroup<ChangelogScanTask>>
     implements IncrementalChangelogScan {
 
-  BaseIncrementalChangelogScan(TableOperations ops, Table table) {
-    this(ops, table, table.schema(), new TableScanContext());
+  BaseIncrementalChangelogScan(Table table) {
+    this(table, table.schema(), new TableScanContext());
   }
 
-  BaseIncrementalChangelogScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
+  private BaseIncrementalChangelogScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
   }
 
   @Override
   protected IncrementalChangelogScan newRefinedScan(
-      TableOperations newOps, Table newTable, Schema newSchema, TableScanContext newContext) {
-    return new BaseIncrementalChangelogScan(newOps, newTable, newSchema, newContext);
+      Table newTable, Schema newSchema, TableScanContext newContext) {
+    return new BaseIncrementalChangelogScan(newTable, newSchema, newContext);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
@@ -27,9 +27,8 @@ import org.apache.iceberg.util.SnapshotUtil;
 abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends BaseScan<ThisT, T, G> implements IncrementalScan<ThisT, T, G> {
 
-  protected BaseIncrementalScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
+  protected BaseIncrementalScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
   }
 
   protected abstract CloseableIterable<T> doPlanFiles(
@@ -42,7 +41,7 @@ abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTask
         "Cannot find the starting snapshot: %s",
         fromSnapshotId);
     TableScanContext newContext = context().fromSnapshotIdInclusive(fromSnapshotId);
-    return newRefinedScan(tableOps(), table(), schema(), newContext);
+    return newRefinedScan(table(), schema(), newContext);
   }
 
   @Override
@@ -50,7 +49,7 @@ abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTask
     // for exclusive behavior, table().snapshot(fromSnapshotId) check can't be applied
     // as fromSnapshotId could be matched to a parent snapshot that is already expired
     TableScanContext newContext = context().fromSnapshotIdExclusive(fromSnapshotId);
-    return newRefinedScan(tableOps(), table(), schema(), newContext);
+    return newRefinedScan(table(), schema(), newContext);
   }
 
   @Override
@@ -58,7 +57,7 @@ abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTask
     Preconditions.checkArgument(
         table().snapshot(toSnapshotId) != null, "Cannot find the end snapshot: %s", toSnapshotId);
     TableScanContext newContext = context().toSnapshotId(toSnapshotId);
-    return newRefinedScan(tableOps(), table(), schema(), newContext);
+    return newRefinedScan(table(), schema(), newContext);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -36,15 +36,14 @@ import org.apache.iceberg.transforms.Transforms;
  * the metadata table using a {@link StaticTableOperations}. This way no Catalog related calls are
  * needed when reading the table data after deserialization.
  */
-public abstract class BaseMetadataTable extends BaseReadOnlyTable implements HasTableOperations, Serializable {
+public abstract class BaseMetadataTable extends BaseReadOnlyTable
+    implements HasTableOperations, Serializable {
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
   private final BaseTable table;
   private final String name;
 
-  /**
-   * @deprecated will be removed in 1.3.0; use BaseMetadataTable(Table, String) instead.
-   */
+  /** @deprecated will be removed in 1.3.0; use BaseMetadataTable(Table, String) instead. */
   @Deprecated
   protected BaseMetadataTable(TableOperations ignored, Table table, String name) {
     this(table, name);
@@ -87,9 +86,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Has
     return table;
   }
 
-  /**
-   * @deprecated will be removed in 2.0.0; do not use metadata table TableOperations
-   */
+  /** @deprecated will be removed in 2.0.0; do not use metadata table TableOperations */
   @Override
   @Deprecated
   public TableOperations operations() {

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.transforms.Transforms;
@@ -35,16 +36,17 @@ import org.apache.iceberg.transforms.Transforms;
  * the metadata table using a {@link StaticTableOperations}. This way no Catalog related calls are
  * needed when reading the table data after deserialization.
  */
-public abstract class BaseMetadataTable implements Table, HasTableOperations, Serializable {
+public abstract class BaseMetadataTable extends BaseReadOnlyTable implements HasTableOperations, Serializable {
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
-  private final TableOperations ops;
-  private final Table table;
+  private final BaseTable table;
   private final String name;
 
-  protected BaseMetadataTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
+  protected BaseMetadataTable(Table table, String name) {
+    super("metadata");
+    Preconditions.checkArgument(
+        table instanceof BaseTable, "Cannot create metadata table for non-data table: %s", table);
+    this.table = (BaseTable) table;
     this.name = name;
   }
 
@@ -73,13 +75,13 @@ public abstract class BaseMetadataTable implements Table, HasTableOperations, Se
 
   abstract MetadataTableType metadataTableType();
 
-  protected Table table() {
+  protected BaseTable table() {
     return table;
   }
 
   @Override
   public TableOperations operations() {
-    return ops;
+    return table.operations();
   }
 
   @Override
@@ -170,86 +172,6 @@ public abstract class BaseMetadataTable implements Table, HasTableOperations, Se
   @Override
   public Map<String, SnapshotRef> refs() {
     return table().refs();
-  }
-
-  @Override
-  public UpdateSchema updateSchema() {
-    throw new UnsupportedOperationException("Cannot update the schema of a metadata table");
-  }
-
-  @Override
-  public UpdatePartitionSpec updateSpec() {
-    throw new UnsupportedOperationException("Cannot update the partition spec of a metadata table");
-  }
-
-  @Override
-  public UpdateProperties updateProperties() {
-    throw new UnsupportedOperationException("Cannot update the properties of a metadata table");
-  }
-
-  @Override
-  public ReplaceSortOrder replaceSortOrder() {
-    throw new UnsupportedOperationException("Cannot update the sort order of a metadata table");
-  }
-
-  @Override
-  public UpdateLocation updateLocation() {
-    throw new UnsupportedOperationException("Cannot update the location of a metadata table");
-  }
-
-  @Override
-  public AppendFiles newAppend() {
-    throw new UnsupportedOperationException("Cannot append to a metadata table");
-  }
-
-  @Override
-  public RewriteFiles newRewrite() {
-    throw new UnsupportedOperationException("Cannot rewrite in a metadata table");
-  }
-
-  @Override
-  public RewriteManifests rewriteManifests() {
-    throw new UnsupportedOperationException("Cannot rewrite manifests in a metadata table");
-  }
-
-  @Override
-  public OverwriteFiles newOverwrite() {
-    throw new UnsupportedOperationException("Cannot overwrite in a metadata table");
-  }
-
-  @Override
-  public RowDelta newRowDelta() {
-    throw new UnsupportedOperationException("Cannot remove or replace rows in a metadata table");
-  }
-
-  @Override
-  public ReplacePartitions newReplacePartitions() {
-    throw new UnsupportedOperationException("Cannot replace partitions in a metadata table");
-  }
-
-  @Override
-  public DeleteFiles newDelete() {
-    throw new UnsupportedOperationException("Cannot delete from a metadata table");
-  }
-
-  @Override
-  public UpdateStatistics updateStatistics() {
-    throw new UnsupportedOperationException("Cannot update statistics of a metadata table");
-  }
-
-  @Override
-  public ExpireSnapshots expireSnapshots() {
-    throw new UnsupportedOperationException("Cannot expire snapshots from a metadata table");
-  }
-
-  @Override
-  public ManageSnapshots manageSnapshots() {
-    throw new UnsupportedOperationException("Cannot manage snapshots in a metadata table");
-  }
-
-  @Override
-  public Transaction newTransaction() {
-    throw new UnsupportedOperationException("Cannot create transactions for a metadata table");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -42,6 +42,14 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Has
   private final BaseTable table;
   private final String name;
 
+  /**
+   * @deprecated will be removed in 1.3.0; use BaseMetadataTable(Table, String) instead.
+   */
+  @Deprecated
+  protected BaseMetadataTable(TableOperations ignored, Table table, String name) {
+    this(table, name);
+  }
+
   protected BaseMetadataTable(Table table, String name) {
     super("metadata");
     Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -79,7 +79,11 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Has
     return table;
   }
 
+  /**
+   * @deprecated will be removed in 2.0.0; do not use metadata table TableOperations
+   */
   @Override
+  @Deprecated
   public TableOperations operations() {
     return table.operations();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -25,7 +25,7 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
   private final MetadataTableType tableType;
 
   protected BaseMetadataTableScan(Table table, Schema schema, MetadataTableType tableType) {
-    super(table, schema);
+    super(table, schema, new TableScanContext());
     this.tableType = tableType;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -24,19 +24,14 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
 
   private final MetadataTableType tableType;
 
-  protected BaseMetadataTableScan(
-      TableOperations ops, Table table, Schema schema, MetadataTableType tableType) {
-    super(ops, table, schema);
+  protected BaseMetadataTableScan(Table table, Schema schema, MetadataTableType tableType) {
+    super(table, schema);
     this.tableType = tableType;
   }
 
   protected BaseMetadataTableScan(
-      TableOperations ops,
-      Table table,
-      Schema schema,
-      MetadataTableType tableType,
-      TableScanContext context) {
-    super(ops, table, schema, context);
+      Table table, Schema schema, MetadataTableType tableType, TableScanContext context) {
+    super(table, schema, context);
     this.tableType = tableType;
   }
 
@@ -65,7 +60,8 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
   @Override
   public long targetSplitSize() {
     long tableValue =
-        tableOps()
+        ((BaseTable) table())
+            .operations()
             .current()
             .propertyAsLong(
                 TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);

--- a/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+abstract class BaseReadOnlyTable implements Table {
+
+  private final String descriptor;
+
+  BaseReadOnlyTable(String descriptor) {
+    this.descriptor = descriptor;
+  }
+
+  @Override
+  public UpdateSchema updateSchema() {
+    throw new UnsupportedOperationException("Cannot update the schema of a " + descriptor + " table");
+  }
+
+  @Override
+  public UpdatePartitionSpec updateSpec() {
+    throw new UnsupportedOperationException("Cannot update the partition spec of a " + descriptor + " table");
+  }
+
+  @Override
+  public UpdateProperties updateProperties() {
+    throw new UnsupportedOperationException("Cannot update the properties of a " + descriptor + " table");
+  }
+
+  @Override
+  public ReplaceSortOrder replaceSortOrder() {
+    throw new UnsupportedOperationException("Cannot update the sort order of a " + descriptor + " table");
+  }
+
+  @Override
+  public UpdateLocation updateLocation() {
+    throw new UnsupportedOperationException("Cannot update the location of a " + descriptor + " table");
+  }
+
+  @Override
+  public AppendFiles newAppend() {
+    throw new UnsupportedOperationException("Cannot append to a " + descriptor + " table");
+  }
+
+  @Override
+  public RewriteFiles newRewrite() {
+    throw new UnsupportedOperationException("Cannot rewrite in a " + descriptor + " table");
+  }
+
+  @Override
+  public RewriteManifests rewriteManifests() {
+    throw new UnsupportedOperationException("Cannot rewrite manifests in a " + descriptor + " table");
+  }
+
+  @Override
+  public OverwriteFiles newOverwrite() {
+    throw new UnsupportedOperationException("Cannot overwrite in a " + descriptor + " table");
+  }
+
+  @Override
+  public RowDelta newRowDelta() {
+    throw new UnsupportedOperationException("Cannot remove or replace rows in a " + descriptor + " table");
+  }
+
+  @Override
+  public ReplacePartitions newReplacePartitions() {
+    throw new UnsupportedOperationException("Cannot replace partitions in a " + descriptor + " table");
+  }
+
+  @Override
+  public DeleteFiles newDelete() {
+    throw new UnsupportedOperationException("Cannot delete from a " + descriptor + " table");
+  }
+
+  @Override
+  public UpdateStatistics updateStatistics() {
+    throw new UnsupportedOperationException("Cannot update statistics of a " + descriptor + " table");
+  }
+
+  @Override
+  public ExpireSnapshots expireSnapshots() {
+    throw new UnsupportedOperationException("Cannot expire snapshots from a " + descriptor + " table");
+  }
+
+  @Override
+  public ManageSnapshots manageSnapshots() {
+    throw new UnsupportedOperationException("Cannot manage snapshots in a " + descriptor + " table");
+  }
+
+  @Override
+  public Transaction newTransaction() {
+    throw new UnsupportedOperationException("Cannot create transactions for a " + descriptor + " table");
+  }
+
+}

--- a/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.iceberg;
 
 abstract class BaseReadOnlyTable implements Table {
@@ -29,27 +28,32 @@ abstract class BaseReadOnlyTable implements Table {
 
   @Override
   public UpdateSchema updateSchema() {
-    throw new UnsupportedOperationException("Cannot update the schema of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update the schema of a " + descriptor + " table");
   }
 
   @Override
   public UpdatePartitionSpec updateSpec() {
-    throw new UnsupportedOperationException("Cannot update the partition spec of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update the partition spec of a " + descriptor + " table");
   }
 
   @Override
   public UpdateProperties updateProperties() {
-    throw new UnsupportedOperationException("Cannot update the properties of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update the properties of a " + descriptor + " table");
   }
 
   @Override
   public ReplaceSortOrder replaceSortOrder() {
-    throw new UnsupportedOperationException("Cannot update the sort order of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update the sort order of a " + descriptor + " table");
   }
 
   @Override
   public UpdateLocation updateLocation() {
-    throw new UnsupportedOperationException("Cannot update the location of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update the location of a " + descriptor + " table");
   }
 
   @Override
@@ -64,7 +68,8 @@ abstract class BaseReadOnlyTable implements Table {
 
   @Override
   public RewriteManifests rewriteManifests() {
-    throw new UnsupportedOperationException("Cannot rewrite manifests in a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot rewrite manifests in a " + descriptor + " table");
   }
 
   @Override
@@ -74,12 +79,14 @@ abstract class BaseReadOnlyTable implements Table {
 
   @Override
   public RowDelta newRowDelta() {
-    throw new UnsupportedOperationException("Cannot remove or replace rows in a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot remove or replace rows in a " + descriptor + " table");
   }
 
   @Override
   public ReplacePartitions newReplacePartitions() {
-    throw new UnsupportedOperationException("Cannot replace partitions in a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot replace partitions in a " + descriptor + " table");
   }
 
   @Override
@@ -89,21 +96,25 @@ abstract class BaseReadOnlyTable implements Table {
 
   @Override
   public UpdateStatistics updateStatistics() {
-    throw new UnsupportedOperationException("Cannot update statistics of a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot update statistics of a " + descriptor + " table");
   }
 
   @Override
   public ExpireSnapshots expireSnapshots() {
-    throw new UnsupportedOperationException("Cannot expire snapshots from a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot expire snapshots from a " + descriptor + " table");
   }
 
   @Override
   public ManageSnapshots manageSnapshots() {
-    throw new UnsupportedOperationException("Cannot manage snapshots in a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot manage snapshots in a " + descriptor + " table");
   }
 
   @Override
   public Transaction newTransaction() {
-    throw new UnsupportedOperationException("Cannot create transactions for a " + descriptor + " table");
+    throw new UnsupportedOperationException(
+        "Cannot create transactions for a " + descriptor + " table");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReadOnlyTable.java
@@ -106,5 +106,4 @@ abstract class BaseReadOnlyTable implements Table {
   public Transaction newTransaction() {
     throw new UnsupportedOperationException("Cannot create transactions for a " + descriptor + " table");
   }
-
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -72,6 +72,18 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     this.context = context;
   }
 
+  /**
+   * @deprecated will be removed in 1.3.0; avoid using TableOperations for scans or use BaseTable
+   */
+  @Deprecated
+  protected TableOperations tableOps() {
+    if (table instanceof BaseTable) {
+      return ((BaseTable) table).operations();
+    }
+
+    return null;
+  }
+
   protected Table table() {
     return table;
   }
@@ -98,6 +110,16 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
 
   protected ExecutorService planExecutor() {
     return context().planExecutor();
+  }
+
+  /**
+   * @deprecated will be removed in 1.3.0; use newRefinedScan(Table, Schema, TableScanContext)
+   *     instead.
+   */
+  @Deprecated
+  protected ThisT newRefinedScan(
+      TableOperations ignored, Table newTable, Schema newSchema, TableScanContext newContext) {
+    return newRefinedScan(newTable, newSchema, newContext);
   }
 
   protected abstract ThisT newRefinedScan(

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -62,20 +62,14 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   private static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
 
-  private final TableOperations ops;
   private final Table table;
   private final Schema schema;
   private final TableScanContext context;
 
-  protected BaseScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    this.ops = ops;
+  protected BaseScan(Table table, Schema schema, TableScanContext context) {
     this.table = table;
     this.schema = schema;
     this.context = context;
-  }
-
-  protected TableOperations tableOps() {
-    return ops;
   }
 
   protected Table table() {
@@ -107,21 +101,21 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   }
 
   protected abstract ThisT newRefinedScan(
-      TableOperations newOps, Table newTable, Schema newSchema, TableScanContext newContext);
+      Table newTable, Schema newSchema, TableScanContext newContext);
 
   @Override
   public ThisT option(String property, String value) {
-    return newRefinedScan(ops, table, schema, context.withOption(property, value));
+    return newRefinedScan(table, schema, context.withOption(property, value));
   }
 
   @Override
   public ThisT project(Schema projectedSchema) {
-    return newRefinedScan(ops, table, schema, context.project(projectedSchema));
+    return newRefinedScan(table, schema, context.project(projectedSchema));
   }
 
   @Override
   public ThisT caseSensitive(boolean caseSensitive) {
-    return newRefinedScan(ops, table, schema, context.setCaseSensitive(caseSensitive));
+    return newRefinedScan(table, schema, context.setCaseSensitive(caseSensitive));
   }
 
   @Override
@@ -131,18 +125,18 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
 
   @Override
   public ThisT includeColumnStats() {
-    return newRefinedScan(ops, table, schema, context.shouldReturnColumnStats(true));
+    return newRefinedScan(table, schema, context.shouldReturnColumnStats(true));
   }
 
   @Override
   public ThisT select(Collection<String> columns) {
-    return newRefinedScan(ops, table, schema, context.selectColumns(columns));
+    return newRefinedScan(table, schema, context.selectColumns(columns));
   }
 
   @Override
   public ThisT filter(Expression expr) {
     return newRefinedScan(
-        ops, table, schema, context.filterRows(Expressions.and(context.rowFilter(), expr)));
+        table, schema, context.filterRows(Expressions.and(context.rowFilter(), expr)));
   }
 
   @Override
@@ -152,12 +146,12 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
 
   @Override
   public ThisT ignoreResiduals() {
-    return newRefinedScan(ops, table, schema, context.ignoreResiduals(true));
+    return newRefinedScan(table, schema, context.ignoreResiduals(true));
   }
 
   @Override
   public ThisT planWith(ExecutorService executorService) {
-    return newRefinedScan(ops, table, schema, context.planWith(executorService));
+    return newRefinedScan(table, schema, context.planWith(executorService));
   }
 
   @Override
@@ -168,16 +162,18 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   @Override
   public long targetSplitSize() {
     long tableValue =
-        ops.current()
-            .propertyAsLong(TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
+        PropertyUtil.propertyAsLong(
+            table().properties(), TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
     return PropertyUtil.propertyAsLong(context.options(), TableProperties.SPLIT_SIZE, tableValue);
   }
 
   @Override
   public int splitLookback() {
     int tableValue =
-        ops.current()
-            .propertyAsInt(TableProperties.SPLIT_LOOKBACK, TableProperties.SPLIT_LOOKBACK_DEFAULT);
+        PropertyUtil.propertyAsInt(
+            table().properties(),
+            TableProperties.SPLIT_LOOKBACK,
+            TableProperties.SPLIT_LOOKBACK_DEFAULT);
     return PropertyUtil.propertyAsInt(
         context.options(), TableProperties.SPLIT_LOOKBACK, tableValue);
   }
@@ -185,9 +181,10 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   @Override
   public long splitOpenFileCost() {
     long tableValue =
-        ops.current()
-            .propertyAsLong(
-                TableProperties.SPLIT_OPEN_FILE_COST, TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+        PropertyUtil.propertyAsLong(
+            table().properties(),
+            TableProperties.SPLIT_OPEN_FILE_COST,
+            TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     return PropertyUtil.propertyAsLong(
         context.options(), TableProperties.SPLIT_OPEN_FILE_COST, tableValue);
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -68,18 +68,18 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public TableScan newScan() {
-    return new DataTableScan(ops, this, schema(), new TableScanContext().reportWith(reporter));
+    return new DataTableScan(this, schema(), new TableScanContext().reportWith(reporter));
   }
 
   @Override
   public IncrementalAppendScan newIncrementalAppendScan() {
     return new BaseIncrementalAppendScan(
-        ops, this, schema(), new TableScanContext().reportWith(reporter));
+        this, schema(), new TableScanContext().reportWith(reporter));
   }
 
   @Override
   public IncrementalChangelogScan newIncrementalChangelogScan() {
-    return new BaseIncrementalChangelogScan(ops, this);
+    return new BaseIncrementalChangelogScan(this);
   }
 
   @Override
@@ -229,17 +229,17 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
 
   @Override
   public FileIO io() {
-    return operations().io();
+    return ops.io();
   }
 
   @Override
   public EncryptionManager encryption() {
-    return operations().encryption();
+    return ops.encryption();
   }
 
   @Override
   public LocationProvider locationProvider() {
-    return operations().locationProvider();
+    return ops.locationProvider();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -48,10 +48,6 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
   private static final Logger LOG = LoggerFactory.getLogger(BaseTableScan.class);
   private ScanMetrics scanMetrics;
 
-  protected BaseTableScan(Table table, Schema schema) {
-    this(table, schema, new TableScanContext());
-  }
-
   protected BaseTableScan(Table table, Schema schema, TableScanContext context) {
     super(table, schema, context);
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -48,13 +48,12 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
   private static final Logger LOG = LoggerFactory.getLogger(BaseTableScan.class);
   private ScanMetrics scanMetrics;
 
-  protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
-    this(ops, table, schema, new TableScanContext());
+  protected BaseTableScan(Table table, Schema schema) {
+    this(table, schema, new TableScanContext());
   }
 
-  protected BaseTableScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
+  protected BaseTableScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
   }
 
   protected Long snapshotId() {
@@ -95,11 +94,10 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
     Preconditions.checkArgument(
         snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
     Preconditions.checkArgument(
-        tableOps().current().snapshot(scanSnapshotId) != null,
+        table().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s",
         scanSnapshotId);
-    return newRefinedScan(
-        tableOps(), table(), tableSchema(), context().useSnapshotId(scanSnapshotId));
+    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(scanSnapshotId));
   }
 
   @Override
@@ -108,8 +106,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
         snapshotId() == null, "Cannot override ref, already set snapshot id=%s", snapshotId());
     Snapshot snapshot = table().snapshot(name);
     Preconditions.checkArgument(snapshot != null, "Cannot find ref %s", name);
-    return newRefinedScan(
-        tableOps(), table(), tableSchema(), context().useSnapshotId(snapshot.snapshotId()));
+    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(snapshot.snapshotId()));
   }
 
   @Override
@@ -174,9 +171,7 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
 
   @Override
   public Snapshot snapshot() {
-    return snapshotId() != null
-        ? tableOps().current().snapshot(snapshotId())
-        : tableOps().current().currentSnapshot();
+    return snapshotId() != null ? table().snapshot(snapshotId()) : table().currentSnapshot();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -23,17 +23,17 @@ import org.apache.iceberg.io.CloseableIterable;
 /** A {@link Table} implementation that exposes a table's data files as rows. */
 public class DataFilesTable extends BaseFilesTable {
 
-  DataFilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".data_files");
+  DataFilesTable(Table table) {
+    this(table, table.name() + ".data_files");
   }
 
-  DataFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  DataFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new DataFilesTableScan(operations(), table(), schema());
+    return new DataFilesTableScan(table(), schema());
   }
 
   @Override
@@ -43,23 +43,22 @@ public class DataFilesTable extends BaseFilesTable {
 
   public static class DataFilesTableScan extends BaseFilesTableScan {
 
-    DataFilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.DATA_FILES);
+    DataFilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.DATA_FILES);
     }
 
-    DataFilesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.DATA_FILES, context);
+    DataFilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.DATA_FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DataFilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new DataFilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return CloseableIterable.withNoopClose(snapshot().dataManifests(tableOps().io()));
+      return CloseableIterable.withNoopClose(snapshot().dataManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -25,6 +25,25 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.SnapshotUtil;
 
 public class DataTableScan extends BaseTableScan {
+  /**
+   * @deprecated will be removed in 1.3.0; use DataTableScan(Table, Schema, TableScanContext)
+   *     instead.
+   */
+  @Deprecated
+  public DataTableScan(TableOperations ignored, Table table) {
+    this(table, table.schema(), new TableScanContext());
+  }
+
+  /**
+   * @deprecated will be removed in 1.3.0; use DataTableScan(Table, Schema, TableScanContext)
+   *     instead.
+   */
+  @Deprecated
+  protected DataTableScan(
+      TableOperations ignored, Table table, Schema schema, TableScanContext context) {
+    this(table, schema, context);
+  }
+
   protected DataTableScan(Table table, Schema schema, TableScanContext context) {
     super(table, schema, context);
   }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -25,14 +25,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.SnapshotUtil;
 
 public class DataTableScan extends BaseTableScan {
-
-  public DataTableScan(TableOperations ops, Table table) {
-    super(ops, table, table.schema());
-  }
-
-  protected DataTableScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context);
+  protected DataTableScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
   }
 
   @Override
@@ -42,7 +36,6 @@ public class DataTableScan extends BaseTableScan {
         "Cannot enable incremental scan, scan-snapshot set to id=%s",
         snapshotId());
     return new IncrementalDataTableScan(
-        tableOps(),
         table(),
         schema(),
         context().fromSnapshotIdExclusive(fromSnapshotId).toSnapshotId(toSnapshotId));
@@ -64,14 +57,12 @@ public class DataTableScan extends BaseTableScan {
     // we do not use its return value
     super.useSnapshot(scanSnapshotId);
     Schema snapshotSchema = SnapshotUtil.schemaFor(table(), scanSnapshotId);
-    return newRefinedScan(
-        tableOps(), table(), snapshotSchema, context().useSnapshotId(scanSnapshotId));
+    return newRefinedScan(table(), snapshotSchema, context().useSnapshotId(scanSnapshotId));
   }
 
   @Override
-  protected TableScan newRefinedScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new DataTableScan(ops, table, schema, context);
+  protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+    return new DataTableScan(table, schema, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -23,17 +23,17 @@ import org.apache.iceberg.io.CloseableIterable;
 /** A {@link Table} implementation that exposes a table's delete files as rows. */
 public class DeleteFilesTable extends BaseFilesTable {
 
-  DeleteFilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".delete_files");
+  DeleteFilesTable(Table table) {
+    this(table, table.name() + ".delete_files");
   }
 
-  DeleteFilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  DeleteFilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new DeleteFilesTableScan(operations(), table(), schema());
+    return new DeleteFilesTableScan(table(), schema());
   }
 
   @Override
@@ -43,24 +43,22 @@ public class DeleteFilesTable extends BaseFilesTable {
 
   public static class DeleteFilesTableScan extends BaseFilesTableScan {
 
-    DeleteFilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.DELETE_FILES);
+    DeleteFilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.DELETE_FILES);
     }
 
-    DeleteFilesTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.DELETE_FILES, context);
+    DeleteFilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.DELETE_FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DeleteFilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new DeleteFilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return CloseableIterable.withNoopClose(snapshot().deleteManifests(tableOps().io()));
+      return CloseableIterable.withNoopClose(snapshot().deleteManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/FilesTable.java
@@ -23,17 +23,17 @@ import org.apache.iceberg.io.CloseableIterable;
 /** A {@link Table} implementation that exposes a table's files as rows. */
 public class FilesTable extends BaseFilesTable {
 
-  FilesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".files");
+  FilesTable(Table table) {
+    this(table, table.name() + ".files");
   }
 
-  FilesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  FilesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new FilesTableScan(operations(), table(), schema());
+    return new FilesTableScan(table(), schema());
   }
 
   @Override
@@ -43,23 +43,22 @@ public class FilesTable extends BaseFilesTable {
 
   public static class FilesTableScan extends BaseFilesTableScan {
 
-    FilesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.FILES);
+    FilesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.FILES);
     }
 
-    FilesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.FILES, context);
+    FilesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.FILES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new FilesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new FilesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
-      return CloseableIterable.withNoopClose(snapshot().allManifests(tableOps().io()));
+      return CloseableIterable.withNoopClose(snapshot().allManifests(table().io()));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -41,17 +41,17 @@ public class HistoryTable extends BaseMetadataTable {
           Types.NestedField.optional(3, "parent_id", Types.LongType.get()),
           Types.NestedField.required(4, "is_current_ancestor", Types.BooleanType.get()));
 
-  HistoryTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".history");
+  HistoryTable(Table table) {
+    this(table, table.name() + ".history");
   }
 
-  HistoryTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  HistoryTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new HistoryScan(operations(), table());
+    return new HistoryScan(table());
   }
 
   @Override
@@ -65,29 +65,26 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   private DataTask task(TableScan scan) {
-    TableOperations ops = operations();
     return StaticDataTask.of(
-        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        table().io().newInputFile(table().operations().current().metadataFileLocation()),
         schema(),
         scan.schema(),
-        ops.current().snapshotLog(),
+        table().history(),
         convertHistoryEntryFunc(table()));
   }
 
   private class HistoryScan extends StaticTableScan {
-    HistoryScan(TableOperations ops, Table table) {
-      super(ops, table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task);
+    HistoryScan(Table table) {
+      super(table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task);
     }
 
-    HistoryScan(TableOperations ops, Table table, TableScanContext context) {
-      super(
-          ops, table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task, context);
+    HistoryScan(Table table, TableScanContext context) {
+      super(table, HISTORY_SCHEMA, MetadataTableType.HISTORY, HistoryTable.this::task, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new HistoryScan(ops, table, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new HistoryScan(table, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -31,10 +31,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.SnapshotUtil;
 
 class IncrementalDataTableScan extends DataTableScan {
-
-  IncrementalDataTableScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context.useSnapshotId(null));
+  IncrementalDataTableScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context.useSnapshotId(null));
     validateSnapshotIds(table, context.fromSnapshotId(), context.toSnapshotId());
   }
 
@@ -66,7 +64,6 @@ class IncrementalDataTableScan extends DataTableScan {
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     validateSnapshotIdsRefinement(fromSnapshotId, toSnapshotId);
     return new IncrementalDataTableScan(
-        tableOps(),
         table(),
         schema(),
         context().fromSnapshotIdExclusive(fromSnapshotId).toSnapshotId(toSnapshotId));
@@ -91,7 +88,7 @@ class IncrementalDataTableScan extends DataTableScan {
     Set<Long> snapshotIds = Sets.newHashSet(Iterables.transform(snapshots, Snapshot::snapshotId));
     Set<ManifestFile> manifests =
         FluentIterable.from(snapshots)
-            .transformAndConcat(snapshot -> snapshot.dataManifests(tableOps().io()))
+            .transformAndConcat(snapshot -> snapshot.dataManifests(table().io()))
             .filter(manifestFile -> snapshotIds.contains(manifestFile.snapshotId()))
             .toSet();
 
@@ -124,9 +121,8 @@ class IncrementalDataTableScan extends DataTableScan {
 
   @Override
   @SuppressWarnings("checkstyle:HiddenField")
-  protected TableScan newRefinedScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new IncrementalDataTableScan(ops, table, schema, context);
+  protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+    return new IncrementalDataTableScan(table, schema, context);
   }
 
   private static List<Snapshot> snapshotsWithin(

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -29,17 +29,17 @@ import org.apache.iceberg.io.CloseableIterable;
  */
 public class ManifestEntriesTable extends BaseEntriesTable {
 
-  ManifestEntriesTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".entries");
+  ManifestEntriesTable(Table table) {
+    this(table, table.name() + ".entries");
   }
 
-  ManifestEntriesTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  ManifestEntriesTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new EntriesTableScan(operations(), table(), schema());
+    return new EntriesTableScan(table(), schema());
   }
 
   @Override
@@ -49,25 +49,23 @@ public class ManifestEntriesTable extends BaseEntriesTable {
 
   private static class EntriesTableScan extends BaseMetadataTableScan {
 
-    EntriesTableScan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema, MetadataTableType.ENTRIES);
+    EntriesTableScan(Table table, Schema schema) {
+      super(table, schema, MetadataTableType.ENTRIES);
     }
 
-    private EntriesTableScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, MetadataTableType.ENTRIES, context);
+    private EntriesTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, MetadataTableType.ENTRIES, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new EntriesTableScan(ops, table, schema, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new EntriesTableScan(table, schema, context);
     }
 
     @Override
     protected CloseableIterable<FileScanTask> doPlanFiles() {
       CloseableIterable<ManifestFile> manifests =
-          CloseableIterable.withNoopClose(snapshot().allManifests(tableOps().io()));
+          CloseableIterable.withNoopClose(snapshot().allManifests(table().io()));
       return BaseEntriesTable.planFiles(table(), manifests, tableSchema(), schema(), context());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -31,8 +31,7 @@ public class MetadataTableUtils {
 
   public static Table createMetadataTableInstance(Table table, MetadataTableType type) {
     if (table instanceof BaseTable) {
-      TableOperations ops = ((BaseTable) table).operations();
-      return createMetadataTableInstance(ops, table, metadataTableName(table.name(), type), type);
+      return createMetadataTableInstance(table, metadataTableName(table.name(), type), type);
     } else {
       throw new IllegalArgumentException(
           String.format("Cannot create metadata table for table %s: not a base table", table));
@@ -42,42 +41,42 @@ public class MetadataTableUtils {
   public static Table createMetadataTableInstance(
       TableOperations ops, String baseTableName, String metadataTableName, MetadataTableType type) {
     Table baseTable = new BaseTable(ops, baseTableName);
-    return createMetadataTableInstance(ops, baseTable, metadataTableName, type);
+    return createMetadataTableInstance(baseTable, metadataTableName, type);
   }
 
   private static Table createMetadataTableInstance(
-      TableOperations ops, Table baseTable, String metadataTableName, MetadataTableType type) {
+      Table baseTable, String metadataTableName, MetadataTableType type) {
     switch (type) {
       case ENTRIES:
-        return new ManifestEntriesTable(ops, baseTable, metadataTableName);
+        return new ManifestEntriesTable(baseTable, metadataTableName);
       case FILES:
-        return new FilesTable(ops, baseTable, metadataTableName);
+        return new FilesTable(baseTable, metadataTableName);
       case DATA_FILES:
-        return new DataFilesTable(ops, baseTable, metadataTableName);
+        return new DataFilesTable(baseTable, metadataTableName);
       case DELETE_FILES:
-        return new DeleteFilesTable(ops, baseTable, metadataTableName);
+        return new DeleteFilesTable(baseTable, metadataTableName);
       case HISTORY:
-        return new HistoryTable(ops, baseTable, metadataTableName);
+        return new HistoryTable(baseTable, metadataTableName);
       case SNAPSHOTS:
-        return new SnapshotsTable(ops, baseTable, metadataTableName);
+        return new SnapshotsTable(baseTable, metadataTableName);
       case METADATA_LOG_ENTRIES:
-        return new MetadataLogEntriesTable(ops, baseTable, metadataTableName);
+        return new MetadataLogEntriesTable(baseTable, metadataTableName);
       case REFS:
-        return new RefsTable(ops, baseTable, metadataTableName);
+        return new RefsTable(baseTable, metadataTableName);
       case MANIFESTS:
-        return new ManifestsTable(ops, baseTable, metadataTableName);
+        return new ManifestsTable(baseTable, metadataTableName);
       case PARTITIONS:
-        return new PartitionsTable(ops, baseTable, metadataTableName);
+        return new PartitionsTable(baseTable, metadataTableName);
       case ALL_DATA_FILES:
-        return new AllDataFilesTable(ops, baseTable, metadataTableName);
+        return new AllDataFilesTable(baseTable, metadataTableName);
       case ALL_DELETE_FILES:
-        return new AllDeleteFilesTable(ops, baseTable, metadataTableName);
+        return new AllDeleteFilesTable(baseTable, metadataTableName);
       case ALL_FILES:
-        return new AllFilesTable(ops, baseTable, metadataTableName);
+        return new AllFilesTable(baseTable, metadataTableName);
       case ALL_MANIFESTS:
-        return new AllManifestsTable(ops, baseTable, metadataTableName);
+        return new AllManifestsTable(baseTable, metadataTableName);
       case ALL_ENTRIES:
-        return new AllEntriesTable(ops, baseTable, metadataTableName);
+        return new AllEntriesTable(baseTable, metadataTableName);
       default:
         throw new NoSuchTableException(
             "Unknown metadata table type: %s for %s", type, metadataTableName);

--- a/core/src/main/java/org/apache/iceberg/RefsTable.java
+++ b/core/src/main/java/org/apache/iceberg/RefsTable.java
@@ -39,17 +39,17 @@ public class RefsTable extends BaseMetadataTable {
           Types.NestedField.optional(5, "min_snapshots_to_keep", Types.IntegerType.get()),
           Types.NestedField.optional(6, "max_snapshot_age_in_ms", Types.LongType.get()));
 
-  RefsTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".refs");
+  RefsTable(Table table) {
+    this(table, table.name() + ".refs");
   }
 
-  RefsTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  RefsTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new RefsTableScan(operations(), table());
+    return new RefsTableScan(table());
   }
 
   @Override
@@ -58,14 +58,13 @@ public class RefsTable extends BaseMetadataTable {
   }
 
   private DataTask task(BaseTableScan scan) {
-    TableOperations ops = operations();
-    Collection<String> refNames = ops.current().refs().keySet();
+    Collection<String> refNames = table().refs().keySet();
     return StaticDataTask.of(
-        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        table().io().newInputFile(table().operations().current().metadataFileLocation()),
         schema(),
         scan.schema(),
         refNames,
-        referencesToRows(ops.current().refs()));
+        referencesToRows(table().refs()));
   }
 
   @Override
@@ -74,18 +73,17 @@ public class RefsTable extends BaseMetadataTable {
   }
 
   private class RefsTableScan extends StaticTableScan {
-    RefsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task);
+    RefsTableScan(Table table) {
+      super(table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task);
     }
 
-    RefsTableScan(TableOperations ops, Table table, TableScanContext context) {
-      super(ops, table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task, context);
+    RefsTableScan(Table table, TableScanContext context) {
+      super(table, SNAPSHOT_REF_SCHEMA, MetadataTableType.REFS, RefsTable.this::task, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new RefsTableScan(ops, table, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new RefsTableScan(table, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -39,17 +39,17 @@ public class SnapshotsTable extends BaseMetadataTable {
               "summary",
               Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())));
 
-  SnapshotsTable(TableOperations ops, Table table) {
-    this(ops, table, table.name() + ".snapshots");
+  SnapshotsTable(Table table) {
+    this(table, table.name() + ".snapshots");
   }
 
-  SnapshotsTable(TableOperations ops, Table table, String name) {
-    super(ops, table, name);
+  SnapshotsTable(Table table, String name) {
+    super(table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new SnapshotsTableScan(operations(), table());
+    return new SnapshotsTableScan(table());
   }
 
   @Override
@@ -58,12 +58,11 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private DataTask task(BaseTableScan scan) {
-    TableOperations ops = operations();
     return StaticDataTask.of(
-        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        table().io().newInputFile(table().operations().current().metadataFileLocation()),
         schema(),
         scan.schema(),
-        ops.current().snapshots(),
+        table().snapshots(),
         SnapshotsTable::snapshotToRow);
   }
 
@@ -73,24 +72,18 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private class SnapshotsTableScan extends StaticTableScan {
-    SnapshotsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, MetadataTableType.SNAPSHOTS, SnapshotsTable.this::task);
+    SnapshotsTableScan(Table table) {
+      super(table, SNAPSHOT_SCHEMA, MetadataTableType.SNAPSHOTS, SnapshotsTable.this::task);
     }
 
-    SnapshotsTableScan(TableOperations ops, Table table, TableScanContext context) {
+    SnapshotsTableScan(Table table, TableScanContext context) {
       super(
-          ops,
-          table,
-          SNAPSHOT_SCHEMA,
-          MetadataTableType.SNAPSHOTS,
-          SnapshotsTable.this::task,
-          context);
+          table, SNAPSHOT_SCHEMA, MetadataTableType.SNAPSHOTS, SnapshotsTable.this::task, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new SnapshotsTableScan(ops, table, context);
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new SnapshotsTableScan(table, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -25,30 +25,27 @@ class StaticTableScan extends BaseMetadataTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
 
   StaticTableScan(
-      TableOperations ops,
       Table table,
       Schema schema,
       MetadataTableType tableType,
       Function<StaticTableScan, DataTask> buildTask) {
-    super(ops, table, schema, tableType);
+    super(table, schema, tableType);
     this.buildTask = buildTask;
   }
 
   StaticTableScan(
-      TableOperations ops,
       Table table,
       Schema schema,
       MetadataTableType tableType,
       Function<StaticTableScan, DataTask> buildTask,
       TableScanContext context) {
-    super(ops, table, schema, tableType, context);
+    super(table, schema, tableType, context);
     this.buildTask = buildTask;
   }
 
   @Override
-  protected TableScan newRefinedScan(
-      TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new StaticTableScan(ops, table, schema, tableType(), buildTask, context);
+  protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+    return new StaticTableScan(table, schema, tableType(), buildTask, context);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestBatchScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestBatchScans.java
@@ -83,7 +83,7 @@ public class TestBatchScans extends TableTestBase {
             .collect(Collectors.toList());
     Assert.assertEquals("Must have 2 manifests", 2, manifestPaths.size());
 
-    FilesTable filesTable = new FilesTable(table.ops(), table);
+    FilesTable filesTable = new FilesTable(table);
 
     BatchScan scan = filesTable.newBatchScan();
 

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -44,7 +44,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
   public void testEntriesTable() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table entriesTable = new ManifestEntriesTable(table);
 
     Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());
 
@@ -58,7 +58,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
   public void testEntriesTableScan() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table entriesTable = new ManifestEntriesTable(table);
     TableScan scan = entriesTable.newScan();
 
     Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());
@@ -88,7 +88,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
         .set(TableProperties.METADATA_SPLIT_SIZE, String.valueOf(128 * 1024 * 1024))
         .commit();
 
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table entriesTable = new ManifestEntriesTable(table);
 
     Assert.assertEquals(1, Iterables.size(entriesTable.newScan().planTasks()));
 
@@ -113,7 +113,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
     int splitSize =
         (int) TableProperties.METADATA_SPLIT_SIZE_DEFAULT; // default split size is 32 MB
 
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table entriesTable = new ManifestEntriesTable(table);
     Assert.assertEquals(1, entriesTable.currentSnapshot().allManifests(table.io()).size());
 
     int expectedSplits =
@@ -134,7 +134,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
 
     table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
 
-    Table entriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table entriesTable = new ManifestEntriesTable(table);
     TableScan scan = entriesTable.newScan();
 
     Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -109,21 +109,21 @@ public class TestMetadataTableFilters extends TableTestBase {
   private Table createMetadataTable() {
     switch (type) {
       case FILES:
-        return new FilesTable(table.ops(), table);
+        return new FilesTable(table);
       case DATA_FILES:
-        return new DataFilesTable(table.ops(), table);
+        return new DataFilesTable(table);
       case DELETE_FILES:
-        return new DeleteFilesTable(table.ops(), table);
+        return new DeleteFilesTable(table);
       case ALL_DATA_FILES:
-        return new AllDataFilesTable(table.ops(), table);
+        return new AllDataFilesTable(table);
       case ALL_DELETE_FILES:
-        return new AllDeleteFilesTable(table.ops(), table);
+        return new AllDeleteFilesTable(table);
       case ALL_FILES:
-        return new AllFilesTable(table.ops(), table);
+        return new AllFilesTable(table);
       case ENTRIES:
-        return new ManifestEntriesTable(table.ops(), table);
+        return new ManifestEntriesTable(table);
       case ALL_ENTRIES:
-        return new AllEntriesTable(table.ops(), table);
+        return new AllEntriesTable(table);
       default:
         throw new IllegalArgumentException("Unsupported metadata table type:" + type);
     }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -79,7 +79,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table manifestsTable = new ManifestsTable(table.ops(), table);
+    Table manifestsTable = new ManifestsTable(table);
     TableScan scan = manifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -91,7 +91,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testManifestsTableAlwaysIgnoresResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table manifestsTable = new ManifestsTable(table.ops(), table);
+    Table manifestsTable = new ManifestsTable(table);
 
     TableScan scan = manifestsTable.newScan().filter(Expressions.lessThan("length", 10000L));
 
@@ -118,7 +118,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+    Table dataFilesTable = new DataFilesTable(table);
     TableScan scan = dataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -130,7 +130,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+    Table dataFilesTable = new DataFilesTable(table);
 
     TableScan scan1 = dataFilesTable.newScan().filter(Expressions.equal("record_count", 1));
     validateTaskScanResiduals(scan1, false);
@@ -144,7 +144,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testManifestEntriesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table manifestEntriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table manifestEntriesTable = new ManifestEntriesTable(table);
 
     TableScan scan1 = manifestEntriesTable.newScan().filter(Expressions.equal("snapshot_id", 1L));
     validateTaskScanResiduals(scan1, false);
@@ -172,7 +172,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table manifestEntriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table manifestEntriesTable = new ManifestEntriesTable(table);
     TableScan scan = manifestEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -184,7 +184,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testAllDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+    Table allDataFilesTable = new AllDataFilesTable(table);
 
     TableScan scan1 = allDataFilesTable.newScan().filter(Expressions.equal("record_count", 1));
     validateTaskScanResiduals(scan1, false);
@@ -209,7 +209,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+    Table allDataFilesTable = new AllDataFilesTable(table);
     TableScan scan = allDataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -221,7 +221,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testAllEntriesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+    Table allEntriesTable = new AllEntriesTable(table);
 
     TableScan scan1 = allEntriesTable.newScan().filter(Expressions.equal("snapshot_id", 1L));
     validateTaskScanResiduals(scan1, false);
@@ -246,7 +246,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+    Table allEntriesTable = new AllEntriesTable(table);
     TableScan scan = allEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -269,7 +269,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table allManifestsTable = new AllManifestsTable(table.ops(), table);
+    Table allManifestsTable = new AllManifestsTable(table);
 
     TableScan scan = allManifestsTable.newScan();
 
@@ -282,7 +282,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testAllManifestsTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table allManifestsTable = new AllManifestsTable(table.ops(), table);
+    Table allManifestsTable = new AllManifestsTable(table);
 
     TableScan scan1 = allManifestsTable.newScan().filter(Expressions.lessThan("length", 10000L));
     validateTaskScanResiduals(scan1, false);
@@ -299,7 +299,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanNoFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
     Types.StructType expected =
         new Schema(
                 required(
@@ -323,7 +323,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanWithProjection() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
     Types.StructType expected =
         new Schema(required(3, "file_count", Types.IntegerType.get())).asStruct();
 
@@ -342,7 +342,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanNoStats() {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
     CloseableIterable<FileScanTask> tasksAndEq =
         PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan());
     for (FileScanTask fileTask : tasksAndEq) {
@@ -358,7 +358,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanAndFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression andEquals =
         Expressions.and(
@@ -375,7 +375,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanLtFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression ltAnd =
         Expressions.and(
@@ -393,7 +393,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanOrFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression or =
         Expressions.or(
@@ -411,7 +411,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   @Test
   public void testPartitionsScanNotFilter() {
     preparePartitionedTable();
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
@@ -425,7 +425,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanInFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
@@ -439,7 +439,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanNotNullFilter() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
@@ -474,7 +474,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
 
-    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+    Table dataFilesTable = new DataFilesTable(table);
     TableScan scan = dataFilesTable.newScan();
 
     Schema schema = dataFilesTable.schema();
@@ -506,7 +506,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_A2_DELETES).commit();
 
-    Table deleteFilesTable = new DeleteFilesTable(table.ops(), table);
+    Table deleteFilesTable = new DeleteFilesTable(table);
 
     TableScan scan =
         deleteFilesTable
@@ -529,7 +529,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
   @Test
   public void testFilesTableReadableMetricsSchema() {
-    Table filesTable = new FilesTable(table.ops(), table);
+    Table filesTable = new FilesTable(table);
     Types.StructType actual = filesTable.newScan().schema().select("readable_metrics").asStruct();
     int highestId = filesTable.schema().highestFieldId();
 
@@ -647,7 +647,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
-    Table metadataTable = new PartitionsTable(table.ops(), table);
+    Table metadataTable = new PartitionsTable(table);
     Expression filter =
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
@@ -701,7 +701,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(data10).commit();
     table.newFastAppend().appendFile(data11).commit();
 
-    Table metadataTable = new PartitionsTable(table.ops(), table);
+    Table metadataTable = new PartitionsTable(table);
     Expression filter =
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
@@ -781,7 +781,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(par1).commit();
     table.newFastAppend().appendFile(par2).commit();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
 
     Expression andEquals =
         Expressions.and(
@@ -798,7 +798,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testAllDataFilesTableScanWithPlanExecutor() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+    Table allDataFilesTable = new AllDataFilesTable(table);
     AtomicInteger planThreadsIndex = new AtomicInteger(0);
     TableScan scan =
         allDataFilesTable
@@ -821,7 +821,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testAllEntriesTableScanWithPlanExecutor() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
-    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+    Table allEntriesTable = new AllEntriesTable(table);
     AtomicInteger planThreadsIndex = new AtomicInteger(0);
     TableScan scan =
         allEntriesTable
@@ -844,7 +844,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   public void testPartitionsTableScanWithPlanExecutor() {
     preparePartitionedTable();
 
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
     AtomicInteger planThreadsIndex = new AtomicInteger(0);
     TableScan scan =
         partitionsTable
@@ -869,7 +869,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThan("reference_snapshot_id", 2));
 
@@ -884,7 +884,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.greaterThanOrEqual("reference_snapshot_id", 3));
 
@@ -899,7 +899,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThan("reference_snapshot_id", 3));
 
@@ -914,7 +914,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.lessThanOrEqual("reference_snapshot_id", 2));
 
@@ -929,7 +929,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.equal("reference_snapshot_id", 2));
 
@@ -944,7 +944,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notEqual("reference_snapshot_id", 2));
 
@@ -959,7 +959,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
 
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.in("reference_snapshot_id", 1, 3));
@@ -974,7 +974,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable.newScan().filter(Expressions.notIn("reference_snapshot_id", 1, 3));
 
@@ -989,7 +989,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
 
     TableScan manifestsTableScan =
         manifestsTable
@@ -1009,7 +1009,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
 
     TableScan manifestsTableScan =
         manifestsTable
@@ -1029,7 +1029,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();
 
-    Table manifestsTable = new AllManifestsTable(table.ops(), table);
+    Table manifestsTable = new AllManifestsTable(table);
     TableScan manifestsTableScan =
         manifestsTable
             .newScan()

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -66,7 +66,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testManifestsTableWithAddPartitionOnNestedField() throws IOException {
-    Table manifestsTable = new ManifestsTable(table.ops(), table);
+    Table manifestsTable = new ManifestsTable(table);
     TableScan scan = manifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -77,7 +77,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testDataFilesTableWithAddPartitionOnNestedField() throws IOException {
-    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+    Table dataFilesTable = new DataFilesTable(table);
     TableScan scan = dataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -88,7 +88,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testManifestEntriesWithAddPartitionOnNestedField() throws IOException {
-    Table manifestEntriesTable = new ManifestEntriesTable(table.ops(), table);
+    Table manifestEntriesTable = new ManifestEntriesTable(table);
     TableScan scan = manifestEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -99,7 +99,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testAllDataFilesTableWithAddPartitionOnNestedField() throws IOException {
-    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+    Table allDataFilesTable = new AllDataFilesTable(table);
     TableScan scan = allDataFilesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -110,7 +110,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testAllEntriesTableWithAddPartitionOnNestedField() throws IOException {
-    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+    Table allEntriesTable = new AllEntriesTable(table);
     TableScan scan = allEntriesTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -121,7 +121,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testAllManifestsTableWithAddPartitionOnNestedField() throws IOException {
-    Table allManifestsTable = new AllManifestsTable(table.ops(), table);
+    Table allManifestsTable = new AllManifestsTable(table);
     TableScan scan = allManifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -132,7 +132,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
   @Test
   public void testPartitionsTableScanWithAddPartitionOnNestedField() throws IOException {
-    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    Table partitionsTable = new PartitionsTable(table);
     Types.StructType idPartition =
         new Schema(
                 required(


### PR DESCRIPTION
This removes the use of `TableOperations` from metadata tables. Where `TableMetadata` is needed, operations is fetched from the `Table` instance instead of passing the ops explicitly. This is in preparation for metadata tables that are not tied to a particular Iceberg table.