### PR TITLE
Core: Support access to response headers from POST requests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -112,6 +112,30 @@ public interface RESTClient extends Closeable {
     return post(path, body, responseType, headers.get(), errorHandler);
   }
 
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Supplier<Map<String, String>> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    return post(path, body, responseType, headers.get(), errorHandler, responseHeaders);
+  }
+
+  default <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    if (null != responseHeaders) {
+      throw new UnsupportedOperationException("Returning response headers is not supported");
+    }
+
+    return post(path, body, responseType, headers, errorHandler);
+  }
+
   <T extends RESTResponse> T post(
       String path,
       RESTRequest body,

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -125,7 +127,8 @@ public class TestHTTPClient {
 
     String path = addRequestTestCaseAndGetPath(method, body, statusCode);
 
-    Item successResponse = doExecuteRequest(method, path, body, onError);
+    Item successResponse =
+        doExecuteRequest(method, path, body, onError, h -> assertThat(h).isNotEmpty());
 
     if (method.usesRequestBody()) {
       Assert.assertEquals(
@@ -157,7 +160,7 @@ public class TestHTTPClient {
         RuntimeException.class,
         String.format(
             "Called error handler for method %s due to status code: %d", method, statusCode),
-        () -> doExecuteRequest(method, path, body, onError));
+        () -> doExecuteRequest(method, path, body, onError, h -> {}));
 
     verify(onError).accept(any());
   }
@@ -208,11 +211,15 @@ public class TestHTTPClient {
   }
 
   private static Item doExecuteRequest(
-      HttpMethod method, String path, Item body, ErrorHandler onError) {
+      HttpMethod method,
+      String path,
+      Item body,
+      ErrorHandler onError,
+      Consumer<Map<String, String>> responseHeaders) {
     Map<String, String> headers = ImmutableMap.of("Authorization", "Bearer " + BEARER_AUTH_TOKEN);
     switch (method) {
       case POST:
-        return restClient.post(path, body, Item.class, headers, onError);
+        return restClient.post(path, body, Item.class, headers, onError, responseHeaders);
       case GET:
         return restClient.get(path, Item.class, headers, onError);
       case HEAD:


### PR DESCRIPTION
For some context: In https://github.com/apache/iceberg/pull/6169#discussion_r1031590899 we're sending back a  `cache-control` header to indicate to the client whether something can be safely cached or not. 
However, our `HTTPClient` didn't have a way to retrieve the response headers from a given request, so a workaround in https://github.com/apache/iceberg/pull/6169 was done, where response headers are sent back as part of the actual response.

