### PR TITLE
Spark 3.3: Add RemoveDanglingDeletes action

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -56,6 +56,17 @@ public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
   }
 
   /**
+   * Delete a file tracked by a {@link DeleteFile} from the underlying table.
+   *
+   * @param file a DeleteFile to remove from the table
+   * @return this for method chaining
+   */
+  default DeleteFiles deleteFile(DeleteFile file) {
+    deleteFile(file.path());
+    return this;
+  }
+
+  /**
    * Delete files that match an {@link Expression} on data rows from the table.
    *
    * <p>A file is selected to be deleted by the expression if it could contain any rows that match

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -64,4 +64,10 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /** Instantiates an action to remove dangling delete files from current snapshot. */
+  default RemoveDanglingDeleteFiles removeDanglingDeleteFiles(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement removeDanglingDeleteFiles");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFiles.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+
+/**
+ * An action that removes dangling delete files from the current snapshot. A delete file is dangling
+ * if its deletes no longer applies to any data file.
+ *
+ * <p>The following dangling delete files are removed:
+ *
+ * <ul>
+ *   <li>Position delete files with a sequence number less than that of any data file in the same
+ *       partition
+ *   <li>Equality delete files with a sequence number less than or equal to that of any data file in
+ *       the same partition
+ * </ul>
+ */
+public interface RemoveDanglingDeleteFiles
+    extends Action<RemoveDanglingDeleteFiles, RemoveDanglingDeleteFiles.Result> {
+
+  /** The action result that contains a summary of the execution. */
+  interface Result {
+    /** Removes representation of removed delete files. */
+    List<DeleteFile> removedDeleteFiles();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -55,6 +55,12 @@ public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implem
   }
 
   @Override
+  public StreamingDelete deleteFile(DeleteFile file) {
+    delete(file);
+    return this;
+  }
+
+  @Override
   public StreamingDelete deleteFromRowFilter(Expression expr) {
     deleteByRowFilter(expr);
     return this;

--- a/core/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RemoveDanglingDeleteFilesActionResult.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+public class RemoveDanglingDeleteFilesActionResult implements RemoveDanglingDeleteFiles.Result {
+
+  private static final RemoveDanglingDeleteFilesActionResult EMPTY =
+      new RemoveDanglingDeleteFilesActionResult(ImmutableList.of());
+
+  private List<DeleteFile> removedDeleteFiles;
+
+  public RemoveDanglingDeleteFilesActionResult(List<DeleteFile> removeDeleteFiles) {
+    this.removedDeleteFiles = removeDeleteFiles;
+  }
+
+  public static RemoveDanglingDeleteFilesActionResult empty() {
+    return EMPTY;
+  }
+
+  @Override
+  public List<DeleteFile> removedDeleteFiles() {
+    return removedDeleteFiles;
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.MetadataTableType.ENTRIES;
+import static org.apache.spark.sql.functions.min;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.actions.RemoveDanglingDeleteFilesActionResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema;
+import scala.collection.JavaConverters;
+
+/**
+ * An action that removes dangling delete files from the current snapshot. A delete file is dangling
+ * if its deletes no longer applies to any data file.
+ *
+ * <p>The following dangling delete files are removed:
+ *
+ * <ul>
+ *   <li>Position delete files with a sequence number less than that of any data file in the same
+ *       partition
+ *   <li>Equality delete files with a sequence number less than or equal to that of any data file in
+ *       the same partition
+ * </ul>
+ */
+public class RemoveDanglingDeletesSparkAction
+    extends BaseSnapshotUpdateSparkAction<RemoveDanglingDeletesSparkAction>
+    implements RemoveDanglingDeleteFiles {
+
+  private final Table table;
+
+  protected RemoveDanglingDeletesSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+  }
+
+  @Override
+  protected RemoveDanglingDeletesSparkAction self() {
+    return this;
+  }
+
+  @Override
+  public Result execute() {
+    if (table.specs().size() == 1 && table.spec().isUnpartitioned()) {
+      // ManifestFilterManager already performs this table-wide on each commit
+      return RemoveDanglingDeleteFilesActionResult.empty();
+    }
+
+    String desc = String.format("Remove dangling delete files for %s", table.name());
+    JobGroupInfo info = newJobGroupInfo("REWRITE-MANIFESTS", desc);
+    return withJobGroupInfo(info, this::doExecute);
+  }
+
+  private Result doExecute() {
+    Dataset<Row> entries =
+        loadMetadataTable(table, ENTRIES)
+            .filter("status < 2") // live entries
+            .selectExpr(
+                "data_file.partition as partition",
+                "data_file.spec_id as spec_id",
+                "data_file.file_path as file_path",
+                "data_file.content as content",
+                "data_file.file_size_in_bytes as file_size_in_bytes",
+                "data_file.record_count as record_count",
+                "sequence_number");
+
+    DeleteFiles deleteFiles = table.newDelete();
+    List<DeleteFile> toRemove = withReusableDS(entries, this::danglingDeletes);
+    toRemove.forEach(deleteFiles::deleteFile);
+    deleteFiles.commit();
+
+    return new RemoveDanglingDeleteFilesActionResult(toRemove);
+  }
+
+  /**
+   * Calculate dangling delete files
+   *
+   * <ul>
+   *   <li>Group all files by partition, calculate the minimum data file sequence number in each.
+   *   <li>For each partition, check if any position delete files have a sequence number less than
+   *       the partition's min_data_sequence_number
+   *   <li>For each partition, check if any equality delete files have a sequence number less than
+   *       or equal to the partition's min_data_sequence_number
+   * </ul>
+   *
+   * @param entries dataset of file entries, marked by content (0 for data, 1 for posDeletes, 2 for
+   *     eqDeletes)
+   * @return list of dangling delete files
+   */
+  private List<DeleteFile> danglingDeletes(Dataset<Row> entries) {
+    List<DeleteFile> removedDeleteFiles = Lists.newArrayList();
+
+    // Minimum sequence number of data files in each partition
+    Dataset<Row> minDataSeqNumberPerPartition =
+        entries
+            .filter("content == 0") // data files
+            .groupBy("partition", "spec_id")
+            .agg(min("sequence_number"))
+            .toDF("partition", "spec_id", "min_data_sequence_number");
+
+    // Dangling position delete files
+    Dataset<Row> posDeleteDs =
+        entries
+            .filter("content == 1") // position delete files
+            .join(
+                minDataSeqNumberPerPartition,
+                JavaConverters.asScalaBuffer(ImmutableList.of("partition", "spec_id")))
+            .filter("sequence_number < min_data_sequence_number")
+            .selectExpr("partition", "spec_id", "file_path", "file_size_in_bytes", "record_count");
+    MakeDeleteFile makePosDeleteFn =
+        new MakeDeleteFile(true, Partitioning.partitionType(table), table.specs());
+    Dataset<DeleteFile> posDeletesToRemove =
+        posDeleteDs.map(makePosDeleteFn, Encoders.javaSerialization(DeleteFile.class));
+
+    removedDeleteFiles.addAll(posDeletesToRemove.collectAsList());
+
+    // Dangling equality delete files
+    Dataset<Row> eqDeleteDs =
+        entries
+            .filter("content == 2") // equality delete files
+            .join(
+                minDataSeqNumberPerPartition,
+                JavaConverters.asScalaBuffer(ImmutableList.of("partition", "spec_id")))
+            .filter("sequence_number <= min_data_sequence_number")
+            .selectExpr("partition", "spec_id", "file_path", "file_size_in_bytes", "record_count");
+    MakeDeleteFile makeEqDeleteFn =
+        new MakeDeleteFile(false, Partitioning.partitionType(table), table.specs());
+    Dataset<DeleteFile> eqDeletesToRemove =
+        eqDeleteDs.map(makeEqDeleteFn, Encoders.javaSerialization(DeleteFile.class));
+
+    removedDeleteFiles.addAll(eqDeletesToRemove.collectAsList());
+    return removedDeleteFiles;
+  }
+
+  private static class MakeDeleteFile implements MapFunction<Row, DeleteFile> {
+
+    private final boolean posDeletes;
+    private final Types.StructType partitionType;
+    private final Map<Integer, PartitionSpec> specsById;
+
+    /**
+     * Map function that transforms entries table rows into {@link DeleteFile}
+     *
+     * @param posDeletes true for position deletes, false for equality deletes
+     * @param partitionType partition type of table
+     * @param specsById table's partition specs
+     */
+    MakeDeleteFile(
+        boolean posDeletes, Types.StructType partitionType, Map<Integer, PartitionSpec> specsById) {
+      this.posDeletes = posDeletes;
+      this.partitionType = partitionType;
+      this.specsById = specsById;
+    }
+
+    @Override
+    public DeleteFile call(Row row) throws Exception {
+      PartitionData partition = new PartitionData(partitionType);
+      GenericRowWithSchema partitionRow = row.getAs(0);
+
+      for (int i = 0; i < partitionRow.length(); i++) {
+        partition.set(i, partitionRow.get(i));
+      }
+      int specId = row.getAs(1);
+      String path = row.getAs(2);
+      long fileSize = row.getAs(3);
+      long recordCount = row.getAs(4);
+
+      FileMetadata.Builder builder = FileMetadata.deleteFileBuilder(specsById.get(specId));
+      if (posDeletes) {
+        builder.ofPositionDeletes();
+      } else {
+        builder.ofEqualityDeletes();
+      }
+
+      return builder
+          .withPath(path)
+          .withPartition(partition)
+          .withFileSizeInBytes(fileSize)
+          .withRecordCount(recordCount)
+          .build();
+    }
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.Path;
@@ -57,7 +56,6 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
-import org.apache.spark.api.java.function.MapFunction;
 import org.apache.spark.api.java.function.MapPartitionsFunction;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.Column;
@@ -66,7 +64,6 @@ import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +78,6 @@ import org.slf4j.LoggerFactory;
  */
 public class RewriteManifestsSparkAction
     extends BaseSnapshotUpdateSparkAction<RewriteManifestsSparkAction> implements RewriteManifests {
-
-  public static final String USE_CACHING = "use-caching";
-  public static final boolean USE_CACHING_DEFAULT = true;
 
   private static final Logger LOG = LoggerFactory.getLogger(RewriteManifestsSparkAction.class);
 
@@ -264,27 +258,6 @@ public class RewriteManifestsSparkAction
                   manifestEncoder)
               .collectAsList();
         });
-  }
-
-  private <T, U> U withReusableDS(Dataset<T> ds, Function<Dataset<T>, U> func) {
-    Dataset<T> reusableDS;
-    boolean useCaching =
-        PropertyUtil.propertyAsBoolean(options(), USE_CACHING, USE_CACHING_DEFAULT);
-    if (useCaching) {
-      reusableDS = ds.cache();
-    } else {
-      int parallelism = SQLConf.get().numShufflePartitions();
-      reusableDS =
-          ds.repartition(parallelism).map((MapFunction<T, T>) value -> value, ds.exprEnc());
-    }
-
-    try {
-      return func.apply(reusableDS);
-    } finally {
-      if (useCaching) {
-        reusableDS.unpersist(false);
-      }
-    }
   }
 
   private List<ManifestFile> findMatchingManifests() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java
@@ -91,4 +91,9 @@ public class SparkActions implements ActionsProvider {
   public DeleteReachableFilesSparkAction deleteReachableFiles(String metadataLocation) {
     return new DeleteReachableFilesSparkAction(spark, metadataLocation);
   }
+
+  @Override
+  public RemoveDanglingDeletesSparkAction removeDanglingDeleteFiles(Table table) {
+    return new RemoveDanglingDeletesSparkAction(spark, table);
+  }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -1,0 +1,437 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.RemoveDanglingDeleteFiles;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Encoders;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import scala.Tuple2;
+
+public class TestRemoveDanglingDeleteAction extends SparkTestBase {
+
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA =
+      new Schema(
+          optional(1, "c1", Types.StringType.get()),
+          optional(2, "c2", Types.StringType.get()),
+          optional(3, "c3", Types.StringType.get()));
+
+  private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+
+  static final DataFile FILE_A =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-a.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_A2 =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-a.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_B =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-b.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_B2 =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-b.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_C =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-c.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=c") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_C2 =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-c.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=c") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_D =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-d.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=d") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DataFile FILE_D2 =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/data-d.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=d") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_A_POS_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_A2_POS_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-a2-pos-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_A_EQ_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_A2_EQ_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-a2-eq-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=a") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_B_POS_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-b-pos-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_B2_POS_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofPositionDeletes()
+          .withPath("/path/to/data-b2-pos-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_B_EQ_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-b-eq-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_B2_EQ_DELETES =
+      FileMetadata.deleteFileBuilder(SPEC)
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-b2-eq-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withPartitionPath("c1=b") // easy way to set partition data for now
+          .withRecordCount(1)
+          .build();
+
+  static final DataFile FILE_UNPARTITIONED =
+      DataFiles.builder(PartitionSpec.unpartitioned())
+          .withPath("/path/to/data-unpartitioned.parquet")
+          .withFileSizeInBytes(10)
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_UNPARTITIONED_POS_DELETE =
+      FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-unpartitioned-pos-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withRecordCount(1)
+          .build();
+  static final DeleteFile FILE_UNPARTITIONED_EQ_DELETE =
+      FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+          .ofEqualityDeletes()
+          .withPath("/path/to/data-unpartitioned-eq-deletes.parquet")
+          .withFileSizeInBytes(10)
+          .withRecordCount(1)
+          .build();
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private String tableLocation;
+  private Table table;
+
+  @Before
+  public void before() throws Exception {
+    File tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  @After
+  public void after() {
+    TABLES.dropTable(tableLocation);
+  }
+
+  private void setupNormalPartitionedTable() {
+    this.table =
+        TABLES.create(
+            SCHEMA, SPEC, ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"), tableLocation);
+  }
+
+  private void setupUnpartitionedTable() {
+    this.table =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"),
+            tableLocation);
+  }
+
+  @Test
+  public void testPartitionedDeletesWithLesserSeqNo() {
+    setupNormalPartitionedTable();
+
+    // Add Data Files
+    table.newAppend().appendFile(FILE_B).appendFile(FILE_C).appendFile(FILE_D).commit();
+
+    // Add Delete Files
+    table
+        .newRowDelta()
+        .addDeletes(FILE_A_POS_DELETES)
+        .addDeletes(FILE_A2_POS_DELETES)
+        .addDeletes(FILE_B_POS_DELETES)
+        .addDeletes(FILE_B2_POS_DELETES)
+        .addDeletes(FILE_A_EQ_DELETES)
+        .addDeletes(FILE_A2_EQ_DELETES)
+        .addDeletes(FILE_B_EQ_DELETES)
+        .addDeletes(FILE_B2_EQ_DELETES)
+        .commit();
+
+    // Add More Data Files
+    table
+        .newAppend()
+        .appendFile(FILE_A2)
+        .appendFile(FILE_B2)
+        .appendFile(FILE_C2)
+        .appendFile(FILE_D2)
+        .commit();
+
+    List<Tuple2<Long, String>> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#entries")
+            .select("sequence_number", "data_file.file_path")
+            .sort("sequence_number", "data_file.file_path")
+            .as(Encoders.tuple(Encoders.LONG(), Encoders.STRING()))
+            .collectAsList();
+    List<Tuple2<Long, String>> expected =
+        ImmutableList.of(
+            Tuple2.apply(1L, FILE_B.path().toString()),
+            Tuple2.apply(1L, FILE_C.path().toString()),
+            Tuple2.apply(1L, FILE_D.path().toString()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
+            Tuple2.apply(3L, FILE_A2.path().toString()),
+            Tuple2.apply(3L, FILE_B2.path().toString()),
+            Tuple2.apply(3L, FILE_C2.path().toString()),
+            Tuple2.apply(3L, FILE_D2.path().toString()));
+    Assert.assertEquals(expected, actual);
+
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+
+    // All Delete files of the FILE A partition should be removed
+    // because there are no data files in partition with a lesser sequence number
+    Set<CharSequence> removedDeleteFiles =
+        result.removedDeleteFiles().stream().map(DeleteFile::path).collect(Collectors.toSet());
+    Assert.assertEquals("Expected two delete files removed", 4, removedDeleteFiles.size());
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_A_POS_DELETES.path()));
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_A2_POS_DELETES.path()));
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_A_EQ_DELETES.path()));
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_A2_EQ_DELETES.path()));
+
+    List<Tuple2<Long, String>> actualAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#entries")
+            .filter("status < 2") // live files
+            .select("sequence_number", "data_file.file_path")
+            .sort("sequence_number", "data_file.file_path")
+            .as(Encoders.tuple(Encoders.LONG(), Encoders.STRING()))
+            .collectAsList();
+    List<Tuple2<Long, String>> expectedAfter =
+        ImmutableList.of(
+            Tuple2.apply(1L, FILE_B.path().toString()),
+            Tuple2.apply(1L, FILE_C.path().toString()),
+            Tuple2.apply(1L, FILE_D.path().toString()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
+            Tuple2.apply(3L, FILE_A2.path().toString()),
+            Tuple2.apply(3L, FILE_B2.path().toString()),
+            Tuple2.apply(3L, FILE_C2.path().toString()),
+            Tuple2.apply(3L, FILE_D2.path().toString()));
+    Assert.assertEquals(expectedAfter, actualAfter);
+  }
+
+  @Test
+  public void testPartitionedDeletesWithEqSeqNo() {
+    setupNormalPartitionedTable();
+
+    // Add Data Files
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_C).appendFile(FILE_D).commit();
+
+    // Add Data Files with EQ and POS deletes
+    table
+        .newRowDelta()
+        .addRows(FILE_A2)
+        .addRows(FILE_B2)
+        .addRows(FILE_C2)
+        .addRows(FILE_D2)
+        .addDeletes(FILE_A_POS_DELETES)
+        .addDeletes(FILE_A2_POS_DELETES)
+        .addDeletes(FILE_A_EQ_DELETES)
+        .addDeletes(FILE_A2_EQ_DELETES)
+        .addDeletes(FILE_B_POS_DELETES)
+        .addDeletes(FILE_B2_POS_DELETES)
+        .addDeletes(FILE_B_EQ_DELETES)
+        .addDeletes(FILE_B2_EQ_DELETES)
+        .commit();
+
+    List<Tuple2<Long, String>> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#entries")
+            .select("sequence_number", "data_file.file_path")
+            .sort("sequence_number", "data_file.file_path")
+            .as(Encoders.tuple(Encoders.LONG(), Encoders.STRING()))
+            .collectAsList();
+    List<Tuple2<Long, String>> expected =
+        ImmutableList.of(
+            Tuple2.apply(1L, FILE_A.path().toString()),
+            Tuple2.apply(1L, FILE_C.path().toString()),
+            Tuple2.apply(1L, FILE_D.path().toString()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2.path().toString()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2.path().toString()),
+            Tuple2.apply(2L, FILE_B2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_C2.path().toString()),
+            Tuple2.apply(2L, FILE_D2.path().toString()));
+    Assert.assertEquals(expected, actual);
+
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+
+    // Eq Delete files of the FILE B partition should be removed
+    // because there are no data files in partition with a lesser sequence number
+    Set<CharSequence> removedDeleteFiles =
+        result.removedDeleteFiles().stream().map(DeleteFile::path).collect(Collectors.toSet());
+    Assert.assertEquals("Expected two delete files removed", 2, removedDeleteFiles.size());
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_B_EQ_DELETES.path()));
+    Assert.assertTrue(removedDeleteFiles.contains(FILE_B2_EQ_DELETES.path()));
+
+    List<Tuple2<Long, String>> actualAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation + "#entries")
+            .filter("status < 2") // live files
+            .select("sequence_number", "data_file.file_path")
+            .sort("sequence_number", "data_file.file_path")
+            .as(Encoders.tuple(Encoders.LONG(), Encoders.STRING()))
+            .collectAsList();
+    List<Tuple2<Long, String>> expectedAfter =
+        ImmutableList.of(
+            Tuple2.apply(1L, FILE_A.path().toString()),
+            Tuple2.apply(1L, FILE_C.path().toString()),
+            Tuple2.apply(1L, FILE_D.path().toString()),
+            Tuple2.apply(2L, FILE_A_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2.path().toString()),
+            Tuple2.apply(2L, FILE_A2_EQ_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_A2_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_B2.path().toString()),
+            Tuple2.apply(2L, FILE_B2_POS_DELETES.path().toString()),
+            Tuple2.apply(2L, FILE_C2.path().toString()),
+            Tuple2.apply(2L, FILE_D2.path().toString()));
+    Assert.assertEquals(expectedAfter, actualAfter);
+  }
+
+  @Test
+  public void testUnpartitionedTable() {
+    setupUnpartitionedTable();
+
+    table
+        .newRowDelta()
+        .addDeletes(FILE_UNPARTITIONED_POS_DELETE)
+        .addDeletes(FILE_UNPARTITIONED_EQ_DELETE)
+        .commit();
+    table.newAppend().appendFile(FILE_UNPARTITIONED).commit();
+
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+    Assert.assertEquals("No-op for unpartitioned tables", 0, result.removedDeleteFiles().size());
+  }
+}


### PR DESCRIPTION
This adds an action to cleanup dangling (invalid) DeleteFiles that may otherwise keep getting carried over with the table's current snapshot and which may negatively impact read performance.

The problem and design doc is here: https://docs.google.com/document/d/11d-cIUR_89kRsMmWnEoxXGZCvp7L4TUmPJqUC60zB5M/edit#

In a nutshell, the current table-wide mechanism is crude and may miss many instances of aging off DeleteFiles, even after they become invalid after compaction.  This implements a spark action to perform a partition-by-partition removal using the same rules.