### PR TITLE
Build: Fix ./gradlew refreshJavadoc

### DIFF
--- a/tasks.gradle
+++ b/tasks.gradle
@@ -43,11 +43,10 @@ task removeJavadoc(type: Exec) {
   commandLine 'rm', '-rf', "site/docs/javadoc/${getJavadocVersion()}"
 }
 
-task refreshJavadoc(type: Exec) {
+task refreshJavadoc() {
   dependsOn aggregateJavadoc
   dependsOn removeJavadoc
   aggregateJavadoc.mustRunAfter removeJavadoc
-  commandLine 'git', 'add', "site/docs/javadoc/${getJavadocVersion()}"
 }
 
 task deploySite(type: Exec) {


### PR DESCRIPTION
Since site/ folder was added to .gitignore the refreshJavadoc task started to fail. The reson is that as a last step it wanted to do a 'git add' on the Javadoc files under site/docs/javadoc/<VERSION> folder, however it couldn't due to site/ being added to gitignore. The Javadoc files anyway were generated successfully.
Not adding these files to git is on purpose as they are meant to be copied over to iceberg-docs repo and released from there. So this 'git add' step is removed from the task.