### PR TITLE
Core: Add information_schema.namespaces table

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -52,6 +52,7 @@ public class Namespace {
   }
 
   private final String[] levels;
+  private transient Namespace parent = null;
 
   private Namespace(String[] levels) {
     this.levels = levels;
@@ -67,6 +68,14 @@ public class Namespace {
 
   public boolean isEmpty() {
     return levels.length == 0;
+  }
+
+  public Namespace parent() {
+    if (parent == null && levels.length > 0) {
+      this.parent = Namespace.of(Arrays.copyOf(levels, levels.length - 1));
+    }
+
+    return parent;
   }
 
   public int length() {

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java
@@ -66,9 +66,9 @@ public interface SupportsNamespaces {
    *
    * <p>If an object such as a table, view, or function exists, its parent namespaces must also
    * exist and must be returned by this discovery method. For example, if table a.b.t exists, this
-   * method must return ["a"] in the result array.
+   * method must return Namespace.of("a") in the result array.
    *
-   * @return an List of namespace {@link Namespace} names
+   * @return a List of namespace {@link Namespace} names
    */
   default List<Namespace> listNamespaces() {
     return listNamespaces(Namespace.empty());
@@ -78,7 +78,7 @@ public interface SupportsNamespaces {
    * List namespaces from the namespace.
    *
    * <p>For example, if table a.b.t exists, use 'SELECT NAMESPACE IN a' this method must return
-   * Namepace.of("a","b") {@link Namespace}.
+   * Namespace.of("a","b") {@link Namespace}.
    *
    * @return a List of namespace {@link Namespace} names
    * @throws NoSuchNamespaceException If the namespace does not exist (optional)

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -814,6 +814,62 @@ public class TestExpressionUtil {
             true));
   }
 
+  @Test
+  public void testExtractByIdInclusiveOr() {
+    Expression expr =
+        Expressions.or(Expressions.equal("id", 5), Expressions.greaterThan("data", "a"));
+    Assert.assertEquals(
+        "Should not split a partial or expression (inclusive)",
+        Expressions.alwaysTrue(),
+        ExpressionUtil.extractByIdInclusive(expr, SCHEMA, true, SCHEMA.findField("id").fieldId()));
+
+    Assert.assertEquals(
+        "Should not split a partial or expression (inclusive)",
+        Expressions.alwaysTrue(),
+        ExpressionUtil.extractByIdInclusive(
+            expr, SCHEMA, true, SCHEMA.findField("data").fieldId()));
+
+    Expression bothFieldsResult =
+        ExpressionUtil.extractByIdInclusive(
+            expr,
+            SCHEMA,
+            true,
+            SCHEMA.findField("id").fieldId(),
+            SCHEMA.findField("data").fieldId());
+    Assert.assertTrue("Should return an or expression", bothFieldsResult instanceof Or);
+    Or orResult = (Or) bothFieldsResult;
+
+    assertEquals(Expressions.equal("id", 5L), orResult.left());
+    assertEquals(Expressions.greaterThan("data", "a"), orResult.right());
+  }
+
+  @Test
+  public void testExtractByIdInclusiveAnd() {
+    Expression expr =
+        Expressions.and(Expressions.equal("id", 5), Expressions.greaterThan("data", "a"));
+    assertEquals(
+        Expressions.equal("id", 5L),
+        ExpressionUtil.extractByIdInclusive(expr, SCHEMA, true, SCHEMA.findField("id").fieldId()));
+
+    assertEquals(
+        Expressions.greaterThan("data", "a"),
+        ExpressionUtil.extractByIdInclusive(
+            expr, SCHEMA, true, SCHEMA.findField("data").fieldId()));
+
+    Expression bothFieldsResult =
+        ExpressionUtil.extractByIdInclusive(
+            expr,
+            SCHEMA,
+            true,
+            SCHEMA.findField("id").fieldId(),
+            SCHEMA.findField("data").fieldId());
+    Assert.assertTrue("Should return an and expression", bothFieldsResult instanceof And);
+    And orResult = (And) bothFieldsResult;
+
+    assertEquals(Expressions.equal("id", 5L), orResult.left());
+    assertEquals(Expressions.greaterThan("data", "a"), orResult.right());
+  }
+
   private void assertEquals(Expression expected, Expression actual) {
     Assertions.assertThat(expected).isInstanceOf(UnboundPredicate.class);
     assertEquals((UnboundPredicate<?>) expected, (UnboundPredicate<?>) actual);

--- a/core/src/main/java/org/apache/iceberg/BaseInformationSchemaTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseInformationSchemaTableScan.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Collection;
+import java.util.concurrent.ExecutorService;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.TableScanUtil;
+
+abstract class BaseInformationSchemaTableScan implements BatchScan {
+
+  private final InformationSchemaTable table;
+  private final TableScanContext context;
+
+  protected BaseInformationSchemaTableScan(
+      InformationSchemaTable table, TableScanContext context) {
+    this.table = table;
+    this.context = context;
+  }
+
+  protected TableScanContext context() {
+    return context;
+  }
+
+  protected abstract BatchScan newRefinedScan(TableScanContext newContext);
+
+  @Override
+  public Table table() {
+    return table;
+  }
+
+  @Override
+  public Snapshot snapshot() {
+    throw new UnsupportedOperationException(
+        "Cannot return snapshot for information_schema." + table.typeName());
+  }
+
+  @Override
+  public BatchScan useSnapshot(long scanSnapshotId) {
+    throw new UnsupportedOperationException(
+        "Cannot time travel with information_schema." + table.typeName());
+  }
+
+  @Override
+  public BatchScan asOfTime(long timestampMillis) {
+    throw new UnsupportedOperationException(
+        "Cannot time travel with information_schema." + table.typeName());
+  }
+
+  @Override
+  public BatchScan useRef(String name) {
+    Preconditions.checkArgument(
+        SnapshotRef.MAIN_BRANCH.equalsIgnoreCase(name), "Unknown branch: %s", name);
+    return this;
+  }
+
+  @Override
+  public BatchScan option(String property, String value) {
+    return newRefinedScan(context.withOption(property, value));
+  }
+
+  @Override
+  public BatchScan project(Schema schema) {
+    return newRefinedScan(context.project(schema));
+  }
+
+  @Override
+  public BatchScan caseSensitive(boolean caseSensitive) {
+    return newRefinedScan(context.setCaseSensitive(caseSensitive));
+  }
+
+  @Override
+  public BatchScan select(Collection<String> columns) {
+    return newRefinedScan(context.selectColumns(columns));
+  }
+
+  @Override
+  public BatchScan filter(Expression expr) {
+    return newRefinedScan(context.filterRows(Expressions.and(context.rowFilter(), expr)));
+  }
+
+  @Override
+  public BatchScan includeColumnStats() {
+    return newRefinedScan(context.shouldReturnColumnStats(true));
+  }
+
+  @Override
+  public BatchScan planWith(ExecutorService executorService) {
+    return newRefinedScan(context.planWith(executorService));
+  }
+
+  @Override
+  public boolean isCaseSensitive() {
+    return context.caseSensitive();
+  }
+
+  @Override
+  public BatchScan ignoreResiduals() {
+    return newRefinedScan(context.ignoreResiduals(true));
+  }
+
+  @Override
+  public Expression filter() {
+    return context.rowFilter();
+  }
+
+  @Override
+  public CloseableIterable<ScanTaskGroup<ScanTask>> planTasks() {
+    return TableScanUtil.planTaskGroups(planFiles(), targetSplitSize(), splitLookback(), splitOpenFileCost());
+  }
+
+  @Override
+  public long targetSplitSize() {
+    return PropertyUtil.propertyAsLong(
+        context.options(), TableProperties.SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
+  }
+
+  @Override
+  public int splitLookback() {
+    return PropertyUtil.propertyAsInt(
+        context.options(), TableProperties.SPLIT_LOOKBACK, TableProperties.SPLIT_LOOKBACK_DEFAULT);
+  }
+
+  @Override
+  public long splitOpenFileCost() {
+    return PropertyUtil.propertyAsLong(
+        context.options(),
+        TableProperties.SPLIT_OPEN_FILE_COST,
+        TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/InformationSchemaNamespacesTable.java
+++ b/core/src/main/java/org/apache/iceberg/InformationSchemaNamespacesTable.java
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Bound;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionUtil;
+import org.apache.iceberg.expressions.ExpressionVisitors;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+
+public class InformationSchemaNamespacesTable extends InformationSchemaTable {
+  private static final int NAME_COLUMN_ID = 1;
+  private static final int PARENT_COLUMN_ID = 2;
+
+  private static final Schema NAMESPACES_SCHEMA =
+      new Schema(
+          Types.NestedField.required(
+              NAME_COLUMN_ID,
+              "namespace_name",
+              Types.StringType.get(),
+              "Namespace identifier as a dotted string"),
+          Types.NestedField.optional(
+              PARENT_COLUMN_ID,
+              "parent_namespace_name",
+              Types.StringType.get(),
+              "Parent identifier as a dotted string"));
+
+  public InformationSchemaNamespacesTable(Catalog catalog) {
+    super(catalog, Type.NAMESPACES);
+  }
+
+  @Override
+  public BatchScan newBatchScan() {
+    return new NamespacesTableScan(new TableScanContext());
+  }
+
+  @Override
+  public Schema schema() {
+    return NAMESPACES_SCHEMA;
+  }
+
+  private List<Namespace> listAllNamespaces(Expression filter, boolean caseSensitive) {
+    if (!(catalog() instanceof SupportsNamespaces)) {
+      return ImmutableList.of();
+    }
+
+    PartialNamespaceEvaluator inclusiveEvaluator =
+        new PartialNamespaceEvaluator(filter, caseSensitive);
+    Evaluator evaluator = new Evaluator(NAMESPACES_SCHEMA.asStruct(), filter, caseSensitive);
+
+    SupportsNamespaces catalog = (SupportsNamespaces) catalog();
+    Deque<Namespace> namespaces = Lists.newLinkedList(catalog.listNamespaces());
+    ImmutableList.Builder<Namespace> allNamespaces = ImmutableList.builder();
+    while (!namespaces.isEmpty()) {
+      Namespace ns = namespaces.removeFirst();
+
+      String nsAsString = ns.toString();
+      String parentAsString = ns.parent().isEmpty() ? null : ns.parent().toString();
+
+      if (evaluator.eval(StaticDataTask.Row.of(nsAsString, parentAsString))) {
+        allNamespaces.add(ns);
+      }
+
+      // top-level namespaces have an empty parent, but no filter on parent_namespace_name will
+      // match empty parents. for example, if ns = ['a'] and the filter is parent_namespace_name
+      // like 'a%', the namespace will be ignored even though its children can match.
+      // to work around this problem, the namespace itself is passed as the parent. this works
+      // because the inclusive evaluator matches any namespace that may contain matching children.
+      if (inclusiveEvaluator.eval(
+          nsAsString, parentAsString != null ? parentAsString : nsAsString)) {
+        // the namespace matches or may contain matches
+        List<Namespace> nestedNamespaces = catalog.listNamespaces(ns);
+
+        // add nested namespaces to be processed first, in reverse order to maintain the listing
+        // order
+        for (int i = nestedNamespaces.size() - 1; i >= 0; i -= 1) {
+          namespaces.addFirst(nestedNamespaces.get(i));
+        }
+      }
+    }
+
+    return allNamespaces.build();
+  }
+
+  private DataTask task(TableScanContext context) {
+    // extract filters on the parent column, which can be used to limit catalog queries
+    Expression filters =
+        ExpressionUtil.extractByIdInclusive(
+            context.rowFilter(),
+            NAMESPACES_SCHEMA,
+            context.caseSensitive(),
+            PARENT_COLUMN_ID,
+            NAME_COLUMN_ID);
+
+    // list namespaces recursively while applying filters
+    List<Namespace> namespaces = listAllNamespaces(filters, context.caseSensitive());
+
+    return StaticDataTask.of(
+        new EmptyInputFile("information_schema:namespaces"),
+        NAMESPACES_SCHEMA,
+        NAMESPACES_SCHEMA,
+        namespaces,
+        ns ->
+            StaticDataTask.Row.of(
+                ns.toString(), ns.parent().isEmpty() ? null : ns.parent().toString()));
+  }
+
+  private class NamespacesTableScan extends BaseInformationSchemaTableScan {
+
+    protected NamespacesTableScan(TableScanContext context) {
+      super(InformationSchemaNamespacesTable.this, context);
+    }
+
+    @Override
+    protected NamespacesTableScan newRefinedScan(TableScanContext newContext) {
+      return new NamespacesTableScan(newContext);
+    }
+
+    @Override
+    public Schema schema() {
+      // this table does not project columns
+      return NAMESPACES_SCHEMA;
+    }
+
+    @Override
+    public CloseableIterable<ScanTask> planFiles() {
+      return CloseableIterable.withNoopClose(task(context()));
+    }
+  }
+
+  static class PartialNamespaceEvaluator extends ExpressionVisitors.BoundVisitor<Boolean> {
+    private final Expression bound;
+    private String namespaceAsString = null;
+    private String parentAsString = null;
+
+    PartialNamespaceEvaluator(Expression expr, boolean caseSensitive) {
+      this.bound = Binder.bind(NAMESPACES_SCHEMA.asStruct(), expr, caseSensitive);
+    }
+
+    boolean eval(String namespaceAsString, String parentAsString) {
+      this.namespaceAsString = namespaceAsString;
+      this.parentAsString = parentAsString;
+      return ExpressionVisitors.visitEvaluator(bound, this);
+    }
+
+    @Override
+    public Boolean alwaysTrue() {
+      return true;
+    }
+
+    @Override
+    public Boolean alwaysFalse() {
+      return false;
+    }
+
+    @Override
+    public Boolean not(Boolean result) {
+      return !result;
+    }
+
+    @Override
+    public Boolean and(Boolean leftResult, Boolean rightResult) {
+      return leftResult && rightResult;
+    }
+
+    @Override
+    public Boolean or(Boolean leftResult, Boolean rightResult) {
+      return leftResult || rightResult;
+    }
+
+    @Override
+    public <T> Boolean isNull(Bound<T> expr) {
+      return false;
+    }
+
+    @Override
+    public <T> Boolean notNull(Bound<T> expr) {
+      return true;
+    }
+
+    @Override
+    public <T> Boolean isNaN(Bound<T> expr) {
+      return false;
+    }
+
+    @Override
+    public <T> Boolean notNaN(Bound<T> expr) {
+      return true;
+    }
+
+    @Override
+    public <T> Boolean lt(Bound<T> expr, Literal<T> lit) {
+      // namespace_name < a.b
+      // should match: a.a, a
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, parentAsString)) {
+          return !litAsString.equals(parentAsString); // cannot be equal
+        } else {
+          return Comparators.charSequences().compare(parentAsString, litAsString) < 0;
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, namespaceAsString)) {
+          return !litAsString.equals(namespaceAsString); // cannot be equal
+        } else {
+          return Comparators.charSequences().compare(namespaceAsString, litAsString) < 0;
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean ltEq(Bound<T> expr, Literal<T> lit) {
+      // namespace_name < a.b
+      // should match: a.a, a.b, a
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, parentAsString)) {
+          return true;
+        } else {
+          return Comparators.charSequences().compare(parentAsString, litAsString) < 0;
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, namespaceAsString)) {
+          return true;
+        } else {
+          return Comparators.charSequences().compare(namespaceAsString, litAsString) < 0;
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean gt(Bound<T> expr, Literal<T> lit) {
+      // namespace_name > a.b
+      // should match: a.c, a
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, parentAsString)) {
+          return !litAsString.equals(parentAsString); // cannot be equal
+        } else {
+          return Comparators.charSequences().compare(parentAsString, litAsString) > 0;
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, namespaceAsString)) {
+          return !litAsString.equals(namespaceAsString); // cannot be equal
+        } else {
+          return Comparators.charSequences().compare(namespaceAsString, litAsString) > 0;
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean gtEq(Bound<T> expr, Literal<T> lit) {
+      // namespace_name > a.b
+      // should match: a.c, a.b, a
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, parentAsString)) {
+          return true;
+        } else {
+          return Comparators.charSequences().compare(parentAsString, litAsString) > 0;
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (isMatchOrParent(litAsString, namespaceAsString)) {
+          return true;
+        } else {
+          return Comparators.charSequences().compare(namespaceAsString, litAsString) > 0;
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean eq(Bound<T> expr, Literal<T> lit) {
+      // this matches any namespace that may be a parent of the matching namespace
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        return isMatchOrParent(lit.value().toString(), parentAsString);
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        return isMatchOrParent(lit.value().toString(), namespaceAsString);
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean notEq(Bound<T> expr, Literal<T> lit) {
+      // namespace_name != a.b
+      // should match a, b, a.b.c
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        return !lit.value().toString().equalsIgnoreCase(parentAsString);
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        return !lit.value().toString().equalsIgnoreCase(namespaceAsString);
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean in(Bound<T> expr, Set<T> literalSet) {
+      // this matches any namespace that may be a parent of any namespace in the set
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        for (T value : literalSet) {
+          if (isMatchOrParent(value.toString(), parentAsString)) {
+            return true;
+          }
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        for (T value : literalSet) {
+          if (isMatchOrParent(value.toString(), namespaceAsString)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean notIn(Bound<T> expr, Set<T> literalSet) {
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        for (T value : literalSet) {
+          if (value.toString().equalsIgnoreCase(parentAsString)) {
+            return false;
+          }
+        }
+        return true;
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        for (T value : literalSet) {
+          if (value.toString().equalsIgnoreCase(namespaceAsString)) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean startsWith(Bound<T> expr, Literal<T> lit) {
+      // this matches any namespace that may be a parent of the matching namespace
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        return isPrefix(lit.value().toString(), parentAsString);
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        return isPrefix(lit.value().toString(), namespaceAsString);
+      }
+
+      return false;
+    }
+
+    @Override
+    public <T> Boolean notStartsWith(Bound<T> expr, Literal<T> lit) {
+      if (expr.ref().fieldId() == PARENT_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (litAsString.length() <= parentAsString.length()) {
+          return !parentAsString.startsWith(litAsString);
+        } else {
+          return true;
+        }
+      } else if (expr.ref().fieldId() == NAME_COLUMN_ID) {
+        String litAsString = lit.value().toString();
+        if (litAsString.length() <= namespaceAsString.length()) {
+          return !namespaceAsString.startsWith(litAsString);
+        } else {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    private boolean isMatchOrParent(String toMatch, String toTest) {
+      // toMatch: a.b
+      // should match: a, a.b
+      // should not match: b, a.bc, a.b.c
+
+      int sign = Integer.signum(toTest.length() - toMatch.length());
+      switch (sign) {
+        case 1:
+          // namespace to test is longer, so it cannot match or be a parent
+          return false;
+        case 0:
+          return toTest.equalsIgnoreCase(toMatch);
+        default:
+          // namespace is shorter and may be a parent if the one to match starts with it, followed
+          // by '.'
+          return toMatch.startsWith(toTest) && toMatch.charAt(toTest.length()) == '.';
+      }
+    }
+
+    private boolean isPrefix(String toMatch, String toTest) {
+      // toMatch: a.b
+      // should match: a, a.b, a.bc
+      // should not match: b, a.b.c
+
+      int sign = Integer.signum(toTest.length() - toMatch.length());
+      switch (sign) {
+        case 1:
+          return toTest.startsWith(toMatch);
+        case 0:
+          return toTest.equalsIgnoreCase(toMatch);
+        default:
+          // namespace is shorter and may be a parent if the one to match starts with it, followed
+          // by '.'
+          return toMatch.startsWith(toTest) && toMatch.charAt(toTest.length()) == '.';
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/InformationSchemaTable.java
+++ b/core/src/main/java/org/apache/iceberg/InformationSchemaTable.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.io.ByteBufferInputStream;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+/**
+ * Base class for information_schema tables.
+ *
+ * <p>Serializing and deserializing a metadata table object returns a read only implementation of
+ * the metadata table using a {@link StaticTableOperations}. This way no Catalog related calls are
+ * needed when reading the table data after deserialization.
+ */
+abstract class InformationSchemaTable extends BaseReadOnlyTable implements Serializable {
+  private static final String INFORMATION_SCHEMA = "information_schema";
+
+  enum Type {
+    NAMESPACES("namespaces"),
+    TABLES("tables");
+
+    public static Type from(String name) {
+      try {
+        return Type.valueOf(name.toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ignored) {
+        return null;
+      }
+    }
+
+    private String name;
+
+    Type(String name) {
+      this.name = name;
+    }
+
+    public String typeName() {
+      return name;
+    }
+  }
+
+  private final Catalog catalog;
+  private final Type type;
+
+  protected InformationSchemaTable(Catalog catalog, Type type) {
+    super(INFORMATION_SCHEMA);
+    this.catalog = catalog;
+    this.type = type;
+  }
+
+  String typeName() {
+    return type.typeName();
+  }
+
+  @Override
+  public String name() {
+    return catalog.name() + "." + INFORMATION_SCHEMA + "." + typeName();
+  }
+
+  protected Catalog catalog() {
+    return catalog;
+  }
+
+  @Override
+  public TableScan newScan() {
+    throw new UnsupportedOperationException(
+        "newBatchScan() must be used for information_schema tables");
+  }
+
+  @Override
+  public FileIO io() {
+    return null;
+  }
+
+  @Override
+  public String location() {
+    return typeName();
+  }
+
+  @Override
+  public EncryptionManager encryption() {
+    return new PlaintextEncryptionManager();
+  }
+
+  @Override
+  public LocationProvider locationProvider() {
+    return null;
+  }
+
+  @Override
+  public void refresh() {}
+
+  @Override
+  public Map<Integer, Schema> schemas() {
+    return ImmutableMap.of(TableMetadata.INITIAL_SCHEMA_ID, schema());
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return PartitionSpec.unpartitioned();
+  }
+
+  @Override
+  public Map<Integer, PartitionSpec> specs() {
+    return ImmutableMap.of(0, PartitionSpec.unpartitioned());
+  }
+
+  @Override
+  public SortOrder sortOrder() {
+    return SortOrder.unsorted();
+  }
+
+  @Override
+  public Map<Integer, SortOrder> sortOrders() {
+    return ImmutableMap.of(0, SortOrder.unsorted());
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  public Snapshot currentSnapshot() {
+    return null;
+  }
+
+  @Override
+  public Iterable<Snapshot> snapshots() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public Snapshot snapshot(long snapshotId) {
+    return null;
+  }
+
+  @Override
+  public List<HistoryEntry> history() {
+    return null;
+  }
+
+  @Override
+  public List<StatisticsFile> statisticsFiles() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public Map<String, SnapshotRef> refs() {
+    return ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return name();
+  }
+
+  final Object writeReplace() {
+    return SerializableTable.copyOf(this);
+  }
+
+  /** An InputFile instance for static tasks. */
+  static class EmptyInputFile implements InputFile {
+    private final String location;
+
+    EmptyInputFile(String location) {
+      this.location = location;
+    }
+
+    @Override
+    public long getLength() {
+      return 0;
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return ByteBufferInputStream.wrap(ByteBuffer.allocate(0));
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public boolean exists() {
+      return true;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/InformationSchemaTablesTable.java
+++ b/core/src/main/java/org/apache/iceberg/InformationSchemaTablesTable.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionUtil;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+
+public class InformationSchemaTablesTable extends InformationSchemaTable {
+  private static final int NAME_COLUMN_ID = 1;
+  private static final int NAMESPACE_COLUMN_ID = 2;
+
+  private static final Schema TABLES_SCHEMA =
+      new Schema(
+          Types.NestedField.required(
+              NAME_COLUMN_ID, "table_name", Types.StringType.get(), "Table name"),
+          Types.NestedField.required(
+              NAMESPACE_COLUMN_ID,
+              "namespace_name",
+              Types.StringType.get(),
+              "Namespace identifier as a dotted string"));
+
+  public InformationSchemaTablesTable(Catalog catalog) {
+    super(catalog, Type.TABLES);
+  }
+
+  @Override
+  public BatchScan newBatchScan() {
+    return new TablesTableScan(new TableScanContext());
+  }
+
+  @Override
+  public Schema schema() {
+    return TABLES_SCHEMA;
+  }
+
+  private List<TableIdentifier> listAllTables(Expression filter, boolean caseSensitive) {
+    return ImmutableList.of();
+  }
+
+  private DataTask task(TableScanContext context) {
+    // extract filters on the parent column, which can be used to limit catalog queries
+    Expression filters =
+        ExpressionUtil.extractByIdInclusive(
+            context.rowFilter(),
+            TABLES_SCHEMA,
+            context.caseSensitive(),
+            NAME_COLUMN_ID,
+            NAMESPACE_COLUMN_ID);
+
+    // list namespaces recursively while applying filters
+    List<TableIdentifier> tables = listAllTables(filters, context.caseSensitive());
+
+    return StaticDataTask.of(
+        new EmptyInputFile("information_schema:tables"),
+        TABLES_SCHEMA,
+        TABLES_SCHEMA,
+        tables,
+        table -> StaticDataTask.Row.of(table.toString()));
+  }
+
+  private class TablesTableScan extends BaseInformationSchemaTableScan {
+
+    protected TablesTableScan(TableScanContext context) {
+      super(InformationSchemaTablesTable.this, context);
+    }
+
+    @Override
+    protected TablesTableScan newRefinedScan(TableScanContext newContext) {
+      return new TablesTableScan(newContext);
+    }
+
+    @Override
+    public Schema schema() {
+      // this table does not project columns
+      return TABLES_SCHEMA;
+    }
+
+    @Override
+    public CloseableIterable<ScanTask> planFiles() {
+      return CloseableIterable.withNoopClose(task(context()));
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestPartialNamespaceEvaluator.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartialNamespaceEvaluator.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.InformationSchemaNamespacesTable.PartialNamespaceEvaluator;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestPartialNamespaceEvaluator {
+  @Parameterized.Parameters(name = "column = {0}")
+  public static Object[] parameters() {
+    return new Object[] {"namespace_name", "parent_namespace_name"};
+  }
+
+  private final String column;
+
+  public TestPartialNamespaceEvaluator(String column) {
+    this.column = column;
+  }
+
+  @Test
+  public void testNullChecksName() {
+    Assert.assertFalse("Should never be null", eval(Expressions.isNull(column), Namespace.of("a")));
+    Assert.assertTrue("Should never be null", eval(Expressions.notNull(column), Namespace.of("a")));
+  }
+
+  @Test
+  public void testAnd() {
+    Expression expr =
+        Expressions.and(
+            Expressions.startsWith("namespace_name", "a.b"),
+            Expressions.startsWith("parent_namespace_name", "a"));
+
+    PartialNamespaceEvaluator evaluator = new PartialNamespaceEvaluator(expr, true);
+
+    Namespace ab = Namespace.of("a", "b");
+    Assert.assertTrue("Should match exact namespace", evaluator.eval(ab.toString(), ab.parent().toString()));
+
+    Namespace aab = Namespace.of("aa", "b");
+    Assert.assertFalse("Should not match namespace name", evaluator.eval(aab.toString(), aab.parent().toString()));
+  }
+
+  @Test
+  public void testOr() {
+    Expression expr =
+        Expressions.or(
+            Expressions.startsWith("namespace_name", "b.c"),
+            Expressions.startsWith("parent_namespace_name", "a"));
+
+    PartialNamespaceEvaluator evaluator = new PartialNamespaceEvaluator(expr, true);
+
+    Namespace aab = Namespace.of("aa", "b");
+    Assert.assertTrue("Should match by parent name", evaluator.eval(aab.toString(), aab.parent().toString()));
+
+    Namespace bcd = Namespace.of("b.c", "d");
+    Assert.assertTrue("Should match by parent name", evaluator.eval(bcd.toString(), bcd.parent().toString()));
+
+    Namespace c = Namespace.of("c");
+    Assert.assertFalse("Should not match either part", evaluator.eval(c.toString(), c.parent().toString()));
+  }
+
+  @Test
+  public void testLessThanOrEqualToName() {
+    Expression ltEq = Expressions.lessThanOrEqual(column, "b.b");
+
+    Assert.assertTrue("Should match containing parent", eval(ltEq, Namespace.of("b")));
+    Assert.assertTrue("Should match exact namespace", eval(ltEq, Namespace.of("b", "b")));
+    Assert.assertTrue("Should match exact namespace", eval(ltEq, Namespace.of("b.b")));
+    Assert.assertTrue("Should match unrelated lower parent", eval(ltEq, Namespace.of("a")));
+    Assert.assertTrue("Should match unrelated lower peer", eval(ltEq, Namespace.of("b.a")));
+    Assert.assertFalse("Should not match unrelated greater parent", eval(ltEq, Namespace.of("c")));
+    Assert.assertFalse("Should not match unrelated greater peer", eval(ltEq, Namespace.of("b.c")));
+    Assert.assertFalse("Should not match child", eval(ltEq, Namespace.of("b.b.c")));
+    Assert.assertFalse("Should not match child", eval(ltEq, Namespace.of("b", "b", "c")));
+  }
+
+  @Test
+  public void testLessThanName() {
+    Expression lt = Expressions.lessThan(column, "b.b");
+
+    Assert.assertTrue("Should match containing parent", eval(lt, Namespace.of("b")));
+    Assert.assertFalse("Should not match exact namespace", eval(lt, Namespace.of("b", "b")));
+    Assert.assertFalse("Should not match exact namespace", eval(lt, Namespace.of("b.b")));
+    Assert.assertTrue("Should match unrelated lower parent", eval(lt, Namespace.of("a")));
+    Assert.assertTrue("Should match unrelated lower peer", eval(lt, Namespace.of("b.a")));
+    Assert.assertFalse("Should not match unrelated greater parent", eval(lt, Namespace.of("c")));
+    Assert.assertFalse("Should not match unrelated greater peer", eval(lt, Namespace.of("b.c")));
+    Assert.assertFalse("Should not match child", eval(lt, Namespace.of("b.b.c")));
+    Assert.assertFalse("Should not match child", eval(lt, Namespace.of("b", "b", "c")));
+  }
+
+  @Test
+  public void testGreaterThanOrEqualToName() {
+    Expression gtEq = Expressions.greaterThanOrEqual(column, "b.b");
+
+    Assert.assertTrue("Should match containing parent", eval(gtEq, Namespace.of("b")));
+    Assert.assertTrue("Should match exact namespace", eval(gtEq, Namespace.of("b", "b")));
+    Assert.assertTrue("Should match exact namespace", eval(gtEq, Namespace.of("b.b")));
+    Assert.assertFalse("Should not match unrelated lower parent", eval(gtEq, Namespace.of("a")));
+    Assert.assertFalse("Should not match unrelated lower peer", eval(gtEq, Namespace.of("b.a")));
+    Assert.assertTrue("Should match unrelated greater parent", eval(gtEq, Namespace.of("c")));
+    Assert.assertTrue("Should match unrelated greater peer", eval(gtEq, Namespace.of("b.c")));
+    Assert.assertTrue("Should match child", eval(gtEq, Namespace.of("b.b.c")));
+    Assert.assertTrue("Should match child", eval(gtEq, Namespace.of("b", "b", "c")));
+  }
+
+  @Test
+  public void testGreaterThanName() {
+    Expression gt = Expressions.greaterThan(column, "b.b");
+
+    Assert.assertTrue("Should match containing parent", eval(gt, Namespace.of("b")));
+    Assert.assertFalse("Should not match exact namespace", eval(gt, Namespace.of("b", "b")));
+    Assert.assertFalse("Should not match exact namespace", eval(gt, Namespace.of("b.b")));
+    Assert.assertFalse("Should not match unrelated lower parent", eval(gt, Namespace.of("a")));
+    Assert.assertFalse("Should not match unrelated lower peer", eval(gt, Namespace.of("b.a")));
+    Assert.assertTrue("Should match unrelated greater parent", eval(gt, Namespace.of("c")));
+    Assert.assertTrue("Should match unrelated greater peer", eval(gt, Namespace.of("b.c")));
+    Assert.assertTrue("Should match child", eval(gt, Namespace.of("b.b.c")));
+    Assert.assertTrue("Should match child", eval(gt, Namespace.of("b", "b", "c")));
+  }
+
+  @Test
+  public void testEqualsName() {
+    Expression eq = Expressions.equal(column, "a.b");
+
+    Assert.assertTrue("Should match containing parent", eval(eq, Namespace.of("a")));
+    Assert.assertTrue("Should match exact namespace", eval(eq, Namespace.of("a", "b")));
+    Assert.assertTrue("Should match exact namespace", eval(eq, Namespace.of("a.b")));
+    Assert.assertFalse("Should not match unrelated parent", eval(eq, Namespace.of("b")));
+    Assert.assertFalse("Should not match unrelated peer", eval(eq, Namespace.of("a.c")));
+    Assert.assertFalse("Should not match child", eval(eq, Namespace.of("a.b.c")));
+    Assert.assertFalse("Should not match child", eval(eq, Namespace.of("a", "b", "c")));
+  }
+
+  @Test
+  public void testNotEqualsName() {
+    Expression notEq = Expressions.notEqual(column, "a.b");
+
+    Assert.assertTrue("Should match containing parent", eval(notEq, Namespace.of("a")));
+    Assert.assertFalse("Should not match exact namespace", eval(notEq, Namespace.of("a", "b")));
+    Assert.assertFalse("Should not match exact namespace", eval(notEq, Namespace.of("a.b")));
+    Assert.assertTrue("Should match unrelated parent", eval(notEq, Namespace.of("b")));
+    Assert.assertTrue("Should match unrelated peer", eval(notEq, Namespace.of("a.c")));
+    Assert.assertTrue("Should match child", eval(notEq, Namespace.of("a.b.c")));
+    Assert.assertTrue("Should match child", eval(notEq, Namespace.of("a", "b", "c")));
+  }
+
+  @Test
+  public void testInName() {
+    Expression in = Expressions.in(column, "a.b", "a.d.e");
+
+    Assert.assertTrue("Should match containing parent", eval(in, Namespace.of("a")));
+    Assert.assertTrue("Should match containing parent", eval(in, Namespace.of("a", "d")));
+    Assert.assertTrue("Should match containing parent", eval(in, Namespace.of("a.d")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a", "b")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a.b")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a", "d", "e")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a.d", "e")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a", "d.e")));
+    Assert.assertTrue("Should match exact namespace", eval(in, Namespace.of("a.d.e")));
+    Assert.assertFalse("Should not match unrelated parent", eval(in, Namespace.of("b")));
+    Assert.assertFalse("Should not match unrelated peer", eval(in, Namespace.of("a.c")));
+    Assert.assertFalse("Should not match child", eval(in, Namespace.of("a.b.c")));
+    Assert.assertFalse("Should not match child", eval(in, Namespace.of("a", "b", "c")));
+    Assert.assertFalse("Should not match child", eval(in, Namespace.of("a.d.e.f")));
+    Assert.assertFalse("Should not match child", eval(in, Namespace.of("a.d", "e.f")));
+  }
+
+  @Test
+  public void testNotInName() {
+    Expression notIn = Expressions.notIn(column, "a.b", "a.d.e");
+
+    Assert.assertTrue("Should match containing parent", eval(notIn, Namespace.of("a")));
+    Assert.assertTrue("Should match containing parent", eval(notIn, Namespace.of("a", "d")));
+    Assert.assertTrue("Should match containing parent", eval(notIn, Namespace.of("a.d")));
+    Assert.assertFalse("Should not match exact namespace", eval(notIn, Namespace.of("a", "b")));
+    Assert.assertFalse("Should not match exact namespace", eval(notIn, Namespace.of("a.b")));
+    Assert.assertFalse(
+        "Should not match exact namespace", eval(notIn, Namespace.of("a", "d", "e")));
+    Assert.assertFalse("Should not match exact namespace", eval(notIn, Namespace.of("a.d", "e")));
+    Assert.assertFalse("Should not match exact namespace", eval(notIn, Namespace.of("a", "d.e")));
+    Assert.assertFalse("Should not match exact namespace", eval(notIn, Namespace.of("a.d.e")));
+    Assert.assertTrue("Should match unrelated parent", eval(notIn, Namespace.of("b")));
+    Assert.assertTrue("Should match unrelated peer", eval(notIn, Namespace.of("a.c")));
+    Assert.assertTrue("Should match child", eval(notIn, Namespace.of("a.b.c")));
+    Assert.assertTrue("Should match child", eval(notIn, Namespace.of("a", "b", "c")));
+    Assert.assertTrue("Should match child", eval(notIn, Namespace.of("a.d.e.f")));
+    Assert.assertTrue("Should match child", eval(notIn, Namespace.of("a.d", "e.f")));
+  }
+
+  @Test
+  public void testStartsWithName() {
+    Expression startsWith = Expressions.startsWith(column, "a.b");
+
+    Assert.assertTrue("Should match containing parent", eval(startsWith, Namespace.of("a")));
+    Assert.assertTrue("Should match exact namespace", eval(startsWith, Namespace.of("a", "b")));
+    Assert.assertTrue("Should match exact namespace", eval(startsWith, Namespace.of("a.b")));
+    Assert.assertTrue("Should match prefix", eval(startsWith, Namespace.of("a.bc")));
+    Assert.assertTrue("Should match child", eval(startsWith, Namespace.of("a.b.c")));
+    Assert.assertTrue("Should match child", eval(startsWith, Namespace.of("a", "b", "c")));
+    Assert.assertFalse("Should not match unrelated parent", eval(startsWith, Namespace.of("b")));
+    Assert.assertFalse("Should not match unrelated peer", eval(startsWith, Namespace.of("a.c")));
+  }
+
+  @Test
+  public void testNotStartsWithName() {
+    Expression notStartsWith = Expressions.notStartsWith(column, "a.b");
+
+    Assert.assertTrue(
+        "Should match containing parent (may contain not matching)",
+        eval(notStartsWith, Namespace.of("a")));
+    Assert.assertFalse(
+        "Should not match exact namespace", eval(notStartsWith, Namespace.of("a", "b")));
+    Assert.assertFalse(
+        "Should not match exact namespace", eval(notStartsWith, Namespace.of("a.b")));
+    Assert.assertFalse("Should not match prefix", eval(notStartsWith, Namespace.of("a.bc")));
+    Assert.assertFalse("Should not match child", eval(notStartsWith, Namespace.of("a.b.c")));
+    Assert.assertFalse("Should not match child", eval(notStartsWith, Namespace.of("a", "b", "c")));
+    Assert.assertTrue("Should match unrelated parent", eval(notStartsWith, Namespace.of("b")));
+    Assert.assertTrue("Should match unrelated peer", eval(notStartsWith, Namespace.of("a.c")));
+  }
+
+  public boolean eval(Expression expr, Namespace ns) {
+    PartialNamespaceEvaluator evaluator = new PartialNamespaceEvaluator(expr, true);
+    // pass the same namespace as a parent and ns to reuse test cases
+    return evaluator.eval(ns.toString(), ns.toString());
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.InformationSchemaNamespacesTable;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Transaction;
@@ -602,6 +603,12 @@ public class SparkCatalog extends BaseCatalog {
   private Table load(Identifier ident) {
     if (isPathIdentifier(ident)) {
       return loadFromPathIdentifier((PathIdentifier) ident);
+    }
+
+    if (Arrays.equals(new String[] {"information_schema"}, ident.namespace())) {
+      if (ident.name().equalsIgnoreCase("namespaces")) {
+        return new SparkTable(new InformationSchemaNamespacesTable((Catalog) asNamespaceCatalog), false);
+      }
     }
 
     try {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestInformationSchema.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestInformationSchema.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.sql;
+
+import java.util.Arrays;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestInformationSchema extends SparkTestBaseWithCatalog {
+  @Before
+  public void createNamespaces() {
+    validationNamespaceCatalog.createNamespace(Namespace.of("a.b"));
+    validationNamespaceCatalog.createNamespace(Namespace.of("a", "c"));
+    validationNamespaceCatalog.createNamespace(Namespace.of("b", "c"));
+    validationNamespaceCatalog.createNamespace(Namespace.of("aa", "bb"));
+  }
+
+  @After
+  public void cleanNamespaces() {
+    validationNamespaceCatalog.dropNamespace(Namespace.of("a.b"));
+    validationNamespaceCatalog.dropNamespace(Namespace.of("a", "c"));
+    validationNamespaceCatalog.dropNamespace(Namespace.of("b", "c"));
+    validationNamespaceCatalog.dropNamespace(Namespace.of("aa", "bb"));
+  }
+
+  @Test
+  public void testNamespacesTable() {
+    assertEquals(
+        "Should contain the expected namespaces",
+        Arrays.asList(
+            row("a", null),
+            row("a.b", null),
+            row("a.c", "a"),
+            row("aa", null),
+            row("aa.bb", "aa"),
+            row("b", null),
+            row("b.c", "b")),
+        sql("SELECT * FROM %s.information_schema.namespaces ORDER BY namespace_name", catalogName));
+  }
+
+  @Test
+  public void testNamespacesTableProjection() {
+    Object[] rowOfNull = row((Object) null);
+    assertEquals(
+        "Should contain the expected namespaces",
+        Arrays.asList(rowOfNull, rowOfNull, row("a"), rowOfNull, row("aa"), rowOfNull, row("b")),
+        sql(
+            "SELECT parent_namespace_name FROM %s.information_schema.namespaces ORDER BY namespace_name",
+            catalogName));
+  }
+
+  @Test
+  public void testNamespacesTableFilter() {
+    assertEquals(
+        "Should contain the expected namespaces",
+        Arrays.asList(row("a.c"), row("aa.bb")),
+        sql(
+            "SELECT namespace_name FROM %s.information_schema.namespaces "
+                + "WHERE parent_namespace_name like 'a%%' ORDER BY namespace_name",
+            catalogName));
+  }
+}


### PR DESCRIPTION
This is based on #6357 and will be rebased once that PR is merged.

This adds `information_schema.namespaces` and base classes for creating new `information_schema` tables. Namespace filtering is implemented to avoid too many queries against catalogs.