### PR TITLE
Dynamo/Jdbc/Ecs/Nessie: Expose catalog properties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -111,11 +111,13 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   private AwsProperties awsProperties;
   private FileIO fileIO;
   private CloseableGroup closeableGroup;
+  private Map<String, String> catalogProperties;
 
   public DynamoDbCatalog() {}
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     initialize(
         name,
         properties.get(CatalogProperties.WAREHOUSE_LOCATION),
@@ -685,5 +687,10 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
     } catch (ConditionalCheckFailedException e) {
       return false;
     }
+  }
+
+  @Override
+  protected Map<String, String> properties() {
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -588,4 +588,9 @@ public class JdbcCatalog extends BaseMetastoreCatalog
 
     return execute(JdbcUtil.deletePropertiesStatement(properties), args) > 0;
   }
+
+  @Override
+  protected Map<String, String> properties() {
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
+  }
 }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.apache.iceberg.util.LocationUtil;
@@ -84,6 +85,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   private FileIO fileIO;
   private CloseableGroup closeableGroup;
+  private Map<String, String> catalogProperties;
 
   /**
    * No-arg constructor to load the catalog dynamically.
@@ -94,6 +96,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    this.catalogProperties = ImmutableMap.copyOf(properties);
     String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
     Preconditions.checkArgument(
         inputWarehouseLocation != null && inputWarehouseLocation.length() > 0,
@@ -494,5 +497,10 @@ public class EcsCatalog extends BaseMetastoreCatalog
   @Override
   public void setConf(Object conf) {
     this.hadoopConf = conf;
+  }
+
+  @Override
+  protected Map<String, String> properties() {
+    return catalogProperties == null ? ImmutableMap.of() : catalogProperties;
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -331,4 +331,9 @@ public class NessieCatalog extends BaseMetastoreCatalog
     }
     return identifier;
   }
+
+  @Override
+  protected Map<String, String> properties() {
+    return catalogOptions == null ? ImmutableMap.of() : catalogOptions;
+  }
 }


### PR DESCRIPTION
While reviewing https://github.com/apache/iceberg/pull/6410 (which accesses the catalog properties via `properties()`), I've noticed that not every catalog exposes their properties. This PR aligns the affected catalog with how other catalogs expose their properties.