### PR TITLE
Doc: Add a page explaining migration from other table formats to iceberg

### DIFF
--- a/docs/delta-lake-conversion.md
+++ b/docs/delta-lake-conversion.md
@@ -1,0 +1,123 @@
+---
+title: "Delta Lake Conversion"
+url: delta-conversion
+weight: 400
+menu: main
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+# Delta Lake Conversion
+Iceberg supports converting Delta Lake tables to Iceberg tables through the `iceberg-delta-lake` module
+by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
+
+
+## Enabling Converting from Delta Lake to Iceberg
+The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. Users need to manually include this module in their environment to enable the conversion.
+Also, users need to provide [Delta Standalone](https://github.com/delta-io/connectors/releases/tag/v0.6.0) and [Delta Storage](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/)
+because they are what `iceberg-delta-lake` uses to read Delta Lake tables.
+
+## Compatibilities
+The module is built and tested with `Delta Standalone:0.6.0` and supports Delta Lake tables with the following protocol version:
+* `minReaderVersion`: 1
+* `minWriterVersion`: 2
+
+Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
+
+## API
+The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.
+The supported actions are:
+* `snapshotDeltaLakeTable`: snapshot an existing Delta Lake table to an Iceberg table
+
+## Default Implementation
+The `iceberg-delta-lake` module also provides a default implementation of the interface which can be accessed by
+```java
+DeltaLakeToIcebergMigrationActionsProvider defaultActions = DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+```
+
+### `snapshotDeltaLakeTable`
+The action reads the Delta Lake table's most recent snapshot and converts it to a new Iceberg table with the same schema and partitioning in one iceberg transaction.
+The original Delta Lake table remains unchanged.
+
+The newly created table can be changed or written to without affecting the source table, but the snapshot uses the original table's data files.
+Existing data files are added to the Iceberg table's metadata and can be read using a name-to-id mapping created from the original table schema.
+
+When inserts or overwrites run on the snapshot, new files are placed in the snapshot table's location. The location is default to be the same as that
+of the source Delta Lake Table. Users can also specify a different location for the snapshot table.
+
+{{< hint info >}}
+Because tables created by `snapshotDeltaLakeTable` are not the sole owners of their data files, they are prohibited from
+actions like `expire_snapshots` which would physically delete data files. Iceberg deletes, which only effect metadata,
+are still allowed. In addition, any operations which affect the original data files will disrupt the Snapshot's
+integrity. DELETE statements executed against the original Delta Lake table will remove original data files and the
+`snapshotDeltaLakeTable` table will no longer be able to access them.
+{{< /hint >}}
+
+#### Arguments
+The delta table's location is required to be provided when initializing the action.
+
+| Argument Name | Required? | Type | Description |
+|---------------|-----------|------|-------------|
+|`sourceTableLocation` | Yes | String | The location of the source Delta Lake table | 
+
+#### Configurations
+The configurations can be gave via method chaining
+
+| Method Name | Arguments      | Required? | Type                                       | Description                                                                                                  |
+|---------------------------|----------------|-----------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `as`                      | `identifier`   | Yes       | org.apache.iceberg.catalog.TableIdentifier | The identifier of the Iceberg table to be created.                                                           |
+| `icebergCatalog`          | `catalog`      | Yes       | org.apache.iceberg.catalog.Catalog         | The Iceberg catalog for the Iceberg table to be created                                                      |
+| `deltaLakeConfiguration`  | `conf`         | Yes       | org.apache.hadoop.conf.Configuration       | The Hadoop Configuration to access Delta Lake Table's log and datafiles                                      |
+| `tableLocation`           | `location`     | No        | String                                     | The location of the Iceberg table to be created. Defaults to the same location as the given Delta Lake table |
+| `tableProperty`           | `name`,`value` | No        | String, String                             | A property entry to add to the Iceberg table to be created                                                   |
+| `tableProperties`         | `properties`   | No        | Map<String, String>                        | Properties to add to the the Iceberg table to be created                                                     |
+
+#### Output
+| Output Name | Type | Description |
+| ------------|------|-------------|
+| `imported_files_count` | long | Number of files added to the new table |
+
+#### Added Table Properties
+The following table properties are added to the Iceberg table to be created by default:
+
+| Property Name                 | Value                                     | Description                                                        |
+|-------------------------------|-------------------------------------------|--------------------------------------------------------------------|
+| `snapshot_source`             | `delta`                                   | Indicates that the table is snapshot from a delta lake table       |
+| `original_location`           | location of the delta lake table          | The absolute path to the location of the original delta lake table |
+| `schema.name-mapping.default` | JSON name mapping derived from the schema | The name mapping string used to read Delta Lake table's data files |
+
+#### Examples
+Snapshot a Delta Lake table located at `s3://my-bucket/delta-table` to an Iceberg table named `my_table` in the `my_db` database in the `my_catalog` catalog.
+```java
+DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+    .snapshotDeltaLakeTable("s3://my-bucket/delta-table")
+    .as("my_db.my_table")
+    .icebergCatalog("my_catalog")
+    .deltaLakeConfiguration(new Configuration())
+    .execute();
+```
+Snapshot a Delta Lake table located at `s3://my-bucket/delta-table` to an Iceberg table named `my_table` in the `my_db` database in the `my_catalog` catalog at a manually
+specified location `s3://my-bucket/snapshot-loc`. Also, add a table property `my_property` with value `my_value` to the Iceberg table.
+```java
+DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+    .snapshotDeltaLakeTable("s3://my-bucket/delta-table")
+    .as("my_db.my_table")
+    .icebergCatalog("my_catalog")
+    .deltaLakeConfiguration(new Configuration())
+    .tableLocation("s3://my-bucket/snapshot-loc")
+    .tableProperty("my_property", "my_value")
+    .execute();
+```

--- a/docs/delta-lake-conversion.md
+++ b/docs/delta-lake-conversion.md
@@ -37,6 +37,9 @@ The module is built and tested with `Delta Standalone:0.6.0` and supports Delta 
 
 Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
 
+For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader doesn't support `INT96` yet.
+Such support is under development in according to this [issue](https://github.com/apache/iceberg/issues/4200)
+
 ## API
 The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.
 The supported actions are:

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -34,7 +34,7 @@ The Add Transaction action, a variant of the Add File action, is still under dev
 
 ## Enabling Migration from Delta Lake to Iceberg
 The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. To enable migration from delta lake features, the minimum required dependencies are:
-- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.0/iceberg-delta-lake-1.2.0.jar)
+- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.1/iceberg-delta-lake-1.2.1.jar)
 - [delta-standalone-0.6.0](https://repo1.maven.org/maven2/io/delta/delta-standalone_2.13/0.6.0/delta-standalone_2.13-0.6.0.jar)
 - [delta-storage-2.2.0](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/delta-storage-2.2.0.jar)
 

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -34,9 +34,9 @@ The Add Transaction action, a variant of the Add File action, is still under dev
 
 ## Enabling Migration from Delta Lake to Iceberg
 The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. To enable migration from delta lake features, the minimum required dependencies are:
-- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.0/)
-- [delta-standalone-0.6.0](https://repo1.maven.org/maven2/io/delta/delta-standalone_2.13/0.6.0/)
-- [delta-storage-2.2.0](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/)
+- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.0/iceberg-delta-lake-1.2.0.jar)
+- [delta-standalone-0.6.0](https://repo1.maven.org/maven2/io/delta/delta-standalone_2.13/0.6.0/delta-standalone_2.13-0.6.0.jar)
+- [delta-storage-2.2.0](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/delta-storage-2.2.0.jar)
 
 ### Compatibilities
 The module is built and tested with `Delta Standalone:0.6.0` and supports Delta Lake tables with the following protocol version:

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -22,6 +22,7 @@ menu:
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
+
 # Delta Lake Table Migration
 Delta Lake is a table format that supports Parquet file format and provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
 it is common to migrate all snapshots to maintain the history of the data.

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -1,0 +1,126 @@
+---
+title: "Delta Lake Migration"
+url: delta-lake-migration
+weight: 400
+menu: main
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+# Delta Lake Table Migration
+Iceberg supports converting Delta Lake tables to Iceberg tables through the `iceberg-delta-lake` module
+by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
+
+
+## Enabling Migration from Delta Lake to Iceberg
+The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. Users need to manually include this module in their environment to enable the conversion.
+Also, users need to provide [Delta Standalone](https://github.com/delta-io/connectors/releases/tag/v0.6.0) and [Delta Storage](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/)
+because they are what `iceberg-delta-lake` uses to read Delta Lake tables.
+
+## Compatibilities
+The module is built and tested with `Delta Standalone:0.6.0` and supports Delta Lake tables with the following protocol version:
+* `minReaderVersion`: 1
+* `minWriterVersion`: 2
+
+Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
+
+For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader doesn't support `INT96` yet.
+Such support is under development in the [PR#6962](https://github.com/apache/iceberg/pull/6962)
+
+## API
+The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.
+The supported actions are:
+* `snapshotDeltaLakeTable`: snapshot an existing Delta Lake table to an Iceberg table
+
+## Default Implementation
+The `iceberg-delta-lake` module also provides a default implementation of the interface which can be accessed by
+```java
+DeltaLakeToIcebergMigrationActionsProvider defaultActions = DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+```
+
+### `snapshotDeltaLakeTable`
+The action reads the Delta Lake table's most recent snapshot and converts it to a new Iceberg table with the same schema and partitioning in one iceberg transaction.
+The original Delta Lake table remains unchanged.
+
+The newly created table can be changed or written to without affecting the source table, but the snapshot uses the original table's data files.
+Existing data files are added to the Iceberg table's metadata and can be read using a name-to-id mapping created from the original table schema.
+
+When inserts or overwrites run on the snapshot, new files are placed in the snapshot table's location. The location is default to be the same as that
+of the source Delta Lake Table. Users can also specify a different location for the snapshot table.
+
+{{< hint info >}}
+Because tables created by `snapshotDeltaLakeTable` are not the sole owners of their data files, they are prohibited from
+actions like `expire_snapshots` which would physically delete data files. Iceberg deletes, which only effect metadata,
+are still allowed. In addition, any operations which affect the original data files will disrupt the Snapshot's
+integrity. DELETE statements executed against the original Delta Lake table will remove original data files and the
+`snapshotDeltaLakeTable` table will no longer be able to access them.
+{{< /hint >}}
+
+#### Arguments
+The delta table's location is required to be provided when initializing the action.
+
+| Argument Name | Required? | Type | Description |
+|---------------|-----------|------|-------------|
+|`sourceTableLocation` | Yes | String | The location of the source Delta Lake table | 
+
+#### Configurations
+The configurations can be gave via method chaining
+
+| Method Name | Arguments      | Required? | Type                                       | Description                                                                                                  |
+|---------------------------|----------------|-----------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `as`                      | `identifier`   | Yes       | org.apache.iceberg.catalog.TableIdentifier | The identifier of the Iceberg table to be created.                                                           |
+| `icebergCatalog`          | `catalog`      | Yes       | org.apache.iceberg.catalog.Catalog         | The Iceberg catalog for the Iceberg table to be created                                                      |
+| `deltaLakeConfiguration`  | `conf`         | Yes       | org.apache.hadoop.conf.Configuration       | The Hadoop Configuration to access Delta Lake Table's log and datafiles                                      |
+| `tableLocation`           | `location`     | No        | String                                     | The location of the Iceberg table to be created. Defaults to the same location as the given Delta Lake table |
+| `tableProperty`           | `name`,`value` | No        | String, String                             | A property entry to add to the Iceberg table to be created                                                   |
+| `tableProperties`         | `properties`   | No        | Map<String, String>                        | Properties to add to the the Iceberg table to be created                                                     |
+
+#### Output
+| Output Name | Type | Description |
+| ------------|------|-------------|
+| `imported_files_count` | long | Number of files added to the new table |
+
+#### Added Table Properties
+The following table properties are added to the Iceberg table to be created by default:
+
+| Property Name                 | Value                                     | Description                                                        |
+|-------------------------------|-------------------------------------------|--------------------------------------------------------------------|
+| `snapshot_source`             | `delta`                                   | Indicates that the table is snapshot from a delta lake table       |
+| `original_location`           | location of the delta lake table          | The absolute path to the location of the original delta lake table |
+| `schema.name-mapping.default` | JSON name mapping derived from the schema | The name mapping string used to read Delta Lake table's data files |
+
+#### Examples
+Snapshot a Delta Lake table located at `s3://my-bucket/delta-table` to an Iceberg table named `my_table` in the `my_db` database in the `my_catalog` catalog.
+```java
+DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+    .snapshotDeltaLakeTable("s3://my-bucket/delta-table")
+    .as("my_db.my_table")
+    .icebergCatalog("my_catalog")
+    .deltaLakeConfiguration(new Configuration())
+    .execute();
+```
+Snapshot a Delta Lake table located at `s3://my-bucket/delta-table` to an Iceberg table named `my_table` in the `my_db` database in the `my_catalog` catalog at a manually
+specified location `s3://my-bucket/snapshot-loc`. Also, add a table property `my_property` with value `my_value` to the Iceberg table.
+```java
+DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
+    .snapshotDeltaLakeTable("s3://my-bucket/delta-table")
+    .as("my_db.my_table")
+    .icebergCatalog("my_catalog")
+    .deltaLakeConfiguration(new Configuration())
+    .tableLocation("s3://my-bucket/snapshot-loc")
+    .tableProperty("my_property", "my_value")
+    .execute();
+```

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -27,17 +27,16 @@ menu:
 Delta Lake is a table format that supports Parquet file format and provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
 it is common to migrate all snapshots to maintain the history of the data.
 
-Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. It is done via the `iceberg-delta-lake` module
-by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
-Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.
-For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action.
-The Add Snapshot action, a variant of the Add File action, is still under development.
+Currently, Iceberg supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables.
+Since Delta Lake tables maintain transactions, all available transactions will be committed to the new Iceberg table as transactions in order.
+For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding transactions and subsequently added to the new Iceberg table using the Add Transaction action.
+The Add Transaction action, a variant of the Add File action, is still under development.
 
 ## Enabling Migration from Delta Lake to Iceberg
 The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. To enable migration from delta lake features, the minimum required dependencies are:
-- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.0/iceberg-delta-lake-1.2.0.jar)
-- [delta-standalone-0.6.0](https://repo1.maven.org/maven2/io/delta/delta-standalone_2.13/0.6.0/delta-standalone_2.13-0.6.0.jar)
-- [delta-storage-2.2.0](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/delta-storage-2.2.0.jar)
+- [iceberg-delta-lake](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-delta-lake/1.2.0/)
+- [delta-standalone-0.6.0](https://repo1.maven.org/maven2/io/delta/delta-standalone_2.13/0.6.0/)
+- [delta-storage-2.2.0](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/)
 
 ### Compatibilities
 The module is built and tested with `Delta Standalone:0.6.0` and supports Delta Lake tables with the following protocol version:
@@ -58,7 +57,7 @@ DeltaLakeToIcebergMigrationActionsProvider defaultActions = DeltaLakeToIcebergMi
 ```
 
 ## Snapshot Delta Lake Table to Iceberg
-The action `snapshotDeltaLakeTable` reads the Delta Lake table's most recent snapshot and converts it to a new Iceberg table with the same schema and partitioning in one iceberg transaction.
+The action `snapshotDeltaLakeTable` reads the Delta Lake table's transactions and converts them to a new Iceberg table with the same schema and partitioning in one iceberg transaction.
 The original Delta Lake table remains unchanged.
 
 The newly created table can be changed or written to without affecting the source table, but the snapshot uses the original table's data files.
@@ -76,12 +75,12 @@ integrity. DELETE statements executed against the original Delta Lake table will
 {{< /hint >}}
 
 #### Usage
-| Required Input                                  | Configured By                                                                                                                                                                                             |
-|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Source Table Location                           | Argument [`sourceTableLocation`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/DeltaLakeToIcebergMigrationActionsProvider.html#snapshotDeltaLakeTable(java.lang.String))             | 
-| New Iceberg Table Identifier                    | Configuration API [`as`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#as(org.apache.iceberg.catalog.TableIdentifier))                                   |
-| Iceberg Catalog To Create New Iceberg Table     | Configuration API [`icebergCatalog`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#icebergCatalog(org.apache.iceberg.catalog.Catalog))                   |
-| Hadoop Configuration To Access Delta Lake Table | Configuration API [`deltaLakeConfiguration`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#deltaLakeConfiguration(org.apache.hadoop.conf.Configuration)) |
+| Required Input               | Configured By                                                                                                                                                                                             | Description                                                                     |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| Source Table Location        | Argument [`sourceTableLocation`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/DeltaLakeToIcebergMigrationActionsProvider.html#snapshotDeltaLakeTable(java.lang.String))             | The location of the source Delta Lake table                                     | 
+| New Iceberg Table Identifier | Configuration API [`as`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#as(org.apache.iceberg.catalog.TableIdentifier))                                   | The identifier specifies the namespace and table name for the new iceberg table |
+| Iceberg Catalog              | Configuration API [`icebergCatalog`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#icebergCatalog(org.apache.iceberg.catalog.Catalog))                   | The catalog used to create the new iceberg table                                |
+| Hadoop Configuration         | Configuration API [`deltaLakeConfiguration`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#deltaLakeConfiguration(org.apache.hadoop.conf.Configuration)) | The Hadoop Configuration used to read the source Delta Lake table.              |
 
 For detailed usage and other optional configurations, please refer to the [SnapshotDeltaLakeTable API](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html)
 
@@ -101,11 +100,11 @@ The following table properties are added to the Iceberg table to be created by d
 
 #### Examples
 ```java
-sourceDeltaLakeTableLocation = "s3://my-bucket/delta-table";
-destTableIdentifier = TableIdentifier.of("my_db", "my_table");
-destTableLocation = "s3://my-bucket/iceberg-table";
-icebergCatalog = ...; // Iceberg Catalog fetched from engines like Spark or created via CatalogUtil.loadCatalog
-hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and have proper file system configuration to access the Delta Lake table.
+String sourceDeltaLakeTableLocation = "s3://my-bucket/delta-table";
+String destTableLocation = "s3://my-bucket/iceberg-table";
+org.apache.iceberg.catalog.TableIdentifier destTableIdentifier = TableIdentifier.of("my_db", "my_table");
+org.apache.iceberg.catalog.Catalog icebergCatalog = ...; // Iceberg Catalog fetched from engines like Spark or created via CatalogUtil.loadCatalog
+org.apache.hadoop.conf.Configuration hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and have proper file system configuration to access the Delta Lake table.
     
 DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
     .snapshotDeltaLakeTable(sourceDeltaLakeTableLocation)
@@ -116,9 +115,3 @@ DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
     .tableProperty("my_property", "my_value")
     .execute();
 ```
-
-## Migrate Delta Lake Table To Iceberg
-**Not Yet Support**. This action should read the Delta Lake table's most recent snapshot and convert it to a new Iceberg table with the same name, schema and partitioning in one iceberg transaction. The source Delta Lake table should be dropped as the completion of this action.
-
-## Add Files From Delta Lake Table to Iceberg
-**Not Yet Support**. This action should add files from a Delta version of a Delta Lake table to an existing Iceberg table

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -4,7 +4,7 @@ url: delta-lake-migration
 menu:
   main:
     parent: "Migration"
-    weight: 200
+    weight: 300
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -23,9 +23,14 @@ menu:
  - limitations under the License.
  -->
 # Delta Lake Table Migration
-Iceberg supports converting Delta Lake tables to Iceberg tables through the `iceberg-delta-lake` module
-by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
+Delta Lake is a table format that supports Parquet file format and provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
+it is common to migrate all snapshots to maintain the history of the data.
 
+Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. It is done via the `iceberg-delta-lake` module
+by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
+Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.
+For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action. 
+The Add Snapshot action, a variant of the Add File action, is still under development.
 
 ## Enabling Migration from Delta Lake to Iceberg
 The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. To enable migration from delta lake features, the minimum required dependencies are:

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -1,8 +1,12 @@
 ---
 title: "Delta Lake Migration"
 url: delta-lake-migration
-weight: 400
-menu: main
+aliases:
+    - "java/delta-lake-migration"
+menu:
+    main:
+        parent: "API"
+        weight: 400
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -46,9 +46,6 @@ The module is built and tested with `Delta Standalone:0.6.0` and supports Delta 
 
 Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
 
-For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader does not support `INT96` yet.
-Such support is under development in the [PR#6962](https://github.com/apache/iceberg/pull/6962)
-
 ### API
 The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.
 The supported actions are:

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -29,7 +29,7 @@ it is common to migrate all snapshots to maintain the history of the data.
 Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. It is done via the `iceberg-delta-lake` module
 by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
 Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.
-For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action. 
+For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action.
 The Add Snapshot action, a variant of the Add File action, is still under development.
 
 ## Enabling Migration from Delta Lake to Iceberg
@@ -82,19 +82,19 @@ The delta table's location is required to be provided when initializing the acti
 
 | Argument Name | Required? | Type | Description |
 |---------------|-----------|------|-------------|
-|`sourceTableLocation` | Yes | String | The location of the source Delta Lake table | 
+|`sourceTableLocation` | ✔️ | String | The location of the source Delta Lake table | 
 
 #### Configurations
 The configurations can be gave via method chaining
 
 | Method Name | Arguments      | Required? | Type                                       | Description                                                                                                  |
 |---------------------------|----------------|-----------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `as`                      | `identifier`   | Yes       | org.apache.iceberg.catalog.TableIdentifier | The identifier of the Iceberg table to be created.                                                           |
-| `icebergCatalog`          | `catalog`      | Yes       | org.apache.iceberg.catalog.Catalog         | The Iceberg catalog for the Iceberg table to be created                                                      |
-| `deltaLakeConfiguration`  | `conf`         | Yes       | org.apache.hadoop.conf.Configuration       | The Hadoop Configuration to access Delta Lake Table's log and datafiles                                      |
-| `tableLocation`           | `location`     | No        | String                                     | The location of the Iceberg table to be created. Defaults to the same location as the given Delta Lake table |
-| `tableProperty`           | `name`,`value` | No        | String, String                             | A property entry to add to the Iceberg table to be created                                                   |
-| `tableProperties`         | `properties`   | No        | Map<String, String>                        | Properties to add to the the Iceberg table to be created                                                     |
+| `as`                      | `identifier`   | ✔️       | org.apache.iceberg.catalog.TableIdentifier | The identifier of the Iceberg table to be created.                                                           |
+| `icebergCatalog`          | `catalog`      | ✔️       | org.apache.iceberg.catalog.Catalog         | The Iceberg catalog for the Iceberg table to be created                                                      |
+| `deltaLakeConfiguration`  | `conf`         | ✔️       | org.apache.hadoop.conf.Configuration       | The Hadoop Configuration to access Delta Lake Table's log and datafiles                                      |
+| `tableLocation`           | `location`     |         | String                                     | The location of the Iceberg table to be created. Defaults to the same location as the given Delta Lake table |
+| `tableProperty`           | `name`,`value` |         | String, String                             | A property entry to add to the Iceberg table to be created                                                   |
+| `tableProperties`         | `properties`   |         | Map<String, String>                        | Properties to add to the the Iceberg table to be created                                                     |
 
 #### Output
 | Output Name | Type | Description |
@@ -129,7 +129,7 @@ DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
 ```
 
 ## Migrate Delta Lake Table To Iceberg
-Unsupported
+**Not Yet Support**. This action should read the Delta Lake table's most recent snapshot and convert it to a new Iceberg table with the same name, schema and partitioning in one iceberg transaction. The source Delta Lake table should be dropped as the completion of this action.
 
 ## Add Files From Delta Lake Table to Iceberg
-Unsupported
+**Not Yet Support**. This action should add files from a Delta version of a Delta Lake table to an existing Iceberg table

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -45,7 +45,7 @@ The module is built and tested with `Delta Standalone:0.6.0` and supports Delta 
 
 Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
 
-For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader doesn't support `INT96` yet.
+For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader does not support `INT96` yet.
 Such support is under development in the [PR#6962](https://github.com/apache/iceberg/pull/6962)
 
 ### API
@@ -77,24 +77,15 @@ integrity. DELETE statements executed against the original Delta Lake table will
 `snapshotDeltaLakeTable` table will no longer be able to access them.
 {{< /hint >}}
 
-#### Arguments
-The delta table's location is required to be provided when initializing the action.
+#### Usage
+| Required Input                                  | Configured By                                                                                                                                                                                             |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Source Table Location                           | Argument [`sourceTableLocation`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/DeltaLakeToIcebergMigrationActionsProvider.html#snapshotDeltaLakeTable(java.lang.String))             | 
+| New Iceberg Table Identifier                    | Configuration API [`as`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#as(org.apache.iceberg.catalog.TableIdentifier))                                   |
+| Iceberg Catalog To Create New Iceberg Table     | Configuration API [`icebergCatalog`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#icebergCatalog(org.apache.iceberg.catalog.Catalog))                   |
+| Hadoop Configuration To Access Delta Lake Table | Configuration API [`deltaLakeConfiguration`](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html#deltaLakeConfiguration(org.apache.hadoop.conf.Configuration)) |
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-|`sourceTableLocation` | ✔️ | String | The location of the source Delta Lake table | 
-
-#### Configurations
-The configurations can be gave via method chaining
-
-| Method Name | Arguments      | Required? | Type                                       | Description                                                                                                  |
-|---------------------------|----------------|-----------|--------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `as`                      | `identifier`   | ✔️       | org.apache.iceberg.catalog.TableIdentifier | The identifier of the Iceberg table to be created.                                                           |
-| `icebergCatalog`          | `catalog`      | ✔️       | org.apache.iceberg.catalog.Catalog         | The Iceberg catalog for the Iceberg table to be created                                                      |
-| `deltaLakeConfiguration`  | `conf`         | ✔️       | org.apache.hadoop.conf.Configuration       | The Hadoop Configuration to access Delta Lake Table's log and datafiles                                      |
-| `tableLocation`           | `location`     |         | String                                     | The location of the Iceberg table to be created. Defaults to the same location as the given Delta Lake table |
-| `tableProperty`           | `name`,`value` |         | String, String                             | A property entry to add to the Iceberg table to be created                                                   |
-| `tableProperties`         | `properties`   |         | Map<String, String>                        | Properties to add to the the Iceberg table to be created                                                     |
+For detailed usage and other optional configurations, please refer to the [SnapshotDeltaLakeTable API](https://iceberg.apache.org/javadoc/latest/org/apache/iceberg/delta/SnapshotDeltaLakeTable.html)
 
 #### Output
 | Output Name | Type | Description |

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -1,12 +1,10 @@
 ---
 title: "Delta Lake Migration"
 url: delta-lake-migration
-aliases:
-    - "java/delta-lake-migration"
 menu:
-    main:
-        parent: "API"
-        weight: 400
+  main:
+    parent: "Migration"
+    weight: 200
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -103,6 +103,7 @@ The following table properties are added to the Iceberg table to be created by d
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.delta.DeltaLakeToIcebergMigrationActionsProvider;
 
 String sourceDeltaLakeTableLocation = "s3://my-bucket/delta-table";
 String destTableLocation = "s3://my-bucket/iceberg-table";

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -100,11 +100,15 @@ The following table properties are added to the Iceberg table to be created by d
 
 #### Examples
 ```java
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.hadoop.conf.Configuration;
+
 String sourceDeltaLakeTableLocation = "s3://my-bucket/delta-table";
 String destTableLocation = "s3://my-bucket/iceberg-table";
-org.apache.iceberg.catalog.TableIdentifier destTableIdentifier = TableIdentifier.of("my_db", "my_table");
-org.apache.iceberg.catalog.Catalog icebergCatalog = ...; // Iceberg Catalog fetched from engines like Spark or created via CatalogUtil.loadCatalog
-org.apache.hadoop.conf.Configuration hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and have proper file system configuration to access the Delta Lake table.
+TableIdentifier destTableIdentifier = TableIdentifier.of("my_db", "my_table");
+Catalog icebergCatalog = ...; // Iceberg Catalog fetched from engines like Spark or created via CatalogUtil.loadCatalog
+Configuration hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and have proper file system configuration to access the Delta Lake table.
     
 DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
     .snapshotDeltaLakeTable(sourceDeltaLakeTableLocation)

--- a/docs/hive-migration.md
+++ b/docs/hive-migration.md
@@ -32,9 +32,8 @@ the migration process essentially involves creating a new Iceberg table with the
 After the initial migration, any new data files are added to the new Iceberg table using the Add Files action.
 
 ## Enabling Migration from Hive to Iceberg
-The Hive table migration actions are supported by the Spark Integration module via Spark Procedures. The procedures are bundled in the following dependencies:
-- [`iceberg-spark-runtime_3.3_2.12`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.2.0/)
-- [`iceberg-spark-runtime_3.3_2.13`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/1.2.0/)
+The Hive table migration actions are supported by the Spark Integration module via Spark Procedures. 
+The procedures are bundled in the Spark runtime jar, which is available in the [Iceberg Release Downloads](https://iceberg.apache.org/releases/#downloads).
 
 ## Snapshot Hive Table to Iceberg
 To snapshot a Hive table, users can run the following Spark SQL:

--- a/docs/hive-migration.md
+++ b/docs/hive-migration.md
@@ -22,6 +22,7 @@ menu:
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
+
 # Hive Table Migration
 Apache Hive supports ORC, Parquet, and Avro file formats that could be migrated to Iceberg.
 When migrating data to an Iceberg table, which provides versioning and transactional updates, only the most recent data files need to be migrated.

--- a/docs/hive-migration.md
+++ b/docs/hive-migration.md
@@ -1,0 +1,60 @@
+---
+title: "Hive Migration"
+url: hive-migration
+menu:
+  main:
+    parent: "Migration"
+    weight: 200
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+# Hive Table Migration
+Apache Hive supports ORC, Parquet, and Avro file formats that could be migrated to Iceberg.
+When migrating data to an Iceberg table, which provides versioning and transactional updates, only the most recent data files need to be migrated.
+
+Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive tables to Iceberg tables. Since Hive tables do not maintain snapshots,
+the migration process essentially involves creating a new Iceberg table with the existing schema and committing all data files across all partitions to the new Iceberg table.
+After the initial migration, any new data files are added to the new Iceberg table using the Add Files action.
+
+## Enabling Migration from Hive to Iceberg
+The Hive table migration actions are supported by the Spark Integration module via Spark Procedures. The procedures are bundled in the following dependencies:
+- [`iceberg-spark-runtime_3.3_2.12`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.2.0/iceberg-spark-runtime-3.3_2.12-1.2.0.jar)
+- [`iceberg-spark-runtime_3.3_2.13`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/1.2.0/iceberg-spark-runtime-3.3_2.13-1.2.0.jar)
+
+## Snapshot Hive Table to Iceberg
+To snapshot a Hive table, users can run the following Spark SQL:
+```sql
+CALL catalog_name.system.snapshot('db.source', 'db.dest')
+```
+See [Spark Procedure: snapshot](../spark-procedures/#table-migration) for more details.
+
+## Migrate Hive Table To Iceberg
+To migrate a Hive table to Iceberg, users can run the following Spark SQL:
+```sql
+CALL catalog_name.system.migrate('db.sample')
+```
+See [Spark Procedure: migrate](../spark-procedures/#table-migration) for more details.
+
+## Add Files From Delta Lake Table to Iceberg
+To add data files from a Hive table to a given Iceberg table, users can run the following Spark SQL:
+```sql
+CALL spark_catalog.system.add_files(
+table => 'db.tbl',
+source_table => 'db.src_tbl'
+)
+```
+See [Spark Procedure: add_files](../spark-procedures/#table-migration) for more details.

--- a/docs/hive-migration.md
+++ b/docs/hive-migration.md
@@ -33,8 +33,8 @@ After the initial migration, any new data files are added to the new Iceberg tab
 
 ## Enabling Migration from Hive to Iceberg
 The Hive table migration actions are supported by the Spark Integration module via Spark Procedures. The procedures are bundled in the following dependencies:
-- [`iceberg-spark-runtime_3.3_2.12`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.2.0/iceberg-spark-runtime-3.3_2.12-1.2.0.jar)
-- [`iceberg-spark-runtime_3.3_2.13`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/1.2.0/iceberg-spark-runtime-3.3_2.13-1.2.0.jar)
+- [`iceberg-spark-runtime_3.3_2.12`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.2.0/)
+- [`iceberg-spark-runtime_3.3_2.13`](https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.13/1.2.0/)
 
 ## Snapshot Hive Table to Iceberg
 To snapshot a Hive table, users can run the following Spark SQL:

--- a/docs/hive-migration.md
+++ b/docs/hive-migration.md
@@ -40,14 +40,14 @@ To snapshot a Hive table, users can run the following Spark SQL:
 ```sql
 CALL catalog_name.system.snapshot('db.source', 'db.dest')
 ```
-See [Spark Procedure: snapshot](../spark-procedures/#table-migration) for more details.
+See [Spark Procedure: snapshot](../spark-procedures/#snapshot) for more details.
 
 ## Migrate Hive Table To Iceberg
 To migrate a Hive table to Iceberg, users can run the following Spark SQL:
 ```sql
 CALL catalog_name.system.migrate('db.sample')
 ```
-See [Spark Procedure: migrate](../spark-procedures/#table-migration) for more details.
+See [Spark Procedure: migrate](../spark-procedures/#migrate) for more details.
 
 ## Add Files From Delta Lake Table to Iceberg
 To add data files from a Hive table to a given Iceberg table, users can run the following Spark SQL:
@@ -57,4 +57,4 @@ table => 'db.tbl',
 source_table => 'db.src_tbl'
 )
 ```
-See [Spark Procedure: add_files](../spark-procedures/#table-migration) for more details.
+See [Spark Procedure: add_files](../spark-procedures/#add_files) for more details.

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -1,6 +1,6 @@
 ---
-title: "Delta Lake Conversion"
-url: delta-conversion
+title: "Table Migration"
+url: table-migration
 weight: 400
 menu: main
 ---
@@ -20,12 +20,15 @@ menu: main
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
-# Delta Lake Conversion
+# Hive and Spark Table Migration
+Iceberg supports converting Hive and Spark tables to Iceberg tables through Spark Procedures. For specific instructions on how to use the procedures, please refer to the [Table Migration via Spark Procedures](../spark-procedures/#table-migration) page.
+
+# Delta Lake Table Migration
 Iceberg supports converting Delta Lake tables to Iceberg tables through the `iceberg-delta-lake` module
 by using [Delta Standalone](https://docs.delta.io/latest/delta-standalone.html) to read logs of Delta lake tables.
 
 
-## Enabling Converting from Delta Lake to Iceberg
+## Enabling Migration from Delta Lake to Iceberg
 The `iceberg-delta-lake` module is not bundled with Spark and Flink engine runtimes. Users need to manually include this module in their environment to enable the conversion.
 Also, users need to provide [Delta Standalone](https://github.com/delta-io/connectors/releases/tag/v0.6.0) and [Delta Storage](https://repo1.maven.org/maven2/io/delta/delta-storage/2.2.0/)
 because they are what `iceberg-delta-lake` uses to read Delta Lake tables.
@@ -38,7 +41,7 @@ The module is built and tested with `Delta Standalone:0.6.0` and supports Delta 
 Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
 
 For delta lake table contains `TimestampType` columns, please make sure to set table property `read.parquet.vectorization.enabled` to `false` since the vectorized reader doesn't support `INT96` yet.
-Such support is under development in according to this [issue](https://github.com/apache/iceberg/issues/4200)
+Such support is under development in the [PR#6962](https://github.com/apache/iceberg/pull/6962)
 
 ## API
 The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -22,6 +22,7 @@ menu:
  - See the License for the specific language governing permissions and
  - limitations under the License.
  -->
+
 # Table Migration
 Apache Iceberg supports converting existing tables in other formats to Iceberg tables. This section introduces the general concept of table migration, its approaches, and existing implementations in Iceberg.
 

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -29,12 +29,12 @@ Apache Iceberg supports converting existing tables in other formats to Iceberg t
 There are two methods for executing table migration: full data migration and in-place metadata migration.
 
 Full data migration involves copying all data files from the source table to the new Iceberg table. This method makes the new table fully isolated from the source table, but is slower and doubles the space.
-In practice, users can use operations like CTAS, INSERT, and Change-Data-Capture pipelines to perform the full data migration.
-
-In this doc, we will describe more about in-place metadata migration.
+In practice, users can use operations like [Create-Table-As-Select](../spark-ddl/#create-table--as-select), [INSERT](../spark-writes/#insert-into), and Change-Data-Capture pipelines to perform such migration.
 
 In-place metadata migration preserves the existing data files while incorporating Iceberg metadata on top of them.
 This method is not only faster but also eliminates the need for data duplication. However, the new table and the source table are not fully isolated. In other words, if any processes vacuum data files from the source table, the new table will also be affected.
+
+In this doc, we will describe more about in-place metadata migration.
 
 ![In-Place Metadata Migration](../../../img/iceberg-in-place-metadata-migration.png)
 

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -1,7 +1,7 @@
 ---
 title: "Table Migration"
 url: table-migration
-weight: 400
+weight: 1300
 menu: main
 ---
 <!--
@@ -27,7 +27,7 @@ Apache Iceberg supports converting existing tables in other formats to Iceberg t
 There are two main approaches to perform table migration: CTAS (Create Table As Select) and in-place migration.
 
 ### Create-Table-As-Select Migration
-CTAS migration involves creating a new Iceberg table and copying data from the existing table to the new one. This method is preferred when you want to completely cut ties with your old table, ensuring the new table is independent and fully managed by Iceberg. 
+CTAS migration involves creating a new Iceberg table and copying data from the existing table to the new one. This method is preferred when you want to completely cut ties with your old table, ensuring the new table is independent and fully managed by Iceberg.
 However, CTAS migration may require more time to complete and might not be suitable for production use cases where downtime is not acceptable.
 
 ```bash
@@ -70,29 +70,29 @@ The Migrate Table action also creates a new Iceberg table with the same schema a
 Consequently, Migrate Table requires all readers and writers working on the source table to be stopped before the action is performed.
 
 ### Add Files
-After the initial step (either Snapshot Table or Migrate Table), it is common to find some data files that have not been migrated. These files often originate from concurrent writers who continue writing to the source table during or after the migration process. 
+After the initial step (either Snapshot Table or Migrate Table), it is common to find some data files that have not been migrated. These files often originate from concurrent writers who continue writing to the source table during or after the migration process.
 In practice, these files can be new data files in Hive tables or new snapshots (versions) of Delta Lake tables. The Add Files action is essential for incorporating these files into the Iceberg table.
 
 ## In-Place Migration Completion
-Once all data files have been migrated and there are no more concurrent writers writing to the source table, the migration process is complete. 
+Once all data files have been migrated and there are no more concurrent writers writing to the source table, the migration process is complete.
 Readers and writers can now switch to the new Iceberg table for their operations.
 
 ## Migration Implementation: From Hive/Spark to Iceberg
-Apache Hive and Apache Spark are two popular data warehouse systems used for big data processing and analysis. 
-However, both systems do not natively support time travel or rollback to previous snapshots. 
+Apache Hive and Apache Spark are two popular data warehouse systems used for big data processing and analysis.
+However, both systems do not natively support time travel or rollback to previous snapshots.
 When migrating data to an Iceberg table, which provides versioning and transactional updates, only the most recent data files need to be migrated.
 
-Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive or Spark tables to Iceberg tables. Since Hive or Spark tables do not maintain snapshots, 
-the migration process essentially involves creating a new Iceberg table with the existing schema and committing all data files across all partitions to the new Iceberg table. 
+Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive or Spark tables to Iceberg tables. Since Hive or Spark tables do not maintain snapshots,
+the migration process essentially involves creating a new Iceberg table with the existing schema and committing all data files across all partitions to the new Iceberg table.
 After the initial migration, any new data files are added to the new Iceberg table using the Add Files action.
 
 For more details on how to perform the migration on Hive/Spark tables, please refer to the [Table Migration via Spark Procedures](../spark-procedures/#table-migration) page.
 
 ## Migration Implementation: From Delta Lake to Iceberg
-Delta Lake is a popular data storage system that provides time travel and versioning features. When migrating data from Delta Lake to Iceberg, 
+Delta Lake is a popular data storage system that provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
 it is common to migrate all snapshots to maintain the history of the data.
 
-Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order. 
+Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.
 For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action. The Add Snapshot action, a variant of the Add File action, is still under development.
 
 For more details on how to perform the migration on Delta Lake tables, please refer to the [Delta Lake Migration](../delta-lake-migration/#delta-lake-table-migration) page.

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -26,13 +26,35 @@ Apache Iceberg supports converting existing tables in other formats to Iceberg t
 ## Migration Approaches
 There are two main approaches to perform table migration: CTAS (Create Table As Select) and in-place migration.
 
-### CTAS Migration
+### Create-Table-As-Select Migration
 CTAS migration involves creating a new Iceberg table and copying data from the existing table to the new one. This method is preferred when you want to completely cut ties with your old table, ensuring the new table is independent and fully managed by Iceberg. 
 However, CTAS migration may require more time to complete and might not be suitable for production use cases where downtime is not acceptable.
 
+```bash
+  source_table_folder/         migrated_table_folder/
+  ├── data/                    ├── data/
+  │   ├── data_file1           │   ├── data_file1_copy
+  │   ├── data_file2           │   ├── data_file2_copy
+  │   ├── data_file3           │   ├── data_file3_copy
+  │   └── ...                  │   └── ...
+  └── metadata/                └── metadata/
+      ├── metadata_file1           ├── metadata_file2
+      └── ...                      └── ...
+```
 ### In-Place Migration
 In-place migration retains the existing data files but adds Iceberg metadata on top of them. This approach is faster and does not require copying data, making it more suitable for production use cases.
 
+```bash
+  source_table_folder/         migrated_table_folder/
+  ├── data/                    ├── data/
+  │   ├── data_file1           │   ├── <data_file_1_ptr>
+  │   ├── data_file2           │   ├── <data_file_2_ptr>
+  │   ├── data_file3           │   ├── <data_file_3_ptr>
+  │   └── ...                  │   └── ...
+  └── metadata/                └── metadata/
+      ├── metadata_file1           ├── metadata_file2
+      └── ...                      └── ...
+```
 ## In-Place Migration Actions
 Apache Iceberg primarily supports the in-place migration approach, which includes three important actions:
 

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -44,11 +44,11 @@ Apache Iceberg supports the in-place metadata migration approach, which includes
 ## Snapshot Table
 The Snapshot Table action creates a new iceberg table with a different name and with the same schema and partitioning as the source table, leaving the source table unchanged during and after the action.
 
-- Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table and a different name.
+- Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table and a different name. Readers and Writers on the source table can continue to work.
 
 ![Snapshot Table Step 1](../../../img/iceberg-snapshotaction-step1.png)
 
-- Commit all data files across all partitions to the new Iceberg table. The source table remains unchanged.
+- Commit all data files across all partitions to the new Iceberg table. The source table remains unchanged. Readers can be switched to the new Iceberg table.
 
 ![Snapshot Table Step 2](../../../img/iceberg-snapshotaction-step2.png)
 
@@ -64,7 +64,7 @@ Stop all writers interacting with the source table. Readers that also support Ic
 
 ![Migrate Table Step 2](../../../img/iceberg-migrateaction-step2.png)
 
-- Commit all data files across all partitions to the new Iceberg table. Drop the source table.
+- Commit all data files across all partitions to the new Iceberg table. Drop the source table. Writers can start writing to the new Iceberg table.
 
 ![Migrate Table Step 3](../../../img/iceberg-migrateaction-step3.png)
 

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -26,7 +26,7 @@ menu:
 Apache Iceberg supports converting existing tables in other formats to Iceberg tables. This section introduces the general concept of table migration, its approaches, and existing implementations in Iceberg.
 
 ## Migration Approaches
-There are two primary methods for executing table migration: full data migration and in-place metadata migration. 
+There are two methods for executing table migration: full data migration and in-place metadata migration.
 
 Full data migration involves copying all data files from the source table to the new Iceberg table. This method makes the new table fully isolated from the source table, but is slower and doubles the space.
 In practice, users can use operations like CTAS, INSERT, and Change-Data-Capture pipelines to perform the full data migration.

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -49,7 +49,7 @@ The Snapshot Table action creates a new iceberg table with the same schema and p
 The Migrate Table action also creates a new Iceberg table with the same schema and partitioning as the source table. However, during the action execution, it locks and drops the source table from the catalog.
 Consequently, Migrate Table requires all modifications working on the source table to be stopped before the action is performed.
 
-Stop all writers interacting with the source table. Readers that also supports Iceberg may continue reading.
+Stop all writers interacting with the source table. Readers that also support Iceberg may continue reading.
 
 ![Migrate Table Step 1](../../../img/iceberg-migrateaction-step1.png)
 

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -25,26 +25,32 @@ menu:
 # Table Migration
 Apache Iceberg supports converting existing tables in other formats to Iceberg tables. This section introduces the general concept of table migration, its approaches, and existing implementations in Iceberg.
 
-## Migration Approach
-There are two primary methods for executing table migration: full data migration and in-place migration. In this doc, we will describe more about in-place migration.
+## Migration Approaches
+There are two primary methods for executing table migration: full data migration and in-place metadata migration. 
 
-In-place migration preserves the existing data files while incorporating Iceberg metadata on top of them.
-This method is not only faster but also eliminates the need for data duplication, making it more appropriate for production environments.
+Full data migration involves copying all data files from the source table to the new Iceberg table. This method makes the new table fully isolated from the source table, but is slower and doubles the space.
+In practice, users can use operations like CTAS, INSERT, and Change-Data-Capture pipelines to perform the full data migration.
 
-![In-Place Migration](../../../img/iceberg-in-place-migration.png)
+In this doc, we will describe more about in-place metadata migration.
 
-Apache Iceberg primarily supports the in-place migration approach, which includes three important actions: `Snapshot Table`, `Migrate Table`, and `Add Files`.
+In-place metadata migration preserves the existing data files while incorporating Iceberg metadata on top of them.
+This method is not only faster but also eliminates the need for data duplication. However, the new table and the source table are not fully isolated. In other words, if any processes vacuum data files from the source table, the new table will also be affected.
+
+![In-Place Metadata Migration](../../../img/iceberg-in-place-metadata-migration.png)
+
+Apache Iceberg supports the in-place metadata migration approach, which includes three important actions: **Snapshot Table**, **Migrate Table**, and **Add Files**.
 
 ## Snapshot Table
-The Snapshot Table action creates a new iceberg table with the same schema and partitioning as the source table, leaving the source table unchanged during and after the action.
+The Snapshot Table action creates a new iceberg table with a different name and with the same schema and partitioning as the source table, leaving the source table unchanged during and after the action.
 
-- Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table
+- Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table and a different name.
 
 ![Snapshot Table Step 1](../../../img/iceberg-snapshotaction-step1.png)
 
 - Commit all data files across all partitions to the new Iceberg table. The source table remains unchanged.
 
 ![Snapshot Table Step 2](../../../img/iceberg-snapshotaction-step2.png)
+
 ## Migrate Table
 The Migrate Table action also creates a new Iceberg table with the same schema and partitioning as the source table. However, during the action execution, it locks and drops the source table from the catalog.
 Consequently, Migrate Table requires all modifications working on the source table to be stopped before the action is performed.
@@ -60,30 +66,11 @@ Stop all writers interacting with the source table. Readers that also support Ic
 - Commit all data files across all partitions to the new Iceberg table. Drop the source table.
 
 ![Migrate Table Step 3](../../../img/iceberg-migrateaction-step3.png)
+
 ## Add Files
 After the initial step (either Snapshot Table or Migrate Table), it is common to find some data files that have not been migrated. These files often originate from concurrent writers who continue writing to the source table during or after the migration process.
 In practice, these files can be new data files in Hive tables or new snapshots (versions) of Delta Lake tables. The Add Files action is essential for incorporating these files into the Iceberg table.
 
-## In-Place Migration Completion
-Once all data files have been migrated and there are no more concurrent writers writing to the source table, the migration process is complete.
-Readers and writers can now switch to the new Iceberg table for their operations.
-
 # Migrating From Different Table Formats
-## From Hive to Iceberg
-Apache Hive supports ORC, Parquet, and Avro file formats that could be migrated to Iceberg.
-When migrating data to an Iceberg table, which provides versioning and transactional updates, only the most recent data files need to be migrated.
-
-Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive tables to Iceberg tables. Since Hive tables do not maintain snapshots,
-the migration process essentially involves creating a new Iceberg table with the existing schema and committing all data files across all partitions to the new Iceberg table.
-After the initial migration, any new data files are added to the new Iceberg table using the Add Files action.
-
-For more details on how to perform the migration on Hive tables, please refer to the [Hive Table Migration via Spark Procedures](../spark-procedures/#table-migration) page.
-
-## From Delta Lake to Iceberg
-Delta Lake is a table format that supports Parquet file format and provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
-it is common to migrate all snapshots to maintain the history of the data.
-
-Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.
-For Delta Lake tables, any additional data files added after the initial migration will be included in their corresponding snapshots and subsequently added to the new Iceberg table using the Add Snapshot action. The Add Snapshot action, a variant of the Add File action, is still under development.
-
-For more details on how to perform the migration on Delta Lake tables, please refer to the [Delta Lake Migration](../delta-lake-migration/#delta-lake-table-migration) page.
+* [From Hive to Iceberg](../hive-migration)
+* [From Delta Lake to Iceberg](../delta-lake-migration)

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -1,8 +1,10 @@
 ---
-title: "Table Migration"
+title: "Overview"
 url: table-migration
-weight: 1300
-menu: main
+menu:
+  main:
+    parent: "Migration"
+    weight: 100
 ---
 <!--
  - Licensed to the Apache Software Foundation (ASF) under one or more
@@ -23,44 +25,42 @@ menu: main
 # Table Migration
 Apache Iceberg supports converting existing tables in other formats to Iceberg tables. This section introduces the general concept of table migration, its approaches, and existing implementations in Iceberg.
 
-## Migration Approaches
-There are two main approaches to perform table migration: CTAS (Create Table As Select) and in-place migration.
+## Migration Approach
+There are two primary methods for executing table migration: full data migration and in-place migration. In this doc, we will describe more about in-place migration.
 
-### Create-Table-As-Select Migration
-CTAS migration involves creating a new Iceberg table and copying data from the existing table to the new one. This method is preferred when you want to completely cut ties with your old table, ensuring the new table is independent and fully managed by Iceberg.
-However, CTAS migration may require more time to complete and might not be suitable for production use cases where downtime is not acceptable.
-![CTAS Migration](../../../img/iceberg-CTAS.png)
-### In-Place Migration
-In-place migration retains the existing data files but adds Iceberg metadata on top of them. This approach is faster and does not require copying data, making it more suitable for production use cases.
-![In-Place Migration](../../../img/iceberg-In-place.png)
-## In-Place Migration Actions
-Apache Iceberg primarily supports the in-place migration approach, which includes three important actions:
+In-place migration preserves the existing data files while incorporating Iceberg metadata on top of them.
+This method is not only faster but also eliminates the need for data duplication, making it more appropriate for production environments.
 
-1. Snapshot Table
-2. Migrate Table
-3. Add Files
+![In-Place Migration](../../../img/iceberg-in-place-migration.png)
 
-### Snapshot Table
+Apache Iceberg primarily supports the in-place migration approach, which includes three important actions: `Snapshot Table`, `Migrate Table`, and `Add Files`.
+
+## Snapshot Table
 The Snapshot Table action creates a new iceberg table with the same schema and partitioning as the source table, leaving the source table unchanged during and after the action.
 
-**Step 1:** Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table
+- Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table
+
 ![Snapshot Table Step 1](../../../img/iceberg-snapshotaction-step1.png)
 
-**Step 2:** Commit all data files across all partitions to the new Iceberg table. The source table remains unchanged.
-![Snapshot Table Step 2](../../../img/iceberg-snapshotaction-step2.png)
-### Migrate Table
-The Migrate Table action also creates a new Iceberg table with the same schema and partitioning as the source table. However, during the action execution, it locks and drops the source table from the catalog.
-Consequently, Migrate Table requires all readers and writers working on the source table to be stopped before the action is performed.
+- Commit all data files across all partitions to the new Iceberg table. The source table remains unchanged.
 
-**Step 1:** Stop all readers and writers interacting with the source table
+![Snapshot Table Step 2](../../../img/iceberg-snapshotaction-step2.png)
+## Migrate Table
+The Migrate Table action also creates a new Iceberg table with the same schema and partitioning as the source table. However, during the action execution, it locks and drops the source table from the catalog.
+Consequently, Migrate Table requires all modifications working on the source table to be stopped before the action is performed.
+
+Stop all writers interacting with the source table. Readers that also supports Iceberg may continue reading.
+
 ![Migrate Table Step 1](../../../img/iceberg-migrateaction-step1.png)
 
-**Step 2:** Create a new Iceberg table with the same metadata (schema, partition spec, etc.) as the source table. Rename the source table for a backup in case of failure and rollback.
+- Create a new Iceberg table with the same identifier and metadata (schema, partition spec, etc.) as the source table. Rename the source table for a backup in case of failure and rollback.
+
 ![Migrate Table Step 2](../../../img/iceberg-migrateaction-step2.png)
 
-**Step 3:** Commit all data files across all partitions to the new Iceberg table. Drop the source table.
+- Commit all data files across all partitions to the new Iceberg table. Drop the source table.
+
 ![Migrate Table Step 3](../../../img/iceberg-migrateaction-step3.png)
-### Add Files
+## Add Files
 After the initial step (either Snapshot Table or Migrate Table), it is common to find some data files that have not been migrated. These files often originate from concurrent writers who continue writing to the source table during or after the migration process.
 In practice, these files can be new data files in Hive tables or new snapshots (versions) of Delta Lake tables. The Add Files action is essential for incorporating these files into the Iceberg table.
 
@@ -68,19 +68,19 @@ In practice, these files can be new data files in Hive tables or new snapshots (
 Once all data files have been migrated and there are no more concurrent writers writing to the source table, the migration process is complete.
 Readers and writers can now switch to the new Iceberg table for their operations.
 
-## Migration Implementation: From Hive/Spark to Iceberg
-Apache Hive and Apache Spark are two popular data warehouse systems used for big data processing and analysis.
-However, both systems do not natively support time travel or rollback to previous snapshots.
+# Migrating From Different Table Formats
+## From Hive to Iceberg
+Apache Hive supports ORC, Parquet, and Avro file formats that could be migrated to Iceberg.
 When migrating data to an Iceberg table, which provides versioning and transactional updates, only the most recent data files need to be migrated.
 
-Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive or Spark tables to Iceberg tables. Since Hive or Spark tables do not maintain snapshots,
+Iceberg supports all three migration actions: Snapshot Table, Migrate Table, and Add Files for migrating from Hive tables to Iceberg tables. Since Hive tables do not maintain snapshots,
 the migration process essentially involves creating a new Iceberg table with the existing schema and committing all data files across all partitions to the new Iceberg table.
 After the initial migration, any new data files are added to the new Iceberg table using the Add Files action.
 
-For more details on how to perform the migration on Hive/Spark tables, please refer to the [Table Migration via Spark Procedures](../spark-procedures/#table-migration) page.
+For more details on how to perform the migration on Hive tables, please refer to the [Hive Table Migration via Spark Procedures](../spark-procedures/#table-migration) page.
 
-## Migration Implementation: From Delta Lake to Iceberg
-Delta Lake is a popular data storage system that provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
+## From Delta Lake to Iceberg
+Delta Lake is a table format that supports Parquet file format and provides time travel and versioning features. When migrating data from Delta Lake to Iceberg,
 it is common to migrate all snapshots to maintain the history of the data.
 
 Currently, Iceberg only supports the Snapshot Table action for migrating from Delta Lake to Iceberg tables. Since Delta Lake tables maintain snapshots, all available snapshots will be committed to the new Iceberg table as transactions in order.

--- a/docs/table-migration.md
+++ b/docs/table-migration.md
@@ -52,6 +52,8 @@ The Snapshot Table action creates a new iceberg table with a different name and 
 
 ![Snapshot Table Step 2](../../../img/iceberg-snapshotaction-step2.png)
 
+- Eventually, all writers can be switched to the new Iceberg table. Once all writers are transitioned to the new Iceberg table, the migration process will be considered complete.
+
 ## Migrate Table
 The Migrate Table action also creates a new Iceberg table with the same schema and partitioning as the source table. However, during the action execution, it locks and drops the source table from the catalog.
 Consequently, Migrate Table requires all modifications working on the source table to be stopped before the action is performed.


### PR DESCRIPTION
Add documentation for the `iceberg-delta-lake` module created in #6449 and pointers to Hive/Spark table migration procedures specified in Spark Doc.

Closes #6770  