### PR TITLE
Python: fix cast in console CLI

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import (
     Callable,
+    Dict,
     List,
     Optional,
     Set,
@@ -154,7 +155,7 @@ def load_catalog(name: str, **properties: Optional[str]) -> Catalog:
         catalog_type = infer_catalog_type(name, conf)
 
     if catalog_type:
-        return AVAILABLE_CATALOGS[catalog_type](name, cast(dict[str, str], conf))
+        return AVAILABLE_CATALOGS[catalog_type](name, cast(Dict[str, str], conf))
 
     raise ValueError(f"Could not initialize catalog with the following properties: {properties}")
 


### PR DESCRIPTION
When invoking pyiceberg cli, I get the following:
```shell
$ pyiceberg list
'type' object is not subscriptable
```