### PR TITLE
Fix the problem of shadow jar without modifying meta-inf/services at the same time

### DIFF
--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -229,6 +229,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -231,6 +231,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -231,6 +231,8 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -78,6 +78,8 @@ project(':iceberg-hive-runtime') {
     // relocate OrcSplit in order to avoid the conflict from Hive's OrcSplit
     relocate 'org.apache.hadoop.hive.ql.io.orc.OrcSplit', 'org.apache.iceberg.shaded.org.apache.hadoop.hive.ql.io.orc.OrcSplit'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -175,6 +175,8 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -258,6 +258,8 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -270,6 +270,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -262,6 +262,8 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
     relocate 'org.roaringbitmap', 'org.apache.iceberg.shaded.org.roaringbitmap'
 
+    mergeServiceFiles()
+
     classifier null
   }
 


### PR DESCRIPTION
#6561 

When I developed ORC encryption, I found that it can be encrypted successfully on IDEA, but failed to execute it in Flink engine.

After troubleshooting, I found that the package path of orc is '/org/apache/iceberg/shaded/org/apache/orc/impl/mask/MaskProvider' but the in the META-INF/services is 'org.apache.orc.impl.mask.MaskProvider'

So when the code is executed to Datamask.Factory.DataMask the ServiceLoader load the Provider.class failed