### PR TITLE
Parquet: Fixes Incorrect Skipping of RowGroups with NaNs

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -301,6 +301,26 @@ public class TestMetricsRowGroupFilter {
   }
 
   @Test
+  public void testFloatWithNan() {
+    // NaN's should break Parquet's Min/Max stats we should be reading in all cases
+    // Only ORC should be able to distinguish using min/max when NaN is present
+    boolean shouldRead = shouldRead(greaterThan("some_nans", 1.0));
+    Assert.assertTrue(shouldRead);
+
+    shouldRead = shouldRead(greaterThanOrEqual("some_nans", 1.0));
+    Assert.assertTrue(shouldRead);
+
+    shouldRead = shouldRead(lessThan("some_nans", 3.0));
+    Assert.assertTrue(shouldRead);
+
+    shouldRead = shouldRead(lessThanOrEqual("some_nans", 1.0));
+    Assert.assertTrue(shouldRead);
+
+    shouldRead = shouldRead(equal("some_nans", 2.0));
+    Assert.assertTrue(shouldRead);
+  }
+
+  @Test
   public void testIsNaN() {
     boolean shouldRead = shouldRead(isNaN("all_nans"));
     Assert.assertTrue("Should read: NaN counts are not tracked in Parquet metrics", shouldRead);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -574,6 +574,10 @@ public class ParquetMetricsRowGroupFilter {
     return statistics.getMaxBytes() == null || statistics.getMinBytes() == null;
   }
 
+  /**
+   * This check is from Statistics.java in parquet-mr whose toString
+   * method declares undefined min/max when these checks are true
+   */
   static boolean minMaxUndefined(Statistics statistics) {
     return (!statistics.isEmpty() && !statistics.hasNonNullValue()) || nullMinMax(statistics);
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -575,8 +575,8 @@ public class ParquetMetricsRowGroupFilter {
   }
 
   /**
-   * This check is from Statistics.java in parquet-mr whose toString
-   * method declares undefined min/max when these checks are true
+   * This check is from Statistics.java in parquet-mr whose toString method declares undefined
+   * min/max when these checks are true
    */
   static boolean minMaxUndefined(Statistics statistics) {
     return (!statistics.isEmpty() && !statistics.hasNonNullValue()) || nullMinMax(statistics);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -560,8 +560,8 @@ public class ParquetMetricsRowGroupFilter {
   }
 
   /**
-   * Older versions of Parquet statistics which may have a null count but undefined
-   * min and max statistics. This is similar to the current behavior when NaN values are present.
+   * Older versions of Parquet statistics which may have a null count but undefined min and max
+   * statistics. This is similar to the current behavior when NaN values are present.
    *
    * <p>This is specifically for 1.5.0-CDH Parquet builds and later which contain the different
    * unusual hasNonNull behavior. OSS Parquet builds are not effected because PARQUET-251 prohibits

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -575,11 +575,11 @@ public class ParquetMetricsRowGroupFilter {
   }
 
   /**
-   * This check is from Statistics.java in parquet-mr whose toString method declares undefined
-   * min/max when these checks are true
+   * The internal logic of Parquet-MR says that if numNulls is set but hasNonNull value is false,
+   * then the min/max of the column are undefined.
    */
   static boolean minMaxUndefined(Statistics statistics) {
-    return (!statistics.isEmpty() && !statistics.hasNonNullValue()) || nullMinMax(statistics);
+    return (statistics.isNumNullsSet() && !statistics.hasNonNullValue()) || nullMinMax(statistics);
   }
 
   static boolean allNulls(Statistics statistics, long valueCount) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -216,6 +216,10 @@ public class ParquetMetricsRowGroupFilter {
           return ROWS_MIGHT_MATCH;
         }
 
+        if (minMaxUndefined(colStats)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
         if (!colStats.hasNonNullValue()) {
           return ROWS_CANNOT_MATCH;
         }
@@ -243,6 +247,10 @@ public class ParquetMetricsRowGroupFilter {
       Statistics<?> colStats = stats.get(id);
       if (colStats != null && !colStats.isEmpty()) {
         if (hasNonNullButNoMinMax(colStats, valueCount)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
+        if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
 
@@ -276,6 +284,10 @@ public class ParquetMetricsRowGroupFilter {
           return ROWS_MIGHT_MATCH;
         }
 
+        if (minMaxUndefined(colStats)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
         if (!colStats.hasNonNullValue()) {
           return ROWS_CANNOT_MATCH;
         }
@@ -303,6 +315,10 @@ public class ParquetMetricsRowGroupFilter {
       Statistics<?> colStats = stats.get(id);
       if (colStats != null && !colStats.isEmpty()) {
         if (hasNonNullButNoMinMax(colStats, valueCount)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
+        if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
 
@@ -340,6 +356,10 @@ public class ParquetMetricsRowGroupFilter {
       Statistics<?> colStats = stats.get(id);
       if (colStats != null && !colStats.isEmpty()) {
         if (hasNonNullButNoMinMax(colStats, valueCount)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
+        if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
 
@@ -390,6 +410,10 @@ public class ParquetMetricsRowGroupFilter {
       Statistics<?> colStats = stats.get(id);
       if (colStats != null && !colStats.isEmpty()) {
         if (hasNonNullButNoMinMax(colStats, valueCount)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
+        if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
 
@@ -449,6 +473,10 @@ public class ParquetMetricsRowGroupFilter {
       Statistics<Binary> colStats = (Statistics<Binary>) stats.get(id);
       if (colStats != null && !colStats.isEmpty()) {
         if (hasNonNullButNoMinMax(colStats, valueCount)) {
+          return ROWS_MIGHT_MATCH;
+        }
+
+        if (minMaxUndefined(colStats)) {
           return ROWS_MIGHT_MATCH;
         }
 
@@ -578,6 +606,10 @@ public class ParquetMetricsRowGroupFilter {
   static boolean hasNonNullButNoMinMax(Statistics statistics, long valueCount) {
     return statistics.getNumNulls() < valueCount
         && (statistics.getMaxBytes() == null || statistics.getMinBytes() == null);
+  }
+
+  static boolean minMaxUndefined(Statistics statistics) {
+    return !statistics.isEmpty() && !statistics.hasNonNullValue();
   }
 
   private static boolean mayContainNull(Statistics statistics) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestCDHParquetStatistics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestCDHParquetStatistics.java
@@ -39,7 +39,6 @@ public class TestCDHParquetStatistics {
     when(cdhBinaryColumnStats.getMaxBytes()).thenReturn(null);
     when(cdhBinaryColumnStats.getMinBytes()).thenReturn(null);
     when(cdhBinaryColumnStats.getNumNulls()).thenReturn(0L);
-    Assert.assertTrue(
-        ParquetMetricsRowGroupFilter.minMaxUndefined(cdhBinaryColumnStats));
+    Assert.assertTrue(ParquetMetricsRowGroupFilter.minMaxUndefined(cdhBinaryColumnStats));
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestCDHParquetStatistics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestCDHParquetStatistics.java
@@ -27,67 +27,19 @@ import org.junit.Test;
 
 /**
  * Tests for Parquet 1.5.0-Stats which cannot be evaluated like later versions of Parquet stats.
- * They are intercepted by the hasNonNullButNoMinMax function which always returns ROWS_MAY_MATCH
+ * They are intercepted by the minMaxUndefined function which always returns ROWS_MAY_MATCH
  */
 public class TestCDHParquetStatistics {
 
   @Test
   public void testCDHParquetStatistcs() {
     Statistics cdhBinaryColumnStats = mock(Statistics.class);
+    when(cdhBinaryColumnStats.isEmpty()).thenReturn(false);
+    when(cdhBinaryColumnStats.hasNonNullValue()).thenReturn(true);
     when(cdhBinaryColumnStats.getMaxBytes()).thenReturn(null);
     when(cdhBinaryColumnStats.getMinBytes()).thenReturn(null);
     when(cdhBinaryColumnStats.getNumNulls()).thenReturn(0L);
     Assert.assertTrue(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(cdhBinaryColumnStats, 50L));
-  }
-
-  @Test
-  public void testCDHParquetStatisticsNullNotSet() {
-    Statistics cdhBinaryColumnStats = mock(Statistics.class);
-    when(cdhBinaryColumnStats.getMaxBytes()).thenReturn(null);
-    when(cdhBinaryColumnStats.getMinBytes()).thenReturn(null);
-    when(cdhBinaryColumnStats.getNumNulls()).thenReturn(-1L);
-    Assert.assertTrue(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(cdhBinaryColumnStats, 50L));
-  }
-
-  @Test
-  public void testCDHParquetStatistcsAllNull() {
-    Statistics cdhBinaryColumnStats = mock(Statistics.class);
-    when(cdhBinaryColumnStats.getMaxBytes()).thenReturn(null);
-    when(cdhBinaryColumnStats.getMinBytes()).thenReturn(null);
-    when(cdhBinaryColumnStats.getNumNulls()).thenReturn(50L);
-    Assert.assertFalse(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(cdhBinaryColumnStats, 50L));
-  }
-
-  @Test
-  public void testNonCDHParquetStatistics() {
-    Statistics normalBinaryColumnStats = mock(Statistics.class);
-    when(normalBinaryColumnStats.getMaxBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getMinBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getNumNulls()).thenReturn(0L);
-    Assert.assertFalse(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(normalBinaryColumnStats, 50L));
-  }
-
-  @Test
-  public void testNonCDHParquetStatisticsNullNotSet() {
-    Statistics normalBinaryColumnStats = mock(Statistics.class);
-    when(normalBinaryColumnStats.getMaxBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getMinBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getNumNulls()).thenReturn(-1L);
-    Assert.assertFalse(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(normalBinaryColumnStats, 50L));
-  }
-
-  @Test
-  public void testNonCDHParquetStatisticsAllNull() {
-    Statistics normalBinaryColumnStats = mock(Statistics.class);
-    when(normalBinaryColumnStats.getMaxBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getMinBytes()).thenReturn(new byte[2]);
-    when(normalBinaryColumnStats.getNumNulls()).thenReturn(50L);
-    Assert.assertFalse(
-        ParquetMetricsRowGroupFilter.hasNonNullButNoMinMax(normalBinaryColumnStats, 50L));
+        ParquetMetricsRowGroupFilter.minMaxUndefined(cdhBinaryColumnStats));
   }
 }


### PR DESCRIPTION
Previously, the RowGroupFilter would skip any RowGroups whose min or max value was set as NaN because Parquet would report that those row groups "hasNonNull" as false. When the statistics are not empty and hasNonNull is false this actually indicates that the min and max are undefined, not that there are no non nulls.

Fixes #6516 