### PR TITLE
Spark 3.3: Use regular planning for applicable row-level operations

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -446,16 +446,16 @@ object RewriteMergeIntoTable extends RewriteRowLevelIcebergCommand with Predicat
     ProjectingInternalRow(schema, projectedOrdinals)
   }
 
-  // splits the condition into a predicate on the target table, which can be pushed down, and join
-  // condition that must be evaluated while finding matches
+  // splits the MERGE condition into a predicate that references columns only from the target table,
+  // which can be pushed down, and a predicate used as a join condition to find matches
   private def splitMergeCond(
       cond: Expression,
       targetTable: LogicalPlan): (Expression, Expression) = {
 
     val (targetPredicates, joinPredicates) = splitConjunctivePredicates(cond)
       .partition(_.references.subsetOf(targetTable.outputSet))
-    val targetCond = targetPredicates.reduceOption(And).getOrElse(Literal.TrueLiteral)
-    val joinCond = joinPredicates.reduceOption(And).getOrElse(Literal.TrueLiteral)
+    val targetCond = targetPredicates.reduceOption(And).getOrElse(TrueLiteral)
+    val joinCond = joinPredicates.reduceOption(And).getOrElse(TrueLiteral)
     (targetCond, joinCond)
   }
 }

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RowLevelCommandScanRelationPushDown.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RowLevelCommandScanRelationPushDown.scala
@@ -40,7 +40,8 @@ object RowLevelCommandScanRelationPushDown extends Rule[LogicalPlan] with Predic
   import ExtendedDataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
-    // use regular planning for delta-based plans and copy-on-write MERGE operations
+    // use native Spark planning for delta-based plans and copy-on-write MERGE operations
+    // unlike other commands, these plans have filters that can be pushed down directly
     case RewrittenRowLevelCommand(command, _: DataSourceV2Relation, rewritePlan)
         if rewritePlan.isInstanceOf[WriteDelta] || command.isInstanceOf[MergeIntoIcebergTable] =>
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -170,7 +170,11 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
   }
 
   protected void createAndInitTable(String schema, String jsonData) {
-    sql("CREATE TABLE %s (%s) USING iceberg", tableName, schema);
+    createAndInitTable(schema, "", jsonData);
+  }
+
+  protected void createAndInitTable(String schema, String partitioning, String jsonData) {
+    sql("CREATE TABLE %s (%s) USING iceberg %s", tableName, schema, partitioning);
     initTable();
 
     if (jsonData != null) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteOperation.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteOperation.java
@@ -24,7 +24,6 @@ import static org.apache.spark.sql.connector.write.RowLevelOperation.Command.UPD
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
@@ -81,7 +80,6 @@ class SparkCopyOnWriteOperation implements RowLevelOperation {
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
     if (lazyWriteBuilder == null) {
-      Preconditions.checkState(configuredScan != null, "Write must be configured after scan");
       SparkWriteBuilder writeBuilder = new SparkWriteBuilder(spark, table, info);
       lazyWriteBuilder = writeBuilder.overwriteFiles(configuredScan, command, isolationLevel);
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -86,8 +86,6 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
   }
 
   public WriteBuilder overwriteFiles(Scan scan, Command command, IsolationLevel isolationLevel) {
-    Preconditions.checkArgument(
-        scan instanceof SparkCopyOnWriteScan, "%s is not SparkCopyOnWriteScan", scan);
     Preconditions.checkState(!overwriteByFilter, "Cannot overwrite individual files and by filter");
     Preconditions.checkState(
         !overwriteDynamic, "Cannot overwrite individual files and dynamically");


### PR DESCRIPTION
This PR switches all merge-on-read and MERGE copy-on-write operations to use built-in Spark planning. This enables more optimizations for applicable row-level commands like discarding pushed down predicates.