### PR TITLE
Core: Add position deletes metadata table

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -321,6 +321,38 @@ acceptedBreaks:
         \ java.lang.Object, java.lang.Object>)"
       justification: "Removing deprecations for 1.2.0"
     - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.AllDataFilesTable.AllDataFilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.AllDeleteFilesTable.AllDeleteFilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.AllFilesTable.AllFilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.AllManifestsTable.AllManifestsTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.DataFilesTable.DataFilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.DataTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.DeleteFilesTable.DeleteFilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
+        \ @ org.apache.iceberg.FilesTable.FilesTableScan"
+      justification: "Method is still there but moved to parent class"
+    - code: "java.method.removed"
       old: "method void org.apache.iceberg.BaseReplacePartitions::validate(org.apache.iceberg.TableMetadata)"
       justification: "Removing deprecations for 1.2.0"
     - code: "java.method.removed"

--- a/api/src/main/java/org/apache/iceberg/ContentScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/ContentScanTask.java
@@ -38,6 +38,11 @@ public interface ContentScanTask<F extends ContentFile<F>> extends ScanTask, Par
     return file().partition();
   }
 
+  @Override
+  default long sizeBytes() {
+    return length();
+  }
+
   /**
    * The starting position of this scan range in the file.
    *

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -72,12 +72,15 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
    *     inclusive projection
    */
   static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec) {
-    PartitionSpec.Builder identitySpecBuilder =
-        PartitionSpec.builderFor(metadataTableSchema).checkConflicts(false);
+    PartitionSpec.Builder builder =
+        PartitionSpec.builderFor(metadataTableSchema)
+            .withSpecId(spec.specId())
+            .checkConflicts(false);
+
     for (PartitionField field : spec.fields()) {
-      identitySpecBuilder.add(field.fieldId(), field.name(), Transforms.identity());
+      builder.add(field.fieldId(), field.fieldId(), field.name(), Transforms.identity());
     }
-    return identitySpecBuilder.build();
+    return builder.build();
   }
 
   abstract MetadataTableType metadataTableType();

--- a/core/src/main/java/org/apache/iceberg/BasePositionDeletesScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BasePositionDeletesScanTask.java
@@ -18,31 +18,25 @@
  */
 package org.apache.iceberg;
 
-import java.util.Locale;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 
-public enum MetadataTableType {
-  ENTRIES,
-  FILES,
-  DATA_FILES,
-  DELETE_FILES,
-  HISTORY,
-  METADATA_LOG_ENTRIES,
-  SNAPSHOTS,
-  REFS,
-  MANIFESTS,
-  PARTITIONS,
-  ALL_DATA_FILES,
-  ALL_DELETE_FILES,
-  ALL_FILES,
-  ALL_MANIFESTS,
-  ALL_ENTRIES,
-  POSITION_DELETES;
+/** Base implementation of {@link PositionDeletesScanTask} */
+class BasePositionDeletesScanTask extends BaseContentScanTask<PositionDeletesScanTask, DeleteFile>
+    implements PositionDeletesScanTask, SplittableScanTask<PositionDeletesScanTask> {
 
-  public static MetadataTableType from(String name) {
-    try {
-      return MetadataTableType.valueOf(name.toUpperCase(Locale.ROOT));
-    } catch (IllegalArgumentException ignored) {
-      return null;
-    }
+  BasePositionDeletesScanTask(
+      DeleteFile file, String schemaString, String specString, ResidualEvaluator evaluator) {
+    super(file, schemaString, specString, evaluator);
+  }
+
+  @Override
+  protected BasePositionDeletesScanTask self() {
+    return this;
+  }
+
+  @Override
+  protected PositionDeletesScanTask newSplitTask(
+      PositionDeletesScanTask parentTask, long offset, long length) {
+    return new SplitPositionDeletesScanTask(parentTask, offset, length);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import org.apache.iceberg.expressions.Binder;
@@ -59,6 +60,23 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
   private static final List<String> SCAN_WITH_STATS_COLUMNS =
       ImmutableList.<String>builder().addAll(SCAN_COLUMNS).addAll(STATS_COLUMNS).build();
 
+  protected static final List<String> DELETE_SCAN_COLUMNS =
+      ImmutableList.of(
+          "snapshot_id",
+          "content",
+          "file_path",
+          "file_ordinal",
+          "file_format",
+          "block_size_in_bytes",
+          "file_size_in_bytes",
+          "record_count",
+          "partition",
+          "key_metadata",
+          "split_offsets");
+
+  protected static final List<String> DELETE_SCAN_WITH_STATS_COLUMNS =
+      ImmutableList.<String>builder().addAll(DELETE_SCAN_COLUMNS).addAll(STATS_COLUMNS).build();
+
   private static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
 
@@ -84,7 +102,7 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     return null;
   }
 
-  protected Table table() {
+  public Table table() {
     return table;
   }
 
@@ -94,6 +112,10 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
 
   protected TableScanContext context() {
     return context;
+  }
+
+  protected Map<String, String> options() {
+    return context().options();
   }
 
   protected List<String> scanColumns() {

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -18,61 +18,15 @@
  */
 package org.apache.iceberg;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.iceberg.events.Listeners;
-import org.apache.iceberg.events.ScanEvent;
-import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.metrics.DefaultMetricsContext;
-import org.apache.iceberg.metrics.ImmutableScanReport;
-import org.apache.iceberg.metrics.ScanMetrics;
-import org.apache.iceberg.metrics.ScanMetricsResult;
-import org.apache.iceberg.metrics.ScanReport;
-import org.apache.iceberg.metrics.Timer;
-import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.TableScanUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Base class for {@link TableScan} implementations. */
-abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedScanTask>
+abstract class BaseTableScan extends SnapshotScan<TableScan, FileScanTask, CombinedScanTask>
     implements TableScan {
-  private static final Logger LOG = LoggerFactory.getLogger(BaseTableScan.class);
-  private ScanMetrics scanMetrics;
 
   protected BaseTableScan(Table table, Schema schema, TableScanContext context) {
     super(table, schema, context);
-  }
-
-  protected Long snapshotId() {
-    return context().snapshotId();
-  }
-
-  protected Map<String, String> options() {
-    return context().options();
-  }
-
-  protected abstract CloseableIterable<FileScanTask> doPlanFiles();
-
-  protected ScanMetrics scanMetrics() {
-    if (scanMetrics == null) {
-      this.scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
-    }
-
-    return scanMetrics;
-  }
-
-  @Override
-  public Table table() {
-    return super.table();
   }
 
   @Override
@@ -86,98 +40,11 @@ abstract class BaseTableScan extends BaseScan<TableScan, FileScanTask, CombinedS
   }
 
   @Override
-  public TableScan useSnapshot(long scanSnapshotId) {
-    Preconditions.checkArgument(
-        snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
-    Preconditions.checkArgument(
-        table().snapshot(scanSnapshotId) != null,
-        "Cannot find snapshot with ID %s",
-        scanSnapshotId);
-    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(scanSnapshotId));
-  }
-
-  @Override
-  public TableScan useRef(String name) {
-    Preconditions.checkArgument(
-        snapshotId() == null, "Cannot override ref, already set snapshot id=%s", snapshotId());
-    Snapshot snapshot = table().snapshot(name);
-    Preconditions.checkArgument(snapshot != null, "Cannot find ref %s", name);
-    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(snapshot.snapshotId()));
-  }
-
-  @Override
-  public TableScan asOfTime(long timestampMillis) {
-    Preconditions.checkArgument(
-        snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
-
-    return useSnapshot(SnapshotUtil.snapshotIdAsOfTime(table(), timestampMillis));
-  }
-
-  @Override
-  public CloseableIterable<FileScanTask> planFiles() {
-    Snapshot snapshot = snapshot();
-    if (snapshot != null) {
-      LOG.info(
-          "Scanning table {} snapshot {} created at {} with filter {}",
-          table(),
-          snapshot.snapshotId(),
-          DateTimeUtil.formatTimestampMillis(snapshot.timestampMillis()),
-          ExpressionUtil.toSanitizedString(filter()));
-
-      Listeners.notifyAll(new ScanEvent(table().name(), snapshot.snapshotId(), filter(), schema()));
-      List<Integer> projectedFieldIds = Lists.newArrayList(TypeUtil.getProjectedIds(schema()));
-      List<String> projectedFieldNames =
-          projectedFieldIds.stream().map(schema()::findColumnName).collect(Collectors.toList());
-
-      Timer.Timed planningDuration = scanMetrics().totalPlanningDuration().start();
-
-      return CloseableIterable.whenComplete(
-          doPlanFiles(),
-          () -> {
-            planningDuration.stop();
-            Map<String, String> metadata = Maps.newHashMap(context().options());
-            metadata.putAll(EnvironmentContext.get());
-            ScanReport scanReport =
-                ImmutableScanReport.builder()
-                    .schemaId(schema().schemaId())
-                    .projectedFieldIds(projectedFieldIds)
-                    .projectedFieldNames(projectedFieldNames)
-                    .tableName(table().name())
-                    .snapshotId(snapshot.snapshotId())
-                    .filter(ExpressionUtil.sanitize(filter()))
-                    .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
-                    .metadata(metadata)
-                    .build();
-            context().metricsReporter().report(scanReport);
-          });
-    } else {
-      LOG.info("Scanning empty table {}", table());
-      return CloseableIterable.empty();
-    }
-  }
-
-  @Override
   public CloseableIterable<CombinedScanTask> planTasks() {
     CloseableIterable<FileScanTask> fileScanTasks = planFiles();
     CloseableIterable<FileScanTask> splitFiles =
         TableScanUtil.splitFiles(fileScanTasks, targetSplitSize());
     return TableScanUtil.planTasks(
         splitFiles, targetSplitSize(), splitLookback(), splitOpenFileCost());
-  }
-
-  @Override
-  public Snapshot snapshot() {
-    return snapshotId() != null ? table().snapshot(snapshotId()) : table().currentSnapshot();
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("table", table())
-        .add("projection", schema().asStruct())
-        .add("filter", filter())
-        .add("ignoreResiduals", shouldIgnoreResiduals())
-        .add("caseSensitive", isCaseSensitive())
-        .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -30,12 +30,11 @@ public class MetadataColumns {
   private MetadataColumns() {}
 
   // IDs Integer.MAX_VALUE - (1-100) are used for metadata columns
+  public static final int FILE_PATH_COLUMN_ID = Integer.MAX_VALUE - 1;
+  public static final String FILE_PATH_COLUMN_DOC = "Path of the file in which a row is stored";
   public static final NestedField FILE_PATH =
       NestedField.required(
-          Integer.MAX_VALUE - 1,
-          "_file",
-          Types.StringType.get(),
-          "Path of the file in which a row is stored");
+          FILE_PATH_COLUMN_ID, "_file", Types.StringType.get(), FILE_PATH_COLUMN_DOC);
   public static final NestedField ROW_POSITION =
       NestedField.required(
           Integer.MAX_VALUE - 2,
@@ -48,12 +47,11 @@ public class MetadataColumns {
           "_deleted",
           Types.BooleanType.get(),
           "Whether the row has been deleted");
+  public static final int SPEC_ID_COLUMN_ID = Integer.MAX_VALUE - 4;
+  public static final String SPEC_ID_COLUMN_DOC = "Spec ID used to track the file containing a row";
   public static final NestedField SPEC_ID =
       NestedField.required(
-          Integer.MAX_VALUE - 4,
-          "_spec_id",
-          Types.IntegerType.get(),
-          "Spec ID used to track the file containing a row");
+          SPEC_ID_COLUMN_ID, "_spec_id", Types.IntegerType.get(), SPEC_ID_COLUMN_DOC);
   // the partition column type is not static and depends on all specs in the table
   public static final int PARTITION_COLUMN_ID = Integer.MAX_VALUE - 5;
   public static final String PARTITION_COLUMN_NAME = "_partition";

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -77,6 +77,8 @@ public class MetadataTableUtils {
         return new AllManifestsTable(baseTable, metadataTableName);
       case ALL_ENTRIES:
         return new AllEntriesTable(baseTable, metadataTableName);
+      case POSITION_DELETES:
+        return new PositionDeletesTable(baseTable, metadataTableName);
       default:
         throw new NoSuchTableException(
             "Unknown metadata table type: %s for %s", type, metadataTableName);

--- a/core/src/main/java/org/apache/iceberg/PositionDeletesScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/PositionDeletesScanTask.java
@@ -18,31 +18,5 @@
  */
 package org.apache.iceberg;
 
-import java.util.Locale;
-
-public enum MetadataTableType {
-  ENTRIES,
-  FILES,
-  DATA_FILES,
-  DELETE_FILES,
-  HISTORY,
-  METADATA_LOG_ENTRIES,
-  SNAPSHOTS,
-  REFS,
-  MANIFESTS,
-  PARTITIONS,
-  ALL_DATA_FILES,
-  ALL_DELETE_FILES,
-  ALL_FILES,
-  ALL_MANIFESTS,
-  ALL_ENTRIES,
-  POSITION_DELETES;
-
-  public static MetadataTableType from(String name) {
-    try {
-      return MetadataTableType.valueOf(name.toUpperCase(Locale.ROOT));
-    } catch (IllegalArgumentException ignored) {
-      return null;
-    }
-  }
-}
+/** A {@link ScanTask} for position delete files */
+public interface PositionDeletesScanTask extends ContentScanTask<DeleteFile> {}

--- a/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
+++ b/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ParallelIterable;
+import org.apache.iceberg.util.TableScanUtil;
+
+/**
+ * A {@link Table} implementation whose {@link Scan} provides {@link PositionDeletesScanTask}, for
+ * reading of position delete files.
+ */
+public class PositionDeletesTable extends BaseMetadataTable {
+
+  private final Schema schema;
+
+  PositionDeletesTable(Table table) {
+    super(table, table.name() + ".position_deletes");
+    this.schema = calculateSchema();
+  }
+
+  PositionDeletesTable(Table table, String name) {
+    super(table, name);
+    this.schema = calculateSchema();
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.POSITION_DELETES;
+  }
+
+  @Override
+  public TableScan newScan() {
+    throw new UnsupportedOperationException(
+        "Cannot create TableScan from table of type POSITION_DELETES");
+  }
+
+  @Override
+  public BatchScan newBatchScan() {
+    return new PositionDeletesBatchScan(table(), schema());
+  }
+
+  @Override
+  public Schema schema() {
+    return schema;
+  }
+
+  private Schema calculateSchema() {
+    Types.StructType partitionType = Partitioning.partitionType(table());
+    Schema result =
+        new Schema(
+            MetadataColumns.DELETE_FILE_PATH,
+            MetadataColumns.DELETE_FILE_POS,
+            Types.NestedField.optional(
+                MetadataColumns.DELETE_FILE_ROW_FIELD_ID,
+                MetadataColumns.DELETE_FILE_ROW_FIELD_NAME,
+                table().schema().asStruct(),
+                MetadataColumns.DELETE_FILE_ROW_DOC),
+            Types.NestedField.required(
+                MetadataColumns.PARTITION_COLUMN_ID,
+                "partition",
+                partitionType,
+                "Partition that position delete row belongs to"),
+            Types.NestedField.required(
+                MetadataColumns.SPEC_ID_COLUMN_ID,
+                "spec_id",
+                Types.IntegerType.get(),
+                MetadataColumns.SPEC_ID_COLUMN_DOC),
+            Types.NestedField.required(
+                MetadataColumns.FILE_PATH_COLUMN_ID,
+                "delete_file_path",
+                Types.StringType.get(),
+                MetadataColumns.FILE_PATH_COLUMN_DOC));
+
+    if (partitionType.fields().size() > 0) {
+      return result;
+    } else {
+      // avoid returning an empty struct, which is not always supported.
+      // instead, drop the partition field
+      return TypeUtil.selectNot(result, Sets.newHashSet(MetadataColumns.PARTITION_COLUMN_ID));
+    }
+  }
+
+  public static class PositionDeletesBatchScan
+      extends SnapshotScan<BatchScan, ScanTask, ScanTaskGroup<ScanTask>> implements BatchScan {
+
+    protected PositionDeletesBatchScan(Table table, Schema schema) {
+      super(table, schema, new TableScanContext());
+    }
+
+    protected PositionDeletesBatchScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, context);
+    }
+
+    @Override
+    protected PositionDeletesBatchScan newRefinedScan(
+        Table newTable, Schema newSchema, TableScanContext newContext) {
+      return new PositionDeletesBatchScan(newTable, newSchema, newContext);
+    }
+
+    @Override
+    public CloseableIterable<ScanTaskGroup<ScanTask>> planTasks() {
+      return TableScanUtil.planTaskGroups(
+          planFiles(), targetSplitSize(), splitLookback(), splitOpenFileCost());
+    }
+
+    @Override
+    protected List<String> scanColumns() {
+      return context().returnColumnStats() ? DELETE_SCAN_WITH_STATS_COLUMNS : DELETE_SCAN_COLUMNS;
+    }
+
+    @Override
+    protected CloseableIterable<ScanTask> doPlanFiles() {
+      String schemaString = SchemaParser.toJson(tableSchema());
+
+      // prepare transformed partition specs and caches
+      Map<Integer, PartitionSpec> transformedSpecs =
+          table().specs().values().stream()
+              .map(spec -> transformSpec(tableSchema(), spec))
+              .collect(Collectors.toMap(PartitionSpec::specId, spec -> spec));
+
+      LoadingCache<Integer, ResidualEvaluator> residualCache =
+          partitionCacheOf(
+              transformedSpecs,
+              spec ->
+                  ResidualEvaluator.of(
+                      spec,
+                      shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter(),
+                      isCaseSensitive()));
+
+      LoadingCache<Integer, String> specStringCache =
+          partitionCacheOf(transformedSpecs, PartitionSpecParser::toJson);
+
+      LoadingCache<Integer, ManifestEvaluator> evalCache =
+          partitionCacheOf(
+              transformedSpecs,
+              spec -> ManifestEvaluator.forRowFilter(filter(), spec, isCaseSensitive()));
+
+      // iterate through delete manifests
+      List<ManifestFile> manifests = snapshot().deleteManifests(table().io());
+
+      CloseableIterable<ManifestFile> matchingManifests =
+          CloseableIterable.filter(
+              scanMetrics().skippedDeleteManifests(),
+              CloseableIterable.withNoopClose(manifests),
+              manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
+
+      matchingManifests =
+          CloseableIterable.count(scanMetrics().scannedDeleteManifests(), matchingManifests);
+
+      Iterable<CloseableIterable<ScanTask>> tasks =
+          CloseableIterable.transform(
+              matchingManifests,
+              manifest ->
+                  posDeletesScanTasks(
+                      manifest, schemaString, transformedSpecs, residualCache, specStringCache));
+
+      if (planExecutor() != null) {
+        return new ParallelIterable<>(tasks, planExecutor());
+      } else {
+        return CloseableIterable.concat(tasks);
+      }
+    }
+
+    private CloseableIterable<ScanTask> posDeletesScanTasks(
+        ManifestFile manifest,
+        String schemaString,
+        Map<Integer, PartitionSpec> transformedSpecs,
+        LoadingCache<Integer, ResidualEvaluator> residualCache,
+        LoadingCache<Integer, String> specStringCache) {
+      return new CloseableIterable<ScanTask>() {
+        private CloseableIterable<ScanTask> iterable;
+
+        @Override
+        public void close() throws IOException {
+          if (iterable != null) {
+            iterable.close();
+          }
+        }
+
+        @Override
+        public CloseableIterator<ScanTask> iterator() {
+          // Filter partitions
+          CloseableIterable<ManifestEntry<DeleteFile>> deleteFileEntries =
+              ManifestFiles.readDeleteManifest(manifest, table().io(), transformedSpecs)
+                  .caseSensitive(isCaseSensitive())
+                  .select(scanColumns())
+                  .filterRows(filter())
+                  .scanMetrics(scanMetrics())
+                  .liveEntries();
+
+          // Filter delete file type
+          CloseableIterable<ManifestEntry<DeleteFile>> positionDeleteEntries =
+              CloseableIterable.filter(
+                  deleteFileEntries,
+                  entry -> entry.file().content().equals(FileContent.POSITION_DELETES));
+
+          this.iterable =
+              CloseableIterable.transform(
+                  positionDeleteEntries,
+                  entry -> {
+                    int specId = entry.file().specId();
+                    return new BasePositionDeletesScanTask(
+                        entry.file().copy(context().returnColumnStats()),
+                        schemaString,
+                        specStringCache.get(specId),
+                        residualCache.get(specId));
+                  });
+          return iterable.iterator();
+        }
+      };
+    }
+
+    private <T> LoadingCache<Integer, T> partitionCacheOf(
+        Map<Integer, PartitionSpec> specs, Function<PartitionSpec, T> constructor) {
+      return Caffeine.newBuilder()
+          .build(
+              specId -> {
+                PartitionSpec spec = specs.get(specId);
+                return constructor.apply(spec);
+              });
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -258,6 +258,11 @@ public class SerializableTable implements Table, Serializable {
   }
 
   @Override
+  public BatchScan newBatchScan() {
+    return lazyTable().newBatchScan();
+  }
+
+  @Override
   public Snapshot currentSnapshot() {
     return lazyTable().currentSnapshot();
   }
@@ -374,6 +379,10 @@ public class SerializableTable implements Table, Serializable {
     @Override
     protected Table newTable(TableOperations ops, String tableName) {
       return MetadataTableUtils.createMetadataTableInstance(ops, baseTableName, tableName, type);
+    }
+
+    public MetadataTableType type() {
+      return type;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.events.Listeners;
+import org.apache.iceberg.events.ScanEvent;
+import org.apache.iceberg.expressions.ExpressionUtil;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ScanMetrics;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.metrics.Timer;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a common base class to share code between different BaseScan implementations that handle
+ * scans of a particular snapshot.
+ *
+ * @param <ThisT> actual BaseScan implementation class type
+ * @param <T> type of ScanTask returned
+ * @param <G> type of ScanTaskGroup returned
+ */
+public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
+    extends BaseScan<ThisT, T, G> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotScan.class);
+
+  private ScanMetrics scanMetrics;
+
+  protected SnapshotScan(Table table, Schema schema, TableScanContext context) {
+    super(table, schema, context);
+  }
+
+  protected Long snapshotId() {
+    return context().snapshotId();
+  }
+
+  protected abstract CloseableIterable<T> doPlanFiles();
+
+  @VisibleForTesting
+  ScanMetrics scanMetrics() {
+    if (scanMetrics == null) {
+      this.scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
+    }
+
+    return scanMetrics;
+  }
+
+  public ThisT useSnapshot(long scanSnapshotId) {
+    Preconditions.checkArgument(
+        snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
+    Preconditions.checkArgument(
+        table().snapshot(scanSnapshotId) != null,
+        "Cannot find snapshot with ID %s",
+        scanSnapshotId);
+    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(scanSnapshotId));
+  }
+
+  public ThisT useRef(String name) {
+    Preconditions.checkArgument(
+        snapshotId() == null, "Cannot override ref, already set snapshot id=%s", snapshotId());
+    Snapshot snapshot = table().snapshot(name);
+    Preconditions.checkArgument(snapshot != null, "Cannot find ref %s", name);
+    return newRefinedScan(table(), tableSchema(), context().useSnapshotId(snapshot.snapshotId()));
+  }
+
+  public ThisT asOfTime(long timestampMillis) {
+    Preconditions.checkArgument(
+        snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
+
+    return useSnapshot(SnapshotUtil.snapshotIdAsOfTime(table(), timestampMillis));
+  }
+
+  @Override
+  public CloseableIterable<T> planFiles() {
+    Snapshot snapshot = snapshot();
+
+    if (snapshot == null) {
+      LOG.info("Scanning empty table {}", table());
+      return CloseableIterable.empty();
+    }
+
+    LOG.info(
+        "Scanning table {} snapshot {} created at {} with filter {}",
+        table(),
+        snapshot.snapshotId(),
+        DateTimeUtil.formatTimestampMillis(snapshot.timestampMillis()),
+        ExpressionUtil.toSanitizedString(filter()));
+
+    Listeners.notifyAll(new ScanEvent(table().name(), snapshot.snapshotId(), filter(), schema()));
+    List<Integer> projectedFieldIds = Lists.newArrayList(TypeUtil.getProjectedIds(schema()));
+    List<String> projectedFieldNames =
+        projectedFieldIds.stream().map(schema()::findColumnName).collect(Collectors.toList());
+
+    Timer.Timed planningDuration = scanMetrics().totalPlanningDuration().start();
+
+    return CloseableIterable.whenComplete(
+        doPlanFiles(),
+        () -> {
+          planningDuration.stop();
+          Map<String, String> metadata = Maps.newHashMap(context().options());
+          metadata.putAll(EnvironmentContext.get());
+          ScanReport scanReport =
+              ImmutableScanReport.builder()
+                  .schemaId(schema().schemaId())
+                  .projectedFieldIds(projectedFieldIds)
+                  .projectedFieldNames(projectedFieldNames)
+                  .tableName(table().name())
+                  .snapshotId(snapshot.snapshotId())
+                  .filter(ExpressionUtil.sanitize(filter()))
+                  .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
+                  .metadata(metadata)
+                  .build();
+          context().metricsReporter().report(scanReport);
+        });
+  }
+
+  public Snapshot snapshot() {
+    return snapshotId() != null ? table().snapshot(snapshotId()) : table().currentSnapshot();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("table", table())
+        .add("projection", schema().asStruct())
+        .add("filter", filter())
+        .add("ignoreResiduals", shouldIgnoreResiduals())
+        .add("caseSensitive", isCaseSensitive())
+        .toString();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/SplitPositionDeletesScanTask.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+/** A split of a {@link PositionDeletesScanTask} that is mergeable. */
+class SplitPositionDeletesScanTask
+    implements PositionDeletesScanTask, MergeableScanTask<PositionDeletesScanTask> {
+
+  private final PositionDeletesScanTask parentTask;
+  private final long offset;
+  private final long length;
+
+  protected SplitPositionDeletesScanTask(
+      PositionDeletesScanTask parentTask, long offset, long length) {
+    this.parentTask = parentTask;
+    this.offset = offset;
+    this.length = length;
+  }
+
+  @Override
+  public DeleteFile file() {
+    return parentTask.file();
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return parentTask.spec();
+  }
+
+  @Override
+  public long start() {
+    return offset;
+  }
+
+  @Override
+  public long length() {
+    return length;
+  }
+
+  @Override
+  public Expression residual() {
+    return parentTask.residual();
+  }
+
+  @Override
+  public boolean canMerge(org.apache.iceberg.ScanTask other) {
+    if (other instanceof SplitPositionDeletesScanTask) {
+      SplitPositionDeletesScanTask that = (SplitPositionDeletesScanTask) other;
+      return file().equals(that.file()) && offset + length == that.start();
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public SplitPositionDeletesScanTask merge(org.apache.iceberg.ScanTask other) {
+    SplitPositionDeletesScanTask that = (SplitPositionDeletesScanTask) other;
+    return new SplitPositionDeletesScanTask(parentTask, offset, length + that.length());
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("file", file().path())
+        .add("partition_data", file().partition())
+        .add("offset", offset)
+        .add("length", length)
+        .add("residual", residual())
+        .toString();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -26,6 +27,8 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PartitionUtil;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -95,5 +98,10 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
 
                   return partition.get(position, Object.class).equals(partValue);
                 }));
+  }
+
+  protected Map<Integer, ?> constantsMap(
+      PositionDeletesScanTask task, Types.StructType partitionType) {
+    return PartitionUtil.constantsMap(task, partitionType, (type, constant) -> constant);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -20,15 +20,21 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.Stream;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -155,6 +161,65 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
       validateIncludesPartitionScan(tasksNoFilter, 1, 2);
       validateIncludesPartitionScan(tasksNoFilter, 1, 3);
     }
+  }
+
+  @Test
+  public void testPositionDeletesPartitionSpecRemoval() {
+    Assume.assumeTrue("Position deletes supported only for v2 tables", formatVersion == 2);
+
+    table.updateSpec().removeField("id").commit();
+
+    DeleteFile deleteFile = newDeleteFile(table.ops().current().spec().specId(), "nested.id=1");
+    table.newRowDelta().addDeletes(deleteFile).commit();
+
+    PositionDeletesTable positionDeletesTable = new PositionDeletesTable(table);
+
+    Expression expression =
+        Expressions.and(
+            Expressions.equal("partition.nested.id", 1), Expressions.greaterThan("pos", 0));
+    BatchScan scan = positionDeletesTable.newBatchScan().filter(expression);
+
+    assertThat(scan).isInstanceOf(PositionDeletesTable.PositionDeletesBatchScan.class);
+
+    List<ScanTask> tasks = Lists.newArrayList(scan.planFiles());
+    assertThat(tasks).hasSize(1);
+
+    ScanTask task = tasks.get(0);
+    assertThat(task).isInstanceOf(PositionDeletesScanTask.class);
+
+    Types.StructType partitionType = Partitioning.partitionType(table);
+    PositionDeletesScanTask posDeleteTask = (PositionDeletesScanTask) task;
+
+    int filePartition = posDeleteTask.file().partition().get(0, Integer.class);
+    Assert.assertEquals("Expected correct partition on task", 1, filePartition);
+
+    // Constant partition struct is common struct that includes even deleted partition column
+    int taskConstantPartition =
+        ((StructLike)
+                constantsMap(posDeleteTask, partitionType).get(MetadataColumns.PARTITION_COLUMN_ID))
+            .get(1, Integer.class);
+    Assert.assertEquals("Expected correct partition on constant column", 1, taskConstantPartition);
+
+    Assert.assertEquals(
+        "Expected correct partition field id on task's spec",
+        table.ops().current().spec().partitionType().fields().get(0).fieldId(),
+        posDeleteTask.spec().fields().get(0).fieldId());
+
+    Assert.assertEquals(
+        "Expected correct partition spec id on task",
+        table.ops().current().spec().specId(),
+        posDeleteTask.file().specId());
+    Assert.assertEquals(
+        "Expected correct partition spec id on constant column",
+        table.ops().current().spec().specId(),
+        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.SPEC_ID.fieldId()));
+
+    Assert.assertEquals(
+        "Expected correct delete file on task", deleteFile.path(), posDeleteTask.file().path());
+    Assert.assertEquals(
+        "Expected correct delete file on constant column",
+        deleteFile.path(),
+        constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
   }
 
   private Stream<StructLike> allRows(Iterable<FileScanTask> tasks) {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -71,11 +71,20 @@ public class TestStaticTable extends HadoopTableTestBase {
 
     for (MetadataTableType type : MetadataTableType.values()) {
       Table staticTable = getStaticTable(type);
-      AssertHelpers.assertThrows(
-          "Static tables do not support incremental scans",
-          UnsupportedOperationException.class,
-          String.format("Cannot incrementally scan table of type %s", type),
-          () -> staticTable.newScan().appendsAfter(1));
+
+      if (type.equals(MetadataTableType.POSITION_DELETES)) {
+        AssertHelpers.assertThrows(
+            "POSITION_DELETES table does not support TableScan",
+            UnsupportedOperationException.class,
+            "Cannot create TableScan from table of type POSITION_DELETES",
+            staticTable::newScan);
+      } else {
+        AssertHelpers.assertThrows(
+            "Static tables do not support incremental scans",
+            UnsupportedOperationException.class,
+            String.format("Cannot incrementally scan table of type %s", type),
+            () -> staticTable.newScan().appendsAfter(1));
+      }
     }
   }
 


### PR DESCRIPTION
This breaks up the pr https://github.com/apache/iceberg/pull/4812 , and is just the part to add the table PositionDeletesTable.

It is now based on @aokolnychyi 's newly-added BatchScan interface (#5922), added for this purpose so the scan is free to not return FileScanTask.  It returns a custom ScanTask that scan DeleteFiles rather than DataFiles.