### PR TITLE
Flink: add table setter to FLIP-27 IcebergSource#Builder.

### DIFF
--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
@@ -103,6 +103,7 @@ public class TestIcebergSourceBounded extends TestFlinkScan {
     IcebergSource.Builder<RowData> sourceBuilder =
         IcebergSource.forRowData()
             .tableLoader(tableLoader())
+            .table(table)
             .assignerFactory(new SimpleSplitAssignerFactory())
             .flinkConfig(config);
     if (projectedSchema != null) {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
@@ -103,6 +103,7 @@ public class TestIcebergSourceBounded extends TestFlinkScan {
     IcebergSource.Builder<RowData> sourceBuilder =
         IcebergSource.forRowData()
             .tableLoader(tableLoader())
+            .table(table)
             .assignerFactory(new SimpleSplitAssignerFactory())
             .flinkConfig(config);
     if (projectedSchema != null) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
@@ -103,6 +103,7 @@ public class TestIcebergSourceBounded extends TestFlinkScan {
     IcebergSource.Builder<RowData> sourceBuilder =
         IcebergSource.forRowData()
             .tableLoader(tableLoader())
+            .table(table)
             .assignerFactory(new SimpleSplitAssignerFactory())
             .flinkConfig(config);
     if (projectedSchema != null) {


### PR DESCRIPTION
This is to avoid double loading if table is already loaded before the builder. This is also the same pattern as the pre FLIP-27 FlinkSource#Builder.