### PR TITLE
Spec: View spec rename sql field to query

### DIFF
--- a/format/view-spec.md
+++ b/format/view-spec.md
@@ -107,7 +107,7 @@ This type of representation stores the original view definition in SQL and its S
 | Required/Optional | Field Name | Description |
 |-------------------|------------|-------------|
 | Required | type | A string indicating the type of representation. It is set to "sql" for this type. |
-| Required | sql | A string representing the original view definition in SQL |
+| Required | query | A string representing the original view definition in SQL |
 | Required | dialect | A string specifying the dialect of the ‘sql’ field. It can be used by the engines to detect the SQL dialect. |
 | Optional | schema-id | ID of the view's schema when the version was created |
 | Optional | default-catalog | A string specifying the catalog to use when the table or view references in the view definition do not contain an explicit catalog. |


### PR DESCRIPTION
In the API/data model layer we call the field query now instead of "sql" https://github.com/apache/iceberg/pull/4925/files#diff-ec2ce8e1a850dc93199ebfe18a04747589a102882e052e9a83dd6602e366ac7aR33. This change updates the spec to reflect that