### PR TITLE
Python-legacy: Fix CI

### DIFF
--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -49,7 +49,7 @@ jobs:
     - working-directory: ./python_legacy
       run: |
         pip install -e .[dev]
-        pip install -U tox-gh-actions
+        pip install -U "tox-gh-actions==2.12.0"
     - working-directory: ./python_legacy
       run: tox
 

--- a/python_legacy/setup.py
+++ b/python_legacy/setup.py
@@ -41,6 +41,7 @@ setup(
     extras_require={
         "dev": [
             "tox-travis==0.12",
+            "tox>=2.0,<4",
             "virtualenv<20.0.0",
         ],
     },


### PR DESCRIPTION
It looks like the latest version of `tox` clashes with `tox-travis`.

The tox version wasn't pinned in `tox-travis`, and it would just follow the latest version that's available.

This has been fixed in the repository:
https://github.com/tox-dev/tox-travis/commit/e11bacf107903375b5c42bda799e94f5dbe12978

I think it is good to add this constraint in our `setup.py` as well.