### PR TITLE
Spark 3.3: Fix predicate pushdown for copy-on-write MERGE commands

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RowLevelCommandScanRelationPushDown.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RowLevelCommandScanRelationPushDown.scala
@@ -19,14 +19,20 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.spark.sql.catalyst.expressions.And
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.expressions.AttributeSet
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
 import org.apache.spark.sql.catalyst.planning.RewrittenRowLevelCommand
+import org.apache.spark.sql.catalyst.planning.ScanOperation
+import org.apache.spark.sql.catalyst.plans.logical.Join
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.MergeIntoIcebergTable
+import org.apache.spark.sql.catalyst.plans.logical.NoStatsUnaryNode
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceIcebergData
+import org.apache.spark.sql.catalyst.plans.logical.RowLevelCommand
 import org.apache.spark.sql.catalyst.plans.logical.WriteDelta
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
@@ -40,12 +46,46 @@ object RowLevelCommandScanRelationPushDown extends Rule[LogicalPlan] with Predic
   import ExtendedDataSourceV2Implicits._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan transformDown {
-    // use native Spark planning for delta-based plans and copy-on-write MERGE operations
+    // use native Spark planning for delta-based plans
     // unlike other commands, these plans have filters that can be pushed down directly
-    case RewrittenRowLevelCommand(command, _: DataSourceV2Relation, rewritePlan)
-        if rewritePlan.isInstanceOf[WriteDelta] || command.isInstanceOf[MergeIntoIcebergTable] =>
-
+    case RewrittenRowLevelCommand(command, _: DataSourceV2Relation, rewritePlan: WriteDelta) =>
       val newRewritePlan = V2ScanRelationPushDown.apply(rewritePlan)
+      command.withNewRewritePlan(newRewritePlan)
+
+    // group-based MERGE operations are rewritten as joins and may be planned in a special way
+    // the join condition is the MERGE condition and can be pushed into the source
+    // this allows us to remove completely pushed down predicates from the join condition
+    case UnplannedGroupBasedMergeOperation(command, rd: ReplaceIcebergData,
+        join @ Join(_, _, _, Some(joinCond), _), relation: DataSourceV2Relation) =>
+
+      val table = relation.table.asRowLevelOperationTable
+      val scanBuilder = table.newScanBuilder(relation.options)
+
+      val (pushedFilters, newJoinCond) = pushMergeFilters(joinCond, relation, scanBuilder)
+      val pushedFiltersStr = if (pushedFilters.isLeft) {
+        pushedFilters.left.get.mkString(", ")
+      } else {
+        pushedFilters.right.get.mkString(", ")
+      }
+
+      val (scan, output) = PushDownUtils.pruneColumns(scanBuilder, relation, relation.output, Nil)
+
+      logInfo(
+        s"""
+           |Pushing MERGE operators to ${relation.name}
+           |Pushed filters: $pushedFiltersStr
+           |Original JOIN condition: $joinCond
+           |New JOIN condition: $newJoinCond
+           |Output: ${output.mkString(", ")}
+         """.stripMargin)
+
+      val newRewritePlan = rd transformDown {
+        case j: Join if j eq join =>
+          j.copy(condition = newJoinCond)
+        case r: DataSourceV2Relation if r.table eq table =>
+          DataSourceV2ScanRelation(r, scan, PushDownUtils.toOutputAttrs(scan.readSchema(), r))
+      }
+
       command.withNewRewritePlan(newRewritePlan)
 
     // push down the filter from the command condition instead of the filter in the rewrite plan,
@@ -94,6 +134,24 @@ object RowLevelCommandScanRelationPushDown extends Rule[LogicalPlan] with Predic
     (pushedFilters.left.getOrElse(Seq.empty), pushedFilters.right.getOrElse(Seq.empty))
   }
 
+  // splits the join condition into predicates and tries to push down each predicate into the scan
+  // completely pushed down predicates are removed from the join condition
+  // joinCond can't have subqueries as it is validated by the rule that rewrites MERGE as a join
+  private def pushMergeFilters(
+      joinCond: Expression,
+      relation: DataSourceV2Relation,
+      scanBuilder: ScanBuilder): (Either[Seq[Filter], Seq[Predicate]], Option[Expression]) = {
+
+    val (tableFilters, commonFilters) =
+      splitConjunctivePredicates(joinCond).partition(_.references.subsetOf(relation.outputSet))
+    val normalizedTableFilters = DataSourceStrategy.normalizeExprs(tableFilters, relation.output)
+    val (pushedFilters, postScanFilters) =
+      PushDownUtils.pushFilters(scanBuilder, normalizedTableFilters)
+    val newJoinCond = (commonFilters ++ postScanFilters).reduceLeftOption(And)
+
+    (pushedFilters, newJoinCond)
+  }
+
   private def toOutputAttrs(
       schema: StructType,
       relation: DataSourceV2Relation): Seq[AttributeReference] = {
@@ -103,5 +161,35 @@ object RowLevelCommandScanRelationPushDown extends Rule[LogicalPlan] with Predic
       // keep the attribute id during transformation
       a => a.withExprId(nameToAttr(a.name).exprId)
     }
+  }
+}
+
+object UnplannedGroupBasedMergeOperation {
+  type ReturnType = (RowLevelCommand, ReplaceIcebergData, Join, DataSourceV2Relation)
+
+  def unapply(plan: LogicalPlan): Option[ReturnType] = plan match {
+    case m @ MergeIntoIcebergTable(_, _, _, _, _, Some(rewritePlan)) =>
+      rewritePlan match {
+        case rd @ ReplaceIcebergData(DataSourceV2Relation(table, _, _, _, _), query, _, _) =>
+          val joinsAndRelations = query.collect {
+            case j @ Join(
+                NoStatsUnaryNode(ScanOperation(_, filters, r: DataSourceV2Relation)), _, _, _, _)
+                if filters.isEmpty && r.table.eq(table) =>
+              j -> r
+          }
+
+          joinsAndRelations match {
+            case Seq((join, relation)) =>
+              Some(m, rd, join, relation)
+            case _ =>
+              None
+          }
+
+        case _ =>
+          None
+      }
+
+    case _ =>
+      None
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -180,7 +180,7 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
     if (jsonData != null) {
       try {
         Dataset<Row> ds = toDS(schema, jsonData);
-        ds.writeTo(tableName).append();
+        ds.coalesce(1).writeTo(tableName).append();
       } catch (NoSuchTableException e) {
         throw new RuntimeException("Failed to write data", e);
       }


### PR DESCRIPTION
This PR fixes predicate pushdown for copy-on-write MERGE commands, which was broken after #6534. This change contains a test that would previously fail and lead to a data correctness issue.