### PR TITLE
Spark: Cleanup commented out code in SparkValueReaders

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueReaders.java
@@ -94,10 +94,6 @@ public class SparkValueReaders {
 
       Utf8 string = decoder.readString(utf8);
       return UTF8String.fromBytes(string.getBytes(), 0, string.getByteLength());
-      //      int length = decoder.readInt();
-      //      byte[] bytes = new byte[length];
-      //      decoder.readFixed(bytes, 0, length);
-      //      return UTF8String.fromBytes(bytes);
     }
   }
 


### PR DESCRIPTION
Was going through SparkValueReaders and saw some commented out code which can be removed. 