### PR TITLE
Python: Parse UUID as binary in PyArrow

### DIFF
--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -291,20 +291,6 @@ def schema_to_pyarrow(schema: Schema) -> pa.schema:
     return visit(schema, _ConvertToArrowSchema())
 
 
-class UuidType(pa.PyExtensionType):
-    """Custom type for UUID
-
-    For more information:
-    https://arrow.apache.org/docs/python/extending_types.html#defining-extension-types-user-defined-types
-    """
-
-    def __init__(self) -> None:
-        pa.PyExtensionType.__init__(self, pa.binary(16))
-
-    def __reduce__(self) -> Tuple[pa.PyExtensionType, Tuple[Any, ...]]:
-        return UuidType, ()
-
-
 class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType], Singleton):
     def schema(self, _: Schema, struct_result: pa.StructType) -> pa.schema:
         return pa.schema(list(struct_result))
@@ -366,7 +352,7 @@ class _ConvertToArrowSchema(SchemaVisitorPerPrimitiveType[pa.DataType], Singleto
         return pa.string()
 
     def visit_uuid(self, _: UUIDType) -> pa.DataType:
-        return UuidType()
+        return pa.binary(16)
 
     def visit_binary(self, _: BinaryType) -> pa.DataType:
         return pa.binary()


### PR DESCRIPTION
It causes to throw a cast exception:
```
---------------------------------------------------------------------------
ArrowNotImplementedError                  Traceback (most recent call last)
Input In [1], in <cell line: 7>()
      3 cat = load_catalog('rest')
      5 tbl = cat.load_table('fokko.uuid_partitioned')
----> 7 tbl.scan().to_arrow()

File ~/Desktop/iceberg/python/pyiceberg/table/__init__.py:386, in DataScan.to_arrow(self)
    375 from pyarrow.dataset import dataset
    377 ds = dataset(
    378     source=locations,
    379     filesystem=fs,
   (...)
    383     schema=schema_to_pyarrow(self.table.schema()),
    384 )
--> 386 return ds.to_table(filter=pyarrow_filter, columns=columns)

File /opt/homebrew/lib/python3.9/site-packages/pyarrow/_dataset.pyx:304, in pyarrow._dataset.Dataset.to_table()

File /opt/homebrew/lib/python3.9/site-packages/pyarrow/_dataset.pyx:2549, in pyarrow._dataset.Scanner.to_table()

File /opt/homebrew/lib/python3.9/site-packages/pyarrow/error.pxi:144, in pyarrow.lib.pyarrow_internal_check_status()

File /opt/homebrew/lib/python3.9/site-packages/pyarrow/error.pxi:121, in pyarrow.lib.check_status()

ArrowNotImplementedError: Unsupported cast from fixed_size_binary[16] to extension<pyiceberg.uuid<UuidType>> (no available cast function for target type)
```

I tried to deserialize it into the custom type, but I didn't get to the buffers. I decided to keep it a fixed[16] because:

- It would be a major performance penalty to move this to Python
- Also downstream have limited support for UUID