### PR TITLE
AWS: Print logs whether Glue optimistic locking is used or not

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -151,7 +151,12 @@ public class GlueCatalog extends BaseMetastoreCatalog
     if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
       return LockManagers.from(properties);
     } else if (SET_VERSION_ID.isNoop()) {
+      LOG.warn(
+          "Optimistic locking is not available in the environment. Using in-memory lock manager."
+              + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
       return LockManagers.defaultLockManager();
+    } else {
+      LOG.debug("Using optimistic locking for Glue Data Catalog tables.");
     }
     return null;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -153,7 +153,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
     } else if (SET_VERSION_ID.isNoop()) {
       LOG.warn(
           "Optimistic locking is not available in the environment. Using in-memory lock manager."
-              + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
+              + " To ensure atomic transaction, please configure a distributed lock manager"
+              + " such as the DynamoDB lock manager.");
       return LockManagers.defaultLockManager();
     } else {
       LOG.debug("Using optimistic locking for Glue Data Catalog tables.");

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -318,8 +318,9 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
         LOG.debug("Using optimistic locking with table version: {}", glueTable.versionId());
         SET_VERSION_ID.invoke(updateTableRequest, glueTable.versionId());
       } else if (lockManager == null) {
-        LOG.warn("Optimistic locking is not available in the environment. Using in-memory lock manager."
-            + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
+        LOG.warn(
+            "Optimistic locking is not available in the environment. Using in-memory lock manager."
+                + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
       }
 
       glue.updateTable(updateTableRequest.build());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -315,6 +315,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .build());
       // Use Optimistic locking with table version id while updating table
       if (!SET_VERSION_ID.isNoop() && lockManager == null) {
+        LOG.debug("Use optimistic locking with table version: {}", glueTable.versionId());
         SET_VERSION_ID.invoke(updateTableRequest, glueTable.versionId());
       }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -315,12 +315,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .build());
       // Use Optimistic locking with table version id while updating table
       if (!SET_VERSION_ID.isNoop() && lockManager == null) {
-        LOG.debug("Using optimistic locking with table version: {}", glueTable.versionId());
         SET_VERSION_ID.invoke(updateTableRequest, glueTable.versionId());
-      } else if (lockManager == null) {
-        LOG.warn(
-            "Optimistic locking is not available in the environment. Using in-memory lock manager."
-                + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
       }
 
       glue.updateTable(updateTableRequest.build());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -315,8 +315,11 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .build());
       // Use Optimistic locking with table version id while updating table
       if (!SET_VERSION_ID.isNoop() && lockManager == null) {
-        LOG.debug("Use optimistic locking with table version: {}", glueTable.versionId());
+        LOG.debug("Using optimistic locking with table version: {}", glueTable.versionId());
         SET_VERSION_ID.invoke(updateTableRequest, glueTable.versionId());
+      } else if (lockManager == null) {
+        LOG.warn("Optimistic locking is not available in the environment. Using in-memory lock manager."
+            + " To ensure atomic transaction, you need to setup a DynamoDB lock manager.");
       }
 
       glue.updateTable(updateTableRequest.build());


### PR DESCRIPTION
### Background

Glue optimistic locking is automatically enabled if aws-java-sdk version is >= 2.17.131, however, users sometimes cannot check what version of aws-java-sdk is actually used in the runtime environment. Therefore I suppose it's good to add logging for users to understand whether the optimistic locking is actually enabled or not.