### PR TITLE
Core: Don't produce partition summaries on unpartitioned table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner.MapJoiner;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
@@ -194,7 +195,7 @@ public class SnapshotSummary {
         setIf(changedPartitions.size() > 0, builder, PARTITION_SUMMARY_PROP, "true");
         for (String key : changedPartitions) {
           setIf(
-              key != null,
+              !Strings.isNullOrEmpty(key),
               builder,
               CHANGED_PARTITION_PREFIX + key,
               partitionSummary(partitionMetrics.get(key)));

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -403,6 +404,36 @@ public class TestFastAppend extends TableTestBase {
         IllegalArgumentException.class,
         "Cannot append manifest with deleted files",
         () -> table.newFastAppend().appendManifest(manifestWithDeletedFiles).commit());
+  }
+
+  @Test
+  public void testPartitionSummariesOnUnpartitionedTable() {
+    Table table =
+        TestTables.create(
+            tableDir,
+            "x",
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            formatVersion);
+
+    table.updateProperties().set(TableProperties.WRITE_PARTITION_SUMMARY_LIMIT, "1").commit();
+    table
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/path/to/data-a.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .build())
+        .commit();
+
+    Assertions.assertThat(
+            table.currentSnapshot().summary().keySet().stream()
+                .filter(key -> key.startsWith(SnapshotSummary.CHANGED_PARTITION_PREFIX))
+                .collect(Collectors.toSet()))
+        .as("Should not include any partition summaries")
+        .isEmpty();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -906,9 +906,6 @@ public class TestRowDelta extends V2TableTestBase {
 
     Assert.assertTrue(
         "Partition metrics must be correct",
-        summary.get(CHANGED_PARTITION_PREFIX).contains(ADDED_DELETE_FILES_PROP + "=1"));
-    Assert.assertTrue(
-        "Partition metrics must be correct",
         summary
             .get(CHANGED_PARTITION_PREFIX + "data_bucket=0")
             .contains(ADDED_DELETE_FILES_PROP + "=1"));


### PR DESCRIPTION
Previously, having an unpartitioned table would produce a `"partitions."` entry in the snapshot summary when the partition summary limit was configured