### PR TITLE
Flink: Refactor sink tests to use HadoopCatalogResource

### DIFF
--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/HadoopTableResource.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/HadoopTableResource.java
@@ -58,18 +58,6 @@ public class HadoopTableResource extends HadoopCatalogResource {
     tableLoader.open();
   }
 
-  @Override
-  protected void after() {
-    try {
-      catalog.dropTable(TableIdentifier.of(database, tableName));
-      catalog.close();
-      tableLoader.close();
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to close catalog resource");
-    }
-    super.after();
-  }
-
   public Table table() {
     return table;
   }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.flink.sink;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -36,12 +35,16 @@ import org.apache.flink.types.Row;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.HadoopCatalogResource;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.BoundedTestSource;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -50,6 +53,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -63,6 +67,10 @@ public class TestFlinkIcebergSink {
       MiniClusterResource.createWithClassloaderCheckDisabled();
 
   @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Rule
+  public final HadoopCatalogResource catalogResource =
+      new HadoopCatalogResource(TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE);
 
   private static final TypeInformation<Row> ROW_TYPE_INFO =
       new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
@@ -103,14 +111,16 @@ public class TestFlinkIcebergSink {
 
   @Before
   public void before() throws IOException {
-    File folder = TEMPORARY_FOLDER.newFolder();
-    String warehouse = folder.getAbsolutePath();
-
-    String tablePath = warehouse.concat("/test");
-    Assert.assertTrue("Should create the table path correctly.", new File(tablePath).mkdir());
-
-    Map<String, String> props = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name());
-    table = SimpleDataUtil.createTable(tablePath, props, partitioned);
+    table =
+        catalogResource
+            .catalog()
+            .createTable(
+                TestFixtures.TABLE_IDENTIFIER,
+                SimpleDataUtil.SCHEMA,
+                partitioned
+                    ? PartitionSpec.builderFor(SimpleDataUtil.SCHEMA).identity("data").build()
+                    : PartitionSpec.unpartitioned(),
+                ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name()));
 
     env =
         StreamExecutionEnvironment.getExecutionEnvironment(
@@ -119,7 +129,7 @@ public class TestFlinkIcebergSink {
             .setParallelism(parallelism)
             .setMaxParallelism(parallelism);
 
-    tableLoader = TableLoader.fromHadoopTable(tablePath);
+    tableLoader = catalogResource.tableLoader();
   }
 
   private List<RowData> convertToRowData(List<Row> rows) {
@@ -279,15 +289,31 @@ public class TestFlinkIcebergSink {
   public void testTwoSinksInDisjointedDAG() throws Exception {
     Map<String, String> props = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name());
 
-    String leftTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath().concat("/left");
-    Assert.assertTrue("Should create the table path correctly.", new File(leftTablePath).mkdir());
-    Table leftTable = SimpleDataUtil.createTable(leftTablePath, props, partitioned);
-    TableLoader leftTableLoader = TableLoader.fromHadoopTable(leftTablePath);
+    Table leftTable =
+        catalogResource
+            .catalog()
+            .createTable(
+                TableIdentifier.of("left"),
+                SimpleDataUtil.SCHEMA,
+                partitioned
+                    ? PartitionSpec.builderFor(SimpleDataUtil.SCHEMA).identity("data").build()
+                    : PartitionSpec.unpartitioned(),
+                props);
+    TableLoader leftTableLoader =
+        TableLoader.fromCatalog(catalogResource.catalogLoader(), TableIdentifier.of("left"));
 
-    String rightTablePath = TEMPORARY_FOLDER.newFolder().getAbsolutePath().concat("/right");
-    Assert.assertTrue("Should create the table path correctly.", new File(rightTablePath).mkdir());
-    Table rightTable = SimpleDataUtil.createTable(rightTablePath, props, partitioned);
-    TableLoader rightTableLoader = TableLoader.fromHadoopTable(rightTablePath);
+    Table rightTable =
+        catalogResource
+            .catalog()
+            .createTable(
+                TableIdentifier.of("right"),
+                SimpleDataUtil.SCHEMA,
+                partitioned
+                    ? PartitionSpec.builderFor(SimpleDataUtil.SCHEMA).identity("data").build()
+                    : PartitionSpec.unpartitioned(),
+                props);
+    TableLoader rightTableLoader =
+        TableLoader.fromCatalog(catalogResource.catalogLoader(), TableIdentifier.of("right"));
 
     env =
         StreamExecutionEnvironment.getExecutionEnvironment(
@@ -329,8 +355,8 @@ public class TestFlinkIcebergSink {
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
 
-    SimpleDataUtil.assertTableRows(leftTablePath, convertToRowData(leftRows));
-    SimpleDataUtil.assertTableRows(rightTablePath, convertToRowData(rightRows));
+    SimpleDataUtil.assertTableRows(leftTable, convertToRowData(leftRows));
+    SimpleDataUtil.assertTableRows(rightTable, convertToRowData(rightRows));
 
     leftTable.refresh();
     Assert.assertNull(leftTable.currentSnapshot().summary().get("flink.test"));


### PR DESCRIPTION
Refactor Flink Sink tests to use the HadoopCatalogResource.
This is a groundwork for adding encryption tests for Flink Sources and Sinks