### PR TITLE
flink iceberg hadoop catalog support hadoop-conf-dir option to read hadoop conf

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -98,18 +98,18 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
+    // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
+    // that case it will
+    // fallback to parse those values from hadoop configuration which is loaded from classpath.
+    String hiveConfDir = properties.get(HIVE_CONF_DIR);
+    String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
+    Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
     switch (catalogType.toLowerCase(Locale.ENGLISH)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
-        // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
-        // that case it will
-        // fallback to parse those values from hadoop configuration which is loaded from classpath.
-        String hiveConfDir = properties.get(HIVE_CONF_DIR);
-        String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
-        Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
         return CatalogLoader.hive(name, newHadoopConf, properties);
 
       case ICEBERG_CATALOG_TYPE_HADOOP:
-        return CatalogLoader.hadoop(name, hadoopConf, properties);
+        return CatalogLoader.hadoop(name, newHadoopConf, properties);
 
       default:
         throw new UnsupportedOperationException(

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -98,18 +98,18 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
+    // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
+    // that case it will
+    // fallback to parse those values from hadoop configuration which is loaded from classpath.
+    String hiveConfDir = properties.get(HIVE_CONF_DIR);
+    String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
+    Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
     switch (catalogType.toLowerCase(Locale.ENGLISH)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
-        // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
-        // that case it will
-        // fallback to parse those values from hadoop configuration which is loaded from classpath.
-        String hiveConfDir = properties.get(HIVE_CONF_DIR);
-        String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
-        Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
         return CatalogLoader.hive(name, newHadoopConf, properties);
 
       case ICEBERG_CATALOG_TYPE_HADOOP:
-        return CatalogLoader.hadoop(name, hadoopConf, properties);
+        return CatalogLoader.hadoop(name, newHadoopConf, properties);
 
       default:
         throw new UnsupportedOperationException(

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -98,18 +98,18 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
+    // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
+    // that case it will
+    // fallback to parse those values from hadoop configuration which is loaded from classpath.
+    String hiveConfDir = properties.get(HIVE_CONF_DIR);
+    String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
+    Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
     switch (catalogType.toLowerCase(Locale.ENGLISH)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
-        // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
-        // that case it will
-        // fallback to parse those values from hadoop configuration which is loaded from classpath.
-        String hiveConfDir = properties.get(HIVE_CONF_DIR);
-        String hadoopConfDir = properties.get(HADOOP_CONF_DIR);
-        Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir, hadoopConfDir);
         return CatalogLoader.hive(name, newHadoopConf, properties);
 
       case ICEBERG_CATALOG_TYPE_HADOOP:
-        return CatalogLoader.hadoop(name, hadoopConf, properties);
+        return CatalogLoader.hadoop(name, newHadoopConf, properties);
 
       default:
         throw new UnsupportedOperationException(


### PR DESCRIPTION
 This pr supports create flink iceberg hadoop catalog like this to add the hadoopConf to hadoop catalog. And the parameter 'warehouse' can use hdfs nameservice instead of only namenode host:port.
`
CREATE CATALOG hadoop_catalog WITH (  'type'='iceberg',  'catalog-type'='hadoop',  'warehouse'='hdfs://nameservice1/warehouse/path',  'hadoop-conf-dir'='/HadoopConfDir'  );`

