### PR TITLE
API: Add strict metadata cleanup to SnapshotProducer

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/BadRequestException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/BadRequestException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception thrown on HTTP 400 - Bad Request */
-public class BadRequestException extends RuntimeException {
+public class BadRequestException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public BadRequestException(String message, Object... args) {
     super(String.format(message, args));

--- a/api/src/main/java/org/apache/iceberg/exceptions/CleanableFailure.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/CleanableFailure.java
@@ -16,19 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.iceberg.exceptions;
 
-import com.google.errorprone.annotations.FormatMethod;
-
-/** Exception raised when a commit fails because of out of date metadata. */
-public class CommitFailedException extends RuntimeException implements CleanableFailure {
-  @FormatMethod
-  public CommitFailedException(String message, Object... args) {
-    super(String.format(message, args));
-  }
-
-  @FormatMethod
-  public CommitFailedException(Throwable cause, String message, Object... args) {
-    super(String.format(message, args), cause);
-  }
-}
+/**
+ * A marker interface for commit exceptions where the state is known to be failure and uncommitted
+ * metadata can be cleaned up.
+ */
+public interface CleanableFailure {}

--- a/api/src/main/java/org/apache/iceberg/exceptions/ForbiddenException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ForbiddenException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception thrown on HTTP 403 Forbidden - Failed authorization checks. */
-public class ForbiddenException extends RuntimeException {
+public class ForbiddenException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public ForbiddenException(String message, Object... args) {
     super(String.format(message, args));

--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchIcebergTableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchIcebergTableException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** NoSuchTableException thrown when a table is found but it is not an Iceberg table. */
-public class NoSuchIcebergTableException extends NoSuchTableException {
+public class NoSuchIcebergTableException extends NoSuchTableException implements CleanableFailure {
   @FormatMethod
   public NoSuchIcebergTableException(String message, Object... args) {
     super(message, args);

--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchNamespaceException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchNamespaceException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception raised when attempting to load a namespace that does not exist. */
-public class NoSuchNamespaceException extends RuntimeException {
+public class NoSuchNamespaceException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public NoSuchNamespaceException(String message, Object... args) {
     super(String.format(message, args));

--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchTableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchTableException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception raised when attempting to load a table that does not exist. */
-public class NoSuchTableException extends RuntimeException {
+public class NoSuchTableException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public NoSuchTableException(String message, Object... args) {
     super(String.format(message, args));

--- a/api/src/main/java/org/apache/iceberg/exceptions/NotAuthorizedException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NotAuthorizedException.java
@@ -24,7 +24,7 @@ import com.google.errorprone.annotations.FormatMethod;
  * Exception thrown on HTTP 401 Unauthorized. The user is either not authenticated or failed
  * authorization checks.
  */
-public class NotAuthorizedException extends RESTException {
+public class NotAuthorizedException extends RESTException implements CleanableFailure {
   @FormatMethod
   public NotAuthorizedException(String message, Object... args) {
     super(message, args);

--- a/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ServiceUnavailableException.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.exceptions;
 import com.google.errorprone.annotations.FormatMethod;
 
 /** Exception thrown on HTTP 503: service is unavailable */
-public class ServiceUnavailableException extends RESTException {
+public class ServiceUnavailableException extends RESTException implements CleanableFailure {
   @FormatMethod
   public ServiceUnavailableException(String message, Object... args) {
     super(message, args);

--- a/api/src/main/java/org/apache/iceberg/exceptions/ValidationException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/ValidationException.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.Schema;
  * <p>For example, this is thrown when attempting to create a table with a {@link PartitionSpec}
  * that is not compatible with the table {@link Schema}
  */
-public class ValidationException extends RuntimeException {
+public class ValidationException extends RuntimeException implements CleanableFailure {
   @FormatMethod
   public ValidationException(String message, Object... args) {
     super(String.format(message, args));

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -114,5 +115,14 @@ public interface TableOperations {
    */
   default long newSnapshotId() {
     return SnapshotIdGeneratorUtil.generateSnapshotID();
+  }
+
+  /**
+   * Whether to clean up uncommitted metadata files only when a commit fails with a {@link CleanableFailure} exception.
+   *
+   * <p>This defaults to false: any unexpected exception will cause metadata files to be cleaned up.
+   */
+  default boolean requireStrictCleanup() {
+    return false;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -232,4 +232,9 @@ class RESTTableOperations implements TableOperations {
       }
     };
   }
+
+  @Override
+  public boolean requireStrictCleanup() {
+    return true;
+  }
 }


### PR DESCRIPTION
In most catalogs, the `CommitStateUnknownException` is used to signal to `SnapshotProducer` that it is not safe to clean up metadata files because they may have been committed. This introduces another option, "strict cleanup", that will only clean up metadata files if the commit fails with an exception that implements a marker interface, `CleanableFailure`.

The new strict mode allows catalogs to default to not cleaning up metadata files, unless the failure is known to be safe -- that the commit state is known. This is useful for the REST catalog, which allows plugging in alternative HTTP libraries. Because exceptions thrown by the REST HTTP client may change, it isn't possible to mark which ones signal that the commit state is unknown.

To signal strict cleanup, this adds `requireStrictCleanup` to `TableOperations`.