### PR TITLE
API: Rename query to sql on SQLViewRepresentation API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
+++ b/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
@@ -30,7 +30,7 @@ public interface SQLViewRepresentation extends ViewRepresentation {
   }
 
   /** The view query SQL text. */
-  String query();
+  String sql();
 
   /** The view query SQL dialect. */
   String dialect();


### PR DESCRIPTION
The spec defines "sql" as the field in SQL view representation but at the API level it's called query. Renaming the API for consistency purposes and as discussed on https://github.com/apache/iceberg/pull/6612 concluded that sql is the best field name (rather than updating the spec to use query) since this will always be a SQL string and not some generic query string for SQL view representation