### PR TITLE
AWS, Core, Hive: Fix `checkCommitStatus` when create table commit fails

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -340,11 +340,14 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
         .run(
             location -> {
               TableMetadata metadata = refresh();
-              String currentMetadataFileLocation = metadata.metadataFileLocation();
-              boolean commitSuccess =
-                  currentMetadataFileLocation.equals(newMetadataLocation)
-                      || metadata.previousFiles().stream()
-                          .anyMatch(log -> log.file().equals(newMetadataLocation));
+              boolean commitSuccess = false;
+              if (metadata != null) {
+                String currentMetadataFileLocation = metadata.metadataFileLocation();
+                commitSuccess =
+                    currentMetadataFileLocation.equals(newMetadataLocation)
+                        || metadata.previousFiles().stream()
+                            .anyMatch(log -> log.file().equals(newMetadataLocation));
+              }
               if (commitSuccess) {
                 LOG.info(
                     "Commit status check: Commit to {} of {} succeeded",

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
@@ -52,7 +53,7 @@ public class HiveTableBaseTest extends HiveMetastoreTest {
                   optional(2, "data", Types.LongType.get()))
               .fields());
 
-  private static final PartitionSpec partitionSpec = builderFor(schema).identity("id").build();
+  protected static final PartitionSpec partitionSpec = builderFor(schema).identity("id").build();
 
   private Path tableLocation;
 
@@ -104,5 +105,9 @@ public class HiveTableBaseTest extends HiveMetastoreTest {
     return metadataFiles(tableName).stream()
         .filter(f -> f.endsWith(extension))
         .collect(Collectors.toList());
+  }
+
+  public static String getRandomName() {
+    return UUID.randomUUID().toString().replace("-", "");
   }
 }


### PR DESCRIPTION
**Issue:**
`checkCommitStatus` is not checking the NULL value for metadata. This will cause NPE  when the commit fails for table operations while creating a new table with RuntimeException and the call goes to check the commit status via `checkCommitStatus`. Since the table might not be created then `refresh()` will return NULL.

This PR fixes the issue when creating a new table fails to commit with RuntimeException.

I am adding missing test cases as well for commit failure during table creation.

Though I have a couple of questions.
1. Should we clean up the metadata file in case of createTable commit failure even if `commitStatus` is `UNKNOWN`?
2. Should we add test cases for every table operation? For now, test cases are added for Hive and Glue table operations.

