### PR TITLE
Spark 3.3: support version travel by reference name

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -159,7 +160,15 @@ public class SparkCatalog extends BaseCatalog {
           sparkTable.snapshotId() == null,
           "Cannot do time-travel based on both table identifier and AS OF");
 
-      return sparkTable.copyWithSnapshotId(Long.parseLong(version));
+      try {
+        return sparkTable.copyWithSnapshotId(Long.parseLong(version));
+      } catch (NumberFormatException e) {
+        SnapshotRef ref = sparkTable.table().refs().get(version);
+        ValidationException.check(
+            ref != null,
+            "Cannot find matching snapshot ID or reference name for version " + version);
+        return sparkTable.copyWithSnapshotId(ref.snapshotId());
+      }
 
     } else if (table instanceof SparkChangelogTable) {
       throw new UnsupportedOperationException("AS OF is not supported for changelogs");

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -272,11 +272,14 @@ public class TestSelect extends SparkCatalogTestBase {
     table.manageSnapshots().createTag(Long.toString(snapshotId1), snapshotId2).commit();
 
     // currently Spark version travel ignores the type of the AS OF
-    // this means if a tag name matches a snapshot ID, it will always choose snapshotID to travel to.
-    List<Object[]> travelWithStringResult = sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, snapshotId1);
+    // this means if a tag name matches a snapshot ID, it will always choose snapshotID to travel
+    // to.
+    List<Object[]> travelWithStringResult =
+        sql("SELECT * FROM %s VERSION AS OF '%s'", tableName, snapshotId1);
     assertEquals("Snapshot at specific tag reference name", actual, travelWithStringResult);
 
-    List<Object[]> travelWithLongResult = sql("SELECT * FROM %s VERSION AS OF %s", tableName, snapshotId1);
+    List<Object[]> travelWithLongResult =
+        sql("SELECT * FROM %s VERSION AS OF %s", tableName, snapshotId1);
     assertEquals("Snapshot at specific tag reference name", actual, travelWithLongResult);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -316,7 +316,7 @@ public class TestSelect extends SparkCatalogTestBase {
   public void testUnknownReferenceAsOf() {
     Assertions.assertThatThrownBy(
             () -> sql("SELECT * FROM %s VERSION AS OF 'test_unknown'", tableName))
-        .hasMessage("Cannot find matching snapshot ID or reference name for version")
+        .hasMessageContaining("Cannot find matching snapshot ID or reference name for version")
         .isInstanceOf(ValidationException.class);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -288,11 +289,10 @@ public class TestSelect extends SparkCatalogTestBase {
 
   @Test
   public void testUnknownReferenceAsOf() {
-    AssertHelpers.assertThrows(
-        "Cannot find matching snapshot ID or reference name for version",
-        ValidationException.class,
-        "Cannot find matching snapshot ID or reference name for version",
-        () -> sql("SELECT * FROM %s VERSION AS OF 'test_unknown'", tableName));
+    Assertions.assertThatThrownBy(
+            () -> sql("SELECT * FROM %s VERSION AS OF 'test_unknown'", tableName))
+        .as("Cannot find matching snapshot ID or reference name for version")
+        .isInstanceOf(ValidationException.class);
   }
 
   @Test


### PR DESCRIPTION
Similar to the Trino PR I am trying to push https://github.com/trinodb/trino/pull/15646, support using reference name for the `VERSION AS OF` clause.

We have a related PR https://github.com/apache/iceberg/pull/5294 by @hililiwei that tries to directly add the reference info in table name, while we are consolidating that experience, I think we can first have this feature added in parallel.

@amogh-jahagirdar 