### PR TITLE
AWS: Fix check for isTableRegisteredWithLF leading to CREATE table failure

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.regions.PartitionMetadata;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
 import software.amazon.awssdk.services.glue.model.GetTableRequest;
 import software.amazon.awssdk.services.glue.model.GetTableResponse;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -110,15 +111,19 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
     Preconditions.checkArgument(
         tableName != null && !tableName.isEmpty(), "Table name can not be empty");
 
-    GetTableResponse response =
-        glue()
-            .getTable(
-                GetTableRequest.builder()
-                    .catalogId(glueCatalogId)
-                    .databaseName(dbName)
-                    .name(tableName)
-                    .build());
-    return response.table().isRegisteredWithLakeFormation();
+    try {
+      GetTableResponse response =
+          glue()
+              .getTable(
+                  GetTableRequest.builder()
+                      .catalogId(glueCatalogId)
+                      .databaseName(dbName)
+                      .name(tableName)
+                      .build());
+      return response.table().isRegisteredWithLakeFormation();
+    } catch (EntityNotFoundException e) {
+      return false;
+    }
   }
 
   private String buildTableArn() {


### PR DESCRIPTION
Solves https://github.com/apache/iceberg/issues/6523

The check of isTableRegisteredWithLakeFormation is performed even before the table is created in glue when a create table command is called from spark hence resulting in failure, if the entity is not found then as per my understanding, we can assume the table is not enrolled in LF and hence should return false (need to double check with LF experts as my understanding of LF is a bit limited. 

Testing done: 
TODO add unit tests

cc @jackye1995 @xiaoxuandev 