### PR TITLE
Add InMemoryFileIO as a test helper class

### DIFF
--- a/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class InMemoryFileIO implements FileIO {
 
-  private Map<String, byte[]> inMemoryFiles = Maps.newHashMap();
+  private Map<String, byte[]> inMemoryFiles = Maps.newConcurrentMap();
   private boolean closed = false;
 
   public void addFile(String location, byte[] contents) {

--- a/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
@@ -28,37 +28,37 @@ public class InMemoryFileIO implements FileIO {
   private Map<String, byte[]> inMemoryFiles = Maps.newHashMap();
   private boolean closed = false;
 
-  public void addFile(String path, byte[] contents) {
+  public void addFile(String location, byte[] contents) {
     Preconditions.checkState(!closed, "Cannot call addFile after calling close()");
-    inMemoryFiles.put(path, contents);
+    inMemoryFiles.put(location, contents);
   }
 
-  public boolean fileExists(String path) {
-    return inMemoryFiles.containsKey(path);
+  public boolean fileExists(String location) {
+    return inMemoryFiles.containsKey(location);
   }
 
   @Override
-  public InputFile newInputFile(String path) {
+  public InputFile newInputFile(String location) {
     Preconditions.checkState(!closed, "Cannot call newInputFile after calling close()");
-    if (!inMemoryFiles.containsKey(path)) {
-      throw new NotFoundException("No in-memory file found for path: %s", path);
+    byte[] contents = inMemoryFiles.get(location);
+    if (null == contents) {
+      throw new NotFoundException("No in-memory file found for location: %s", location);
     }
-    return new InMemoryInputFile(path, inMemoryFiles.get(path));
+    return new InMemoryInputFile(location, contents);
   }
 
   @Override
-  public OutputFile newOutputFile(String path) {
+  public OutputFile newOutputFile(String location) {
     Preconditions.checkState(!closed, "Cannot call newOutputFile after calling close()");
-    return new InMemoryOutputFile(path, this);
+    return new InMemoryOutputFile(location, this);
   }
 
   @Override
-  public void deleteFile(String path) {
+  public void deleteFile(String location) {
     Preconditions.checkState(!closed, "Cannot call deleteFile after calling close()");
-    if (!inMemoryFiles.containsKey(path)) {
-      throw new NotFoundException("No in-memory file found for path: %s", path);
+    if (null == inMemoryFiles.remove(location)) {
+      throw new NotFoundException("No in-memory file found for location: %s", location);
     }
-    inMemoryFiles.remove(path);
   }
 
   public boolean isClosed() {

--- a/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/InMemoryFileIO.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import java.util.Map;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class InMemoryFileIO implements FileIO {
+
+  private Map<String, byte[]> inMemoryFiles = Maps.newHashMap();
+  private boolean closed = false;
+
+  public void addFile(String path, byte[] contents) {
+    Preconditions.checkState(!closed, "Cannot call addFile after calling close()");
+    inMemoryFiles.put(path, contents);
+  }
+
+  public boolean fileExists(String path) {
+    return inMemoryFiles.containsKey(path);
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    Preconditions.checkState(!closed, "Cannot call newInputFile after calling close()");
+    if (!inMemoryFiles.containsKey(path)) {
+      throw new NotFoundException("No in-memory file found for path: %s", path);
+    }
+    return new InMemoryInputFile(path, inMemoryFiles.get(path));
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    Preconditions.checkState(!closed, "Cannot call newOutputFile after calling close()");
+    return new InMemoryOutputFile(path, this);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    Preconditions.checkState(!closed, "Cannot call deleteFile after calling close()");
+    if (!inMemoryFiles.containsKey(path)) {
+      throw new NotFoundException("No in-memory file found for path: %s", path);
+    }
+    inMemoryFiles.remove(path);
+  }
+
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/io/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestInMemoryFileIO.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestInMemoryFileIO {
+  String location = "s3://foo/bar.txt";
+
+  @Test
+  public void testBasicEndToEnd() throws IOException {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    Assertions.assertThat(fileIO.fileExists(location)).isFalse();
+
+    OutputStream outputStream = fileIO.newOutputFile(location).create();
+    byte[] data = "hello world".getBytes();
+    outputStream.write(data);
+    outputStream.close();
+    Assertions.assertThat(fileIO.fileExists(location)).isTrue();
+
+    InputStream inputStream = fileIO.newInputFile(location).newStream();
+    byte[] buf = new byte[data.length];
+    inputStream.read(buf);
+    inputStream.close();
+    Assertions.assertThat(new String(buf)).isEqualTo("hello world");
+
+    fileIO.deleteFile(location);
+    Assertions.assertThat(fileIO.fileExists(location)).isFalse();
+  }
+
+  @Test
+  public void testNewInputFileNotFound() throws IOException {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    Assertions.assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> fileIO.newInputFile("s3://nonexistent/file"));
+  }
+
+  @Test
+  public void testDeleteFileNotFound() throws IOException {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    Assertions.assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> fileIO.deleteFile("s3://nonexistent/file"));
+  }
+
+  @Test
+  public void testCreateNoOverwrite() throws IOException {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.addFile(location, "hello world".getBytes());
+    Assertions.assertThatExceptionOfType(AlreadyExistsException.class)
+        .isThrownBy(() -> fileIO.newOutputFile(location).create());
+  }
+
+  @Test
+  public void testOverwriteBeforeAndAfterClose() throws IOException {
+    byte[] oldData = "old data".getBytes();
+    byte[] newData = "new data".getBytes();
+
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    OutputStream outputStream = fileIO.newOutputFile(location).create();
+    outputStream.write(oldData);
+
+    // Even though we've called create() and started writing data, this file won't yet exist
+    // in the parentFileIO before we've closed it.
+    Assertions.assertThat(fileIO.fileExists(location)).isFalse();
+
+    // File appears after closing it.
+    outputStream.close();
+    Assertions.assertThat(fileIO.fileExists(location)).isTrue();
+
+    // Start a new OutputFile and write new data but don't close() it yet.
+    outputStream = fileIO.newOutputFile(location).createOrOverwrite();
+    outputStream.write(newData);
+
+    // We'll still read old data.
+    InputStream inputStream = fileIO.newInputFile(location).newStream();
+    byte[] buf = new byte[oldData.length];
+    inputStream.read(buf);
+    inputStream.close();
+    Assertions.assertThat(new String(buf)).isEqualTo("old data");
+
+    // Finally, close the new output stream; data should be overwritten with new data now.
+    outputStream.close();
+    inputStream = fileIO.newInputFile(location).newStream();
+    buf = new byte[newData.length];
+    inputStream.read(buf);
+    inputStream.close();
+    Assertions.assertThat(new String(buf)).isEqualTo("new data");
+  }
+}


### PR DESCRIPTION
Add InMemoryFileIO alongside existing InMemoryOutputFile and InMemoryInputFile as a test helper class stitching the two together and maintaining an in-memory listing of files. Add a dedicated unittest for the new test helper.