### PR TITLE
Core: Fix drop table without purge for REST session catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -223,7 +223,7 @@ public class CatalogHandlers {
   }
 
   public static void dropTable(Catalog catalog, TableIdentifier ident) {
-    boolean dropped = catalog.dropTable(ident);
+    boolean dropped = catalog.dropTable(ident, false);
     if (!dropped) {
       throw new NoSuchTableException("Table does not exist: %s", ident);
     }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -821,6 +821,31 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testDropTableWithoutPurge() {
+    C catalog = catalog();
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(NS);
+    }
+
+    Assert.assertFalse("Table should not exist before create", catalog.tableExists(TABLE));
+
+    Table table = catalog.buildTable(TABLE, SCHEMA).create();
+    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+    Set<String> actualMetadataFileLocations = ReachableFileUtil.metadataFileLocations(table, false);
+
+    boolean dropped = catalog.dropTable(TABLE, false);
+    Assert.assertTrue("Should drop a table that does exist", dropped);
+    Assert.assertFalse("Table should not exist after drop", catalog.tableExists(TABLE));
+    Set<String> expectedMetadataFileLocations =
+        ReachableFileUtil.metadataFileLocations(table, false);
+    Assertions.assertThat(actualMetadataFileLocations)
+        .hasSameElementsAs(expectedMetadataFileLocations)
+        .hasSize(1)
+        .as("Should have one metadata file");
+  }
+
+  @Test
   public void testDropMissingTable() {
     C catalog = catalog();
 


### PR DESCRIPTION
**Issue:**
As per documentation of [`SessionCataog.dropTable`](https://github.com/apache/iceberg/blob/2a3a297d134aeaaf2bc19bc75135bea89811228b/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java#L180-L189) says 
> Drop a table, without requesting that files are immediately deleted.

But the [`RESTSessionCatalog#dropTable`](https://github.com/apache/iceberg/blob/67b5ca239ead5549122a5b10e8a372cd1c8dca81/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L221-L232) API purges the table even if we are not setting `purgeRequested` to `true`.

The issue is happening because, While handling `DROP_TABLE` request in [`RESTCatalogAdapter`](https://github.com/apache/iceberg/blob/79bf0f69a2ccc723174c40a1678bc0dcdf32ae7f/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java#L323-L331), the call goes to `CatalogHandlers.dropTable(Catalog catalog, TableIdentifier ident)` when `purgeRequested` is not set and internally calls `catalog.dropTable(ident)` that always drops the table with purge.
 https://github.com/apache/iceberg/blob/cd21f68e7bb62d3be76e98ac519849944e4dbedf/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java#L225-L230


**Fix:**
Fix `CatalogHandlers.dropTable(Catalog catalog, TableIdentifier ident)` API  that drops the table without purge.

This PR is to fix the `dropTable` API for REST Session Catalog for dropping table without purging.
