### PR TITLE
Python: Add typing-extensions as a pylint dependency

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
     hooks:
       - id: pylint
         args: [ --rcfile=python/pylintrc ]
+        additional_dependencies: [ typing-extensions==4.4.0 ]
   - repo: https://github.com/pycqa/flake8
     rev: '6.0.0'
     hooks:


### PR DESCRIPTION
It is an issue in a downstream dependency and is currently being fixed in pylint: https://github.com/PyCQA/pylint/pull/8030 but we're still waiting for the release

Has been fixed in Astroid at: https://github.com/PyCQA/astroid/pull/1944