### PR TITLE
Core: Throw CommitStateUnknownException for 502 responses

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -79,6 +79,7 @@ public class ErrorHandlers {
         case 409:
           throw new CommitFailedException("Commit failed: %s", error.message());
         case 500:
+        case 502:
         case 504:
           throw new CommitStateUnknownException(
               new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -614,6 +614,20 @@ paths:
               }
         503:
           $ref: '#/components/responses/ServiceUnavailableResponse'
+        502:
+          description:
+            A gateway or proxy received an invalid response from the upstream server; the commit state is unknown.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+              example: {
+                "error": {
+                  "message": "Invalid response from the upstream server",
+                  "type": "CommitStateUnknownException",
+                  "code": 502
+                }
+              }
         504:
           description:
             A server-side gateway timeout occurred; the commit state is unknown.


### PR DESCRIPTION
This updates the commit error handler to throw `CommitStateUnknownException` for 502 responses. A 502 can be thrown from a load balancer when something goes wrong with the upstream service, after that service successfully commits.