### PR TITLE
Python: Fix reading UUIDs

### DIFF
--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -18,6 +18,7 @@ import decimal
 import struct
 from datetime import date, datetime, time
 from io import SEEK_CUR
+from uuid import UUID
 
 from pyiceberg.io import InputStream
 from pyiceberg.utils.datetime import (
@@ -166,6 +167,10 @@ class BinaryDecoder:
         Adjusted to UTC
         """
         return micros_to_timestamptz(self.read_int())
+
+    def read_uuid_from_fixed(self) -> UUID:
+        """Reads a UUID as a fixed[16]"""
+        return UUID(bytes=self.read(16))
 
     def skip_boolean(self) -> None:
         self.skip(1)

--- a/python/pyiceberg/avro/reader.py
+++ b/python/pyiceberg/avro/reader.py
@@ -64,6 +64,7 @@ from pyiceberg.types import (
     TimestampType,
     TimestamptzType,
     TimeType,
+    UUIDType,
 )
 from pyiceberg.utils.singleton import Singleton
 
@@ -209,10 +210,10 @@ class StringReader(Reader):
 
 class UUIDReader(Reader):
     def read(self, decoder: BinaryDecoder) -> UUID:
-        return UUID(decoder.read_utf8())
+        return decoder.read_uuid_from_fixed()
 
     def skip(self, decoder: BinaryDecoder) -> None:
-        decoder.skip_utf8()
+        decoder.skip(16)
 
 
 @dataclass(frozen=True)
@@ -431,3 +432,8 @@ def _(_: StringType) -> Reader:
 @primitive_reader.register
 def _(_: BinaryType) -> Reader:
     return BinaryReader()
+
+
+@primitive_reader.register
+def _(_: UUIDType) -> Reader:
+    return UUIDReader()

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -75,6 +75,7 @@ from pyiceberg.types import (
     TimestampType,
     TimestamptzType,
     TimeType,
+    UUIDType,
 )
 
 
@@ -379,6 +380,11 @@ def _(_: TimestamptzType) -> pa.DataType:
 @_iceberg_to_pyarrow_type.register
 def _(_: StringType) -> pa.DataType:
     return pa.string()
+
+
+@_iceberg_to_pyarrow_type.register
+def _(_: UUIDType) -> pa.DataType:
+    return pa.binary(16)
 
 
 @_iceberg_to_pyarrow_type.register

--- a/python/pyiceberg/utils/schema_conversion.py
+++ b/python/pyiceberg/utils/schema_conversion.py
@@ -68,7 +68,7 @@ LOGICAL_FIELD_TYPE_MAPPING: dict[tuple[str, str], PrimitiveType] = {
     ("timestamp-millis", "long"): TimestampType(),
     ("time-micros", "int"): TimeType(),
     ("timestamp-micros", "long"): TimestampType(),
-    ("uuid", "string"): UUIDType(),
+    ("uuid", "fixed"): UUIDType(),
 }
 
 

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -17,6 +17,7 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from io import SEEK_SET
+from uuid import UUID
 
 import pytest
 
@@ -221,3 +222,9 @@ def test_read_int_as_float():
     reader = promote(FloatType(), DoubleType())
 
     assert reader.read(decoder) == 19.25
+
+
+def test_read_uuid_from_fixed() -> None:
+    mis = MemoryInputStream(b"\x12\x34\x56\x78" * 4)
+    decoder = BinaryDecoder(mis)
+    assert decoder.read_uuid_from_fixed() == UUID("{12345678-1234-5678-1234-567812345678}")

--- a/python/tests/avro/test_reader.py
+++ b/python/tests/avro/test_reader.py
@@ -34,6 +34,7 @@ from pyiceberg.avro.reader import (
     TimeReader,
     TimestampReader,
     TimestamptzReader,
+    UUIDReader,
     primitive_reader,
 )
 from pyiceberg.manifest import _convert_pos_to_dict
@@ -57,6 +58,7 @@ from pyiceberg.types import (
     TimestampType,
     TimestamptzType,
     TimeType,
+    UUIDType,
 )
 from tests.io.test_io import LocalInputFile
 
@@ -501,3 +503,7 @@ def test_unknown_type():
         primitive_reader(UnknownType())
 
     assert "Unknown type:" in str(exc_info.value)
+
+
+def test_uuid_reader() -> None:
+    assert primitive_reader(UUIDType()) == UUIDReader()


### PR DESCRIPTION
Tested:
```
➜  python git:(fd-fix-uuid1925) ✗ python3
Python 3.10.9 (main, Dec 15 2022, 17:11:09) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from pyiceberg.catalog import load_catalog
>>>
>>> catalog = load_catalog('rest')
>>>
>>> tbl = catalog.load_table('fokko.uuid_partitioned')
>>>
>>> tbl.scan().to_arrow()
/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/table/__init__.py:340: UserWarning: Projection is currently done by name instead of Field ID, this can lead to incorrect results in some cases.
  warnings.warn(

pyarrow.Table
identifier: fixed_size_binary[16]
----
identifier: [[A61DC527E858449E9D22C77D90B53A41],[A61DC527E858449E9D22C77D90B53A40],...,[A61DC527E858449E9D22C77D90B53A31],[A61DC527E858449E9D22C77D90B53A30]]
```