### PR TITLE
Python: Move `adlfs` import inline

### DIFF
--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -28,12 +28,10 @@ from typing import (
 from urllib.parse import urlparse
 
 import requests
-from adlfs import AzureBlobFileSystem
 from botocore import UNSIGNED
 from botocore.awsrequest import AWSRequest
 from fsspec import AbstractFileSystem
 from requests import HTTPError
-from s3fs import S3FileSystem
 
 from pyiceberg.catalog import TOKEN
 from pyiceberg.exceptions import SignError
@@ -81,6 +79,8 @@ SIGNERS: Dict[str, Callable[[Properties, AWSRequest], AWSRequest]] = {"S3V4RestS
 
 
 def _s3(properties: Properties) -> AbstractFileSystem:
+    from s3fs import S3FileSystem
+
     client_kwargs = {
         "endpoint_url": properties.get("s3.endpoint"),
         "aws_access_key_id": properties.get("s3.access-key-id"),
@@ -110,6 +110,8 @@ def _s3(properties: Properties) -> AbstractFileSystem:
 
 
 def _adlfs(properties: Properties) -> AbstractFileSystem:
+    from adlfs import AzureBlobFileSystem
+
     fs = AzureBlobFileSystem(**properties)
     return fs
 


### PR DESCRIPTION
Otherwise it will throw an error when it isn't installed:

```
│ /Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/io/fsspec.py:31 in <module>              │
│                                                                                                  │
│    28 from urllib.parse import urlparse                                                          │
│    29                                                                                            │
│    30 import requests                                                                            │
│ ❱  31 from adlfs import AzureBlobFileSystem                                                      │
│    32 from botocore import UNSIGNED                                                              │
│    33 from botocore.awsrequest import AWSRequest                                                 │
│    34 from fsspec import AbstractFileSystem                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ModuleNotFoundError: No module named 'adlfs'
```

cc @cccs-eric 