### PR TITLE
Docs: Remove backticks from Spark procedure headings

### DIFF
--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -493,7 +493,7 @@ CALL spark_catalog.system.add_files(
 )
 ```
 
-## `Metadata information`
+## Metadata information
 
 ### `ancestors_of`
 


### PR DESCRIPTION
This PR removes backticks from the Spark procedure headings.

Official docs page: https://iceberg.apache.org/docs/latest/spark-procedures/#metadata-information where other headings don't have the backticks.