### PR TITLE
Python: Add Docker suggestion for testing

### DIFF
--- a/python/mkdocs/docs/verify-release.md
+++ b/python/mkdocs/docs/verify-release.md
@@ -71,6 +71,15 @@ Run RAT checks to validate license header:
 
 ## Testing
 
+This section explains how to run the tests of the source distribution.
+
+!!! note "Clean environment"
+    To make sure that your environment is fresh is to run the tests in a new Docker container:
+    ```
+    docker run -t -i -v `pwd`:/pyiceberg/ python:3.9 bash
+    ```.
+    And change directory: `cd /pyiceberg/`
+
 First step is to install the package:
 
 ```sh

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -195,62 +195,6 @@ def test_raise_on_opening_a_local_file_not_found() -> None:
         assert "[Errno 2] Failed to open local file" in str(exc_info.value)
 
 
-def test_raise_on_opening_a_local_file_no_permission() -> None:
-    """Test that a PyArrowFile raises appropriately when opening a local file without permission"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chmod(tmpdirname, 0o600)
-        file_location = os.path.join(tmpdirname, "foo.txt")
-        f = PyArrowFileIO().new_input(file_location)
-
-        with pytest.raises(PermissionError) as exc_info:
-            f.open()
-
-        assert "[Errno 13] Failed to open local file" in str(exc_info.value)
-
-
-def test_raise_on_checking_if_local_file_exists_no_permission() -> None:
-    """Test that a PyArrowFile raises when checking for existence on a file without permission"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chmod(tmpdirname, 0o600)
-        file_location = os.path.join(tmpdirname, "foo.txt")
-        f = PyArrowFileIO().new_input(file_location)
-
-        with pytest.raises(PermissionError) as exc_info:
-            f.create()
-
-        assert "Cannot get file info, access denied:" in str(exc_info.value)
-
-
-def test_raise_on_creating_a_local_file_no_permission() -> None:
-    """Test that a PyArrowFile raises appropriately when creating a local file without permission"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chmod(tmpdirname, 0o600)
-        file_location = os.path.join(tmpdirname, "foo.txt")
-        f = PyArrowFileIO().new_input(file_location)
-
-        with pytest.raises(PermissionError) as exc_info:
-            f.create()
-
-        assert "Cannot get file info, access denied:" in str(exc_info.value)
-
-
-def test_raise_on_delete_file_with_no_permission() -> None:
-    """Test that a PyArrowFile raises when deleting a local file without permission"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chmod(tmpdirname, 0o600)
-        file_location = os.path.join(tmpdirname, "foo.txt")
-        file_io = PyArrowFileIO()
-
-        with pytest.raises(PermissionError) as exc_info:
-            file_io.delete(file_location)
-
-        assert "Cannot delete file" in str(exc_info.value)
-
-
 def test_raise_on_opening_an_s3_file_no_permission() -> None:
     """Test that opening a PyArrowFile raises a PermissionError when the pyarrow error includes 'AWS Error [code 15]'"""
 


### PR DESCRIPTION
Running the tests in Docker makes sure that the tests aren't affected by the host system:

![image](https://user-images.githubusercontent.com/1134248/210528369-2fdc3729-c227-4933-b380-0ba3f66b0f96.png)

I had to remove a couple of tests since they don't work inside Docker. This is because by default you're root in docker, and chmod'ing certain directories doesn't work, because you can still read them as root.
