### PR TITLE
Python: Fix reading 0-bytes binary

### DIFF
--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -50,10 +50,10 @@ class BinaryDecoder:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
         read_bytes = self._input_stream.read(n)
         read_len = len(read_bytes)
-        if read_len <= 0:
-            raise EOFError
+        if read_len < 0:
+            raise EOFError(f"Got negative length: {read_len}")
         elif read_len != n:
-            raise ValueError(f"Read {len(read_bytes)} bytes, expected {n} bytes")
+            raise EOFError(f"Read {read_len} bytes, expected {n} bytes")
         return read_bytes
 
     def skip(self, n: int) -> None:
@@ -115,7 +115,8 @@ class BinaryDecoder:
         """
         Bytes are encoded as a long followed by that many bytes of data.
         """
-        return self.read(self.read_int())
+        num_bytes = self.read_int()
+        return self.read(num_bytes) if num_bytes > 0 else b""
 
     def read_utf8(self) -> str:
         """

--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -48,13 +48,18 @@ class BinaryDecoder:
         """
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
-        read_bytes = self._input_stream.read(n)
-        read_len = len(read_bytes)
-        if read_len <= 0:
-            raise EOFError(f"Got negative length: {read_len}")
-        elif read_len != n:
-            raise ValueError(f"Read {read_len} bytes, expected {n} bytes")
-        return read_bytes
+        data = b''
+
+        n_remaining = n
+        while n_remaining > 0:
+            data_read = self._input_stream.read(n_remaining)
+            read_len = len(data_read)
+            if read_len <= 0:
+                raise EOFError(f"Got negative length: {read_len}")
+            data += data_read
+            n_remaining -= read_len
+
+        return data
 
     def skip(self, n: int) -> None:
         self._input_stream.seek(n, SEEK_CUR)

--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -50,10 +50,10 @@ class BinaryDecoder:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
         read_bytes = self._input_stream.read(n)
         read_len = len(read_bytes)
-        if read_len < 0:
+        if read_len <= 0:
             raise EOFError(f"Got negative length: {read_len}")
         elif read_len != n:
-            raise EOFError(f"Read {read_len} bytes, expected {n} bytes")
+            raise ValueError(f"Read {read_len} bytes, expected {n} bytes")
         return read_bytes
 
     def skip(self, n: int) -> None:

--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -48,7 +48,7 @@ class BinaryDecoder:
         """
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
-        data = b''
+        data = b""
 
         n_remaining = n
         while n_remaining > 0:

--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -49,7 +49,7 @@ class BinaryDecoder:
         """
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
-        data: List[bytes] = list()
+        data: List[bytes] = []
 
         n_remaining = n
         while n_remaining > 0:

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -137,7 +137,7 @@ class OneByteAtATimeInputStream(InputStream):
 def test_read_single_byte_at_the_time() -> None:
     decoder = BinaryDecoder(OneByteAtATimeInputStream())
 
-    with pytest.raises(EOFError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         decoder.read(2)
 
     assert "Read 1 bytes, expected 2 bytes" in str(exc_info.value)

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -109,7 +109,7 @@ class OneByteAtATimeInputStream(InputStream):
 
     def read(self, size: int = 0) -> bytes:
         self.pos += 1
-        return int.to_bytes(1, self.pos, byteorder="little")
+        return self.pos.to_bytes(1, byteorder="little")
 
     def seek(self, offset: int, whence: int = SEEK_SET) -> int:
         self.pos = offset
@@ -117,10 +117,6 @@ class OneByteAtATimeInputStream(InputStream):
 
     def tell(self) -> int:
         return self.pos
-
-    @property
-    def closed(self) -> bool:
-        return False
 
     def close(self) -> None:
         pass
@@ -136,11 +132,7 @@ class OneByteAtATimeInputStream(InputStream):
 
 def test_read_single_byte_at_the_time() -> None:
     decoder = BinaryDecoder(OneByteAtATimeInputStream())
-
-    with pytest.raises(ValueError) as exc_info:
-        decoder.read(2)
-
-    assert "Read 1 bytes, expected 2 bytes" in str(exc_info.value)
+    assert decoder.read(2) == b"\x01\x02"
 
 
 def test_read_float() -> None:

--- a/python/tests/avro/test_decoder.py
+++ b/python/tests/avro/test_decoder.py
@@ -137,7 +137,7 @@ class OneByteAtATimeInputStream(InputStream):
 def test_read_single_byte_at_the_time() -> None:
     decoder = BinaryDecoder(OneByteAtATimeInputStream())
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(EOFError) as exc_info:
         decoder.read(2)
 
     assert "Read 1 bytes, expected 2 bytes" in str(exc_info.value)


### PR DESCRIPTION
When a binary field would be zero bytes, we would still read the stream, causing a EOFErrors:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/manifest.py", line 139, in read_manifest_entry
    for record in reader:
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/file.py", line 194, in __next__
    return self.__next__()
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/file.py", line 186, in __next__
    return next(self.block)
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/file.py", line 113, in __next__
    return self.reader.read(self.block_decoder)
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/reader.py", line 260, in read
    struct.set(pos, field.read(decoder))  # later: pass reuse in here
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/reader.py", line 260, in read
    struct.set(pos, field.read(decoder))  # later: pass reuse in here
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/reader.py", line 233, in read
    return self.option.read(decoder)
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/reader.py", line 313, in read
    read_items[key] = self.value.read(decoder)
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/reader.py", line 200, in read
    return decoder.read_bytes()
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/decoder.py", line 118, in read_bytes
    return self.read(self.read_int())
  File "/Users/fokkodriesprong/Desktop/iceberg/python/pyiceberg/avro/decoder.py", line 54, in read
    raise EOFError
EOFError
```

Fixes #6435

Many thanks to @joshuarobinson for reporting this 🙏🏻 