### PR TITLE
Consider moving to ParallelIterable in Deletes::toPositionIndex 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -42,7 +42,7 @@ public class SystemProperties {
   public static final int IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT = 8;
 
   public static final String DELETE_POS_FILES_THREAD_POOL_SIZE =
-      "iceberg.delete.pos.read-worker-pool";
+      "iceberg.delete-pos.worker.num-threads";
 
   public static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -41,7 +41,10 @@ public class SystemProperties {
 
   public static final int IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT = 8;
 
-  static boolean getBoolean(String systemProperty, boolean defaultValue) {
+  public static final String DELETE_POS_FILES_THREADS_ENABLED =
+      "iceberg.delete.pos.read-worker-pool";
+
+  public static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);
     if (value != null) {
       return Boolean.parseBoolean(value);

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -41,7 +41,7 @@ public class SystemProperties {
 
   public static final int IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT = 8;
 
-  public static final String DELETE_POS_FILES_THREADS_ENABLED =
+  public static final String DELETE_POS_FILES_THREAD_POOL_SIZE =
       "iceberg.delete.pos.read-worker-pool";
 
   public static boolean getBoolean(String systemProperty, boolean defaultValue) {

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -42,9 +42,9 @@ public class SystemProperties {
   public static final int IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT = 8;
 
   public static final String DELETE_POS_FILES_THREAD_POOL_SIZE =
-      "iceberg.delete-pos.worker.num-threads";
+      "iceberg.worker.delete-num-threads";
 
-  public static boolean getBoolean(String systemProperty, boolean defaultValue) {
+  static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);
     if (value != null) {
       return Boolean.parseBoolean(value);

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -28,7 +28,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   }
 
   @Override
-  public void delete(long position) {
+  public synchronized void delete(long position) {
     roaring64Bitmap.add(position);
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -53,7 +53,7 @@ public class Deletes {
   private static final Accessor<StructLike> POSITION_ACCESSOR =
       POSITION_DELETE_SCHEMA.accessorForField(MetadataColumns.DELETE_FILE_POS.fieldId());
 
-  private static ExecutorService deletePosThreadPool = ThreadPools.newDeleteWorkerPool();
+  private static ExecutorService deletePosThreadPool = ThreadPools.getDeleteWorkerPool();
 
   private Deletes() {}
 
@@ -142,8 +142,8 @@ public class Deletes {
   }
 
   @VisibleForTesting
-  static void resetDeletePosThreadPool() {
-    deletePosThreadPool = ThreadPools.newDeleteWorkerPool();
+  static void setDeletePosThreadPool(ExecutorService threadPool) {
+    deletePosThreadPool = threadPool;
   }
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -56,6 +56,22 @@ public class ThreadPools {
     return WORKER_POOL;
   }
 
+  /**
+   * Returns delete worker pool for Positional Deletes.
+   *
+   * <p>Size of this thread-pool is controlled by System Property {@code
+   * iceberg.delete.pos.read-worker-pool}.
+   *
+   * @return {@link ExecutorService} that is delete worker pool
+   */
+  public static ExecutorService newDeleteWorkerPool() {
+    int poolSize =
+        getPoolSize(
+            SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE,
+            Math.max(2, Runtime.getRuntime().availableProcessors()));
+    return newWorkerPool("iceberg-delete-files-worker-pool", poolSize);
+  }
+
   public static ExecutorService newWorkerPool(String namePrefix) {
     return newWorkerPool(namePrefix, WORKER_THREAD_POOL_SIZE);
   }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -68,7 +68,7 @@ public class ThreadPools {
    * Return an {@link ExecutorService} that uses "delete worker" thread-pool.
    *
    * <p>The size of this thread-pool is controlled by the Java system property {@code
-   * iceberg.delete-pos.worker.num-threads}.
+   * iceberg.worker.delete-num-threads}.
    *
    * @return an {@link ExecutorService} that uses delete worker pool
    */

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -41,6 +41,14 @@ public class ThreadPools {
 
   private static final ExecutorService WORKER_POOL = newWorkerPool("iceberg-worker-pool");
 
+  public static final int DELETE_WORKER_THREAD_POOL_SIZE =
+      getPoolSize(
+          SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE,
+          Math.max(2, Runtime.getRuntime().availableProcessors()));
+
+  private static final ExecutorService DELETE_WORKER_POOL =
+      newWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);
+
   /**
    * Return an {@link ExecutorService} that uses the "worker" thread-pool.
    *
@@ -57,19 +65,15 @@ public class ThreadPools {
   }
 
   /**
-   * Returns delete worker pool for Positional Deletes.
+   * Return an {@link ExecutorService} that uses "delete worker" thread-pool.
    *
-   * <p>Size of this thread-pool is controlled by System Property {@code
-   * iceberg.delete.pos.read-worker-pool}.
+   * <p>The size of this thread-pool is controlled by the Java system property {@code
+   * iceberg.delete-pos.worker.num-threads}.
    *
-   * @return {@link ExecutorService} that is delete worker pool
+   * @return an {@link ExecutorService} that uses delete worker pool
    */
-  public static ExecutorService newDeleteWorkerPool() {
-    int poolSize =
-        getPoolSize(
-            SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE,
-            Math.max(2, Runtime.getRuntime().availableProcessors()));
-    return newWorkerPool("iceberg-delete-files-worker-pool", poolSize);
+  public static ExecutorService getDeleteWorkerPool() {
+    return DELETE_WORKER_POOL;
   }
 
   public static ExecutorService newWorkerPool(String namePrefix) {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -42,7 +42,7 @@ public class ThreadPools {
   private static final ExecutorService WORKER_POOL = newWorkerPool("iceberg-worker-pool");
 
   public static final int DELETE_WORKER_THREAD_POOL_SIZE =
-      getPoolSize(SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE, 4));
+      getPoolSize(SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE, 4);
 
   private static final ExecutorService DELETE_WORKER_POOL =
       newWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -42,9 +42,7 @@ public class ThreadPools {
   private static final ExecutorService WORKER_POOL = newWorkerPool("iceberg-worker-pool");
 
   public static final int DELETE_WORKER_THREAD_POOL_SIZE =
-      getPoolSize(
-          SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE,
-          Math.max(2, Runtime.getRuntime().availableProcessors()));
+      getPoolSize(SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE, 4));
 
   private static final ExecutorService DELETE_WORKER_POOL =
       newWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -282,17 +282,17 @@ public class TestPositionFilter {
 
   @Test
   public void testCombinedPositionSetRowFilter() {
-    testCombinedPositionSetRowFilter(false);
+    testCombinedPositionSetRowFilter("1");
+    testCombinedPositionSetRowFilter("");
   }
 
   @Test
   public void testCombinedPositionSetRowFilterInParallel() {
-    testCombinedPositionSetRowFilter(true);
+    testCombinedPositionSetRowFilter("4");
   }
 
-  void testCombinedPositionSetRowFilter(boolean deletePosProperty) {
-    System.setProperty(
-        SystemProperties.DELETE_POS_FILES_THREADS_ENABLED, Boolean.toString(deletePosProperty));
+  void testCombinedPositionSetRowFilter(String threadPoolSize) {
+    System.setProperty(SystemProperties.DELETE_POS_FILES_THREAD_POOL_SIZE, threadPoolSize);
     CloseableIterable<StructLike> positionDeletes1 =
         CloseableIterable.withNoopClose(
             Lists.newArrayList(

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.SystemProperties;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -281,6 +282,17 @@ public class TestPositionFilter {
 
   @Test
   public void testCombinedPositionSetRowFilter() {
+    testCombinedPositionSetRowFilter(false);
+  }
+
+  @Test
+  public void testCombinedPositionSetRowFilterInParallel() {
+    testCombinedPositionSetRowFilter(true);
+  }
+
+  void testCombinedPositionSetRowFilter(boolean deletePosProperty) {
+    System.setProperty(
+        SystemProperties.DELETE_POS_FILES_THREADS_ENABLED, Boolean.toString(deletePosProperty));
     CloseableIterable<StructLike> positionDeletes1 =
         CloseableIterable.withNoopClose(
             Lists.newArrayList(
@@ -324,5 +336,8 @@ public class TestPositionFilter {
         "Filter should produce expected rows",
         Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
         Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+
+    // Reset back to default
+    Deletes.resetDeletePosThreadPool();
   }
 }


### PR DESCRIPTION
Issue: https://github.com/apache/iceberg/issues/6387

When tables are updated in "merge-on-read" mode, it creates positional delete files. Performance of reads degrades quite a bit, even with 4+ positional delete files (I tried with tpcds queries).

Depending on workload, data file may have to read multiple "positional delete" files to construct delete positions. This does not sound expensive, but when large number of medium sized files are present in a partition, combinedfiletask ends up with many files. So a task has to process the data files in sequential fashion and every data file reads multiple positional delete file causing slowness.

PR uses "ParallelIterable" in "Deletes::toPositionIndex". RoaringBitMap isn't threadsafe and hence added sync in BitmapPositionDeleteIndex. Tried out in local cluster and confirmed that this is not expensive.