### PR TITLE
API: Fix comments in SQLViewRepresentation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
+++ b/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
@@ -44,9 +44,9 @@ public interface SQLViewRepresentation extends ViewRepresentation {
   /** The query output schema at version create time, without aliases. */
   Schema schema();
 
-  /** The view field aliases. */
+  /** The view field comments. */
   List<String> fieldComments();
 
-  /** The view field comments. */
+  /** The view field aliases. */
   List<String> fieldAliases();
 }


### PR DESCRIPTION
Minor fix for inline comments for fieldComments and fieldAliases, the comments for the two were reversed