### PR TITLE
Parquet: Fix ParquetDictionaryRowGroupFilter evaluating NaN.

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -37,8 +37,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
-import org.apache.iceberg.util.NaNUtil;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.page.DictionaryPage;
@@ -165,12 +165,18 @@ public class ParquetDictionaryRowGroupFilter {
       }
 
       Set<T> dictionary = dict(id, comparatorForNaNPredicate(ref));
-      return dictionary.stream().anyMatch(NaNUtil::isNaN) ? ROWS_MIGHT_MATCH : ROWS_CANNOT_MATCH;
+      return dictionary.contains(naNValueForType(ref.type()))
+          ? ROWS_MIGHT_MATCH
+          : ROWS_CANNOT_MATCH;
     }
 
     @Override
     public <T> Boolean notNaN(BoundReference<T> ref) {
       int id = ref.fieldId();
+
+      if (mayContainNulls.get(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Boolean hasNonDictPage = isFallback.get(id);
       if (hasNonDictPage == null || hasNonDictPage) {
@@ -178,7 +184,22 @@ public class ParquetDictionaryRowGroupFilter {
       }
 
       Set<T> dictionary = dict(id, comparatorForNaNPredicate(ref));
-      return dictionary.stream().allMatch(NaNUtil::isNaN) ? ROWS_CANNOT_MATCH : ROWS_MIGHT_MATCH;
+
+      if (dictionary.size() > 1 || !dictionary.contains(naNValueForType(ref.type()))) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    private Number naNValueForType(Type type) {
+      if (type instanceof Types.DoubleType) {
+        return Double.NaN;
+      } else if (type instanceof Types.FloatType) {
+        return Float.NaN;
+      } else {
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+      }
     }
 
     private <T> Comparator<T> comparatorForNaNPredicate(BoundReference<T> ref) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -372,7 +372,9 @@ public class TestDictionaryRowGroupFilter {
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, notNull("_nans_and_nulls"))
             .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
-    Assert.assertTrue("Should read: _nans_and_nulls column will contain NaN values which are not null", shouldRead);
+    Assert.assertTrue(
+        "Should read: _nans_and_nulls column will contain NaN values which are not null",
+        shouldRead);
 
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, isNaN("_nans_and_nulls"))

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -109,8 +109,8 @@ public class TestDictionaryRowGroupFilter {
           optional(
               14,
               "decimal_fixed",
-              DecimalType.of(20, 10)) // >18 precision to enforce FIXED_LEN_BYTE_ARRAY
-          );
+              DecimalType.of(20, 10)), // >18 precision to enforce FIXED_LEN_BYTE_ARRAY
+          optional(15, "_nans_and_nulls", DoubleType.get()));
 
   private static final Types.StructType _structFieldType =
       Types.StructType.of(Types.NestedField.required(9, "_int_field", IntegerType.get()));
@@ -131,8 +131,8 @@ public class TestDictionaryRowGroupFilter {
           optional(
               14,
               "_decimal_fixed",
-              DecimalType.of(20, 10)) // >18 precision to enforce FIXED_LEN_BYTE_ARRAY
-          );
+              DecimalType.of(20, 10)), // >18 precision to enforce FIXED_LEN_BYTE_ARRAY
+          optional(15, "_nans_and_nulls", DoubleType.get()));
 
   private static final String TOO_LONG_FOR_STATS;
 
@@ -200,6 +200,8 @@ public class TestDictionaryRowGroupFilter {
           // num-nulls=0
           builder.set(
               "_decimal_fixed", DECIMAL_MIN_VALUE.add(DECIMAL_STEP.multiply(new BigDecimal(i))));
+
+          builder.set("_nans_and_nulls", (i % 10 == 0) ? null : Double.NaN); // only nans and nulls
 
           Record structNotNull = new Record(structSchema);
           structNotNull.put("_int_field", INT_MIN_VALUE + i);
@@ -358,6 +360,21 @@ public class TestDictionaryRowGroupFilter {
         new ParquetDictionaryRowGroupFilter(SCHEMA, notNaN("no_nans"))
             .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
     Assert.assertTrue("Should read: no_nans column will contain non-NaN", shouldRead);
+  }
+
+  @Test
+  public void testNotNaNOnNaNsAndNulls() {
+    boolean shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, isNull("_nans_and_nulls"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    Assert.assertTrue("_nans_and_nulls column should contain null values", shouldRead);
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notNaN("_nans_and_nulls"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    Assert.assertTrue(
+        "Should read: _nans_and_nulls column will contain null values which are not NaN",
+        shouldRead);
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -367,7 +367,17 @@ public class TestDictionaryRowGroupFilter {
     boolean shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, isNull("_nans_and_nulls"))
             .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
-    Assert.assertTrue("_nans_and_nulls column should contain null values", shouldRead);
+    Assert.assertTrue("Should read: _nans_and_nulls column will contain null values", shouldRead);
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, notNull("_nans_and_nulls"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    Assert.assertTrue("Should read: _nans_and_nulls column will contain NaN values which are not null", shouldRead);
+
+    shouldRead =
+        new ParquetDictionaryRowGroupFilter(SCHEMA, isNaN("_nans_and_nulls"))
+            .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
+    Assert.assertTrue("Should read: _nans_and_nulls column will contain NaN values", shouldRead);
 
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, notNaN("_nans_and_nulls"))


### PR DESCRIPTION
This PR fixs ParquetDictionaryRowGroupFilter evaluating `notNaN`. 
Because Parquet dictionaries cannot contain null values, ParquetDictionaryRowGroupFilter should check if there is null values in the column chunk when evaluting `notNaN` and return `true` if yes.

~~This also improves looking up `NaN` value in the dictionary set, in Java, both Double.NaN and Float.NaN are considered to be equal to themselves, so:~~
~~- the dict must contain values that are not `NaN` when its' size is greater than 1, can directly return `true` in this case;~~
~~- can use `Set#contains` to look up `NaN` directly instead of comparing elements in the collection one by one.~~