### PR TITLE
AWS: make warehouse path optional for read only catalog use cases

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.aws.glue;
 
 import static org.apache.iceberg.expressions.Expressions.truncate;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 import java.util.Locale;
@@ -152,7 +151,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
       glueCatalog.createTable(identifier, schema, partitionSpec, tableLocationProperties);
       glueCatalog.loadTable(identifier);
     } catch (RuntimeException e) {
-      fail("Create and load table without warehouse location should succeed");
+      throw new RuntimeException(
+          "Create and load table without warehouse location should succeed", e);
     }
   }
 

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -149,13 +149,11 @@ public class TestGlueCatalogTable extends GlueTestBase {
     String tableName = getRandomName();
     TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
     try {
-      glueCatalog.createTable(
-          identifier, schema, partitionSpec, tableLocationProperties);
+      glueCatalog.createTable(identifier, schema, partitionSpec, tableLocationProperties);
       glueCatalog.loadTable(identifier);
     } catch (RuntimeException e) {
       fail("Create and load table without warehouse location should succeed");
     }
-
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.aws.glue;
 
 import static org.apache.iceberg.expressions.Expressions.truncate;
+import static org.junit.Assert.fail;
 
 import java.util.List;
 import java.util.Locale;
@@ -49,6 +50,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.util.LockManagers;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
@@ -130,6 +132,30 @@ public class TestGlueCatalogTable extends GlueTestBase {
         () ->
             glueCatalog.createTable(
                 TableIdentifier.of(namespace, "table-1"), schema, partitionSpec));
+  }
+
+  @Test
+  public void testCreateAndLoadTableWithoutWarehouseLocation() {
+    GlueCatalog glueCatalogWithoutWarehouse = new GlueCatalog();
+    glueCatalogWithoutWarehouse.initialize(
+        catalogName,
+        null,
+        new AwsProperties(),
+        glue,
+        LockManagers.defaultLockManager(),
+        new S3FileIO(clientFactory::s3),
+        ImmutableMap.of());
+    String namespace = createNamespace();
+    String tableName = getRandomName();
+    TableIdentifier identifier = TableIdentifier.of(namespace, tableName);
+    try {
+      glueCatalog.createTable(
+          identifier, schema, partitionSpec, tableLocationProperties);
+      glueCatalog.loadTable(identifier);
+    } catch (RuntimeException e) {
+      fail("Create and load table without warehouse location should succeed");
+    }
+
   }
 
   @Test

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
@@ -177,13 +178,9 @@ public class GlueCatalog extends BaseMetastoreCatalog
       GlueClient client,
       LockManager lock,
       FileIO io) {
-    Preconditions.checkArgument(
-        path != null && path.length() > 0,
-        "Cannot initialize GlueCatalog because warehousePath must not be null or empty");
-
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = LocationUtil.stripTrailingSlash(path);
+    this.warehousePath = path != null ? LocationUtil.stripTrailingSlash(path) : null;
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;
@@ -270,6 +267,10 @@ public class GlueCatalog extends BaseMetastoreCatalog
     if (dbLocationUri != null) {
       return String.format("%s/%s", dbLocationUri, tableIdentifier.name());
     }
+
+    ValidationException.check(
+        warehousePath != null && warehousePath.length() > 0,
+        "Cannot derive default warehouse location, warehouse path must not be null or empty");
 
     return String.format(
         "%s/%s.db/%s",

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -180,7 +180,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
       FileIO io) {
     this.catalogName = name;
     this.awsProperties = properties;
-    this.warehousePath = path != null ? LocationUtil.stripTrailingSlash(path) : null;
+    this.warehousePath =
+        (path != null && path.length() > 0) ? LocationUtil.stripTrailingSlash(path) : null;
     this.glue = client;
     this.lockManager = lock;
     this.fileIO = io;


### PR DESCRIPTION
Currently no matter in what situation warehouse path must be specified, but in many cases the user just want to initialize Glue catalog to read data, and don't want to pass in a warehouse path. This is to support that use case without user having to specify a dummy warehouse path to bypass the checks.