### PR TITLE
Iceberg delete files are read multiple times during query processing causing delays

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -66,6 +66,11 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.io.DataWriter<T>::add(T)"
       justification: "Removing deprecated method"
   "1.1.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.util.CharSequenceWrapper"
+      new: "class org.apache.iceberg.util.CharSequenceWrapper"
+      justification: "Added class field is not serialized"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.noLongerImplementsInterface"
       old: "class org.apache.iceberg.jdbc.JdbcCatalog"

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.util;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
@@ -29,24 +30,36 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.types.Comparators;
 
 public class CharSequenceSet implements Set<CharSequence>, Serializable {
   private static final ThreadLocal<CharSequenceWrapper> wrappers =
       ThreadLocal.withInitial(() -> CharSequenceWrapper.wrap(null));
 
   public static CharSequenceSet of(Iterable<CharSequence> charSequences) {
-    return new CharSequenceSet(charSequences);
+    return of(charSequences, Comparators.charSequences());
+  }
+
+  public static CharSequenceSet of(
+      Iterable<CharSequence> charSequences, Comparator<CharSequence> comparator) {
+    return new CharSequenceSet(charSequences, comparator);
   }
 
   public static CharSequenceSet empty() {
-    return new CharSequenceSet(ImmutableList.of());
+    return empty(Comparators.charSequences());
+  }
+
+  public static CharSequenceSet empty(Comparator<CharSequence> comparator) {
+    return new CharSequenceSet(ImmutableList.of(), comparator);
   }
 
   private final Set<CharSequenceWrapper> wrapperSet;
 
-  private CharSequenceSet(Iterable<CharSequence> charSequences) {
+  private CharSequenceSet(
+      Iterable<CharSequence> charSequences, Comparator<CharSequence> comparator) {
     this.wrapperSet =
-        Sets.newHashSet(Iterables.transform(charSequences, CharSequenceWrapper::wrap));
+        Sets.newHashSet(
+            Iterables.transform(charSequences, seq -> CharSequenceWrapper.wrap(seq, comparator)));
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -19,19 +19,27 @@
 package org.apache.iceberg.util;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.JavaHashes;
 
 /** Wrapper class to adapt CharSequence for use in maps and sets. */
 public class CharSequenceWrapper implements CharSequence, Serializable {
+
   public static CharSequenceWrapper wrap(CharSequence seq) {
-    return new CharSequenceWrapper(seq);
+    return wrap(seq, Comparators.charSequences());
+  }
+
+  public static CharSequenceWrapper wrap(CharSequence seq, Comparator<CharSequence> comparator) {
+    return new CharSequenceWrapper(seq, comparator);
   }
 
   private CharSequence wrapped;
+  private final transient Comparator<CharSequence> comparator;
 
-  private CharSequenceWrapper(CharSequence wrapped) {
+  private CharSequenceWrapper(CharSequence wrapped, Comparator<CharSequence> comparator) {
     this.wrapped = wrapped;
+    this.comparator = comparator;
   }
 
   public CharSequenceWrapper set(CharSequence newWrapped) {
@@ -52,7 +60,7 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
     }
 
     CharSequenceWrapper that = (CharSequenceWrapper) other;
-    return Comparators.charSequences().compare(wrapped, that.wrapped) == 0;
+    return comparator.compare(wrapped, that.wrapped) == 0;
   }
 
   @Override

--- a/build.gradle
+++ b/build.gradle
@@ -395,6 +395,7 @@ project(':iceberg-data') {
       exclude group: 'org.codehaus.jackson'
     }
 
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
 
     testImplementation(libs.hadoop2.client) {

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -42,6 +42,17 @@ public class SystemConfigs {
           Math.max(2, Runtime.getRuntime().availableProcessors()),
           Integer::parseUnsignedInt);
 
+  /**
+   * Sets the size of the delete worker pool. The delete worker pool limits the number of tasks concurrently
+   * processing positional deletes from multiple FileScanTasks.
+   */
+  public static final ConfigEntry<Integer> DELETE_POS_FILES_THREAD_POOL_SIZE =
+      new ConfigEntry<>(
+          "iceberg.worker.num-delete-threads",
+          "ICEBERG_WORKER_NUM_DELETE_THREADS",
+          2,
+          Integer::parseUnsignedInt);
+
   /** Whether to use the shared worker pool when planning table scans. */
   public static final ConfigEntry<Boolean> SCAN_THREAD_POOL_ENABLED =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -43,8 +43,8 @@ public class SystemConfigs {
           Integer::parseUnsignedInt);
 
   /**
-   * Sets the size of the delete worker pool. The delete worker pool limits the number of tasks concurrently
-   * processing positional deletes from multiple FileScanTasks.
+   * Sets the size of the delete worker pool. The delete worker pool limits the number of tasks
+   * concurrently processing positional deletes from multiple FileScanTasks.
    */
   public static final ConfigEntry<Integer> DELETE_POS_FILES_THREAD_POOL_SIZE =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.deletes;
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 class BitmapPositionDeleteIndex implements PositionDeleteIndex {
@@ -45,5 +46,19 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   @Override
   public boolean isEmpty() {
     return roaring64Bitmap.isEmpty();
+  }
+
+  @Override
+  public PositionDeleteIndex or(PositionDeleteIndex deleteIndex) {
+    Preconditions.checkArgument(
+        deleteIndex instanceof BitmapPositionDeleteIndex,
+        "argument should be of type: series[float] PositionDeleteIndex");
+    roaring64Bitmap.or(((BitmapPositionDeleteIndex) deleteIndex).roaring64Bitmap);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return roaring64Bitmap.toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -44,4 +44,9 @@ public interface PositionDeleteIndex {
 
   /** Returns true if this collection contains no element. */
   boolean isEmpty();
+
+  /** In-place bitwise OR (union) operation. The current bitmap is modified. */
+  default PositionDeleteIndex or(PositionDeleteIndex deleteIndex) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -44,6 +44,12 @@ public class ThreadPools {
 
   private static final ExecutorService WORKER_POOL = newWorkerPool("iceberg-worker-pool");
 
+  public static final int DELETE_WORKER_THREAD_POOL_SIZE =
+      SystemConfigs.DELETE_POS_FILES_THREAD_POOL_SIZE.value();
+
+  private static final ExecutorService DELETE_WORKER_POOL =
+      newWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);
+
   /**
    * Return an {@link ExecutorService} that uses the "worker" thread-pool.
    *
@@ -57,6 +63,18 @@ public class ThreadPools {
    */
   public static ExecutorService getWorkerPool() {
     return WORKER_POOL;
+  }
+
+  /**
+   * Return an {@link ExecutorService} that uses "delete worker" thread-pool.
+   *
+   * <p>The size of this thread-pool is controlled by the Java system property {@code
+   * iceberg.worker.num-delete-threads}.
+   *
+   * @return an {@link ExecutorService} that uses delete worker pool
+   */
+  public static ExecutorService getDeleteWorkerPool() {
+    return DELETE_WORKER_POOL;
   }
 
   public static ExecutorService newWorkerPool(String namePrefix) {

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -55,6 +55,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
       exclude group: 'org.codehaus.jackson'
     }
 
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
 
     implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -55,6 +55,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
       exclude group: 'org.codehaus.jackson'
     }
 
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
 
     implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -55,6 +55,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
       exclude group: 'org.codehaus.jackson'
     }
 
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
 
     implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -65,6 +65,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation "org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}"
 
     compileOnly libs.errorprone.annotations
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive32.get()}") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -61,6 +61,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
 
     compileOnly libs.errorprone.annotations
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive33.get()}") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -61,6 +61,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
 
     compileOnly libs.errorprone.annotations
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive34.get()}") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -61,6 +61,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation("org.scala-lang.modules:scala-collection-compat_${scalaVersion}:${libs.versions.scala.collection.compat.get()}")
 
     compileOnly libs.errorprone.annotations
+    compileOnly libs.caffeine
     compileOnly libs.avro.avro
     compileOnly("org.apache.spark:spark-hive_${scalaVersion}:${libs.versions.spark.hive35.get()}") {
       exclude group: 'org.apache.avro', module: 'avro'


### PR DESCRIPTION
ref https://issues.apache.org/jira/browse/HIVE-26714

Current optimization covers only positional deletes by creating a PositionDeleteIndex bitmap for every task in a combined TableScan, avoiding multiple delete file reads for each task.