### PR TITLE
Core: Refactor ManifestListReadTask to avoid extra S3 calls

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -156,6 +156,7 @@ public class AllManifestsTable extends BaseMetadataTable {
     private final String manifestListLocation;
     private final Expression residual;
     private final long referenceSnapshotId;
+    private DataFile lazyDataFile = null;
 
     ManifestListReadTask(
         FileIO io,
@@ -206,11 +207,16 @@ public class AllManifestsTable extends BaseMetadataTable {
 
     @Override
     public DataFile file() {
-      return DataFiles.builder(PartitionSpec.unpartitioned())
-          .withInputFile(io.newInputFile(manifestListLocation))
-          .withRecordCount(1)
-          .withFormat(FileFormat.AVRO)
-          .build();
+      if (lazyDataFile == null) {
+        this.lazyDataFile =
+            DataFiles.builder(PartitionSpec.unpartitioned())
+                .withInputFile(io.newInputFile(manifestListLocation))
+                .withRecordCount(1)
+                .withFormat(FileFormat.AVRO)
+                .build();
+      }
+
+      return lazyDataFile;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
-import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -121,11 +120,8 @@ public class AllManifestsTable extends BaseMetadataTable {
     @Override
     protected CloseableIterable<FileScanTask> doPlanFiles() {
       FileIO io = table().io();
-      String schemaString = SchemaParser.toJson(schema());
-      String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
       Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       SnapshotEvaluator snapshotEvaluator =
           new SnapshotEvaluator(filter, MANIFEST_FILE_SCHEMA.asStruct(), isCaseSensitive());
@@ -137,19 +133,8 @@ public class AllManifestsTable extends BaseMetadataTable {
               filteredSnapshots,
               snap -> {
                 if (snap.manifestListLocation() != null) {
-                  DataFile manifestListAsDataFile =
-                      DataFiles.builder(PartitionSpec.unpartitioned())
-                          .withInputFile(io.newInputFile(snap.manifestListLocation()))
-                          .withRecordCount(1)
-                          .withFormat(FileFormat.AVRO)
-                          .build();
                   return new ManifestListReadTask(
-                      io,
-                      schema(),
-                      specs,
-                      new BaseFileScanTask(
-                          manifestListAsDataFile, null, schemaString, specString, residuals),
-                      snap.snapshotId());
+                      io, schema(), specs, snap.manifestListLocation(), filter, snap.snapshotId());
                 } else {
                   return StaticDataTask.of(
                       io.newInputFile(tableOps().current().metadataFileLocation()),
@@ -168,31 +153,34 @@ public class AllManifestsTable extends BaseMetadataTable {
     private final FileIO io;
     private final Schema schema;
     private final Map<Integer, PartitionSpec> specs;
-    private final FileScanTask manifestListTask;
+    private final String manifestListLocation;
+    private final Expression residual;
     private final long referenceSnapshotId;
 
     ManifestListReadTask(
         FileIO io,
         Schema schema,
         Map<Integer, PartitionSpec> specs,
-        FileScanTask manifestListTask,
+        String manifestListLocation,
+        Expression residual,
         long referenceSnapshotId) {
       this.io = io;
       this.schema = schema;
       this.specs = specs;
-      this.manifestListTask = manifestListTask;
+      this.manifestListLocation = manifestListLocation;
+      this.residual = residual;
       this.referenceSnapshotId = referenceSnapshotId;
     }
 
     @Override
     public List<DeleteFile> deletes() {
-      return manifestListTask.deletes();
+      return ImmutableList.of();
     }
 
     @Override
     public CloseableIterable<StructLike> rows() {
       try (CloseableIterable<ManifestFile> manifests =
-          Avro.read(io.newInputFile(manifestListTask.file().path().toString()))
+          Avro.read(io.newInputFile(manifestListLocation))
               .rename("manifest_file", GenericManifestFile.class.getName())
               .rename("partitions", GenericPartitionFieldSummary.class.getName())
               .rename("r508", GenericPartitionFieldSummary.class.getName())
@@ -212,19 +200,22 @@ public class AllManifestsTable extends BaseMetadataTable {
         return CloseableIterable.transform(rowIterable, projection::wrap);
 
       } catch (IOException e) {
-        throw new RuntimeIOException(
-            e, "Cannot read manifest list file: %s", manifestListTask.file().path());
+        throw new RuntimeIOException(e, "Cannot read manifest list file: %s", manifestListLocation);
       }
     }
 
     @Override
     public DataFile file() {
-      return manifestListTask.file();
+      return DataFiles.builder(PartitionSpec.unpartitioned())
+          .withInputFile(io.newInputFile(manifestListLocation))
+          .withRecordCount(1)
+          .withFormat(FileFormat.AVRO)
+          .build();
     }
 
     @Override
     public PartitionSpec spec() {
-      return manifestListTask.spec();
+      return PartitionSpec.unpartitioned();
     }
 
     @Override
@@ -234,12 +225,14 @@ public class AllManifestsTable extends BaseMetadataTable {
 
     @Override
     public long length() {
-      return manifestListTask.length();
+      // return a generic length to avoid looking up the actual length
+      return 8192;
     }
 
     @Override
     public Expression residual() {
-      return manifestListTask.residual();
+      // this table is unpartitioned so the residual is always constant
+      return residual;
     }
 
     @Override


### PR DESCRIPTION
We noticed throttling on `getLength` calls to S3 in the all manifests table. This avoids those unnecessary calls by no longer creating a fake `DataFile` or `FileScanTask`. Previously, the manifest list scan task wrapped a file scan task so that it could be read as a normal data file. However, since v2 the task has been converted to a `DataTask` to fill in inherited sequence numbers correctly. As a result, the wrapped `FileScanTask` is no longer needed.

Not creating the wrapped `FileScanTask` make it possible to avoid creating a `DataFile` (unless one is for some reason requested by calling `file()` on the task).