### PR TITLE
Python: Add sql command to the CLI

### DIFF
--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -16,7 +16,12 @@
 # under the License.
 import json
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import (
+    Any,
+    List,
+    Optional,
+    Tuple,
+)
 from uuid import UUID
 
 from rich.console import Console
@@ -66,6 +71,10 @@ class Output(ABC):
 
     @abstractmethod
     def uuid(self, uuid: Optional[UUID]) -> None:
+        ...
+
+    @abstractmethod
+    def result_table(self, rows: List[Tuple[Any]]) -> None:
         ...
 
 
@@ -167,6 +176,13 @@ class ConsoleOutput(Output):
     def uuid(self, uuid: Optional[UUID]) -> None:
         Console().print(str(uuid) if uuid else "missing")
 
+    def result_table(self, rows: List[Tuple[Any]]) -> None:
+        output_table = self._table
+        for row in rows:
+            output_table.add_row(str(row))
+
+        Console().print(output_table)
+
 
 class JsonOutput(Output):
     """Writes json to stdout"""
@@ -212,3 +228,6 @@ class JsonOutput(Output):
 
     def uuid(self, uuid: Optional[UUID]) -> None:
         self._out({"uuid": str(uuid) if uuid else "missing"})
+
+    def result_table(self, rows: List[Tuple[Any]]) -> None:
+        print(json.dumps(rows))

--- a/python/pyiceberg/cli/output.py
+++ b/python/pyiceberg/cli/output.py
@@ -230,4 +230,4 @@ class JsonOutput(Output):
         self._out({"uuid": str(uuid) if uuid else "missing"})
 
     def result_table(self, rows: List[Tuple[Any]]) -> None:
-        print(json.dumps(rows))
+        self._out(rows)

--- a/python/pyiceberg/expressions/literals.py
+++ b/python/pyiceberg/expressions/literals.py
@@ -420,6 +420,10 @@ class TimestampLiteral(Literal[int]):
     def _(self, _: TimestampType) -> Literal[int]:
         return self
 
+    @to.register(TimestamptzType)
+    def _(self, _: TimestamptzType) -> Literal[int]:
+        return self
+
     @to.register(DateType)
     def _(self, _: DateType) -> Literal[int]:
         return DateLiteral(micros_to_days(self.value))


### PR DESCRIPTION
This adds an experimental `sql` command to the CLI. The table output is not quite finished, but it can use duckdb to run queries, like this:

```
[blue@work python]$ time poetry run pyiceberg --verbose true sql --table taxi.nyc_taxi_yellow="pickup_time >= '2021-12-01T00:00:00+00:00'" 'select count(1) as ride_count from nyc_taxi_yellow'
(3214368,)

real    2m4.358s
user    0m5.163s
sys     0m4.465s
```

The CLI requires `--table` options to identify tables and set filters for the load. Those tables are planned using the given filter and added by table name to duckdb. In the example above, `taxi.nyc_taxi_yellow` is loaded as `nyc_taxi_yellow` and is filtered using the filter string after `=`.

This also parallelizes scan planning, which now takes about a second in total. The remainder of the time is spent reading the Parquet data files. That apparently needs to be optimized because the read takes a long time (loading the dataset, not the pyiceberg projection).