### PR TITLE
Throw exception when snapshot expiration operation on snapshot table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -91,8 +91,8 @@ class RemoveSnapshots implements ExpireSnapshots {
     this.ops = ops;
     this.base = ops.current();
     ValidationException.check(
-            PropertyUtil.propertyAsBoolean(base.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
-            "Cannot expire snapshots: This is a snapshot table");
+        PropertyUtil.propertyAsBoolean(base.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        "Cannot expire snapshots: This is a snapshot table");
 
     ValidationException.check(
         PropertyUtil.propertyAsBoolean(base.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -91,7 +91,7 @@ class RemoveSnapshots implements ExpireSnapshots {
     this.ops = ops;
     this.base = ops.current();
     ValidationException.check(
-        PropertyUtil.propertyAsBoolean(base.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        !PropertyUtil.propertyAsBoolean(base.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
         "Cannot expire snapshots: This is a snapshot table");
 
     ValidationException.check(

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -34,6 +34,8 @@ import static org.apache.iceberg.TableProperties.MAX_SNAPSHOT_AGE_MS;
 import static org.apache.iceberg.TableProperties.MAX_SNAPSHOT_AGE_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP;
 import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_DEFAULT;
 
 import java.util.Collection;
 import java.util.List;
@@ -88,6 +90,10 @@ class RemoveSnapshots implements ExpireSnapshots {
   RemoveSnapshots(TableOperations ops) {
     this.ops = ops;
     this.base = ops.current();
+    ValidationException.check(
+            PropertyUtil.propertyAsBoolean(base.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+            "Cannot expire snapshots: This is a snapshot table");
+
     ValidationException.check(
         PropertyUtil.propertyAsBoolean(base.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
         "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -311,6 +311,9 @@ public class TableProperties {
   public static final String GC_ENABLED = "gc.enabled";
   public static final boolean GC_ENABLED_DEFAULT = true;
 
+  public static final String SNAPSHOT = "snapshot";
+  public static final Boolean SNAPSHOT_DEFAULT = false;
+
   public static final String MAX_SNAPSHOT_AGE_MS = "history.expire.max-snapshot-age-ms";
   public static final long MAX_SNAPSHOT_AGE_MS_DEFAULT = 5 * 24 * 60 * 60 * 1000; // 5 days
 

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_DEFAULT;
 
 import java.util.Iterator;
 import java.util.List;

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -102,6 +102,10 @@ public class BaseExpireSnapshotsSparkAction
     this.ops = ((HasTableOperations) table).operations();
 
     ValidationException.check(
+        !PropertyUtil.propertyAsBoolean(table.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        "Cannot expire snapshots: This is a snapshot table");
+
+    ValidationException.check(
         PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
         "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -423,6 +423,19 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
+  public void testExpireSnapshotsWithSnapshotTable() {
+    table.updateProperties().set(TableProperties.SNAPSHOT, "true").commit();
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    AssertHelpers.assertThrows(
+            "Should complain about expiring snapshots",
+            ValidationException.class,
+            "Cannot expire snapshots: This is a snapshot table",
+            () -> SparkActions.get().expireSnapshots(table));
+  }
+
+  @Test
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -429,10 +429,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     AssertHelpers.assertThrows(
-            "Should complain about expiring snapshots",
-            ValidationException.class,
-            "Cannot expire snapshots: This is a snapshot table",
-            () -> SparkActions.get().expireSnapshots(table));
+        "Should complain about expiring snapshots",
+        ValidationException.class,
+        "Cannot expire snapshots: This is a snapshot table",
+        () -> SparkActions.get().expireSnapshots(table));
   }
 
   @Test

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_DEFAULT;
 
 import java.util.Iterator;
 import java.util.List;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -102,6 +102,10 @@ public class BaseExpireSnapshotsSparkAction
     this.ops = ((HasTableOperations) table).operations();
 
     ValidationException.check(
+        !PropertyUtil.propertyAsBoolean(table.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        "Cannot expire snapshots: This is a snapshot table");
+
+    ValidationException.check(
         PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
         "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
@@ -187,7 +187,7 @@ public class BaseSnapshotTableSparkAction
 
     // make sure we mark this table as a snapshot table
     properties.put(TableProperties.GC_ENABLED, "false");
-    properties.put("snapshot", "true");
+    properties.put(TableProperties.SNAPSHOT, "true");
 
     // set the destination table location if provided
     if (destTableLocation != null) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -430,10 +430,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     AssertHelpers.assertThrows(
-            "Should complain about expiring snapshots",
-            ValidationException.class,
-            "Cannot expire snapshots: This is a snapshot table",
-            () -> SparkActions.get().expireSnapshots(table));
+        "Should complain about expiring snapshots",
+        ValidationException.class,
+        "Cannot expire snapshots: This is a snapshot table",
+        () -> SparkActions.get().expireSnapshots(table));
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -424,6 +424,19 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
+  public void testExpireSnapshotsWithSnapshotTable() {
+    table.updateProperties().set(TableProperties.SNAPSHOT, "true").commit();
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    AssertHelpers.assertThrows(
+            "Should complain about expiring snapshots",
+            ValidationException.class,
+            "Cannot expire snapshots: This is a snapshot table",
+            () -> SparkActions.get().expireSnapshots(table));
+  }
+
+  @Test
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_DEFAULT;
 
 import java.util.Iterator;
 import java.util.List;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -95,6 +95,10 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     this.ops = ((HasTableOperations) table).operations();
 
     ValidationException.check(
+        !PropertyUtil.propertyAsBoolean(table.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        "Cannot expire snapshots: This is a snapshot table");
+
+    ValidationException.check(
         PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
         "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -174,7 +174,7 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
 
     // make sure we mark this table as a snapshot table
     properties.put(TableProperties.GC_ENABLED, "false");
-    properties.put("snapshot", "true");
+    properties.put(TableProperties.SNAPSHOT, "true");
 
     // set the destination table location if provided
     if (destTableLocation != null) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -462,10 +462,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     AssertHelpers.assertThrows(
-            "Should complain about expiring snapshots",
-            ValidationException.class,
-            "Cannot expire snapshots: This is a snapshot table",
-            () -> SparkActions.get().expireSnapshots(table));
+        "Should complain about expiring snapshots",
+        ValidationException.class,
+        "Cannot expire snapshots: This is a snapshot table",
+        () -> SparkActions.get().expireSnapshots(table));
   }
 
   @Test

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -456,6 +456,19 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
+  public void testExpireSnapshotsWithSnapshotTable() {
+    table.updateProperties().set(TableProperties.SNAPSHOT, "true").commit();
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    AssertHelpers.assertThrows(
+            "Should complain about expiring snapshots",
+            ValidationException.class,
+            "Cannot expire snapshots: This is a snapshot table",
+            () -> SparkActions.get().expireSnapshots(table));
+  }
+
+  @Test
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_DEFAULT;
 
 import java.util.Iterator;
 import java.util.List;
@@ -93,6 +95,10 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
     super(spark);
     this.table = table;
     this.ops = ((HasTableOperations) table).operations();
+
+    ValidationException.check(
+        !PropertyUtil.propertyAsBoolean(table.properties(), SNAPSHOT, SNAPSHOT_DEFAULT),
+        "Cannot expire snapshots: This is a snapshot table");
 
     ValidationException.check(
         PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -174,7 +174,7 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
 
     // make sure we mark this table as a snapshot table
     properties.put(TableProperties.GC_ENABLED, "false");
-    properties.put("snapshot", "true");
+    properties.put(TableProperties.SNAPSHOT, "true");
 
     // set the destination table location if provided
     if (destTableLocation != null) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -462,10 +462,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.newAppend().appendFile(FILE_A).commit();
 
     AssertHelpers.assertThrows(
-            "Should complain about expiring snapshots",
-            ValidationException.class,
-            "Cannot expire snapshots: This is a snapshot table",
-            () -> SparkActions.get().expireSnapshots(table));
+        "Should complain about expiring snapshots",
+        ValidationException.class,
+        "Cannot expire snapshots: This is a snapshot table",
+        () -> SparkActions.get().expireSnapshots(table));
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -456,6 +456,19 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
+  public void testExpireSnapshotsWithSnapshotTable() {
+    table.updateProperties().set(TableProperties.SNAPSHOT, "true").commit();
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    AssertHelpers.assertThrows(
+            "Should complain about expiring snapshots",
+            ValidationException.class,
+            "Cannot expire snapshots: This is a snapshot table",
+            () -> SparkActions.get().expireSnapshots(table));
+  }
+
+  @Test
   public void testExpireOlderThanMultipleCalls() {
     table
         .newAppend()


### PR DESCRIPTION
"snapshot" table property is set by spark snapshot action to indicate a table is snapshot table or not. 

Per https://iceberg.apache.org/docs/latest/spark-procedures/#snapshot a snapshot table is not allowed for snapshot expiration operation. However, this restriction is not in place and such restriction is achieved by another property "gc.enabled".

This diff implemented two things:
1. add "snapshot" property into the table property lists
2. reject any snapshot expiration when such table is a snapshot table (snapshot = true)