### PR TITLE
Spark 3.3: Add Default Parallelism Level for All Spark Driver Based Deletes

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -332,7 +334,26 @@ public class SparkCatalog extends BaseCatalog {
         boolean metadataFileExists = table.io().newInputFile(metadataFileLocation).exists();
 
         if (metadataFileExists) {
-          SparkActions.get().deleteReachableFiles(metadataFileLocation).io(table.io()).execute();
+          SparkSession spark = SparkSession.active();
+          int parallelism = Integer.parseInt(
+                  spark.conf().get(SparkSQLProperties.PURGE_PARALLELISM, SparkSQLProperties.PURGE_PARALLELISM_DEFAULT));
+
+          ExecutorService es = null;
+          try {
+            es = Executors.newFixedThreadPool(parallelism);
+            SparkActions.get()
+                    .deleteReachableFiles(metadataFileLocation)
+                    .executeDeleteWith(es)
+                    .io(table.io())
+                    .execute();
+          } finally {
+            if (es != null) {
+              List<Runnable> uncompletedTasks = es.shutdownNow();
+              // DeleteReachableFiles should complete all tasks before returning so this should be impossible
+              Preconditions.checkState(uncompletedTasks.isEmpty(),
+                      "Deletes did not complete before DeleteReachableFiles returned.");
+            }
+          }
         }
       }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -334,26 +334,7 @@ public class SparkCatalog extends BaseCatalog {
         boolean metadataFileExists = table.io().newInputFile(metadataFileLocation).exists();
 
         if (metadataFileExists) {
-          SparkSession spark = SparkSession.active();
-          int parallelism = Integer.parseInt(
-                  spark.conf().get(SparkSQLProperties.PURGE_PARALLELISM, SparkSQLProperties.PURGE_PARALLELISM_DEFAULT));
-
-          ExecutorService es = null;
-          try {
-            es = Executors.newFixedThreadPool(parallelism);
-            SparkActions.get()
-                    .deleteReachableFiles(metadataFileLocation)
-                    .executeDeleteWith(es)
-                    .io(table.io())
-                    .execute();
-          } finally {
-            if (es != null) {
-              List<Runnable> uncompletedTasks = es.shutdownNow();
-              // DeleteReachableFiles should complete all tasks before returning so this should be impossible
-              Preconditions.checkState(uncompletedTasks.isEmpty(),
-                      "Deletes did not complete before DeleteReachableFiles returned.");
-            }
-          }
+          SparkActions.get().deleteReachableFiles(metadataFileLocation).io(table.io()).execute();
         }
       }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -51,5 +51,5 @@ public class SparkSQLProperties {
   // Controls how many physical file deletes to execute in parallel when not otherwise specified
   public static final String DELETE_PARALLELISM =
       "spark.sql.iceberg.driver-delete-default-parallelism";
-  public static final String DELETE_PARALLELISM_DEFAULT = "25";
+  public static final int DELETE_PARALLELISM_DEFAULT = 25;
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -49,6 +49,7 @@ public class SparkSQLProperties {
   public static final boolean PRESERVE_DATA_GROUPING_DEFAULT = false;
 
   // Controls how many physical file deletes to execute in parallel when not otherwise specified
-  public static final String DELETE_PARALLELISM = "driver-delete-default-parallelism";
+  public static final String DELETE_PARALLELISM =
+      "spark.sql.iceberg.driver-delete-default-parallelism";
   public static final String DELETE_PARALLELISM_DEFAULT = "25";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -48,7 +48,7 @@ public class SparkSQLProperties {
       "spark.sql.iceberg.planning.preserve-data-grouping";
   public static final boolean PRESERVE_DATA_GROUPING_DEFAULT = false;
 
-  // Controls how many deletes to execute in parallel when issuing a drop table purge
-  public static final String PURGE_PARALLELISM = "purge-parallelism";
-  public static final String PURGE_PARALLELISM_DEFAULT = "25";
+  // Controls how many physical file deletes to execute in parallel when not otherwise specified
+  public static final String DELETE_PARALLELISM = "driver-delete-default-parallelism";
+  public static final String DELETE_PARALLELISM_DEFAULT = "25";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -47,4 +47,8 @@ public class SparkSQLProperties {
   public static final String PRESERVE_DATA_GROUPING =
       "spark.sql.iceberg.planning.preserve-data-grouping";
   public static final boolean PRESERVE_DATA_GROUPING_DEFAULT = false;
+
+  // Controls how many deletes to execute in parallel when issuing a drop table purge
+  public static final String PURGE_PARALLELISM = "purge-parallelism";
+  public static final String PURGE_PARALLELISM_DEFAULT = "25";
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.MetadataTableType.ALL_MANIFESTS;
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.lit;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,7 @@ import org.apache.iceberg.spark.JobGroupUtils;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.SparkContext;
@@ -71,6 +73,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
 
 abstract class BaseSparkAction<ThisT> {
 
@@ -230,13 +233,10 @@ abstract class BaseSparkAction<ThisT> {
 
     boolean createdDefaultDeleteService = false;
     if (deleteService == null) {
-      int numThreads =
-          Integer.parseInt(
-              spark
-                  .conf()
-                  .get(
-                      SparkSQLProperties.DELETE_PARALLELISM,
-                      SparkSQLProperties.DELETE_PARALLELISM_DEFAULT));
+      int numThreads = PropertyUtil.propertyAsInt(
+              JavaConverters.mapAsJavaMap(spark.conf().getAll()),
+              SparkSQLProperties.DELETE_PARALLELISM,
+              SparkSQLProperties.DELETE_PARALLELISM_DEFAULT);
       deleteService = ThreadPools.newWorkerPool(this + "-default-delete-service", numThreads);
       createdDefaultDeleteService = true;
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -246,13 +246,15 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     List<String> orphanFiles =
         findOrphanFiles(spark(), actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
 
-    withDefaultDeleteService(deleteExecutorService, deleteService ->
-      Tasks.foreach(orphanFiles)
-          .noRetry()
-          .executeWith(deleteService)
-          .suppressFailureWhenFinished()
-          .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
-          .run(deleteFunc::accept));
+    withDefaultDeleteService(
+        deleteExecutorService,
+        deleteService ->
+            Tasks.foreach(orphanFiles)
+                .noRetry()
+                .executeWith(deleteService)
+                .suppressFailureWhenFinished()
+                .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
+                .run(deleteFunc::accept));
 
     return new BaseDeleteOrphanFilesActionResult(orphanFiles);
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -246,12 +246,13 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     List<String> orphanFiles =
         findOrphanFiles(spark(), actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
 
-    Tasks.foreach(orphanFiles)
-        .noRetry()
-        .executeWith(deleteExecutorService)
-        .suppressFailureWhenFinished()
-        .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
-        .run(deleteFunc::accept);
+    withDefaultDeleteService(deleteExecutorService, deleteService ->
+      Tasks.foreach(orphanFiles)
+          .noRetry()
+          .executeWith(deleteService)
+          .suppressFailureWhenFinished()
+          .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
+          .run(deleteFunc::accept));
 
     return new BaseDeleteOrphanFilesActionResult(orphanFiles);
   }


### PR DESCRIPTION
An issue we've run into frequently is that several Spark actions perform deletes on the driver with a default parallelism of 1. This is quite slow for S3 and painfully slow for very large tables. To fix this we change the default behavior to always be multithreaded deletes.

The default for all Spark related actions can then be changed with a SQL Conf parameter as well as within each command with their own parallelism parameters.