### PR TITLE
Spark 3.3: Discard filters that can be pushed down completely

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -639,9 +639,9 @@ public class Spark3Util {
         case NOT_EQ:
           return pred.ref().name() + " != " + sqlString(pred.literal());
         case STARTS_WITH:
-          return pred.ref().name() + " LIKE '" + pred.literal() + "%'";
+          return pred.ref().name() + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
-          return pred.ref().name() + " NOT LIKE '" + pred.literal() + "%'";
+          return pred.ref().name() + " NOT LIKE '" + pred.literal().value() + "%'";
         case IN:
           return pred.ref().name() + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -125,7 +125,6 @@ public class SparkScanBuilder
         if (expr != null) {
           // try binding the expression to ensure it can be pushed down
           Binder.bind(schema.asStruct(), expr, caseSensitive);
-
           expressions.add(expr);
           pushableFilters.add(filter);
         }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -226,6 +227,16 @@ public abstract class SparkTestBase {
       for (String location : locations) {
         move(location + "_temp", location);
       }
+    }
+  }
+
+  protected void withDefaultTimeZone(String zoneId, Action action) {
+    TimeZone currentZone = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone(zoneId));
+      action.invoke();
+    } finally {
+      TimeZone.setDefault(currentZone);
     }
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Test;
+
+public class TestFilterPushDown extends SparkTestBaseWithCatalog {
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS tmp_view");
+  }
+
+  @Test
+  public void testFilterPushdownWithIdentityTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, salary INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep)",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, 'd1')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, 'd2')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, 'd3')", tableName);
+    sql("INSERT INTO %s VALUES (4, 400, 'd4')", tableName);
+    sql("INSERT INTO %s VALUES (5, 500, 'd5')", tableName);
+    sql("INSERT INTO %s VALUES (6, 600, null)", tableName);
+
+    checkCompleteFilterPushdown(
+        "dep IS NULL" /* query predicate */,
+        "dep IS NULL" /* Iceberg scan filters */,
+        ImmutableList.of(row(6, 600, null)));
+
+    checkCompleteFilterPushdown(
+        "dep IS NOT NULL" /* query predicate */,
+        "dep IS NOT NULL" /* Iceberg scan filters */,
+        ImmutableList.of(
+            row(1, 100, "d1"),
+            row(2, 200, "d2"),
+            row(3, 300, "d3"),
+            row(4, 400, "d4"),
+            row(5, 500, "d5")));
+
+    checkCompleteFilterPushdown(
+        "dep = 'd3'" /* query predicate */,
+        "dep IS NOT NULL, dep = 'd3'" /* Iceberg scan filters */,
+        ImmutableList.of(row(3, 300, "d3")));
+
+    checkCompleteFilterPushdown(
+        "dep > 'd3'" /* query predicate */,
+        "dep IS NOT NULL, dep > 'd3'" /* Iceberg scan filters */,
+        ImmutableList.of(row(4, 400, "d4"), row(5, 500, "d5")));
+
+    checkCompleteFilterPushdown(
+        "dep >= 'd5'" /* query predicate */,
+        "dep IS NOT NULL, dep >= 'd5'" /* Iceberg scan filters */,
+        ImmutableList.of(row(5, 500, "d5")));
+
+    checkCompleteFilterPushdown(
+        "dep < 'd2'" /* query predicate */,
+        "dep IS NOT NULL, dep < 'd2'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkCompleteFilterPushdown(
+        "dep <= 'd2'" /* query predicate */,
+        "dep IS NOT NULL, dep <= 'd2'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
+
+    checkCompleteFilterPushdown(
+        "dep <=> 'd3'" /* query predicate */,
+        "dep = 'd3'" /* Iceberg scan filters */,
+        ImmutableList.of(row(3, 300, "d3")));
+
+    checkCompleteFilterPushdown(
+        "dep IN (null, 'd1')" /* query predicate */,
+        "dep IN ('d1')" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkCompleteFilterPushdown(
+        "dep NOT IN ('d2', 'd4')" /* query predicate */,
+        "(dep IS NOT NULL AND dep NOT IN ('d2', 'd4'))" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1"), row(3, 300, "d3"), row(5, 500, "d5")));
+
+    checkCompleteFilterPushdown(
+        "dep = 'd1' AND dep IS NOT NULL" /* query predicate */,
+        "dep = 'd1', dep IS NOT NULL" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkCompleteFilterPushdown(
+        "dep = 'd1' OR dep = 'd2' OR dep = 'd3'" /* query predicate */,
+        "((dep = 'd1' OR dep = 'd2') OR dep = 'd3')" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2"), row(3, 300, "d3")));
+
+    checkFilterPushdown(
+        "dep = 'd1' AND id = 1" /* query predicate */,
+        "isnotnull(id) AND (id = 1)" /* post scan filter */,
+        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1', id = 1" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkFilterPushdown(
+        "dep = 'd2' OR id = 1" /* query predicate */,
+        "(dep = d2) OR (id = 1)" /* post scan filter */,
+        "(dep = 'd2' OR id = 1)" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
+
+    checkFilterPushdown(
+        "dep LIKE 'd1%' AND id = 1" /* query predicate */,
+        "isnotnull(id) AND (id = 1)" /* post scan filter */,
+        "dep IS NOT NULL, id IS NOT NULL, dep LIKE 'd1%', id = 1" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkFilterPushdown(
+        "dep NOT LIKE 'd5%' AND (id = 1 OR id = 5)" /* query predicate */,
+        "(id = 1) OR (id = 5)" /* post scan filter */,
+        "dep IS NOT NULL, NOT (dep LIKE 'd5%'), (id = 1 OR id = 5)" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+
+    checkFilterPushdown(
+        "dep LIKE '%d5' AND id IN (1, 5)" /* query predicate */,
+        "EndsWith(dep, d5) AND id IN (1,5)" /* post scan filter */,
+        "dep IS NOT NULL, id IN (1, 5)" /* Iceberg scan filters */,
+        ImmutableList.of(row(5, 500, "d5")));
+  }
+
+  @Test
+  public void testFilterPushdownWithHoursTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
+            + "USING iceberg "
+            + "PARTITIONED BY (hours(t))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, TIMESTAMP '2021-06-30 01:00:00.000')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, TIMESTAMP '2021-06-30 02:00:00.000')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, null)", tableName);
+
+    checkCompleteFilterPushdown(
+        "t IS NULL" /* query predicate */,
+        "t IS NULL" /* Iceberg scan filters */,
+        ImmutableList.of(row(3, 300, null)));
+
+    // strict/inclusive projections for t < TIMESTAMP '2021-06-30 02:00:00.000' are equal
+    // so this filter selects entire partitions and can be pushed down completely
+    checkCompleteFilterPushdown(
+        "t < TIMESTAMP '2021-06-30 02:00:00.000'" /* query predicate */,
+        "t IS NOT NULL, t < 1625043600000000" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, Timestamp.valueOf("2021-06-30 01:00:00.0"))));
+
+    // strict/inclusive projections for t < TIMESTAMP '2021-06-30 01:00:00.001' are NOT equal
+    // so this filter does NOT select entire partitions and can't be pushed down completely
+    checkFilterPushdown(
+        "t < TIMESTAMP '2021-06-30 01:00:00.001'" /* query predicate */,
+        "t < 2021-06-30 01:00:00.001" /* post scan filter */,
+        "t IS NOT NULL, t < 1625040000001000" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, Timestamp.valueOf("2021-06-30 01:00:00.0"))));
+
+    // strict/inclusive projections for t <= TIMESTAMP '2021-06-30 01:00:00.000' are NOT equal
+    // so this filter does NOT select entire partitions and can't be pushed down completely
+    checkFilterPushdown(
+        "t <= TIMESTAMP '2021-06-30 01:00:00.000'" /* query predicate */,
+        "t <= 2021-06-30 01:00:00" /* post scan filter */,
+        "t IS NOT NULL, t <= 1625040000000000" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, Timestamp.valueOf("2021-06-30 01:00:00.0"))));
+  }
+
+  @Test
+  public void testFilterPushdownWithDaysTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
+            + "USING iceberg "
+            + "PARTITIONED BY (days(t))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, TIMESTAMP '2021-06-15T01:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, TIMESTAMP '2021-06-30T02:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, TIMESTAMP '2021-07-15T10:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (4, 400, null)", tableName);
+
+    withDefaultTimeZone(
+        "UTC",
+        () -> {
+          checkCompleteFilterPushdown(
+              "t IS NULL" /* query predicate */,
+              "t IS NULL" /* Iceberg scan filters */,
+              ImmutableList.of(row(4, 400, null)));
+
+          // strict/inclusive projections for t < TIMESTAMP '2021-07-05T00:00:00.000Z' are equal
+          // so this filter selects entire partitions and can be pushed down completely
+          checkCompleteFilterPushdown(
+              "t < TIMESTAMP '2021-07-05T00:00:00.000Z'" /* query predicate */,
+              "t IS NOT NULL, t < 1625443200000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-15T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+
+          // strict/inclusive projections for t < TIMESTAMP '2021-06-30T03:00:00.000Z' are NOT equal
+          // so this filter does NOT select entire partitions and can't be pushed down completely
+          checkFilterPushdown(
+              "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
+              "t < 2021-06-30 03:00:00" /* post scan filter */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-15T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+        });
+  }
+
+  @Test
+  public void testFilterPushdownWithMonthsTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
+            + "USING iceberg "
+            + "PARTITIONED BY (months(t))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, TIMESTAMP '2021-06-30T01:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, TIMESTAMP '2021-06-30T02:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, TIMESTAMP '2021-07-15T10:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (4, 400, null)", tableName);
+
+    withDefaultTimeZone(
+        "UTC",
+        () -> {
+          checkCompleteFilterPushdown(
+              "t IS NULL" /* query predicate */,
+              "t IS NULL" /* Iceberg scan filters */,
+              ImmutableList.of(row(4, 400, null)));
+
+          // strict/inclusive projections for t < TIMESTAMP '2021-07-01T00:00:00.000Z' are equal
+          // so this filter selects entire partitions and can be pushed down completely
+          checkCompleteFilterPushdown(
+              "t < TIMESTAMP '2021-07-01T00:00:00.000Z'" /* query predicate */,
+              "t IS NOT NULL, t < 1625097600000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-30T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+
+          // strict/inclusive projections for t < TIMESTAMP '2021-06-30T03:00:00.000Z' are NOT equal
+          // so this filter does NOT select entire partitions and can't be pushed down completely
+          checkFilterPushdown(
+              "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
+              "t < 2021-06-30 03:00:00" /* post scan filter */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-30T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+        });
+  }
+
+  @Test
+  public void testFilterPushdownWithYearsTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, price INT, t TIMESTAMP)"
+            + "USING iceberg "
+            + "PARTITIONED BY (years(t))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, TIMESTAMP '2021-06-30T01:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, TIMESTAMP '2021-06-30T02:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, TIMESTAMP '2022-09-25T02:00:00.000Z')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, null)", tableName);
+
+    withDefaultTimeZone(
+        "UTC",
+        () -> {
+          checkCompleteFilterPushdown(
+              "t IS NULL" /* query predicate */,
+              "t IS NULL" /* Iceberg scan filters */,
+              ImmutableList.of(row(3, 300, null)));
+
+          // strict/inclusive projections for t < TIMESTAMP '2022-01-01T00:00:00.000Z' are equal
+          // so this filter selects entire partitions and can be pushed down completely
+          checkCompleteFilterPushdown(
+              "t < TIMESTAMP '2022-01-01T00:00:00.000Z'" /* query predicate */,
+              "t IS NOT NULL, t < 1640995200000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-30T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+
+          // strict/inclusive projections for t < TIMESTAMP '2021-06-30T03:00:00.000Z' are NOT equal
+          // so this filter does NOT select entire partitions and can't be pushed down completely
+          checkFilterPushdown(
+              "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
+              "t < 2021-06-30 03:00:00" /* post scan filter */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              ImmutableList.of(
+                  row(1, 100, Timestamp.from(Instant.parse("2021-06-30T01:00:00.000Z"))),
+                  row(2, 200, Timestamp.from(Instant.parse("2021-06-30T02:00:00.000Z")))));
+        });
+  }
+
+  @Test
+  public void testFilterPushdownWithBucketTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, salary INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep, bucket(8, id))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, 'd1')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, 'd2')", tableName);
+
+    checkFilterPushdown(
+        "dep = 'd1' AND id = 1" /* query predicate */,
+        "id = 1" /* post scan filter */,
+        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+  }
+
+  @Test
+  public void testFilterPushdownWithTruncateTransform() {
+    sql(
+        "CREATE TABLE %s (id INT, salary INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (truncate(1, dep))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, 'd1')", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, 'd2')", tableName);
+
+    checkFilterPushdown(
+        "dep = 'd1'" /* query predicate */,
+        "dep = d1" /* post scan filter */,
+        "dep IS NOT NULL" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1")));
+  }
+
+  @Test
+  public void testFilterPushdownWithSpecEvolution() {
+    sql(
+        "CREATE TABLE %s (id INT, salary INT, dep STRING, sub_dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep)",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100, 'd1', 'sd1')", tableName);
+
+    // the filter can be pushed completely because all specs include identity(dep)
+    checkCompleteFilterPushdown(
+        "dep = 'd1'" /* query predicate */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1", "sd1")));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateSpec().addField("sub_dep").commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO %s VALUES (2, 200, 'd2', 'sd2')", tableName);
+
+    // the filter can be pushed completely because all specs include identity(dep)
+    checkCompleteFilterPushdown(
+        "dep = 'd1'" /* query predicate */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1", "sd1")));
+
+    table.updateSpec().removeField("sub_dep").removeField("dep").commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, 'd3', 'sd3')", tableName);
+
+    // the filter can't be pushed completely because not all specs include identity(dep)
+    checkFilterPushdown(
+        "dep = 'd1'" /* query predicate */,
+        "isnotnull(dep) AND (dep = d1)" /* post scan filter */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1", "sd1")));
+  }
+
+  @Test
+  public void testFilterPushdownWithSpecialFloatingPointPartitionValues() {
+    sql(
+        "CREATE TABLE %s (id INT, salary DOUBLE)" + "USING iceberg " + "PARTITIONED BY (salary)",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, 100.5)", tableName);
+    sql("INSERT INTO %s VALUES (2, double('NaN'))", tableName);
+    sql("INSERT INTO %s VALUES (3, double('infinity'))", tableName);
+    sql("INSERT INTO %s VALUES (4, double('-infinity'))", tableName);
+
+    checkCompleteFilterPushdown(
+        "salary = 100.5" /* query predicate */,
+        "salary IS NOT NULL, salary = 100.5" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100.5)));
+
+    checkCompleteFilterPushdown(
+        "salary = double('NaN')" /* query predicate */,
+        "salary IS NOT NULL, is_nan(salary)" /* Iceberg scan filters */,
+        ImmutableList.of(row(2, Double.NaN)));
+
+    checkCompleteFilterPushdown(
+        "salary != double('NaN')" /* query predicate */,
+        "salary IS NOT NULL, NOT (is_nan(salary))" /* Iceberg scan filters */,
+        ImmutableList.of(
+            row(1, 100.5), row(3, Double.POSITIVE_INFINITY), row(4, Double.NEGATIVE_INFINITY)));
+
+    checkCompleteFilterPushdown(
+        "salary = double('infinity')" /* query predicate */,
+        "salary IS NOT NULL, salary = Infinity" /* Iceberg scan filters */,
+        ImmutableList.of(row(3, Double.POSITIVE_INFINITY)));
+
+    checkCompleteFilterPushdown(
+        "salary = double('-infinity')" /* query predicate */,
+        "salary IS NOT NULL, salary = -Infinity" /* Iceberg scan filters */,
+        ImmutableList.of(row(4, Double.NEGATIVE_INFINITY)));
+  }
+
+  private void checkCompleteFilterPushdown(
+      String predicate, String pushedFilters, List<Object[]> expectedRows) {
+
+    checkFilterPushdown(predicate, null, pushedFilters, expectedRows);
+  }
+
+  private void checkFilterPushdown(
+      String predicate, String postScanFilter, String pushedFilters, List<Object[]> expectedRows) {
+
+    Action check =
+        () -> {
+          assertEquals(
+              "Rows must match",
+              expectedRows,
+              sql("SELECT * FROM %s WHERE %s ORDER BY id", tableName, predicate));
+        };
+    SparkPlan sparkPlan = executeAndKeepPlan(check);
+    String planAsString = sparkPlan.toString().replaceAll("#(\\d+L?)", "");
+
+    if (postScanFilter != null) {
+      Assertions.assertThat(planAsString)
+          .as("Post scan filter should match")
+          .contains("Filter (" + postScanFilter + ")");
+    } else {
+      Assertions.assertThat(planAsString)
+          .as("Should be no post scan filter")
+          .doesNotContain("Filter (");
+    }
+
+    Assertions.assertThat(planAsString)
+        .as("Pushed filters must match")
+        .contains("[filters=" + pushedFilters + ",");
+  }
+}


### PR DESCRIPTION
This PR enhances our filter pushdown logic in Spark 3.3 to discard filters that can be completely evaluated using partition metadata. That way, we can skip evaluating some predicates which we know are always true or false for rows produced by a scan.

This change leverages `ExpressionUtil$selectsPartitions()` that checks if an expression selects partitions by comparing its strict and inclusive projections.