### PR TITLE
API: Fix inconsistent TimeTransform Type

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -440,7 +440,7 @@ public class PartitionSpec implements Serializable {
               sourceColumn.fieldId(),
               nextFieldId(),
               targetName,
-              Transforms.year(sourceColumn.type()));
+              Transforms.year());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -458,7 +458,7 @@ public class PartitionSpec implements Serializable {
               sourceColumn.fieldId(),
               nextFieldId(),
               targetName,
-              Transforms.month(sourceColumn.type()));
+              Transforms.month());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -476,7 +476,7 @@ public class PartitionSpec implements Serializable {
               sourceColumn.fieldId(),
               nextFieldId(),
               targetName,
-              Transforms.day(sourceColumn.type()));
+              Transforms.day());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;
@@ -494,7 +494,7 @@ public class PartitionSpec implements Serializable {
               sourceColumn.fieldId(),
               nextFieldId(),
               targetName,
-              Transforms.hour(sourceColumn.type()));
+              Transforms.hour());
       checkForRedundantPartitions(field);
       fields.add(field);
       return this;

--- a/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundPartitionSpec.java
@@ -54,13 +54,7 @@ public class UnboundPartitionSpec {
     PartitionSpec.Builder builder = PartitionSpec.builderFor(schema).withSpecId(specId);
 
     for (UnboundPartitionField field : fields) {
-      Type fieldType = schema.findType(field.sourceId);
-      Transform<?, ?> transform;
-      if (fieldType != null) {
-        transform = Transforms.fromString(fieldType, field.transform.toString());
-      } else {
-        transform = Transforms.fromString(field.transform.toString());
-      }
+      Transform<?, ?> transform = Transforms.fromString(field.transform.toString());
       if (field.partitionId != null) {
         builder.add(field.sourceId, field.partitionId, field.name, transform);
       } else {

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -52,7 +52,8 @@ public class TableTestBase {
   // Schema passed to create tables
   public static final Schema SCHEMA =
       new Schema(
-          required(3, "id", Types.IntegerType.get()), required(4, "data", Types.StringType.get()));
+          required(3, "id", Types.IntegerType.get()), required(4, "data", Types.StringType.get()),
+              required(5, "year_field", Types.DateType.get()));
 
   protected static final int BUCKETS_NUMBER = 16;
 

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -52,8 +52,7 @@ public class TableTestBase {
   // Schema passed to create tables
   public static final Schema SCHEMA =
       new Schema(
-          required(3, "id", Types.IntegerType.get()), required(4, "data", Types.StringType.get()),
-              required(5, "year_field", Types.DateType.get()));
+          required(3, "id", Types.IntegerType.get()), required(4, "data", Types.StringType.get()));
 
   protected static final int BUCKETS_NUMBER = 16;
 


### PR DESCRIPTION
After https://github.com/apache/iceberg/pull/5601 and https://github.com/apache/iceberg/pull/6220, there is inconsistent `TimeTransform Type` in some codes. This causes an exception when remove and then add a same time partition(year, month, day, hour).

I added a UT in this pr, and you can use the UT to reproduce this issue. This issue existed in iceberg1.1.0 and it blocked me upgrade iceberg from 1.0.0 to 1.1.0 in Hive repo. https://github.com/apache/hive/pull/3851 and failed tests http://ci.hive.apache.org/blue/organizations/jenkins/hive-precommit/detail/PR-3851/1/tests
