### PR TITLE
Python: Mock home and root folder when running `test_missing_uri`

### DIFF
--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -134,14 +134,17 @@ MOCK_CATALOG = MockCatalog("production", uri="http://somewhere")
 MOCK_ENVIRONMENT = {"PYICEBERG_CATALOG__PRODUCTION__URI": "test://doesnotexist"}
 
 
-def test_missing_uri() -> None:
-    runner = CliRunner()
-    result = runner.invoke(run, ["list"])
-    assert result.exit_code == 1
-    assert (
-        result.output
-        == "URI missing, please provide using --uri, the config or environment variable \nPYICEBERG_CATALOG__DEFAULT__URI\n"
-    )
+def test_missing_uri(empty_home_dir_path: str) -> None:
+
+    # mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
+    with mock.patch.dict(os.environ, {"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path}):
+        runner = CliRunner()
+        result = runner.invoke(run, ["list"])
+        assert result.exit_code == 1
+        assert (
+            result.output
+            == "URI missing, please provide using --uri, the config or environment variable \nPYICEBERG_CATALOG__DEFAULT__URI\n"
+        )
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1259,3 +1259,9 @@ def fixture_glue(_aws_credentials: None) -> Generator[boto3.client, None, None]:
     """Mocked glue client"""
     with mock_glue():
         yield boto3.client("glue", region_name="us-east-1")
+
+
+@pytest.fixture(scope="session")
+def empty_home_dir_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+    home_path = str(tmp_path_factory.mktemp("home"))
+    return home_path

--- a/python/tests/utils/test_config.py
+++ b/python/tests/utils/test_config.py
@@ -17,6 +17,7 @@
 import os
 from unittest import mock
 
+import pytest
 import yaml
 
 from pyiceberg.utils.config import Config, _lowercase_dictionary_keys
@@ -39,7 +40,7 @@ def test_from_environment_variables_uppercase() -> None:
     assert Config().get_catalog_config("PRODUCTION") == {"uri": "https://service.io/api"}
 
 
-def test_from_configuration_files(tmp_path_factory) -> None:  # type: ignore
+def test_from_configuration_files(tmp_path_factory: pytest.TempPathFactory) -> None:
     config_path = str(tmp_path_factory.mktemp("config"))
     with open(f"{config_path}/.pyiceberg.yaml", "w", encoding="utf-8") as file:
         yaml.dump({"catalog": {"production": {"uri": "https://service.io/api"}}}, file)


### PR DESCRIPTION
This could be a way to alleviate this issue https://github.com/apache/iceberg/issues/6361. 

Alternative, you could mock `HOME` and `PYICEBERG_HOME` with an empty folder for all tests automatically. 