### PR TITLE
Docs: Update the description of binary and varbinary type in the type conversion section

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -1015,8 +1015,8 @@ Flink types are converted to Iceberg types according to the following table:
 | char                | string                     |               |
 | varchar             | string                     |               |
 | string              | string                     |               |
-| binary              | binary                     |               |
-| varbinary           | fixed                      |               |
+| binary              | fixed                      |               |
+| varbinary           | binary                     |               |
 | decimal             | decimal                    |               |
 | date                | date                       |               |
 | time                | time                       |               |


### PR DESCRIPTION
Update the description of binary and varbinary types when users convert flink types to iceberg types in the [Type Conversion](https://iceberg.apache.org/docs/latest/flink/#flink-to-iceberg) section.