### PR TITLE
Hive: Use EnvironmentContext instead of Hive Locks to provide transactional commits after HIVE-26882

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -303,6 +303,9 @@ public class TableProperties {
   public static final String ENGINE_HIVE_ENABLED = "engine.hive.enabled";
   public static final boolean ENGINE_HIVE_ENABLED_DEFAULT = false;
 
+  public static final String HIVE_LOCK_ENABLED = "hive.lock.enabled";
+  public static final boolean HIVE_LOCK_ENABLED_DEFAULT = true;
+
   public static final String WRITE_DISTRIBUTION_MODE = "write.distribution-mode";
   public static final String WRITE_DISTRIBUTION_MODE_NONE = "none";
   public static final String WRITE_DISTRIBUTION_MODE_HASH = "hash";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -303,7 +303,7 @@ public class TableProperties {
   public static final String ENGINE_HIVE_ENABLED = "engine.hive.enabled";
   public static final boolean ENGINE_HIVE_ENABLED_DEFAULT = false;
 
-  public static final String HIVE_LOCK_ENABLED = "hive.lock.enabled";
+  public static final String HIVE_LOCK_ENABLED = "engine.hive.lock-enabled";
   public static final boolean HIVE_LOCK_ENABLED_DEFAULT = true;
 
   public static final String WRITE_DISTRIBUTION_MODE = "write.distribution-mode";

--- a/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
@@ -23,6 +23,6 @@ public class ConfigProperties {
   private ConfigProperties() {}
 
   public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
-  public static final String LOCK_HIVE_ENABLED = "iceberg.lock.hive.enabled";
+  public static final String LOCK_HIVE_ENABLED = "iceberg.engine.hive.lock-enabled";
   public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,8 +178,13 @@ The HMS table locking is a 2-step process:
 | iceberg.hive.lock-heartbeat-interval-ms   | 240000 (4 min)  | The heartbeat interval for the HMS locks.                                    |
 | iceberg.hive.metadata-refresh-max-retries | 2               | Maximum number of retries when the metadata file is missing                  |
 | iceberg.hive.table-level-lock-evict-ms    | 600000 (10 min) | The timeout for the JVM table lock is                                        |
+| iceberg.lock.hive.enabled                 | true            | If enabled HMS locks will be used to ensure of the atomicity of the commits  |
 
 Note: `iceberg.hive.lock-check-max-wait-ms` and `iceberg.hive.lock-heartbeat-interval-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) 
 of the Hive Metastore (`hive.txn.timeout` or `metastore.txn.timeout` in the newer versions). Otherwise, the heartbeats on the lock (which happens during the lock checks) would end up expiring in the 
 Hive Metastore before the lock is retried from Iceberg.
+
+Note: `iceberg.lock.hive.enabled` should only be set to `false` if [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882)
+is available on the Hive Metastore server and every writer of a given table is using Iceberg 1.2 or later.
+The `lock.hive.enabled` table property could be used to change this behavior on Table level.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,13 +178,13 @@ The HMS table locking is a 2-step process:
 | iceberg.hive.lock-heartbeat-interval-ms   | 240000 (4 min)  | The heartbeat interval for the HMS locks.                                    |
 | iceberg.hive.metadata-refresh-max-retries | 2               | Maximum number of retries when the metadata file is missing                  |
 | iceberg.hive.table-level-lock-evict-ms    | 600000 (10 min) | The timeout for the JVM table lock is                                        |
-| iceberg.lock.hive.enabled                 | true            | If enabled HMS locks will be used to ensure of the atomicity of the commits  |
+| iceberg.engine.hive.lock-enabled          | true            | If enabled HMS locks will be used to ensure of the atomicity of the commits  |
 
 Note: `iceberg.hive.lock-check-max-wait-ms` and `iceberg.hive.lock-heartbeat-interval-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) 
 of the Hive Metastore (`hive.txn.timeout` or `metastore.txn.timeout` in the newer versions). Otherwise, the heartbeats on the lock (which happens during the lock checks) would end up expiring in the 
 Hive Metastore before the lock is retried from Iceberg.
 
-Note: `iceberg.lock.hive.enabled` should only be set to `false` if [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882)
+Note: `iceberg.engine.hive.lock-enabled` should only be set to `false` if [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882)
 is available on the Hive Metastore server and every writer of a given table is using Iceberg 1.2 or later.
-The `lock.hive.enabled` table property could be used to change this behavior on Table level.
+The `engine.hive.lock-enabled` table property could be used to change this behavior on Table level.
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreUtil.java
@@ -50,8 +50,8 @@ public class MetastoreUtil {
   private MetastoreUtil() {}
 
   /**
-   * Calls alter_table method using the metastore client. If the HMS supports then, environmental
-   * context with will be set in a way that turns off stats updates to avoid recursive file listing.
+   * Calls alter_table method using the metastore client. If the HMS supports it, environmental
+   * context will be set in a way that turns off stats updates to avoid recursive file listing.
    */
   public static void alterTable(
       IMetaStoreClient client, String databaseName, String tblName, Table table) {
@@ -59,8 +59,8 @@ public class MetastoreUtil {
   }
 
   /**
-   * Calls alter_table method using the metastore client. If the HMS supports then, environmental
-   * context with will be set in a way that turns off stats updates to avoid recursive file listing.
+   * Calls alter_table method using the metastore client. If the HMS supports it, environmental
+   * context will be set in a way that turns off stats updates to avoid recursive file listing.
    */
   public static void alterTable(
       IMetaStoreClient client,

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
@@ -16,13 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.hadoop;
+package org.apache.iceberg.hive;
 
-public class ConfigProperties {
+public class NoLock implements HiveLock {
 
-  private ConfigProperties() {}
+  @Override
+  public void lock() throws LockException {
+    // no-op
+  }
 
-  public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
-  public static final String LOCK_HIVE_ENABLED = "iceberg.lock.hive.enabled";
-  public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
+  @Override
+  public void ensureActive() throws LockException {
+    // no-op
+  }
+
+  @Override
+  public void unlock() {
+    // no-op
+  }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/NoLock.java
@@ -18,7 +18,14 @@
  */
 package org.apache.iceberg.hive;
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
 public class NoLock implements HiveLock {
+  public NoLock() {
+    Preconditions.checkArgument(
+        HiveVersion.min(HiveVersion.HIVE_2),
+        "Minimally Hive 2 HMS client is needed to use HIVE-26882 based locking");
+  }
 
   @Override
   public void lock() throws LockException {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.LockState;
@@ -493,5 +495,32 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         CommitFailedException.class,
         "Failed to heartbeat for hive lock. Failed to heart beat.",
         () -> spyOps.doCommit(metadataV2, metadataV1));
+  }
+
+  @Test
+  public void testNoLockCallsWithNoLock() throws TException {
+    doReturn(new NoLock()).when(spyOps).lockObject(any());
+
+    ArgumentCaptor<EnvironmentContext> contextCaptor =
+        ArgumentCaptor.forClass(EnvironmentContext.class);
+
+    doNothing()
+        .when(spyClient)
+        .alter_table_with_environmentContext(any(), any(), any(), contextCaptor.capture());
+
+    spyOps.doCommit(metadataV2, metadataV1);
+
+    // Make sure that the locking is not used
+    verify(spyClient, never()).lock(any(LockRequest.class));
+    verify(spyClient, never()).checkLock(any(Long.class));
+    verify(spyClient, never()).heartbeat(any(Long.class), any(Long.class));
+    verify(spyClient, never()).unlock(any(Long.class));
+
+    // Make sure that the expected parameter context values are set
+    Map<String, String> context = contextCaptor.getValue().getProperties();
+    Assert.assertEquals(3, context.size());
+    Assert.assertEquals(
+        context.get("expected_parameter_key"), HiveTableOperations.METADATA_LOCATION_PROP);
+    Assert.assertEquals(context.get("expected_parameter_value"), metadataV2.metadataFileLocation());
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.hive;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -29,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
@@ -345,10 +343,10 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     // Simulate a concurrent table modification error
     doThrow(
-            new MetaException(
-                "The table has been modified. The parameter value for key 'expected_parameter_key' is"))
+            new RuntimeException(
+                "MetaException(message:The table has been modified. The parameter value for key 'metadata_location' is"))
         .when(spyOps)
-        .persistTable(any(), anyBoolean(), anyString());
+        .persistTable(any(), anyBoolean(), any());
 
     // Should throw a CommitFailedException so the commit could be retried
     AssertHelpers.assertThrows(
@@ -376,7 +374,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
               throw new TException("Datacenter on fire");
             })
         .when(spyOperations)
-        .persistTable(any(), anyBoolean(), anyString());
+        .persistTable(any(), anyBoolean(), any());
   }
 
   private void concurrentCommitAndThrowException(
@@ -399,14 +397,14 @@ public class TestHiveCommits extends HiveTableBaseTest {
               throw new TException("Datacenter on fire");
             })
         .when(spyOperations)
-        .persistTable(any(), anyBoolean(), anyString());
+        .persistTable(any(), anyBoolean(), any());
   }
 
   private void failCommitAndThrowException(HiveTableOperations spyOperations)
       throws TException, InterruptedException {
     doThrow(new TException("Datacenter on fire"))
         .when(spyOperations)
-        .persistTable(any(), anyBoolean(), anyString());
+        .persistTable(any(), anyBoolean(), any());
   }
 
   private void breakFallbackCatalogCommitCheck(HiveTableOperations spyOperations) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -20,14 +20,16 @@ package org.apache.iceberg.hive;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.net.UnknownHostException;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
@@ -35,6 +37,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.types.Types;
@@ -45,7 +48,7 @@ import org.junit.Test;
 public class TestHiveCommits extends HiveTableBaseTest {
 
   @Test
-  public void testSuppressUnlockExceptions() throws TException, InterruptedException {
+  public void testSuppressUnlockExceptions() {
     Table table = catalog.loadTable(TABLE_IDENTIFIER);
     HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
 
@@ -63,7 +66,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     AtomicReference<HiveLock> lockRef = new AtomicReference<>();
 
-    when(spyOps.lockObject())
+    when(spyOps.lockObject(metadataV1))
         .thenAnswer(
             i -> {
               HiveLock lock = (HiveLock) i.callRealMethod();
@@ -259,8 +262,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
    * because it isn't the current one during the recheck phase.
    */
   @Test
-  public void testThriftExceptionConcurrentCommit()
-      throws TException, InterruptedException, UnknownHostException {
+  public void testThriftExceptionConcurrentCommit() throws TException, InterruptedException {
     Table table = catalog.loadTable(TABLE_IDENTIFIER);
     HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
 
@@ -279,11 +281,11 @@ public class TestHiveCommits extends HiveTableBaseTest {
     AtomicReference<HiveLock> lock = new AtomicReference<>();
     doAnswer(
             l -> {
-              lock.set(ops.lockObject());
+              lock.set(ops.lockObject(metadataV1));
               return lock.get();
             })
         .when(spyOps)
-        .lockObject();
+        .lockObject(metadataV1);
 
     concurrentCommitAndThrowException(ops, spyOps, table, lock);
 
@@ -320,6 +322,47 @@ public class TestHiveCommits extends HiveTableBaseTest {
         () -> catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned()));
   }
 
+  /** Uses NoLock and pretends we throw an error because of a concurrent commit */
+  @Test
+  public void testNoLockThriftExceptionConcurrentCommit() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+
+    TableMetadata metadataV1 = ops.current();
+
+    table.updateSchema().addColumn("n", Types.IntegerType.get()).commit();
+
+    ops.refresh();
+
+    TableMetadata metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    HiveTableOperations spyOps = spy(ops);
+
+    // Sets NoLock
+    doReturn(new NoLock()).when(spyOps).lockObject(any());
+
+    // Simulate a concurrent table modification error
+    doThrow(
+            new MetaException(
+                "The table has been modified. The parameter value for key 'expected_parameter_key' is"))
+        .when(spyOps)
+        .persistTable(any(), anyBoolean(), anyString());
+
+    // Should throw a CommitFailedException so the commit could be retried
+    AssertHelpers.assertThrows(
+        "Should throw CommitFailedException since the table has been modified concurrently",
+        CommitFailedException.class,
+        "has been modified concurrently",
+        () -> spyOps.commit(metadataV2, metadataV1));
+
+    ops.refresh();
+    Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
+    Assert.assertTrue("Current metadata should still exist", metadataFileExists(metadataV2));
+    Assert.assertEquals("New metadata files should not exist", 2, metadataFileCount(ops.current()));
+  }
+
   private void commitAndThrowException(
       HiveTableOperations realOperations, HiveTableOperations spyOperations)
       throws TException, InterruptedException {
@@ -328,11 +371,12 @@ public class TestHiveCommits extends HiveTableBaseTest {
             i -> {
               org.apache.hadoop.hive.metastore.api.Table tbl =
                   i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
-              realOperations.persistTable(tbl, true);
+              String location = i.getArgument(2, String.class);
+              realOperations.persistTable(tbl, true, location);
               throw new TException("Datacenter on fire");
             })
         .when(spyOperations)
-        .persistTable(any(), anyBoolean());
+        .persistTable(any(), anyBoolean(), anyString());
   }
 
   private void concurrentCommitAndThrowException(
@@ -346,7 +390,8 @@ public class TestHiveCommits extends HiveTableBaseTest {
             i -> {
               org.apache.hadoop.hive.metastore.api.Table tbl =
                   i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
-              realOperations.persistTable(tbl, true);
+              String location = i.getArgument(2, String.class);
+              realOperations.persistTable(tbl, true, location);
               // Simulate lock expiration or removal
               lock.get().unlock();
               table.refresh();
@@ -354,14 +399,14 @@ public class TestHiveCommits extends HiveTableBaseTest {
               throw new TException("Datacenter on fire");
             })
         .when(spyOperations)
-        .persistTable(any(), anyBoolean());
+        .persistTable(any(), anyBoolean(), anyString());
   }
 
   private void failCommitAndThrowException(HiveTableOperations spyOperations)
       throws TException, InterruptedException {
     doThrow(new TException("Datacenter on fire"))
         .when(spyOperations)
-        .persistTable(any(), anyBoolean());
+        .persistTable(any(), anyBoolean(), anyString());
   }
 
   private void breakFallbackCatalogCommitCheck(HiveTableOperations spyOperations) {


### PR DESCRIPTION
HIVE-26882 gives us the possibility to atomically change the `metadata_location` using a single `alter_table` HMS call. The change is a new feature, so exception is needed from the Hive community to include it to new releases. OTOH I deliberately kept simple, so if someone uses their own Hive release they could backport the change easily.

If we start using this possibility we can avoid using HMS locks to ensure the atomicity of the `HiveTableOperations.commit`. This has the following benefits:
- Instead of 4 HMS calls (lock, getTable, alter_table, unlock) we can use only 2 calls (getTable, alter_table) which could help in commit performance.
- I have seen several complains when the locks were not removed correctly (#3336, #2301) and suggested solutions (#6370). Also did my share to fix the situation as much as possible too (#6451)
- Removing the locks would remove much of this complexity

The solution has 2 parts:
- I rebased and refreshed @szlta's work on #5877 to refactor out the Lock related code to its own class
- Added a new feature to disable the locking mechanism

Some of my concerns and thoughts:
- I am not sure when HIVE-26882 will be available in OS. Here I would ask help from the Hive folks: @InvisibleProgrammer, @TuroczyX, @deniskuzZ.
    - The simplicity of the Hive PR helps alleviating my fears here
- We already have `LockManager` interface defined in the `iceberg-api` module. After some back-and-forth I decided against using it, because of the following reasons:
    - I do not think anyone would like to use HiveLockManager without HiveCatalog
    - The interface is not that useful for us:
        - We would need to keep track of the HMS lockId internally
        - We would need to update the LockManager if the `setConf` method is called on the HiveCatalog
        - We would need to add something like `ensureActive` to the interface which is needed for HiveTableOperations
    - The `BaseLockManager` does not provide too much of a functionality
    - The current configuration keys are different from the ones used by the `LockManager` implementations

WDYT?
Open for comments and suggestions.

Thanks,
Peter