### PR TITLE
Build: Fix minor error-prone warnings

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -84,6 +84,8 @@ subprojects {
           // Enforce hashCode over hash
           '-Xep:ObjectsHashCodeUnnecessaryVarargs:ERROR',
           '-Xep:PreferSafeLogger:OFF',
+          // Enforce safe string splitting
+          '-Xep:StringSplitter:ERROR',
       )
     }
   }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -329,14 +329,14 @@ public class OAuth2Util {
       return null;
     }
 
-    String[] parts = token.split("\\.");
-    if (parts.length != 3) {
+    List<String> parts = Splitter.on('.').splitToList(token);
+    if (parts.size() != 3) {
       return null;
     }
 
     JsonNode node;
     try {
-      node = JsonUtil.mapper().readTree(Base64.getUrlDecoder().decode(parts[1]));
+      node = JsonUtil.mapper().readTree(Base64.getUrlDecoder().decode(parts.get(1)));
     } catch (IOException e) {
       return null;
     }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveVersion.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveVersion.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg.hive;
 
+import java.util.List;
 import org.apache.hive.common.util.HiveVersionInfo;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public enum HiveVersion {
   HIVE_4(4),
@@ -44,8 +46,8 @@ public enum HiveVersion {
 
   private static HiveVersion calculate() {
     String version = HiveVersionInfo.getShortVersion();
-    String[] versions = version.split("\\.");
-    switch (versions[0]) {
+    List<String> versions = Splitter.on('.').splitToList(version);
+    switch (versions.get(0)) {
       case "4":
         return HIVE_4;
       case "3":
@@ -53,7 +55,7 @@ public enum HiveVersion {
       case "2":
         return HIVE_2;
       case "1":
-        if (versions[1].equals("2")) {
+        if (versions.get(1).equals("2")) {
           return HIVE_1_2;
         } else {
           return NOT_SUPPORTED;


### PR DESCRIPTION
I have observed that the build [`./gradlew clean build -x test`] has some warnings. 
So it is an effort to keep the build green. 

Before:
<img width="1754" alt="Screenshot 2023-01-20 at 7 50 45 AM" src="https://user-images.githubusercontent.com/5889404/213606755-f8a491a3-99e4-4e6f-ac57-c6b5437e160c.png">


After:
<img width="825" alt="Screenshot 2023-01-20 at 8 04 01 AM" src="https://user-images.githubusercontent.com/5889404/213606771-87eed4bb-abf9-42d4-887a-f24e1815f3b2.png">
