### PR TITLE
Spark: Extend Timeout During Partial Progress Rewrites

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -254,8 +254,8 @@ public class RewriteDataFilesCommitManager {
       Preconditions.checkArgument(
           !timeout && completedRewrites.isEmpty(),
           "Timeout occurred when waiting for commits to complete. "
-              + "{} file groups committed. {} file groups remain uncommitted. " +
-                  "Retry this operation to attempt rewriting the failed groups.",
+              + "{} file groups committed. {} file groups remain uncommitted. "
+              + "Retry this operation to attempt rewriting the failed groups.",
           committedRewrites.size(),
           completedRewrites.size());
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -225,24 +225,39 @@ public class RewriteDataFilesCommitManager {
       LOG.info("Closing commit service for {}", table);
       committerService.shutdown();
 
+      boolean timeout = false;
+      int waitTime;
       try {
         // All rewrites have completed and all new files have been created, we are now waiting for
         // the commit
-        // pool to finish doing it's commits to Iceberg State. In the case of partial progress this
+        // pool to finish doing its commits to Iceberg State. In the case of partial progress this
         // should
         // have been occurring simultaneously with rewrites, if not there should be only a single
         // commit operation.
-        // In either case this should take much less than 10 minutes to actually complete.
-        if (!committerService.awaitTermination(10, TimeUnit.MINUTES)) {
+        // We will wait 10 minutes plus 5 more minutes for each commit left to perform due to the
+        // time required for writing manifests
+        waitTime = 10 + (completedRewrites.size() / rewritesPerCommit) * 5;
+        if (!committerService.awaitTermination(waitTime, TimeUnit.MINUTES)) {
           LOG.warn(
-              "Commit operation did not complete within 10 minutes of the files being written. This may mean "
-                  + "that changes were not successfully committed to the the Iceberg table.");
+              "Commit operation did not complete within {} (10 + 5 * commitsRemaining) minutes of the all files "
+                  + "being rewritten. This may mean that changes were not successfully committed to the the "
+                  + "Iceberg catalog.",
+              waitTime);
+          timeout = true;
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new RuntimeException(
             "Cannot complete commit for rewrite, commit service interrupted", e);
       }
+
+      Preconditions.checkArgument(
+          !timeout && completedRewrites.isEmpty(),
+          "Timeout ({} minutes) occurred when waiting for commits to complete. "
+              + "{} file groups committed. {} file groups remain uncommitted.",
+          waitTime,
+          committedRewrites.size(),
+          completedRewrites.size());
 
       Preconditions.checkState(
           completedRewrites.isEmpty(),

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -254,7 +254,8 @@ public class RewriteDataFilesCommitManager {
       Preconditions.checkArgument(
           !timeout && completedRewrites.isEmpty(),
           "Timeout occurred when waiting for commits to complete. "
-              + "{} file groups committed. {} file groups remain uncommitted.",
+              + "{} file groups committed. {} file groups remain uncommitted. " +
+                  "Retry this operation to attempt rewriting the failed groups.",
           committedRewrites.size(),
           completedRewrites.size());
 


### PR DESCRIPTION
In order to avoid timing out when writing large manifest files, we increase the timeout allowed for the commit phase of partial progress based on the number of commits left to perform.

Temporary Fix for performance issues in #6367 