### PR TITLE
Core: Allow configuring metrics reporter impl via Catalog property

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
@@ -28,6 +28,11 @@ import org.slf4j.LoggerFactory;
  */
 public class LoggingMetricsReporter implements MetricsReporter {
   private static final Logger LOG = LoggerFactory.getLogger(LoggingMetricsReporter.class);
+  private static final LoggingMetricsReporter INSTANCE = new LoggingMetricsReporter();
+
+  public static LoggingMetricsReporter instance() {
+    return INSTANCE;
+  }
 
   @Override
   public void report(MetricsReport report) {

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -29,6 +29,7 @@ public class CatalogProperties {
   public static final String WAREHOUSE_LOCATION = "warehouse";
   public static final String TABLE_DEFAULT_PREFIX = "table-default.";
   public static final String TABLE_OVERRIDE_PREFIX = "table-override.";
+  public static final String METRICS_REPORTER_IMPL = "metrics-reporter-impl";
 
   /**
    * Controls whether the catalog will cache table entries upon load.


### PR DESCRIPTION
In certain cases it makes sense to make the used metrics reporter customizable, so that users have more control over it and how it's reporting