### PR TITLE
Flink: Fix minor compiler warning

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -26,7 +26,7 @@ public class FlinkPackage {
 
   private FlinkPackage() {}
 
-  /** @return Flink version string like x.y.z */
+  /** Returns Flink version string like x.y.z */
   public static String version() {
     return VERSION;
   }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -26,7 +26,7 @@ public class FlinkPackage {
 
   private FlinkPackage() {}
 
-  /** @return Flink version string like x.y.z */
+  /** Returns Flink version string like x.y.z */
   public static String version() {
     return VERSION;
   }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java
@@ -26,7 +26,7 @@ public class FlinkPackage {
 
   private FlinkPackage() {}
 
-  /** @return Flink version string like x.y.z */
+  /** Returns Flink version string like x.y.z */
   public static String version() {
     return VERSION;
   }


### PR DESCRIPTION
`./gradlew clean build -x test  -x integrationTest` used to be clean without compiler warning. 

#6206 has introduced one compiler warning. Hence, cleaned it up. 

```
/Users/ajantha/Documents/workspace/icebergWorkspace/iceberg/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkPackage.java:29: warning: [MissingSummary] A summary fragment is required; consider using the value of the @return block as a summary fragment instead.
  /** @return Flink version string like x.y.z */
      ^
    (see https://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
  Did you mean '/** Returns flink version string like x.y.z.'?
```

Before:
<img width="483" alt="Screenshot 2022-12-09 at 1 19 42 PM" src="https://user-images.githubusercontent.com/5889404/206652165-cffa6c9f-c526-4911-8f46-9feeadad0f50.png">

After:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/5889404/206652732-cd27acb7-c57c-4181-a39e-0f4094602617.png">

