### PR TITLE
Python: Re-enable mdformat

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ exclude: ^python/vendor/
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -29,7 +29,7 @@ repos:
       - id: check-yaml
       - id: check-ast
   - repo: https://github.com/ambv/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-isort
@@ -43,33 +43,32 @@ repos:
       - id: mypy
         args: [ --install-types, --non-interactive, --config=python/pyproject.toml]
   - repo: https://github.com/hadialqattan/pycln
-    rev: v2.1.1
+    rev: v2.1.2
     hooks:
       - id: pycln
         args: [--config=python/pyproject.toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.0.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [ --py38-plus, --keep-runtime-typing ]
   - repo: https://github.com/pycqa/pylint
-    rev: v2.15.3
+    rev: v2.15.9
     hooks:
       - id: pylint
         args: [ --rcfile=python/pylintrc ]
   - repo: https://github.com/pycqa/flake8
-    rev: '5.0.4'
+    rev: '6.0.0'
     hooks:
       - id: flake8
         args: [ "--ignore=E501,W503,E203,B024" ]
-        additional_dependencies: [ flake8-bugbear==22.9.11, flake8-comprehensions==3.10.0 ]
-# Disabling this for now, we need mdformat-admin, otherwise it will break the note blocks
-#  - repo: https://github.com/executablebooks/mdformat
-#    rev: 0.7.16
-#    hooks:
-#      - id: mdformat
-#        additional_dependencies:
-#          - mdformat-black
-#          - mdformat-config
-#          - mdformat-beautysh
-#          - mdformat-admon
+        additional_dependencies: [ flake8-bugbear==22.12.6, flake8-comprehensions==3.10.1 ]
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-black
+          - mdformat-config
+          - mdformat-beautysh
+          - mdformat-admon

--- a/python/README.md
+++ b/python/README.md
@@ -20,6 +20,7 @@
 PyIceberg is a Python library for programmatic access to Iceberg table metadata as well as to table data in Iceberg format. It is a Python implementation of the [Iceberg table spec](https://iceberg.apache.org/spec/).
 
 The documentation is available at [https://py.iceberg.apache.org/](https://py.iceberg.apache.org/).
+
 # Get in Touch
 
 - [Iceberg community](https://iceberg.apache.org/community/)


### PR DESCRIPTION
The bug that would mess up the alerts in the docs has been fixed 🥳 