### PR TITLE
Python: Fix `test_missing_uri` unit test

### DIFF
--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -35,6 +35,7 @@ from pyiceberg.table import Table
 from pyiceberg.table.metadata import TableMetadataV2
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT, Identifier, Properties
+from pyiceberg.utils.config import Config
 from tests.conftest import EXAMPLE_TABLE_METADATA_V2
 
 
@@ -138,13 +139,14 @@ def test_missing_uri(empty_home_dir_path: str) -> None:
 
     # mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
     with mock.patch.dict(os.environ, {"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path}):
-        runner = CliRunner()
-        result = runner.invoke(run, ["list"])
-        assert result.exit_code == 1
-        assert (
-            result.output
-            == "URI missing, please provide using --uri, the config or environment variable \nPYICEBERG_CATALOG__DEFAULT__URI\n"
-        )
+        with mock.patch('pyiceberg.catalog._ENV_CONFIG', Config()):
+            runner = CliRunner()
+            result = runner.invoke(run, ["list"])
+            assert result.exit_code == 1
+            assert (
+                result.output
+                == "URI missing, please provide using --uri, the config or environment variable \nPYICEBERG_CATALOG__DEFAULT__URI\n"
+            )
 
 
 @mock.patch.dict(os.environ, MOCK_ENVIRONMENT)

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -139,7 +139,7 @@ def test_missing_uri(empty_home_dir_path: str) -> None:
 
     # mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
     with mock.patch.dict(os.environ, {"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path}):
-        with mock.patch('pyiceberg.catalog._ENV_CONFIG', Config()):
+        with mock.patch("pyiceberg.catalog._ENV_CONFIG", Config()):
             runner = CliRunner()
             result = runner.invoke(run, ["list"])
             assert result.exit_code == 1


### PR DESCRIPTION
When running `make test` on mainline branch `test_missing_uri` unit test fails with:

```
empty_home_dir_path = '/private/var/folders/wz/yzqdwvrx0cj1j1h5c3g59rm40000gr/T/pytest-of-najarmin/pytest-22/home0'

    def test_missing_uri(empty_home_dir_path: str) -> None:
    
        # mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
        with mock.patch.dict(os.environ, {"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path}):
            runner = CliRunner()
            result = runner.invoke(run, ["list"])
            assert result.exit_code == 1
>           assert (
                result.output
                == "URI missing, please provide using --uri, the config or environment variable \nPYICEBERG_CATALOG__DEFAULT__URI\n"
            )
E           AssertionError: assert 'You must specify a region.\n' == 'URI missing,...EFAULT__URI\n'
E             + You must specify a region.
E             - URI missing, please provide using --uri, the config or environment variable 
E             - PYICEBERG_CATALOG__DEFAULT__URI

tests/cli/test_console.py:144: AssertionError
```

This is because in the PR that introduces this change (https://github.com/apache/iceberg/pull/6445) needs one more patch. This is because before we get to the below patch line:

```
# mock to prevent parsing ~/.pyiceberg.yaml or {PYICEBERG_HOME}/.pyiceberg.yaml
with mock.patch.dict(os.environ, {"HOME": empty_home_dir_path, "PYICEBERG_HOME": empty_home_dir_path}):
```

`_ENV_CONFIG` is already loaded as part of imports statements in the `test_console.py` file using the real `$HOME` env:

https://github.com/apache/iceberg/blob/596d7b876dcd9a9d5a5242622e3abaf8f069f3dc/python/pyiceberg/catalog/__init__.py#L51

Therefore a new patch is needed before we call the CLI:
```
with mock.patch('pyiceberg.catalog._ENV_CONFIG', Config()):
```

Just FYI the original config file is as follows at the time of producing this issue:

```
> cat ~/.pyiceberg.yaml 
catalog:
  default:
    type: glue
```

