### PR TITLE
🎨 Add "parallelism" parameter to "add_files" syscall and MigrateTable, SnapshotTable.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -50,6 +50,14 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
     throw new UnsupportedOperationException("Dropping a backup is not supported");
   }
 
+  /**
+   * @param numReaders the number of concurrent file read operations to use per partition
+   * @return this for method chaining
+   **/
+  default MigrateTable withParallelReads(int numReaders) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement withParallelReads");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the number of migrated data files. */

--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -51,10 +51,10 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
   }
 
   /**
-   * @param numReaders the number of concurrent file read operations to use per partition
+   * @param parallelism the number of concurrent file read operations to use per partition
    * @return this for method chaining
    */
-  default MigrateTable withParallelReads(int numReaders) {
+  default MigrateTable withParallelReads(int parallelism) {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement withParallelReads");
   }

--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -53,9 +53,10 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
   /**
    * @param numReaders the number of concurrent file read operations to use per partition
    * @return this for method chaining
-   **/
+   */
   default MigrateTable withParallelReads(int numReaders) {
-    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement withParallelReads");
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement withParallelReads");
   }
 
   /** The action result that contains a summary of the execution. */

--- a/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
@@ -60,9 +60,10 @@ public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Resul
   /**
    * @param numReaders the number of concurrent file read operations to use per partition
    * @return this for method chaining
-   **/
+   */
   default SnapshotTable withParallelReads(int numReaders) {
-    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement withParallelReads");
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement withParallelReads");
   }
 
   /** The action result that contains a summary of the execution. */

--- a/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
@@ -58,10 +58,10 @@ public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Resul
   SnapshotTable tableProperty(String key, String value);
 
   /**
-   * @param numReaders the number of concurrent file read operations to use per partition
+   * @param parallelism the number of concurrent file read operations to use per partition
    * @return this for method chaining
    */
-  default SnapshotTable withParallelReads(int numReaders) {
+  default SnapshotTable withParallelReads(int parallelism) {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement withParallelReads");
   }

--- a/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
@@ -57,6 +57,14 @@ public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Resul
    */
   SnapshotTable tableProperty(String key, String value);
 
+  /**
+   * @param numReaders the number of concurrent file read operations to use per partition
+   * @return this for method chaining
+   **/
+  default SnapshotTable withParallelReads(int numReaders) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement withParallelReads");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the number of imported data files. */

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -381,11 +381,13 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result = scalarSql("CALL %s.system.add_files(" +
-            "table => '%s', " +
-            "source_table => '%s', " +
-            "max_concurrent_read_datafiles => 3)",
-        catalogName, tableName, sourceTableName);
+    Object result =
+        scalarSql(
+            "CALL %s.system.add_files("
+                + "table => '%s', "
+                + "source_table => '%s', "
+                + "max_concurrent_read_datafiles => 3)",
+            catalogName, tableName, sourceTableName);
 
     Assert.assertEquals(8L, result);
 
@@ -404,11 +406,13 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result = scalarSql("CALL %s.system.add_files(" +
-            "table => '%s', " +
-            "source_table => '%s', " +
-            "max_concurrent_read_datafiles => 3)",
-        catalogName, tableName, sourceTableName);
+    Object result =
+        scalarSql(
+            "CALL %s.system.add_files("
+                + "table => '%s', "
+                + "source_table => '%s', "
+                + "max_concurrent_read_datafiles => 3)",
+            catalogName, tableName, sourceTableName);
 
     Assert.assertEquals(2L, result);
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -373,6 +373,52 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void addDataPartitionedHiveInParallel() {
+    createPartitionedHiveTable();
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+
+    sql(createIceberg, tableName);
+
+    Object result = scalarSql("CALL %s.system.add_files(" +
+            "table => '%s', " +
+            "source_table => '%s', " +
+            "max_concurrent_read_datafiles => 3)",
+        catalogName, tableName, sourceTableName);
+
+    Assert.assertEquals(8L, result);
+
+    assertEquals(
+        "Iceberg table contains correct data",
+        sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", sourceTableName),
+        sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void addDataUnpartitionedHiveInParallel() {
+    createUnpartitionedHiveTable();
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+
+    sql(createIceberg, tableName);
+
+    Object result = scalarSql("CALL %s.system.add_files(" +
+            "table => '%s', " +
+            "source_table => '%s', " +
+            "max_concurrent_read_datafiles => 3)",
+        catalogName, tableName, sourceTableName);
+
+    Assert.assertEquals(2L, result);
+
+    assertEquals(
+        "Iceberg table contains correct data",
+        sql("SELECT * FROM %s ORDER BY id", sourceTableName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
   public void addPartitionToPartitioned() {
     createPartitionedFileTable("parquet");
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -386,7 +386,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
-                + "max_concurrent_read_datafiles => 3)",
+                + "parallelism => 3)",
             catalogName, tableName, sourceTableName);
 
     Assert.assertEquals(8L, result);
@@ -411,7 +411,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
-                + "max_concurrent_read_datafiles => 3)",
+                + "parallelism => 3)",
             catalogName, tableName, sourceTableName);
 
     Assert.assertEquals(2L, result);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -110,13 +110,16 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
   public void testMigrateWithParallelism() throws IOException {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
-    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'", tableName, location);
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        tableName, location);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
     sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
     sql("INSERT INTO TABLE %s VALUES (3, 'c')", tableName);
 
     Object result =
-        scalarSql("CALL %s.system.migrate(table => '%s', max_concurrent_read_datafiles => 3)",
+        scalarSql(
+            "CALL %s.system.migrate(table => '%s', max_concurrent_read_datafiles => 3)",
             catalogName, tableName);
 
     Assert.assertEquals("Should have added three files", 3L, result);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -119,8 +119,7 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
 
     Object result =
         scalarSql(
-            "CALL %s.system.migrate(table => '%s', max_concurrent_read_datafiles => 3)",
-            catalogName, tableName);
+            "CALL %s.system.migrate(table => '%s', parallelism => 3)", catalogName, tableName);
 
     Assert.assertEquals("Should have added three files", 3L, result);
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -106,13 +106,16 @@ public class TestSnapshotTableProcedure extends SparkExtensionsTestBase {
   @Test
   public void testSnapshotWithParallelism() throws IOException {
     String location = temp.newFolder().toString();
-    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'", sourceName, location);
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        sourceName, location);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", sourceName);
     sql("INSERT INTO TABLE %s VALUES (2, 'b')", sourceName);
     sql("INSERT INTO TABLE %s VALUES (3, 'c')", sourceName);
-    Object result = scalarSql(
-        "CALL %s.system.snapshot(source_table => '%s', table => '%s', max_concurrent_read_datafiles => 4)",
-        catalogName, sourceName, tableName);
+    Object result =
+        scalarSql(
+            "CALL %s.system.snapshot(source_table => '%s', table => '%s', max_concurrent_read_datafiles => 4)",
+            catalogName, sourceName, tableName);
 
     Assert.assertEquals("Should have added three file", 3L, result);
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -114,7 +114,7 @@ public class TestSnapshotTableProcedure extends SparkExtensionsTestBase {
     sql("INSERT INTO TABLE %s VALUES (3, 'c')", sourceName);
     Object result =
         scalarSql(
-            "CALL %s.system.snapshot(source_table => '%s', table => '%s', max_concurrent_read_datafiles => 4)",
+            "CALL %s.system.snapshot(source_table => '%s', table => '%s', parallelism => 4)",
             catalogName, sourceName, tableName);
 
     Assert.assertEquals("Should have added three file", 3L, result);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -486,7 +486,7 @@ public class SparkTableUtil {
         stagingDir,
         Collections.emptyMap(),
         checkDuplicateFiles,
-        1);
+        ThreadPools.WORKER_THREAD_POOL_SIZE);
   }
 
   /**

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -461,9 +461,8 @@ public class SparkTableUtil {
   /**
    * Import files from an existing Spark table to an Iceberg table.
    *
-   * The import uses the Spark session to get table metadata. It assumes no
-   * operation is going on the original and target table and thus is not
-   * thread-safe.
+   * <p>The import uses the Spark session to get table metadata. It assumes no operation is going on
+   * the original and target table and thus is not thread-safe.
    *
    * @param spark a Spark session
    * @param sourceTableIdent an identifier of the source Spark table
@@ -481,13 +480,13 @@ public class SparkTableUtil {
       Map<String, String> partitionFilter,
       boolean checkDuplicateFiles) {
     importSparkTable(
-          spark,
-          sourceTableIdent,
-          targetTable,
-          stagingDir,
-          Collections.emptyMap(),
-          checkDuplicateFiles,
-          1);
+        spark,
+        sourceTableIdent,
+        targetTable,
+        stagingDir,
+        Collections.emptyMap(),
+        checkDuplicateFiles,
+        1);
   }
 
   /**
@@ -605,7 +604,7 @@ public class SparkTableUtil {
    * @param spec a partition spec
    * @param stagingDir a staging directory to store temporary manifest files
    * @param checkDuplicateFiles if true, throw exception if import results in a duplicate data file
-   * @param listPartitionParallelism Max number of concurrent files to read per partition while 
+   * @param listPartitionParallelism Max number of concurrent files to read per partition while
    *     indexing table
    */
   public static void importSparkPartitions(
@@ -638,15 +637,15 @@ public class SparkTableUtil {
             (FlatMapFunction<SparkPartition, DataFile>)
                 sparkPartition ->
                     TableMigrationUtil.listPartition(
-                      sparkPartition.values,
-                      sparkPartition.uri,
-                      sparkPartition.format,
-                      spec,
-                      serializableConf.get(),
-                      metricsConfig,
-                      nameMapping,
-                      listPartitionParallelism).iterator(),
-
+                            sparkPartition.values,
+                            sparkPartition.uri,
+                            sparkPartition.format,
+                            spec,
+                            serializableConf.get(),
+                            metricsConfig,
+                            nameMapping,
+                            listPartitionParallelism)
+                        .iterator(),
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -100,7 +100,7 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
   }
 
   @Override
-  public MigrateTable withParallelReads(int numReaders) {
+  public MigrateTableSparkAction withParallelReads(int numReaders) {
     this.readDatafileParallelism = numReaders;
     return this;
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -100,8 +100,8 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
   }
 
   @Override
-  public MigrateTableSparkAction withParallelReads(int numReaders) {
-    this.readDatafileParallelism = numReaders;
+  public MigrateTableSparkAction withParallelReads(int parallelism) {
+    this.readDatafileParallelism = parallelism;
     return this;
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -102,7 +102,7 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
   }
 
   @Override
-  public MigrateTable withParallelReads(int numReaders) {
+  public SnapshotTableSparkAction withParallelReads(int numReaders) {
     this.readDatafileParallelism = numReaders;
     return this;
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -102,8 +102,8 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
   }
 
   @Override
-  public SnapshotTableSparkAction withParallelReads(int numReaders) {
-    this.readDatafileParallelism = numReaders;
+  public SnapshotTableSparkAction withParallelReads(int parallelism) {
+    this.readDatafileParallelism = parallelism;
     return this;
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -61,7 +61,7 @@ class AddFilesProcedure extends BaseProcedure {
         ProcedureParameter.required("source_table", DataTypes.StringType),
         ProcedureParameter.optional("partition_filter", STRING_MAP),
         ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType),
-        ProcedureParameter.optional("max_concurrent_read_datafiles", DataTypes.IntegerType)
+        ProcedureParameter.optional("parallelism", DataTypes.IntegerType)
       };
 
   private static final StructType OUTPUT_TYPE =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -60,7 +60,8 @@ class AddFilesProcedure extends BaseProcedure {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.required("source_table", DataTypes.StringType),
         ProcedureParameter.optional("partition_filter", STRING_MAP),
-        ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType)
+        ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType),
+        ProcedureParameter.optional("max_concurrent_read_datafiles", DataTypes.IntegerType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -119,8 +120,20 @@ class AddFilesProcedure extends BaseProcedure {
       checkDuplicateFiles = args.getBoolean(3);
     }
 
+    int parallelism;
+    if (!args.isNullAt(4)) {
+      parallelism = args.getInt(4);
+    } else {
+      parallelism = 1;
+    }
+
     long addedFilesCount =
-        importToIceberg(tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles);
+        importToIceberg(
+            tableIdent,
+            sourceIdent,
+            partitionFilter,
+            checkDuplicateFiles,
+            parallelism);
     return new InternalRow[] {newInternalRow(addedFilesCount)};
   }
 
@@ -136,7 +149,8 @@ class AddFilesProcedure extends BaseProcedure {
       Identifier destIdent,
       Identifier sourceIdent,
       Map<String, String> partitionFilter,
-      boolean checkDuplicateFiles) {
+      boolean checkDuplicateFiles,
+      int parallelism) {
     return modifyIcebergTable(
         destIdent,
         table -> {
@@ -146,9 +160,20 @@ class AddFilesProcedure extends BaseProcedure {
           if (isFileIdentifier(sourceIdent)) {
             Path sourcePath = new Path(sourceIdent.name());
             String format = sourceIdent.namespace()[0];
-            importFileTable(table, sourcePath, format, partitionFilter, checkDuplicateFiles);
+            importFileTable(
+                table,
+                sourcePath,
+                format,
+                partitionFilter,
+                checkDuplicateFiles,
+                parallelism);
           } else {
-            importCatalogTable(table, sourceIdent, partitionFilter, checkDuplicateFiles);
+            importCatalogTable(
+                table,
+                sourceIdent,
+                partitionFilter,
+                checkDuplicateFiles,
+                parallelism);
           }
 
           Snapshot snapshot = table.currentSnapshot();
@@ -171,7 +196,8 @@ class AddFilesProcedure extends BaseProcedure {
       Path tableLocation,
       String format,
       Map<String, String> partitionFilter,
-      boolean checkDuplicateFiles) {
+      boolean checkDuplicateFiles,
+      int parallelism) {
     // List Partitions via Spark InMemory file search interface
     List<SparkPartition> partitions =
         Spark3Util.getPartitions(spark(), tableLocation, format, partitionFilter);
@@ -186,11 +212,11 @@ class AddFilesProcedure extends BaseProcedure {
       // Build a Global Partition for the source
       SparkPartition partition =
           new SparkPartition(Collections.emptyMap(), tableLocation.toString(), format);
-      importPartitions(table, ImmutableList.of(partition), checkDuplicateFiles);
+      importPartitions(table, ImmutableList.of(partition), checkDuplicateFiles, parallelism);
     } else {
       Preconditions.checkArgument(
           !partitions.isEmpty(), "Cannot find any matching partitions in table %s", partitions);
-      importPartitions(table, partitions, checkDuplicateFiles);
+      importPartitions(table, partitions, checkDuplicateFiles, parallelism);
     }
   }
 
@@ -198,7 +224,8 @@ class AddFilesProcedure extends BaseProcedure {
       Table table,
       Identifier sourceIdent,
       Map<String, String> partitionFilter,
-      boolean checkDuplicateFiles) {
+      boolean checkDuplicateFiles,
+      int parallelism) {
     String stagingLocation = getMetadataLocation(table);
     TableIdentifier sourceTableIdentifier = Spark3Util.toV1TableIdentifier(sourceIdent);
     SparkTableUtil.importSparkTable(
@@ -207,14 +234,24 @@ class AddFilesProcedure extends BaseProcedure {
         table,
         stagingLocation,
         partitionFilter,
-        checkDuplicateFiles);
+        checkDuplicateFiles,
+        parallelism);
   }
 
   private void importPartitions(
-      Table table, List<SparkTableUtil.SparkPartition> partitions, boolean checkDuplicateFiles) {
+      Table table,
+      List<SparkTableUtil.SparkPartition> partitions,
+      boolean checkDuplicateFiles,
+      int parallelism) {
     String stagingLocation = getMetadataLocation(table);
     SparkTableUtil.importSparkPartitions(
-        spark(), partitions, table, table.spec(), stagingLocation, checkDuplicateFiles);
+        spark(),
+        partitions,
+        table,
+        table.spec(),
+        stagingLocation,
+        checkDuplicateFiles,
+        parallelism);
   }
 
   private String getMetadataLocation(Table table) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
+import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.TableIdentifier;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
@@ -113,19 +114,9 @@ class AddFilesProcedure extends BaseProcedure {
               });
     }
 
-    boolean checkDuplicateFiles;
-    if (args.isNullAt(3)) {
-      checkDuplicateFiles = true;
-    } else {
-      checkDuplicateFiles = args.getBoolean(3);
-    }
+    boolean checkDuplicateFiles = (args.isNullAt(3)) ? true : args.getBoolean(3);
 
-    int parallelism;
-    if (!args.isNullAt(4)) {
-      parallelism = args.getInt(4);
-    } else {
-      parallelism = 1;
-    }
+    int parallelism = (args.isNullAt(4)) ? ThreadPools.WORKER_THREAD_POOL_SIZE : args.getInt(4);
 
     long addedFilesCount =
         importToIceberg(tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, parallelism);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -128,12 +128,7 @@ class AddFilesProcedure extends BaseProcedure {
     }
 
     long addedFilesCount =
-        importToIceberg(
-            tableIdent,
-            sourceIdent,
-            partitionFilter,
-            checkDuplicateFiles,
-            parallelism);
+        importToIceberg(tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, parallelism);
     return new InternalRow[] {newInternalRow(addedFilesCount)};
   }
 
@@ -161,19 +156,10 @@ class AddFilesProcedure extends BaseProcedure {
             Path sourcePath = new Path(sourceIdent.name());
             String format = sourceIdent.namespace()[0];
             importFileTable(
-                table,
-                sourcePath,
-                format,
-                partitionFilter,
-                checkDuplicateFiles,
-                parallelism);
+                table, sourcePath, format, partitionFilter, checkDuplicateFiles, parallelism);
           } else {
             importCatalogTable(
-                table,
-                sourceIdent,
-                partitionFilter,
-                checkDuplicateFiles,
-                parallelism);
+                table, sourceIdent, partitionFilter, checkDuplicateFiles, parallelism);
           }
 
           Snapshot snapshot = table.currentSnapshot();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.actions.MigrateTableSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
@@ -100,7 +101,7 @@ class MigrateTableProcedure extends BaseProcedure {
     if (dropBackup) {
       result = migrateTableSparkAction.dropBackup().execute();
     } else {
-      int parallelism = (args.isNullAt(3)) ? 1 : args.getInt(3);
+      int parallelism = (args.isNullAt(3)) ? ThreadPools.WORKER_THREAD_POOL_SIZE : args.getInt(3);
       result = migrateTableSparkAction.withParallelReads(parallelism).execute();
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -40,7 +40,7 @@ class MigrateTableProcedure extends BaseProcedure {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
         ProcedureParameter.optional("drop_backup", DataTypes.BooleanType),
-        ProcedureParameter.optional("max_concurrent_read_datafiles", DataTypes.IntegerType)
+        ProcedureParameter.optional("parallelism", DataTypes.IntegerType)
       };
 
   private static final StructType OUTPUT_TYPE =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -100,12 +100,7 @@ class MigrateTableProcedure extends BaseProcedure {
     if (dropBackup) {
       result = migrateTableSparkAction.dropBackup().execute();
     } else {
-      int parallelism;
-      if (!args.isNullAt(3)) {
-        parallelism = args.getInt(3);
-      } else {
-        parallelism = 1;
-      }
+      int parallelism = (args.isNullAt(3)) ? 1 : args.getInt(3);
       result = migrateTableSparkAction.withParallelReads(parallelism).execute();
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -39,7 +39,7 @@ class SnapshotTableProcedure extends BaseProcedure {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("location", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
-        ProcedureParameter.optional("max_concurrent_read_datafiles", DataTypes.IntegerType)
+        ProcedureParameter.optional("parallelism", DataTypes.IntegerType)
       };
 
   private static final StructType OUTPUT_TYPE =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -104,10 +104,8 @@ class SnapshotTableProcedure extends BaseProcedure {
     Preconditions.checkArgument(
         !source.equals(dest),
         "Cannot create a snapshot with the same name as the source of the snapshot.");
-    SnapshotTable action = SparkActions.get()
-        .snapshotTable(source)
-        .withParallelReads(parallelism)
-        .as(dest);
+    SnapshotTable action =
+        SparkActions.get().snapshotTable(source).withParallelReads(parallelism).as(dest);
 
     if (snapshotLocation != null) {
       action.tableLocation(snapshotLocation);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.actions.SnapshotTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
@@ -94,7 +95,7 @@ class SnapshotTableProcedure extends BaseProcedure {
               });
     }
 
-    int parallelism = (args.isNullAt(4)) ? 1 : args.getInt(4);
+    int parallelism = (args.isNullAt(4)) ? ThreadPools.WORKER_THREAD_POOL_SIZE : args.getInt(4);
 
     Preconditions.checkArgument(
         !source.equals(dest),

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -94,12 +94,7 @@ class SnapshotTableProcedure extends BaseProcedure {
               });
     }
 
-    int parallelism;
-    if (!args.isNullAt(4)) {
-      parallelism = args.getInt(4);
-    } else {
-      parallelism = 1;
-    }
+    int parallelism = (args.isNullAt(4)) ? 1 : args.getInt(4);
 
     Preconditions.checkArgument(
         !source.equals(dest),


### PR DESCRIPTION
…, SnapshotTable.

Signed-off-by: kingeasternsun <kingeasternsun@gmail.com>

Based on    `Speed up TableMigration By collect the DafaFile In parallel`   #3876 ,  
- add parallelism parameter to `add_files` and the related functions.
- for compatibility，I Keep the original method  and let original method call the newer method with default parallelism = 1
- add parallelism parameter to MigrateTableProcedure
- add parallelism parameter to SnapshotTableProcedure