### PR TITLE
Spark 3.2: Introduce a changelog iterator

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/ChangelogIterator.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+
+/**
+ * An iterator that transforms rows from changelog tables within a single Spark task. It assumes
+ * that rows are sorted by identifier columns and change type.
+ *
+ * <p>It removes the carry-over rows. Carry-over rows are the result of a removal and insertion of
+ * the same row within an operation because of the copy-on-write mechanism. For example, given a
+ * file which contains row1 (id=1, data='a') and row2 (id=2, data='b'). A copy-on-write delete of
+ * row2 would require erasing this file and preserving row1 in a new file. The change-log table
+ * would report this as (id=1, data='a', op='DELETE') and (id=1, data='a', op='INSERT'), despite it
+ * not being an actual change to the table. The iterator finds the carry-over rows and removes them
+ * from the result.
+ *
+ * <p>This iterator also finds delete/insert rows which represent an update, and converts them into
+ * update records. For example, these two rows
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='DELETE')
+ *   <li>(id=1, data='b', op='INSERT')
+ * </ul>
+ *
+ * <p>will be marked as update-rows:
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='UPDATE_BEFORE')
+ *   <li>(id=1, data='b', op='UPDATE_AFTER')
+ * </ul>
+ */
+public class ChangelogIterator implements Iterator<Row>, Serializable {
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+  private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
+  private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
+
+  private final Iterator<Row> rowIterator;
+  private final int changeTypeIndex;
+  private final List<Integer> identifierFieldIdx;
+
+  private Row cachedRow = null;
+  private int[] indicesForIdentifySameRow = null;
+
+  private ChangelogIterator(
+      Iterator<Row> rowIterator, int changeTypeIndex, List<Integer> identifierFieldIdx) {
+    this.rowIterator = rowIterator;
+    this.changeTypeIndex = changeTypeIndex;
+    this.identifierFieldIdx = identifierFieldIdx;
+  }
+
+  /**
+   * Creates an iterator for records of a changelog table.
+   *
+   * @param rowIterator the iterator of rows from a changelog table
+   * @param changeTypeIndex the index of the change type column
+   * @param identifierFieldIdx the indices of the identifier columns, which determine if rows are
+   *     the same
+   * @return a new {@link ChangelogIterator} instance concatenated with the null-removal iterator
+   */
+  public static Iterator<Row> iterator(
+      Iterator<Row> rowIterator, int changeTypeIndex, List<Integer> identifierFieldIdx) {
+    ChangelogIterator changelogIterator =
+        new ChangelogIterator(rowIterator, changeTypeIndex, identifierFieldIdx);
+    return Iterators.filter(changelogIterator, Objects::nonNull);
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (cachedRow != null) {
+      return true;
+    }
+    return rowIterator.hasNext();
+  }
+
+  @Override
+  public Row next() {
+    // if there is an updated cached row, return it directly
+    if (cachedUpdateRecord(cachedRow)) {
+      Row row = cachedRow;
+      cachedRow = null;
+      return row;
+    }
+
+    Row currentRow = currentRow();
+
+    if (indicesForIdentifySameRow == null) {
+      indicesForIdentifySameRow = generateIndicesForIdentifySameRow(currentRow);
+    }
+
+    if (currentRow.getString(changeTypeIndex).equals(DELETE) && rowIterator.hasNext()) {
+      GenericRowWithSchema nextRow = (GenericRowWithSchema) rowIterator.next();
+      cachedRow = nextRow;
+
+      if (isUpdateOrCarryoverRecord(currentRow, nextRow)) {
+        if (isCarryoverRecord(currentRow, nextRow)) {
+          // set carry-over rows to null for filtering out later
+          currentRow = null;
+          cachedRow = null;
+        } else {
+          Row[] rows = createUpdateChangelog((GenericRowWithSchema) currentRow, nextRow);
+          currentRow = rows[0];
+          cachedRow = rows[1];
+        }
+      }
+    }
+
+    return currentRow;
+  }
+
+  private int[] generateIndicesForIdentifySameRow(Row row) {
+    int[] indices = new int[row.length() - 1];
+    for (int i = 0; i < indices.length; i++) {
+      if (i < changeTypeIndex) {
+        indices[i] = i;
+      } else {
+        indices[i] = i + 1;
+      }
+    }
+    return indices;
+  }
+
+  private Row[] createUpdateChangelog(
+      GenericRowWithSchema currentRow, GenericRowWithSchema nextRow) {
+    GenericInternalRow deletedRow = new GenericInternalRow(currentRow.values());
+    GenericInternalRow insertedRow = new GenericInternalRow(nextRow.values());
+
+    deletedRow.update(changeTypeIndex, UPDATE_BEFORE);
+    insertedRow.update(changeTypeIndex, UPDATE_AFTER);
+
+    return new Row[] {
+      RowFactory.create(deletedRow.values()), RowFactory.create(insertedRow.values())
+    };
+  }
+
+  private boolean isCarryoverRecord(Row currentRow, Row nextRow) {
+    for (int idx : indicesForIdentifySameRow) {
+      if (!isColumnSame(currentRow, nextRow, idx)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private boolean cachedUpdateRecord(Row cachedRecord) {
+    return cachedRecord != null
+        && !cachedRecord.getString(changeTypeIndex).equals(DELETE)
+        && !cachedRecord.getString(changeTypeIndex).equals(INSERT);
+  }
+
+  private Row currentRow() {
+    if (cachedRow != null) {
+      Row row = cachedRow;
+      cachedRow = null;
+      return row;
+    } else {
+      return rowIterator.next();
+    }
+  }
+
+  private boolean isUpdateOrCarryoverRecord(Row currentRow, Row nextRow) {
+    return sameLogicalRow(currentRow, nextRow)
+        && currentRow.getString(changeTypeIndex).equals(DELETE)
+        && nextRow.getString(changeTypeIndex).equals(INSERT);
+  }
+
+  private boolean sameLogicalRow(Row currentRow, Row nextRow) {
+    for (int idx : identifierFieldIdx) {
+      if (!isColumnSame(currentRow, nextRow, idx)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isColumnSame(Row currentRow, Row nextRow, int idx) {
+    return Objects.equals(nextRow.get(idx), currentRow.get(idx));
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -28,8 +28,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -50,9 +48,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
-public abstract class SparkTestBase {
-
-  protected static final Object ANY = new Object();
+public abstract class SparkTestBase extends SparkTestHelperBase {
 
   protected static TestHiveMetastore metastore = null;
   protected static HiveConf hiveConf = null;
@@ -111,32 +107,6 @@ public abstract class SparkTestBase {
     return rowsToJava(rows);
   }
 
-  protected List<Object[]> rowsToJava(List<Row> rows) {
-    return rows.stream().map(this::toJava).collect(Collectors.toList());
-  }
-
-  private Object[] toJava(Row row) {
-    return IntStream.range(0, row.size())
-        .mapToObj(
-            pos -> {
-              if (row.isNullAt(pos)) {
-                return null;
-              }
-
-              Object value = row.get(pos);
-              if (value instanceof Row) {
-                return toJava((Row) value);
-              } else if (value instanceof scala.collection.Seq) {
-                return row.getList(pos);
-              } else if (value instanceof scala.collection.Map) {
-                return row.getJavaMap(pos);
-              } else {
-                return value;
-              }
-            })
-        .toArray(Object[]::new);
-  }
-
   protected Object scalarSql(String query, Object... args) {
     List<Object[]> rows = sql(query, args);
     Assert.assertEquals("Scalar SQL should return one row", 1, rows.size());
@@ -147,39 +117,6 @@ public abstract class SparkTestBase {
 
   protected Object[] row(Object... values) {
     return values;
-  }
-
-  protected void assertEquals(
-      String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
-    Assert.assertEquals(
-        context + ": number of results should match", expectedRows.size(), actualRows.size());
-    for (int row = 0; row < expectedRows.size(); row += 1) {
-      Object[] expected = expectedRows.get(row);
-      Object[] actual = actualRows.get(row);
-      Assert.assertEquals("Number of columns should match", expected.length, actual.length);
-      for (int col = 0; col < actualRows.get(row).length; col += 1) {
-        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
-        assertEquals(newContext, expected, actual);
-      }
-    }
-  }
-
-  private void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
-    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
-    for (int col = 0; col < actualRow.length; col += 1) {
-      Object expectedValue = expectedRow[col];
-      Object actualValue = actualRow[col];
-      if (expectedValue != null && expectedValue.getClass().isArray()) {
-        String newContext = String.format("%s (nested col %d)", context, col + 1);
-        if (expectedValue instanceof byte[]) {
-          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
-        } else {
-          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
-        }
-      } else if (expectedValue != ANY) {
-        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
-      }
-    }
   }
 
   protected static String dbPath(String dbName) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestHelperBase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+
+public class SparkTestHelperBase {
+  protected static final Object ANY = new Object();
+
+  protected List<Object[]> rowsToJava(List<Row> rows) {
+    return rows.stream().map(this::toJava).collect(Collectors.toList());
+  }
+
+  private Object[] toJava(Row row) {
+    return IntStream.range(0, row.size())
+        .mapToObj(
+            pos -> {
+              if (row.isNullAt(pos)) {
+                return null;
+              }
+
+              Object value = row.get(pos);
+              if (value instanceof Row) {
+                return toJava((Row) value);
+              } else if (value instanceof scala.collection.Seq) {
+                return row.getList(pos);
+              } else if (value instanceof scala.collection.Map) {
+                return row.getJavaMap(pos);
+              } else {
+                return value;
+              }
+            })
+        .toArray(Object[]::new);
+  }
+
+  protected void assertEquals(
+      String context, List<Object[]> expectedRows, List<Object[]> actualRows) {
+    Assert.assertEquals(
+        context + ": number of results should match", expectedRows.size(), actualRows.size());
+    for (int row = 0; row < expectedRows.size(); row += 1) {
+      Object[] expected = expectedRows.get(row);
+      Object[] actual = actualRows.get(row);
+      Assert.assertEquals("Number of columns should match", expected.length, actual.length);
+      for (int col = 0; col < actualRows.get(row).length; col += 1) {
+        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
+        assertEquals(newContext, expected, actual);
+      }
+    }
+  }
+
+  private void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
+    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
+    for (int col = 0; col < actualRow.length; col += 1) {
+      Object expectedValue = expectedRow[col];
+      Object actualValue = actualRow[col];
+      if (expectedValue != null && expectedValue.getClass().isArray()) {
+        String newContext = String.format("%s (nested col %d)", context, col + 1);
+        if (expectedValue instanceof byte[]) {
+          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+        } else {
+          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        }
+      } else if (expectedValue != ANY) {
+        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
+      }
+    }
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestChangelogIterator extends SparkTestHelperBase {
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+  private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
+  private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
+
+  private final int changeTypeIndex = 3;
+  private final List<Integer> identifierFieldIdx = Lists.newArrayList(0, 1);
+
+  private enum RowType {
+    DELETED,
+    INSERTED,
+    CARRY_OVER,
+    UPDATED
+  }
+
+  @Test
+  public void testIterator() {
+    List<Object[]> permutations = Lists.newArrayList();
+    // generate 24 permutations
+    permute(
+        Arrays.asList(RowType.DELETED, RowType.INSERTED, RowType.CARRY_OVER, RowType.UPDATED),
+        0,
+        permutations);
+    Assert.assertEquals(24, permutations.size());
+
+    for (Object[] permutation : permutations) {
+      validate(permutation);
+    }
+  }
+
+  private void validate(Object[] permutation) {
+    List<Row> rows = Lists.newArrayList();
+    List<Object[]> expectedRows = Lists.newArrayList();
+    for (int i = 0; i < permutation.length; i++) {
+      rows.addAll(toOriginalRows((RowType) permutation[i], i));
+      expectedRows.addAll(toExpectedRows((RowType) permutation[i], i));
+    }
+
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(rows.iterator(), changeTypeIndex, identifierFieldIdx);
+    List<Row> result = Lists.newArrayList(iterator);
+    assertEquals("Rows should match", expectedRows, rowsToJava(result));
+  }
+
+  private List<Row> toOriginalRows(RowType rowType, int index) {
+    switch (rowType) {
+      case DELETED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {index, "b", "data", DELETE}, null));
+      case INSERTED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {index, "c", "data", INSERT}, null));
+      case CARRY_OVER:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {index, "d", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {index, "d", "data", INSERT}, null));
+      case UPDATED:
+        return Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {index, "a", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {index, "a", "new_data", INSERT}, null));
+      default:
+        throw new IllegalArgumentException("Unknown row type: " + rowType);
+    }
+  }
+
+  private List<Object[]> toExpectedRows(RowType rowType, int order) {
+    switch (rowType) {
+      case DELETED:
+        List<Object[]> rows = Lists.newArrayList();
+        rows.add(new Object[] {order, "b", "data", DELETE});
+        return rows;
+      case INSERTED:
+        List<Object[]> insertedRows = Lists.newArrayList();
+        insertedRows.add(new Object[] {order, "c", "data", INSERT});
+        return insertedRows;
+      case CARRY_OVER:
+        return Lists.newArrayList();
+      case UPDATED:
+        return Lists.newArrayList(
+            new Object[] {order, "a", "data", UPDATE_BEFORE},
+            new Object[] {order, "a", "new_data", UPDATE_AFTER});
+      default:
+        throw new IllegalArgumentException("Unknown row type: " + rowType);
+    }
+  }
+
+  private void permute(List<RowType> arr, int start, List<Object[]> pm) {
+    for (int i = start; i < arr.size(); i++) {
+      Collections.swap(arr, i, start);
+      permute(arr, start + 1, pm);
+      Collections.swap(arr, start, i);
+    }
+    if (start == arr.size() - 1) {
+      pm.add(arr.toArray());
+    }
+  }
+
+  @Test
+  public void testRowsWithNullValue() {
+    final List<Row> rowsWithNull =
+        Lists.newArrayList(
+            new GenericRowWithSchema(new Object[] {2, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {3, null, null, INSERT}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {4, null, null, INSERT}, null),
+            // mixed null and non-null value in non-identifier columns
+            new GenericRowWithSchema(new Object[] {5, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {5, null, "data", INSERT}, null),
+            // mixed null and non-null value in identifier columns
+            new GenericRowWithSchema(new Object[] {6, null, null, DELETE}, null),
+            new GenericRowWithSchema(new Object[] {6, "name", null, INSERT}, null));
+
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(rowsWithNull.iterator(), 3, Lists.newArrayList(0, 1));
+    List<Row> result = Lists.newArrayList(iterator);
+
+    assertEquals(
+        "Rows should match",
+        Lists.newArrayList(
+            new Object[] {2, null, null, DELETE},
+            new Object[] {3, null, null, INSERT},
+            new Object[] {5, null, null, UPDATE_BEFORE},
+            new Object[] {5, null, "data", UPDATE_AFTER},
+            new Object[] {6, null, null, DELETE},
+            new Object[] {6, "name", null, INSERT}),
+        rowsToJava(result));
+  }
+
+  @Test
+  public void testUpdatedRowsWithDuplication() {
+    List<Row> rowsWithDuplication =
+        Lists.newArrayList(
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {1, "a", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "data", DELETE}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", INSERT}, null),
+            new GenericRowWithSchema(new Object[] {1, "a", "new_data", INSERT}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {4, "d", "data", DELETE}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", DELETE}, null),
+            // next two rows are identical
+            new GenericRowWithSchema(new Object[] {4, "d", "data", INSERT}, null),
+            new GenericRowWithSchema(new Object[] {4, "d", "data", INSERT}, null));
+
+    Iterator<Row> iterator =
+        ChangelogIterator.iterator(
+            rowsWithDuplication.iterator(), changeTypeIndex, identifierFieldIdx);
+    List<Row> result = Lists.newArrayList(iterator);
+
+    assertEquals(
+        "Duplicate rows should not be removed",
+        Lists.newArrayList(
+            new Object[] {1, "a", "data", DELETE},
+            new Object[] {1, "a", "data", UPDATE_BEFORE},
+            new Object[] {1, "a", "new_data", UPDATE_AFTER},
+            new Object[] {1, "a", "new_data", INSERT},
+            new Object[] {4, "d", "data", DELETE},
+            new Object[] {4, "d", "data", INSERT}),
+        rowsToJava(result));
+  }
+}


### PR DESCRIPTION
This is the Spark 3.2 version of #6344. cc @RussellSpitzer @szehon-ho 