### PR TITLE
Spark-3.2: Use table sort order with sort strategy when user has not specified

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -183,8 +183,10 @@ class RewriteDataFilesProcedure extends BaseProcedure {
                 .flatMap(zOrder -> zOrder.refs().stream().map(NamedReference::name))
                 .toArray(String[]::new);
         return action.zOrder(columnNames);
-      } else {
+      } else if (!sortOrderFields.isEmpty()) {
         return action.sort(buildSortOrder(sortOrderFields, schema));
+      } else {
+        return action.sort();
       }
     }
     if (strategy.equalsIgnoreCase("binpack")) {


### PR DESCRIPTION
Backport of https://github.com/apache/iceberg/pull/6296

