### PR TITLE
Flink: make two test util methods public from SimpleDataUtil

### DIFF
--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -236,8 +236,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  public static void assertRecordsEqual(
-      List<Record> expected, List<Record> actual, Schema schema) {
+  public static void assertRecordsEqual(List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();
     StructLikeSet expectedSet = StructLikeSet.create(type);

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -224,7 +224,7 @@ public class SimpleDataUtil {
     return records;
   }
 
-  private static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
+  public static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
     if (expected.size() != actual.size()) {
       return false;
     }
@@ -236,7 +236,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  private static void assertRecordsEqual(
+  public static void assertRecordsEqual(
       List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -238,8 +238,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  public static void assertRecordsEqual(
-      List<Record> expected, List<Record> actual, Schema schema) {
+  public static void assertRecordsEqual(List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();
     StructLikeSet expectedSet = StructLikeSet.create(type);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -226,7 +226,7 @@ public class SimpleDataUtil {
     return records;
   }
 
-  private static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
+  public static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
     if (expected.size() != actual.size()) {
       return false;
     }
@@ -238,7 +238,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  private static void assertRecordsEqual(
+  public static void assertRecordsEqual(
       List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -238,8 +238,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  public static void assertRecordsEqual(
-      List<Record> expected, List<Record> actual, Schema schema) {
+  public static void assertRecordsEqual(List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();
     StructLikeSet expectedSet = StructLikeSet.create(type);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -226,7 +226,7 @@ public class SimpleDataUtil {
     return records;
   }
 
-  private static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
+  public static boolean equalsRecords(List<Record> expected, List<Record> actual, Schema schema) {
     if (expected.size() != actual.size()) {
       return false;
     }
@@ -238,7 +238,7 @@ public class SimpleDataUtil {
     return expectedSet.equals(actualSet);
   }
 
-  private static void assertRecordsEqual(
+  public static void assertRecordsEqual(
       List<Record> expected, List<Record> actual, Schema schema) {
     Assert.assertEquals(expected.size(), actual.size());
     Types.StructType type = schema.asStruct();


### PR DESCRIPTION
some internal test code (not merged upstream) can use those two util methods