### PR TITLE
Flink: Improve IcebergFilesCommitter logging

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -228,6 +228,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     if (checkpointId > maxCommittedCheckpointId) {
       commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
       this.maxCommittedCheckpointId = checkpointId;
+    } else {
+      LOG.info(
+          "Skipping committing checkpoint {}. {} is already committed.",
+          checkpointId,
+          maxCommittedCheckpointId);
     }
   }
 
@@ -361,7 +366,12 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String description,
       String newFlinkJobId,
       long checkpointId) {
-    LOG.info("Committing {} to table {} with summary: {}", description, table.name(), summary);
+    LOG.info(
+        "Committing {} to table: {}, checkpointId: {} with summary: {}",
+        description,
+        table.name(),
+        checkpointId,
+        summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
     // used by the sink.
@@ -372,9 +382,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table {} in {} ms with summary: {}",
+        "Committed {} to table: {}, checkpointId {} in {} ms with summary: {}",
         description,
         table.name(),
+        checkpointId,
         durationMs,
         summary);
     committerMetrics.commitDuration(durationMs);

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -367,10 +367,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       long checkpointId) {
     LOG.info(
-        "Committing {} to table: {}, checkpointId: {} with summary: {}",
+        "Committing {} for checkpoint {} to table {} with summary: {}",
         description,
-        table.name(),
         checkpointId,
+        table.name(),
         summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
@@ -382,12 +382,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table: {}, checkpointId {} in {} ms with summary: {}",
+        "Committed {} to table: {}, checkpointId {} in {} ms",
         description,
         table.name(),
         checkpointId,
-        durationMs,
-        summary);
+        durationMs);
     committerMetrics.commitDuration(durationMs);
   }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -369,10 +369,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       long checkpointId) {
     LOG.info(
-        "Committing {} to table: {}, checkpointId: {} with summary: {}",
+        "Committing {} for checkpoint {} to table {} with summary: {}",
         description,
-        table.name(),
         checkpointId,
+        table.name(),
         summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
@@ -384,12 +384,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table: {}, checkpointId {} in {} ms with summary: {}",
+        "Committed {} to table: {}, checkpointId {} in {} ms",
         description,
         table.name(),
         checkpointId,
-        durationMs,
-        summary);
+        durationMs);
     committerMetrics.commitDuration(durationMs);
   }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -228,6 +228,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     if (checkpointId > maxCommittedCheckpointId) {
       commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
       this.maxCommittedCheckpointId = checkpointId;
+    } else {
+      LOG.info(
+          "Skipping committing checkpoint {}. {} is already committed.",
+          checkpointId,
+          maxCommittedCheckpointId);
     }
   }
 
@@ -361,7 +366,12 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String description,
       String newFlinkJobId,
       long checkpointId) {
-    LOG.info("Committing {} to table {} with summary: {}", description, table.name(), summary);
+    LOG.info(
+        "Committing {} to table: {}, checkpointId: {} with summary: {}",
+        description,
+        table.name(),
+        checkpointId,
+        summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
     // used by the sink.
@@ -372,9 +382,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table {} in {} ms with summary: {}",
+        "Committed {} to table: {}, checkpointId {} in {} ms with summary: {}",
         description,
         table.name(),
+        checkpointId,
         durationMs,
         summary);
     committerMetrics.commitDuration(durationMs);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -367,10 +367,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String newFlinkJobId,
       long checkpointId) {
     LOG.info(
-        "Committing {} to table: {}, checkpointId: {} with summary: {}",
+        "Committing {} for checkpoint {} to table {} with summary: {}",
         description,
-        table.name(),
         checkpointId,
+        table.name(),
         summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
@@ -382,12 +382,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table: {}, checkpointId {} in {} ms with summary: {}",
+        "Committed {} to table: {}, checkpointId {} in {} ms",
         description,
         table.name(),
         checkpointId,
-        durationMs,
-        summary);
+        durationMs);
     committerMetrics.commitDuration(durationMs);
   }
 


### PR DESCRIPTION
Add some logging to the `IcebergFilesCommitter`. Otherwise it is hard to follow what happens when multiple commits are in progress.