### PR TITLE
[Python] Fix incorrect description when set a property

### DIFF
--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -286,7 +286,7 @@ def get_table(ctx: Context, identifier: str, property_name: str):
 
 @properties.group()
 def set():
-    """Removes properties on tables/namespaces"""
+    """Sets a property on tables/namespaces"""
 
 
 @set.command()  # type: ignore
@@ -321,7 +321,7 @@ def table(ctx: Context, identifier: str, property_name: str, property_value: str
 
 @properties.group()
 def remove():
-    """Removes properties on tables/namespaces"""
+    """Removes a property from tables/namespaces"""
 
 
 @remove.command()  # type: ignore

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -103,7 +103,7 @@ def list(ctx: Context, parent: Optional[str]):  # pylint: disable=redefined-buil
 @click.pass_context
 @catch_exception()
 def describe(ctx: Context, entity: Literal["name", "namespace", "table"], identifier: str):
-    """Describes a namespace xor table"""
+    """Describes a namespace or a table"""
     catalog, output = _catalog_and_output(ctx)
     identifier_tuple = Catalog.identifier_to_tuple(identifier)
 
@@ -198,7 +198,7 @@ def drop():
 @click.pass_context
 @catch_exception()
 def table(ctx: Context, identifier: str):  # noqa: F811
-    """Drop table"""
+    """Drops a table"""
     catalog, output = _catalog_and_output(ctx)
 
     catalog.drop_table(identifier)
@@ -210,7 +210,7 @@ def table(ctx: Context, identifier: str):  # noqa: F811
 @click.pass_context
 @catch_exception()
 def namespace(ctx, identifier: str):
-    """Drop namespace"""
+    """Drops a namespace"""
     catalog, output = _catalog_and_output(ctx)
 
     catalog.drop_namespace(identifier)
@@ -296,7 +296,7 @@ def set():
 @click.pass_context
 @catch_exception()
 def namespace(ctx: Context, identifier: str, property_name: str, property_value: str):  # noqa: F811
-    """Sets a property of a namespace or table"""
+    """Sets a property on a namespace"""
     catalog, output = _catalog_and_output(ctx)
 
     catalog.update_namespace_properties(identifier, updates={property_name: property_value})


### PR DESCRIPTION
Realized there's type/incorrect description when attempt to set a properties on namespace or table level.

Before the change I saw this
```
$ pyiceberg properties --help
Usage: pyiceberg properties [OPTIONS] COMMAND [ARGS]...

  Properties on tables/namespaces

Options:
  --help  Show this message and exit.

Commands:
  get     Fetch properties on tables/namespaces
  remove  Removes properties on tables/namespaces
  set     Removes properties on tables/namespaces
```

After it shall be 
```
Commands:
  get     Fetch properties on tables/namespaces
  remove  Sets a property on tables/namespaces
  set     Removes a property on tables/namespaces
```

CC @Fokko