### PR TITLE
WIP: Support Snapshot Copy-On-Write Hudi Table to Iceberg Table

### DIFF
--- a/.github/workflows/hudi-conversion-ci.yaml
+++ b/.github/workflows/hudi-conversion-ci.yaml
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Hudi Conversion CI"
+on:
+  push:
+    branches:
+      - 'master'
+      - '0.**'
+    tags:
+      - 'apache-iceberg-**'
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+      - '.github/workflows/python-ci.yml'
+      - '.github/workflows/flink-ci.yml'
+      - '.github/workflows/hive-ci.yml'
+      - '.gitignore'
+      - '.asf.yml'
+      - 'dev/**'
+      - 'mr/**'
+      - 'hive3/**'
+      - 'hive3-orc-bundle/**'
+      - 'hive-runtime/**'
+      - 'flink/**'
+      - 'pig/**'
+      - 'python/**'
+      - 'python_legacy/**'
+      - 'docs/**'
+      - 'open-api/**'
+      - 'format/**'
+      - '.gitattributes'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'LICENSE'
+      - 'NOTICE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  hudi-conversion-scala-2-12-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        jvm: [8, 11]
+    env:
+      SPARK_LOCAL_IP: localhost
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: ${{ matrix.jvm }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      - run: ./gradlew -DsparkVersions=3.3 -DscalaVersion=2.12 -DhiveVersions= -DflinkVersions= :iceberg-hudi:check -Pquick=true -x javadoc
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: test logs
+          path: |
+            **/build/testlogs

--- a/build.gradle
+++ b/build.gradle
@@ -458,10 +458,10 @@ project(':iceberg-hudi') {
     implementation project(':iceberg-orc')
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
-    // TODO: we only need hudi-common here, however, hudi-common has some dependency conflicts with hudi-spark-bundle
-    // which is currently used by the integration test. We should fix this in the future.
-    // Also, hudi uses java8, may need to assess if we can use hudi in java11.
-    compileOnly("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
+    // Hudi uses java8, may need to assess if we can use hudi in java11.
+    compileOnly("org.apache.hudi:hudi-common")
+    // Added to resolve dependency conflicts with hudi-spark-bundle
+    compileOnly("org.apache.hudi:hudi-client-common")
     implementation("org.apache.avro:avro") {
       exclude group: 'org.tukaani' // xz compression is not supported
     }
@@ -474,7 +474,10 @@ project(':iceberg-hudi') {
     }
     if (sparkVersions.contains("3.3") && scalaVersion == "2.12") {
       integrationImplementation project(':iceberg-data')
-      integrationImplementation("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
+      integrationImplementation("org.apache.hudi:hudi-spark3.3-bundle_2.12") {
+        exclude group: 'org.apache.hudi', module: 'hudi-common'
+        exclude group: 'org.apache.hudi', module: 'hudi-client-common'
+      }
       integrationImplementation project(path: ":iceberg-spark:iceberg-spark-3.3_${scalaVersion}")
       integrationImplementation("org.apache.hadoop:hadoop-minicluster") {
         exclude group: 'org.apache.avro', module: 'avro'

--- a/build.gradle
+++ b/build.gradle
@@ -458,6 +458,9 @@ project(':iceberg-hudi') {
     implementation project(':iceberg-orc')
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
+    // TODO: we only need hudi-common here, however, hudi-common has some dependency conflicts with hudi-spark-bundle
+    // which is currently used by the integration test. We should fix this in the future.
+    // Also, hudi uses java8, may need to assess if we can use hudi in java11.
     compileOnly("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
     implementation("org.apache.avro:avro") {
       exclude group: 'org.tukaani' // xz compression is not supported

--- a/build.gradle
+++ b/build.gradle
@@ -458,6 +458,7 @@ project(':iceberg-hudi') {
     implementation project(':iceberg-orc')
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
+    compileOnly("org.apache.hudi:hudi-common:0.12.2")
 
     compileOnly("org.apache.hadoop:hadoop-common") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ plugins {
   id 'nebula.dependency-recommender' version '11.0.0'
 }
 
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
+String sparkVersionsString = System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")
+List<String> sparkVersions = sparkVersionsString != null && !sparkVersionsString.isEmpty() ? sparkVersionsString.split(",") : []
+
 try {
   // apply these plugins in a try-catch block so that we can handle cases without .git directory
   apply plugin: 'com.palantir.git-version'
@@ -435,6 +439,70 @@ project(':iceberg-aws') {
   task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integration.output.classesDirs
     classpath = sourceSets.integration.runtimeClasspath
+  }
+}
+
+project(':iceberg-hudi') {
+
+  configurations {
+    integrationImplementation.extendsFrom testImplementation
+    integrationRuntime.extendsFrom testRuntimeOnly
+  }
+
+  dependencies {
+    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    api project(':iceberg-api')
+    implementation project(':iceberg-common')
+    implementation project(':iceberg-core')
+    implementation project(':iceberg-parquet')
+    implementation project(':iceberg-orc')
+    implementation "com.fasterxml.jackson.core:jackson-databind"
+
+
+    compileOnly("org.apache.hadoop:hadoop-common") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'javax.servlet', module: 'servlet-api'
+      exclude group: 'com.google.code.gson', module: 'gson'
+    }
+    if (sparkVersions.contains("3.3") && scalaVersion == "2.12") {
+      integrationImplementation("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
+      integrationImplementation project(path: ":iceberg-spark:iceberg-spark-3.3_${scalaVersion}")
+      integrationImplementation("org.apache.hadoop:hadoop-minicluster") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+      }
+      integrationImplementation project(path: ':iceberg-hive-metastore')
+      integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+      integrationImplementation("org.apache.spark:spark-hive_${scalaVersion}:3.3.1") {
+        exclude group: 'org.apache.avro', module: 'avro'
+        exclude group: 'org.apache.arrow'
+        exclude group: 'org.apache.parquet'
+        // to make sure netty libs only come from project(':iceberg-arrow')
+        exclude group: 'io.netty', module: 'netty-buffer'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'org.roaringbitmap'
+      }
+    }
+  }
+
+  if (sparkVersions.contains("3.3") && scalaVersion == "2.12") {
+    sourceSets {
+      integration {
+        java.srcDir "$projectDir/src/integration/java"
+        resources.srcDir "$projectDir/src/integration/resources"
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+      }
+    }
+
+    task integrationTest(type: Test) {
+      testClassesDirs = sourceSets.integration.output.classesDirs
+      classpath = sourceSets.integration.runtimeClasspath
+    }
+    check.dependsOn integrationTest
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -458,7 +458,7 @@ project(':iceberg-hudi') {
     implementation project(':iceberg-orc')
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
-    compileOnly("org.apache.hudi:hudi-common:0.12.2")
+    compileOnly("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
 
     compileOnly("org.apache.hadoop:hadoop-common") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/build.gradle
+++ b/build.gradle
@@ -459,6 +459,9 @@ project(':iceberg-hudi') {
     implementation "com.fasterxml.jackson.core:jackson-databind"
 
     compileOnly("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
+    implementation("org.apache.avro:avro") {
+      exclude group: 'org.tukaani' // xz compression is not supported
+    }
 
     compileOnly("org.apache.hadoop:hadoop-common") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/build.gradle
+++ b/build.gradle
@@ -473,6 +473,7 @@ project(':iceberg-hudi') {
       exclude group: 'com.google.code.gson', module: 'gson'
     }
     if (sparkVersions.contains("3.3") && scalaVersion == "2.12") {
+      integrationImplementation project(':iceberg-data')
       integrationImplementation("org.apache.hudi:hudi-spark3.3-bundle_2.12:0.12.2")
       integrationImplementation project(path: ":iceberg-spark:iceberg-spark-3.3_${scalaVersion}")
       integrationImplementation("org.apache.hadoop:hadoop-minicluster") {

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/HudiToIcebergMigrationSparkIntegration.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/HudiToIcebergMigrationSparkIntegration.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import org.apache.spark.sql.SparkSession;
+
+public class HudiToIcebergMigrationSparkIntegration {
+  private HudiToIcebergMigrationSparkIntegration() {}
+
+  static SnapshotHudiTable snapshotHudiTable(SparkSession spark, String hudiTablePath) {
+    return new BaseSnapshotHudiTableAction(spark.sessionState().newHadoopConf(), hudiTablePath);
+  }
+}

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/SparkHudiMigrationTestBase.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/SparkHudiMigrationTestBase.java
@@ -45,6 +45,7 @@ public abstract class SparkHudiMigrationTestBase {
             .config(
                 "spark.hadoop." + HiveConf.ConfVars.METASTOREURIS.varname,
                 hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname))
+            .config("spark.hadoop.parquet.avro.write-old-list-structure", "false")
             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
             .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/SparkHudiMigrationTestBase.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/SparkHudiMigrationTestBase.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.util.Map;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+@SuppressWarnings("VisibilityModifier")
+public abstract class SparkHudiMigrationTestBase {
+  protected static TestHiveMetastore metastore = null;
+  protected static HiveConf hiveConf = null;
+  protected static SparkSession spark = null;
+
+  @BeforeClass
+  public static void startMetastoreAndSpark() {
+    SparkHudiMigrationTestBase.metastore = new TestHiveMetastore();
+    metastore.start();
+    SparkHudiMigrationTestBase.hiveConf = metastore.hiveConf();
+
+    SparkHudiMigrationTestBase.spark =
+        SparkSession.builder()
+            .master("local[2]")
+            .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+            .config(
+                "spark.hadoop." + HiveConf.ConfVars.METASTOREURIS.varname,
+                hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname))
+            .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+            .enableHiveSupport()
+            .getOrCreate();
+  }
+
+  @AfterClass
+  public static void stopMetastoreAndSpark() throws Exception {
+    if (metastore != null) {
+      metastore.stop();
+      SparkHudiMigrationTestBase.metastore = null;
+    }
+    if (spark != null) {
+      spark.stop();
+      SparkHudiMigrationTestBase.spark = null;
+    }
+  }
+
+  public SparkHudiMigrationTestBase(
+      String catalogName, String implementation, Map<String, String> config) {
+
+    spark.conf().set("spark.sql.catalog." + catalogName, implementation);
+    config.forEach(
+        (key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
+  }
+}

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -231,6 +231,13 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
     LOG.info("Generated partitioned dataframe: {}", df.showString(10, 20, false));
   }
 
+  @Test
+  public void TestHudiMetaClientAlpha() {
+    SnapshotHudiTable.Result result =
+        HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(spark, unpartitionedLocation)
+            .execute();
+  }
+
   private String destName(String catalogName, String dest) {
     if (catalogName.equals(defaultSparkCatalog)) {
       return NAMESPACE + "." + catalogName + "_" + dest;

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -231,7 +231,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
             .execute();
     Table table = getIcebergTable(newTableIdentifier);
     queryManual(table);
-    // checkSnapshotIntegrity(partitionedLocation, newTableIdentifier);
+    checkSnapshotIntegrity(partitionedLocation, newTableIdentifier);
   }
 
   @Test

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.hudi.DataSourceWriteOptions;
 import org.apache.hudi.QuickstartUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -229,6 +230,58 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
     Dataset<Row> df = spark.read().format("hudi").load(partitionedLocation);
     LOG.info("Generated partitioned dataframe shcema: {}", df.schema().treeString());
     LOG.info("Generated partitioned dataframe: {}", df.showString(10, 20, false));
+  }
+
+  @Test
+  public void TestHudiMetaClientExploration() {
+    HoodieTableMetaClient hoodieTableMetaClient =
+        HoodieTableMetaClient.builder()
+            .setConf(spark.sessionState().newHadoopConf())
+            .setBasePath(partitionedLocation)
+            .setLoadActiveTimelineOnLoad(true)
+            .build();
+
+    LOG.info("Alpha test: hoodie table base path: {}", hoodieTableMetaClient.getBasePathV2());
+    LOG.info(
+        "Alpha test: hoodie getBootStrapIndexByFileId: {}",
+        hoodieTableMetaClient.getBootstrapIndexByFileIdFolderNameFolderPath());
+    LOG.info(
+        "Alpha test: hoodie getBootStrapIndexByPartitionPath: {}",
+        hoodieTableMetaClient.getBootstrapIndexByPartitionFolderPath());
+    LOG.info(
+        "Alpha test: hoodie getCommitActionType: {}", hoodieTableMetaClient.getCommitActionType());
+    LOG.info(
+        "Alpha test: hoodie getCommitsAndCompactionTimeline: {}",
+        hoodieTableMetaClient.getCommitsAndCompactionTimeline());
+    LOG.info(
+        "Alpha test: hoodie getCommitsTimeline: {}", hoodieTableMetaClient.getCommitsTimeline());
+    LOG.info("Alpha test: hoodie getCommitTimeline: {}", hoodieTableMetaClient.getCommitTimeline());
+    LOG.info(
+        "Alpha test: hoodie getConsistencyGuardConfig: {}",
+        hoodieTableMetaClient.getConsistencyGuardConfig().toString());
+    LOG.info(
+        "Alpha test: hoodie getFileSystemRetryConfig: {}",
+        hoodieTableMetaClient.getFileSystemRetryConfig().toString());
+    LOG.info(
+        "Alpha test: hoodie getHashingMetadataPath: {}",
+        hoodieTableMetaClient.getHashingMetadataPath());
+    LOG.info(
+        "Alpha test: hoodie getMetaAuxiliaryPath: {}",
+        hoodieTableMetaClient.getMetaAuxiliaryPath());
+    LOG.info("Alpha test: hoodie getMetaPath: {}", hoodieTableMetaClient.getMetaPath());
+    LOG.info(
+        "Alpha test: hoodie getMetastoreConfig: {}",
+        hoodieTableMetaClient.getMetastoreConfig().toString());
+    LOG.info(
+        "Alpha test: hoodie getSchemaFolderName: {}", hoodieTableMetaClient.getSchemaFolderName());
+    LOG.info(
+        "Alpha test: hoodie getTableConfig: {}", hoodieTableMetaClient.getTableConfig().toString());
+    LOG.info(
+        "Alpha test: hoodie getTableType: {}", hoodieTableMetaClient.getTableType().toString());
+    LOG.info("Alpha test: hoodie getTempFolderPath: {}", hoodieTableMetaClient.getTempFolderPath());
+    LOG.info(
+        "Alpha test: hoodie getTimelineLayoutVersion: {}",
+        hoodieTableMetaClient.getTimelineLayoutVersion());
   }
 
   @Test

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -173,7 +173,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         initialDataFrame,
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);
@@ -181,7 +181,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         initialDataFrame,
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);
@@ -189,7 +189,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         multiDataFrame(2, 5),
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);
@@ -197,7 +197,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         multiDataFrame(0, 1),
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);
@@ -206,7 +206,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         toDelete,
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);
@@ -215,7 +215,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         DataSourceWriteOptions.DELETE_OPERATION_OPT_VAL(),
         "decimalCol",
         "magic_number",
-        "partitionPath",
+        "partitionPath2",
         SaveMode.Append,
         multiCommitTableLocation,
         multiCommitIdentifier);

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.QuickstartUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.hudi.catalog.HoodieCatalog;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestSnapshotHudiTable.class.getName());
+  private static final String row1 =
+      "{\"name\":\"Michael\",\"addresses\":[{\"city\":\"SanJose\",\"state\":\"CA\"},{\"city\":\"Sandiago\",\"state\":\"CA\"}],"
+          + "\"address_nested\":{\"current\":{\"state\":\"NY\",\"city\":\"NewYork\"},\"previous\":{\"state\":\"NJ\",\"city\":\"Newark\"}},"
+          + "\"properties\":{\"hair\":\"brown\",\"eye\":\"black\"},\"secondProp\":{\"height\":\"6\"},\"subjects\":[[\"Java\",\"Scala\",\"C++\"],"
+          + "[\"Spark\",\"Java\"]],\"id\":1,\"magic_number\":1.123123123123}";
+  private static final String row2 =
+      "{\"name\":\"Test\",\"addresses\":[{\"city\":\"SanJos123123e\",\"state\":\"CA\"},{\"city\":\"Sand12312iago\",\"state\":\"CA\"}],"
+          + "\"address_nested\":{\"current\":{\"state\":\"N12Y\",\"city\":\"NewY1231ork\"}},\"properties\":{\"hair\":\"brown\",\"eye\":\"black\"},"
+          + "\"secondProp\":{\"height\":\"6\"},\"subjects\":[[\"Java\",\"Scala\",\"C++\"],[\"Spark\",\"Java\"]],\"id\":2,\"magic_number\":2.123123123123}";
+  private static final String row3 =
+      "{\"name\":\"Test\",\"addresses\":[{\"city\":\"SanJose\",\"state\":\"CA\"},{\"city\":\"Sandiago\",\"state\":\"CA\"}],"
+          + "\"properties\":{\"hair\":\"brown\",\"eye\":\"black\"},\"secondProp\":{\"height\":\"6\"},\"subjects\":"
+          + "[[\"Java\",\"Scala\",\"C++\"],[\"Spark\",\"Java\"]],\"id\":3,\"magic_number\":3.123123123123}";
+  private static final String row4 =
+      "{\"name\":\"John\",\"addresses\":[{\"city\":\"LA\",\"state\":\"CA\"},{\"city\":\"Sandiago\",\"state\":\"CA\"}],"
+          + "\"address_nested\":{\"current\":{\"state\":\"NY\",\"city\":\"NewYork\"},\"previous\":{\"state\":\"NJ123\"}},"
+          + "\"properties\":{\"hair\":\"b12rown\",\"eye\":\"bla3221ck\"},\"secondProp\":{\"height\":\"633\"},\"subjects\":"
+          + "[[\"Spark\",\"Java\"]],\"id\":4,\"magic_number\":4.123123123123}";
+  private static final String row5 =
+      "{\"name\":\"Jonas\",\"addresses\":[{\"city\":\"Pittsburgh\",\"state\":\"PA\"},{\"city\":\"Sandiago\",\"state\":\"CA\"}],"
+          + "\"address_nested\":{\"current\":{\"state\":\"PA\",\"city\":\"Haha\"},\"previous\":{\"state\":\"NJ\"}},"
+          + "\"properties\":{\"hair\":\"black\",\"eye\":\"black\"},\"secondProp\":{\"height\":\"7\"},\"subjects\":[[\"Java\",\"Scala\",\"C++\"],"
+          + "[\"Spark\",\"Java\"]],\"id\":5,\"magic_number\":5.123123123123}";
+  private static final String SNAPSHOT_SOURCE_PROP = "snapshot_source";
+  private static final String DELTA_SOURCE_VALUE = "delta";
+  private static final String ORIGINAL_LOCATION_PROP = "original_location";
+  private static final String NAMESPACE = "delta_conversion_test";
+  private static final String defaultSparkCatalog = "spark_catalog";
+  private static final String icebergCatalogName = "iceberg_hive";
+  private String partitionedIdentifier;
+  private String unpartitionedIdentifier;
+  private String externalDataFilesIdentifier;
+  private final String partitionedTableName = "partitioned_table";
+  private final String unpartitionedTableName = "unpartitioned_table";
+  private final String externalDataFilesTableName = "external_data_files_table";
+  private String partitionedLocation;
+  private String unpartitionedLocation;
+  private String newIcebergTableLocation;
+  private String externalDataFilesTableLocation;
+
+  @Parameterized.Parameters(name = "Catalog Name {0} - Options {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      new Object[] {
+        icebergCatalogName,
+        SparkSessionCatalog.class.getName(),
+        ImmutableMap.of(
+            "type",
+            "hive",
+            "default-namespace",
+            "default",
+            "parquet-enabled",
+            "true",
+            "cache-enabled",
+            "false" // Spark will delete tables using v1, leaving the cache out of sync
+            )
+      }
+    };
+  }
+
+  @Rule public TemporaryFolder temp1 = new TemporaryFolder();
+  @Rule public TemporaryFolder temp2 = new TemporaryFolder();
+  @Rule public TemporaryFolder temp3 = new TemporaryFolder();
+  @Rule public TemporaryFolder temp4 = new TemporaryFolder();
+
+  public TestSnapshotHudiTable(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+    spark.conf().set("spark.sql.catalog." + defaultSparkCatalog, HoodieCatalog.class.getName());
+  }
+
+  @Before
+  public void before() throws IOException {
+    File partitionedFolder = temp1.newFolder();
+    File unpartitionedFolder = temp2.newFolder();
+    File newIcebergTableFolder = temp3.newFolder();
+    File externalDataFilesTableFolder = temp4.newFolder();
+    partitionedLocation = partitionedFolder.toURI().toString();
+    unpartitionedLocation = unpartitionedFolder.toURI().toString();
+    newIcebergTableLocation = newIcebergTableFolder.toURI().toString();
+    externalDataFilesTableLocation = externalDataFilesTableFolder.toURI().toString();
+
+    spark.sql(String.format("CREATE DATABASE IF NOT EXISTS %s", NAMESPACE));
+
+    partitionedIdentifier = destName(defaultSparkCatalog, partitionedTableName);
+    unpartitionedIdentifier = destName(defaultSparkCatalog, unpartitionedTableName);
+    externalDataFilesIdentifier = destName(defaultSparkCatalog, externalDataFilesTableName);
+
+    spark.sql(String.format("DROP TABLE IF EXISTS %s", partitionedIdentifier));
+    spark.sql(String.format("DROP TABLE IF EXISTS %s", unpartitionedIdentifier));
+    spark.sql(String.format("DROP TABLE IF EXISTS %s", externalDataFilesIdentifier));
+
+    // hard code the dataframe
+    List<String> jsonList = Lists.newArrayList();
+    jsonList.add(row1);
+    jsonList.add(row2);
+    jsonList.add(row3);
+    jsonList.add(row4);
+    jsonList.add(row5);
+    JavaSparkContext javaSparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    SQLContext sqlContext = new SQLContext(javaSparkContext);
+    JavaRDD<String> rdd = javaSparkContext.parallelize(jsonList);
+    Dataset<Row> df = sqlContext.read().json(rdd);
+
+    df.write()
+        .format("hudi")
+        .options(QuickstartUtils.getQuickstartWriteConfigs())
+        .option(DataSourceWriteOptions.RECORDKEY_FIELD().key(), "id")
+        .option(DataSourceWriteOptions.PRECOMBINE_FIELD().key(), "name")
+        .option(DataSourceWriteOptions.PARTITIONPATH_FIELD().key(), "")
+        .option(HoodieWriteConfig.TABLE_NAME, unpartitionedIdentifier)
+        .mode(SaveMode.Overwrite)
+        .save(unpartitionedLocation);
+  }
+
+  @Test
+  public void TestHudiTableWrite() {
+    Dataset<Row> df = spark.read().format("hudi").load(unpartitionedLocation);
+    LOG.info("Generated dataframe shcema: {}", df.schema().treeString());
+    LOG.info("Generated dataframe: {}", df.showString(10, 20,false));
+    df.show();
+  }
+
+  private String destName(String catalogName, String dest) {
+    if (catalogName.equals(defaultSparkCatalog)) {
+      return NAMESPACE + "." + catalogName + "_" + dest;
+    }
+    return catalogName + "." + NAMESPACE + "." + catalogName + "_" + dest;
+  }
+}

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -36,6 +36,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.hudi.catalog.HoodieCatalog;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -292,6 +293,24 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(
                 spark, partitionedLocation, newTableIdentifier)
             .execute();
+
+    checkSnapshotIntegrity(partitionedIdentifier, newTableIdentifier);
+  }
+
+  private void checkSnapshotIntegrity(
+      String hudiTableIdentifier,
+      String icebergTableIdentifier) {
+
+//    List<Row> deltaTableContents =
+//        spark.sql("SELECT * FROM " + hudiTableIdentifier).collectAsList();
+    List<Row> icebergTableContents =
+        spark.sql("SELECT * FROM " + icebergTableIdentifier).collectAsList();
+    LOG.info("Iceberg table contents: {}", spark.sql("SELECT * FROM " + icebergTableIdentifier).showString(10, 20, false));
+    return;
+
+//    Assertions.assertThat(deltaTableContents).hasSize(icebergTableContents.size());
+//    Assertions.assertThat(icebergTableContents).containsAll(deltaTableContents);
+//    Assertions.assertThat(deltaTableContents).containsAll(icebergTableContents);
   }
 
   private String destName(String catalogName, String dest) {

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -283,7 +283,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         .withColumn("floatCol", expr("CAST(longCol AS FLOAT)"))
         .withColumn("doubleCol", expr("CAST(longCol AS DOUBLE)"))
         .withColumn("dateCol", date_add(current_date(), 1))
-        //        .withColumn("timestampCol", expr("TO_TIMESTAMP(dateCol)"))
+        .withColumn("timestampCol", expr("TO_TIMESTAMP(dateCol)"))
         .withColumn("stringCol", expr("CAST(dateCol AS STRING)"))
         .withColumn("booleanCol", expr("longCol > 5"))
         .withColumn("binaryCol", expr("CAST(longCol AS BINARY)"))
@@ -291,13 +291,11 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
         .withColumn("decimalCol", expr("CAST(longCol AS DECIMAL(10, 2))"))
         .withColumn("shortCol", expr("CAST(longCol AS SHORT)"))
         .withColumn("mapCol", expr("MAP(stringCol, intCol)")) // Hudi requires Map key to be String
-        //        .withColumn("arrayCol", expr("ARRAY(dateCol)")) // hudi's parquet handles array
-        // type differently from iceberg
+        .withColumn("arrayCol", expr("ARRAY(dateCol)"))
         .withColumn("structCol", expr("STRUCT(longCol AS a, longCol AS b)"))
         .withColumn(
             "partitionPath",
-            expr("CAST(longCol AS STRING)")); // For test convenience, please put the partition col
-    // in the end.
+            expr("CAST(longCol AS STRING)"));
   }
 
   private Dataset<Row> multiDataFrame(int start, int end) {

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -233,8 +233,9 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
 
   @Test
   public void TestHudiMetaClientAlpha() {
+    LOG.info("Alpha test reference: hoodie table path: {}", partitionedLocation);
     SnapshotHudiTable.Result result =
-        HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(spark, unpartitionedLocation)
+        HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(spark, partitionedLocation)
             .execute();
   }
 

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -287,8 +287,10 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
   @Test
   public void TestHudiMetaClientAlpha() {
     LOG.info("Alpha test reference: hoodie table path: {}", partitionedLocation);
+    String newTableIdentifier = destName(icebergCatalogName, "alpha_iceberg_table");
     SnapshotHudiTable.Result result =
-        HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(spark, partitionedLocation)
+        HudiToIcebergMigrationSparkIntegration.snapshotHudiTable(
+                spark, partitionedLocation, newTableIdentifier)
             .execute();
   }
 

--- a/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
+++ b/hudi/src/integration/java/org/apache/iceberg/hudi/TestSnapshotHudiTable.java
@@ -219,21 +219,21 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
   }
 
   @Test
-  public void TestHudiUnpartitionedTableWrite() {
+  public void testHudiUnpartitionedTableWrite() {
     Dataset<Row> df = spark.read().format("hudi").load(unpartitionedLocation);
     LOG.info("Generated unpartitioned dataframe shcema: {}", df.schema().treeString());
     LOG.info("Generated unpartitioned dataframe: {}", df.showString(10, 20, false));
   }
 
   @Test
-  public void TestHudiPartitionedTableWrite() {
+  public void testHudiPartitionedTableWrite() {
     Dataset<Row> df = spark.read().format("hudi").load(partitionedLocation);
     LOG.info("Generated partitioned dataframe shcema: {}", df.schema().treeString());
     LOG.info("Generated partitioned dataframe: {}", df.showString(10, 20, false));
   }
 
   @Test
-  public void TestHudiMetaClientExploration() {
+  public void testHudiMetaClientExploration() {
     HoodieTableMetaClient hoodieTableMetaClient =
         HoodieTableMetaClient.builder()
             .setConf(spark.sessionState().newHadoopConf())
@@ -285,7 +285,7 @@ public class TestSnapshotHudiTable extends SparkHudiMigrationTestBase {
   }
 
   @Test
-  public void TestHudiMetaClientAlpha() {
+  public void testHudiMetaClientAlpha() {
     LOG.info("Alpha test reference: hoodie table path: {}", partitionedLocation);
     String newTableIdentifier = destName(icebergCatalogName, "alpha_iceberg_table");
     SnapshotHudiTable.Result result =

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -321,7 +321,7 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     String[] partitionValues = fileGroup.getPartitionPath().split("/");
     List<PartitionField> partitionFields = spec.fields();
     Preconditions.checkState(
-        partitionValues.length == partitionFields.size(), "Invalid partition values");
+        partitionValues.length == partitionFields.size() || partitionFields.isEmpty(), "Invalid partition values");
     // map partition values to spec
     ImmutableMap.Builder<String, String> partitionValueMapBuilder = ImmutableMap.builder();
     ImmutableMap<String, String> partitionValueMap;

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -153,6 +153,8 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
 
     // Pre-process the timeline, we only need to process all COMPLETED commit for COW table
     // Commit that has been rollbacked will not be in either REQUESTED or INFLIGHT state
+    HoodieTimeline commitsTimeline = hoodieTableMetaClient.getCommitsTimeline();
+    HoodieTimeline archivedTimeline = hoodieTableMetaClient.getArchivedTimeline();
     HoodieTimeline timeline =
         hoodieTableMetaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
     // Initialize the FileSystemView for querying table data files

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -21,6 +21,13 @@ package org.apache.iceberg.hudi;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,11 +36,11 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
   private static final Logger LOG =
       LoggerFactory.getLogger(BaseSnapshotHudiTableAction.class.getName());
 
-  private HoodieTableMetaClient HoodieMetaClient;
+  private HoodieTableMetaClient hoodieTableMetaClient;
 
   public BaseSnapshotHudiTableAction(
       Configuration hoodieConfiguration, String hoodieTableBasePath) {
-    this.HoodieMetaClient = buildTableMetaClient(hoodieConfiguration, hoodieTableBasePath);
+    this.hoodieTableMetaClient = buildTableMetaClient(hoodieConfiguration, hoodieTableBasePath);
   }
 
   @Override
@@ -48,14 +55,57 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
 
   @Override
   public Result execute() {
-    LOG.info("Alpha test: hoodie table base path: {}", HoodieMetaClient.getBasePathV2());
-
+    LOG.info("Alpha test: hoodie table base path: {}", hoodieTableMetaClient.getBasePathV2());
+    LOG.info(
+        "Alpha test: hoodie getBootStrapIndexByFileId: {}",
+        hoodieTableMetaClient.getBootstrapIndexByFileIdFolderNameFolderPath());
+    LOG.info(
+        "Alpha test: hoodie getBootStrapIndexByPartitionPath: {}",
+        hoodieTableMetaClient.getBootstrapIndexByPartitionFolderPath());
+    InternalSchema hudiSchema = getHudiSchema();
+    LOG.info("Alpha test: hoodie table schema: {}", hudiSchema);
+    LOG.info("Alpha test: get record type: {}", hudiSchema.getRecord());
+    Schema icebergSchema = getIcebergSchema(hudiSchema);
+    LOG.info("Alpha test: get converted schema: {}", icebergSchema);
     return null;
+  }
+
+  private InternalSchema getHudiSchema() {
+    TableSchemaResolver schemaUtil = new TableSchemaResolver(hoodieTableMetaClient);
+    Option<InternalSchema> hudiSchema = schemaUtil.getTableInternalSchemaFromCommitMetadata();
+    LOG.info("Alpha test: hoodie schema: {}", hudiSchema);
+    LOG.info("Alpha test: active timeline: {}", hoodieTableMetaClient.getActiveTimeline());
+    LOG.info(
+        "Alpha test: active timeline commit timeline: {}",
+        hoodieTableMetaClient.getActiveTimeline().getCommitsTimeline());
+    LOG.info(
+        "Alpha test: active timeline commit timeline instants: {}",
+        hoodieTableMetaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+    // TODO: need to add support for parquet format table
+    return hudiSchema.orElseGet(
+        () -> {
+          try {
+            return AvroInternalSchemaConverter.convert(schemaUtil.getTableAvroSchema());
+          } catch (Exception e) {
+            throw new HoodieException("cannot find schema for current table");
+          }
+        });
+  }
+
+  private Schema getIcebergSchema(InternalSchema hudiSchema) {
+    Type converted =
+        HudiDataTypeVisitor.visit(
+            hudiSchema.getRecord(), new HudiDataTypeToType(hudiSchema.getRecord()));
+    return new Schema(converted.asNestedType().asStructType().fields());
   }
 
   private static HoodieTableMetaClient buildTableMetaClient(Configuration conf, String basePath) {
     HoodieTableMetaClient metaClient =
-        HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
+        HoodieTableMetaClient.builder()
+            .setConf(conf)
+            .setBasePath(basePath)
+            .setLoadActiveTimelineOnLoad(true)
+            .build();
     return metaClient;
   }
 }

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BaseSnapshotHudiTableAction.class.getName());
+
+  private HoodieTableMetaClient HoodieMetaClient;
+
+  public BaseSnapshotHudiTableAction(
+      Configuration hoodieConfiguration, String hoodieTableBasePath) {
+    this.HoodieMetaClient = buildTableMetaClient(hoodieConfiguration, hoodieTableBasePath);
+  }
+
+  @Override
+  public SnapshotHudiTable tableProperties(Map<String, String> properties) {
+    return null;
+  }
+
+  @Override
+  public SnapshotHudiTable tableProperty(String key, String value) {
+    return null;
+  }
+
+  @Override
+  public Result execute() {
+    LOG.info("Alpha test: hoodie table base path: {}", HoodieMetaClient.getBasePathV2());
+
+    return null;
+  }
+
+  private static HoodieTableMetaClient buildTableMetaClient(Configuration conf, String basePath) {
+    HoodieTableMetaClient metaClient =
+        HoodieTableMetaClient.builder().setConf(conf).setBasePath(basePath).build();
+    return metaClient;
+  }
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -18,15 +18,58 @@
  */
 package org.apache.iceberg.hudi;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileGroup;
+import org.apache.hudi.common.model.HoodieFileGroupId;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.view.FileSystemViewManager;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.mapping.MappingUtil;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.orc.OrcMetrics;
+import org.apache.iceberg.parquet.ParquetUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +78,35 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BaseSnapshotHudiTableAction.class.getName());
-
+  private static final String SNAPSHOT_SOURCE_PROP = "snapshot_source";
+  private static final String HOODIE_SOURCE_VALUE = "hudi";
+  private static final String ORIGINAL_LOCATION_PROP = "original_location";
+  private static final String PARQUET_SUFFIX = ".parquet";
+  private static final String AVRO_SUFFIX = ".avro";
+  private static final String ORC_SUFFIX = ".orc";
   private HoodieTableMetaClient hoodieTableMetaClient;
+  private HoodieTableConfig hoodieTableConfig;
+  private HoodieEngineContext hoodieEngineContext;
+  private HoodieMetadataConfig hoodieMetadataConfig;
+  private String hoodieTableBasePath;
+  private Catalog icebergCatalog;
+  private TableIdentifier newTableIdentifier;
+  private HadoopFileIO hoodieFileIO;
+  private ImmutableMap.Builder<String, String> additionalPropertiesBuilder = ImmutableMap.builder();
 
   public BaseSnapshotHudiTableAction(
-      Configuration hoodieConfiguration, String hoodieTableBasePath) {
+      Configuration hoodieConfiguration,
+      String hoodieTableBasePath,
+      Catalog icebergCatalog,
+      TableIdentifier newTableIdentifier) {
     this.hoodieTableMetaClient = buildTableMetaClient(hoodieConfiguration, hoodieTableBasePath);
+    this.hoodieTableConfig = hoodieTableMetaClient.getTableConfig();
+    this.hoodieEngineContext = new HoodieLocalEngineContext(hoodieConfiguration);
+    this.hoodieTableBasePath = hoodieTableBasePath;
+    this.hoodieMetadataConfig = HoodieInputFormatUtils.buildMetadataConfig(hoodieConfiguration);
+    this.hoodieFileIO = new HadoopFileIO(hoodieConfiguration);
+    this.icebergCatalog = icebergCatalog;
+    this.newTableIdentifier = newTableIdentifier;
   }
 
   @Override
@@ -67,7 +133,165 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     LOG.info("Alpha test: get record type: {}", hudiSchema.getRecord());
     Schema icebergSchema = convertToIcebergSchema(hudiSchema);
     LOG.info("Alpha test: get converted schema: {}", icebergSchema);
-    return null;
+    PartitionSpec partitionSpec = getPartitionSpecFromHoodieMetadataData(icebergSchema);
+    LOG.info("Alpha test: get partition spec: {}", partitionSpec);
+    // TODO: add support for newTableLocation
+    Transaction icebergTransaction =
+        icebergCatalog.newCreateTableTransaction(
+            newTableIdentifier, icebergSchema, partitionSpec, destTableProperties());
+    icebergTransaction
+        .table()
+        .updateProperties()
+        .set(
+            TableProperties.DEFAULT_NAME_MAPPING,
+            NameMappingParser.toJson(MappingUtil.create(icebergTransaction.table().schema())))
+        .commit();
+
+    HoodieTimeline timeline =
+        hoodieTableMetaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
+    LOG.info("Alpha test: hoodie timeline: {}", timeline);
+    HoodieTableFileSystemView hoodieTableFileSystemView =
+        FileSystemViewManager.createInMemoryFileSystemViewWithTimeline(
+            hoodieEngineContext, hoodieTableMetaClient, hoodieMetadataConfig, timeline);
+    Stream<HoodieInstant> completedInstants = timeline.getInstants();
+    LOG.info("Alpha test: get completed instants: {}", completedInstants);
+    // file group id -> Map<timestamp, HoodieBaseFile>
+    Map<HoodieFileGroupId, Map<String, HoodieBaseFile>> allStampedDataFiles =
+        hoodieTableFileSystemView
+            .getAllFileGroups()
+            .collect(
+                ImmutableMap.toImmutableMap(
+                    HoodieFileGroup::getFileGroupId,
+                    fileGroup ->
+                        fileGroup
+                            .getAllBaseFiles()
+                            .collect(
+                                ImmutableMap.toImmutableMap(
+                                    HoodieBaseFile::getCommitTime, baseFile -> baseFile))));
+    List<HoodieFileGroup> testGroups =
+        hoodieTableFileSystemView.getAllFileGroups().collect(Collectors.toList());
+    LOG.info("Alpha test: get all stamped data files: {}", allStampedDataFiles);
+    LOG.info("Alpha test: get all file groups: {}", testGroups);
+    Map<HoodieFileGroupId, DataFile> convertedDataFiles = Maps.newHashMap();
+    completedInstants.forEachOrdered(
+        instant -> {
+          LOG.info("Alpha test: get completed instant: {}", instant);
+          // copyInstants to iceberg table
+          // TODO: need to verify the order of the instants, make sure it is from the oldest to the
+          // newest
+          commitHoodieInstantToIcebergTransaction(
+              instant,
+              hoodieTableFileSystemView.getAllFileGroups(),
+              allStampedDataFiles,
+              convertedDataFiles,
+              icebergTransaction);
+        });
+
+    long totalDataFiles =
+        Long.parseLong(
+            icebergTransaction
+                .table()
+                .currentSnapshot()
+                .summary()
+                .get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    icebergTransaction.commitTransaction();
+    LOG.info(
+        "Successfully created Iceberg table {} from hudi table at {}, total data file count: {}",
+        newTableIdentifier,
+        hoodieTableBasePath,
+        totalDataFiles);
+    return new BaseSnapshotHudiTableActionResult(totalDataFiles);
+  }
+
+  public void commitHoodieInstantToIcebergTransaction(
+      HoodieInstant instant,
+      Stream<HoodieFileGroup> fileGroups,
+      Map<HoodieFileGroupId, Map<String, HoodieBaseFile>> allStampedDataFiles,
+      Map<HoodieFileGroupId, DataFile> convertedDataFiles,
+      Transaction transaction) {
+    List<DataFile> filesToAdd = Lists.newArrayList();
+    List<DataFile> filesToRemove = Lists.newArrayList();
+
+    // TODO: need to add synchronization if want to rely on parallelism here
+    fileGroups
+        .sequential()
+        .forEach(
+            fileGroup -> {
+              HoodieFileGroupId fileGroupId = fileGroup.getFileGroupId();
+              LOG.info("Alpha test: get file group: {}", fileGroup);
+              DataFile currentDataFile =
+                  buildDataFileFromHoodieBaseFile(
+                      instant,
+                      fileGroup,
+                      allStampedDataFiles.get(fileGroupId),
+                      transaction.table());
+              if (currentDataFile != null) {
+                filesToAdd.add(currentDataFile);
+                DataFile previousDataFile = convertedDataFiles.get(fileGroupId);
+                if (previousDataFile != null) {
+                  // need to delete the previous data file since a new version will be added
+                  filesToRemove.add(previousDataFile);
+                }
+                convertedDataFiles.put(fileGroupId, currentDataFile);
+              }
+            });
+    LOG.info("Alpha test: get files to add: {} at instant {}", filesToAdd, instant);
+    if (filesToAdd.size() > 0 && filesToRemove.size() > 0) {
+      // OverwriteFiles case
+      OverwriteFiles overwriteFiles = transaction.newOverwrite();
+      filesToAdd.forEach(overwriteFiles::addFile);
+      filesToRemove.forEach(overwriteFiles::deleteFile);
+      overwriteFiles.commit();
+    } else if (filesToAdd.size() > 0) {
+      // AppendFiles case
+      AppendFiles appendFiles = transaction.newAppend();
+      filesToAdd.forEach(appendFiles::appendFile);
+      appendFiles.commit();
+    } else if (filesToRemove.size() > 0) {
+      // DeleteFiles case
+      DeleteFiles deleteFiles = transaction.newDelete();
+      filesToRemove.forEach(deleteFiles::deleteFile);
+      deleteFiles.commit();
+    }
+  }
+
+  @Nullable
+  private DataFile buildDataFileFromHoodieBaseFile(
+      HoodieInstant instant,
+      HoodieFileGroup fileGroup,
+      Map<String, HoodieBaseFile> stampedDataFiles,
+      Table table) {
+    HoodieBaseFile baseFile = stampedDataFiles.get(instant.getTimestamp());
+    if (baseFile == null) {
+      LOG.info(
+          "Alpha test: does not have base file for instant: {}, fileGroupId {}",
+          instant,
+          fileGroup.getFileGroupId());
+      return null;
+    }
+
+    PartitionSpec spec = table.spec();
+    // TODO: need to verify the path is absolute
+    String path = baseFile.getPath();
+    long fileSize = baseFile.getFileSize();
+    String partitionPath = fileGroup.getPartitionPath();
+
+    MetricsConfig metricsConfig = MetricsConfig.forTable(table);
+    String nameMappingString = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
+    NameMapping nameMapping =
+        nameMappingString != null ? NameMappingParser.fromJson(nameMappingString) : null;
+
+    InputFile file = hoodieFileIO.newInputFile(path);
+    FileFormat format = determineFileFormatFromPath(path);
+    Metrics metrics = getMetricsForFile(file, format, metricsConfig, nameMapping);
+
+    return DataFiles.builder(spec)
+        .withPath(path)
+        .withFormat(format)
+        .withFileSizeInBytes(fileSize)
+        .withPartitionPath(partitionPath) // TODO: need to verify the partition path is correct
+        .withMetrics(metrics)
+        .build();
   }
 
   private InternalSchema getHudiSchema() {
@@ -98,6 +322,32 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     return new Schema(converted.asNestedType().asStructType().fields());
   }
 
+  private PartitionSpec getPartitionSpecFromHoodieMetadataData(Schema schema) {
+    Option<String[]> partitionNames = hoodieTableConfig.getPartitionFields();
+    if (partitionNames.isPresent()) {
+      PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
+      for (String partitionName : partitionNames.get()) {
+        builder.identity(partitionName);
+      }
+      return builder.build();
+    }
+
+    return PartitionSpec.unpartitioned();
+  }
+
+  private Map<String, String> destTableProperties() {
+    // TODO: need to check which hoodie properties to add to
+    additionalPropertiesBuilder.putAll(hoodieTableConfig.propsMap());
+    additionalPropertiesBuilder.putAll(
+        ImmutableMap.of(
+            SNAPSHOT_SOURCE_PROP,
+            HOODIE_SOURCE_VALUE,
+            ORIGINAL_LOCATION_PROP,
+            hoodieTableMetaClient.getBasePathV2().toString()));
+
+    return additionalPropertiesBuilder.build();
+  }
+
   private static HoodieTableMetaClient buildTableMetaClient(Configuration conf, String basePath) {
     HoodieTableMetaClient metaClient =
         HoodieTableMetaClient.builder()
@@ -106,5 +356,32 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
             .setLoadActiveTimelineOnLoad(true)
             .build();
     return metaClient;
+  }
+
+  private FileFormat determineFileFormatFromPath(String path) {
+    if (path.endsWith(PARQUET_SUFFIX)) {
+      return FileFormat.PARQUET;
+    } else if (path.endsWith(AVRO_SUFFIX)) {
+      return FileFormat.AVRO;
+    } else if (path.endsWith(ORC_SUFFIX)) {
+      return FileFormat.ORC;
+    } else {
+      throw new ValidationException("Cannot determine file format from path %s", path);
+    }
+  }
+
+  private Metrics getMetricsForFile(
+      InputFile file, FileFormat format, MetricsConfig metricsSpec, NameMapping mapping) {
+    switch (format) {
+      case AVRO:
+        long rowCount = Avro.rowCount(file);
+        return new Metrics(rowCount, null, null, null, null);
+      case PARQUET:
+        return ParquetUtil.fileMetrics(file, metricsSpec, mapping);
+      case ORC:
+        return OrcMetrics.fromInputFile(file, metricsSpec, mapping);
+      default:
+        throw new ValidationException("Cannot get metrics from file format: %s", format);
+    }
   }
 }

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -65,7 +65,7 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     InternalSchema hudiSchema = getHudiSchema();
     LOG.info("Alpha test: hoodie table schema: {}", hudiSchema);
     LOG.info("Alpha test: get record type: {}", hudiSchema.getRecord());
-    Schema icebergSchema = getIcebergSchema(hudiSchema);
+    Schema icebergSchema = convertToIcebergSchema(hudiSchema);
     LOG.info("Alpha test: get converted schema: {}", icebergSchema);
     return null;
   }
@@ -81,7 +81,6 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     LOG.info(
         "Alpha test: active timeline commit timeline instants: {}",
         hoodieTableMetaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
-    // TODO: need to add support for parquet format table
     return hudiSchema.orElseGet(
         () -> {
           try {
@@ -92,7 +91,7 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
         });
   }
 
-  private Schema getIcebergSchema(InternalSchema hudiSchema) {
+  private Schema convertToIcebergSchema(InternalSchema hudiSchema) {
     Type converted =
         HudiDataTypeVisitor.visit(
             hudiSchema.getRecord(), new HudiDataTypeToType(hudiSchema.getRecord()));

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -41,7 +41,6 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
 import org.apache.hudi.internal.schema.InternalSchema;
 import org.apache.hudi.internal.schema.convert.AvroInternalSchemaConverter;
 import org.apache.iceberg.AppendFiles;
@@ -107,7 +106,7 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     this.hoodieTableConfig = hoodieTableMetaClient.getTableConfig();
     this.hoodieEngineContext = new HoodieLocalEngineContext(hoodieConfiguration);
     this.hoodieTableBasePath = hoodieTableBasePath;
-    this.hoodieMetadataConfig = HoodieInputFormatUtils.buildMetadataConfig(hoodieConfiguration);
+    this.hoodieMetadataConfig = buildMetadataConfig(hoodieConfiguration);
     this.hoodieFileIO = new HadoopFileIO(hoodieConfiguration);
     this.icebergCatalog = icebergCatalog;
     this.newTableIdentifier = newTableIdentifier;
@@ -198,8 +197,6 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     // BEGIN TEST ONLY CODE
     List<HoodieBaseFile> testGroups =
         hoodieTableFileSystemView.getLatestBaseFiles().collect(Collectors.toList());
-    LOG.info("Alpha test: get all stamped data files: {}", allStampedDataFiles);
-    LOG.info("Alpha test: get all file groups: {}", testGroups);
     // END TEST ONLY CODE
 
     // Help tracked if a previous version of the data file has been added to the iceberg table
@@ -447,5 +444,14 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
       default:
         throw new ValidationException("Cannot get metrics from file format: %s", format);
     }
+  }
+
+  private HoodieMetadataConfig buildMetadataConfig(Configuration conf) {
+    return HoodieMetadataConfig.newBuilder()
+        .enable(
+            conf.getBoolean(
+                HoodieMetadataConfig.ENABLE.key(),
+                HoodieMetadataConfig.DEFAULT_METADATA_ENABLE_FOR_READERS))
+        .build();
   }
 }

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableAction.java
@@ -321,7 +321,8 @@ public class BaseSnapshotHudiTableAction implements SnapshotHudiTable {
     String[] partitionValues = fileGroup.getPartitionPath().split("/");
     List<PartitionField> partitionFields = spec.fields();
     Preconditions.checkState(
-        partitionValues.length == partitionFields.size() || partitionFields.isEmpty(), "Invalid partition values");
+        partitionValues.length == partitionFields.size() || partitionFields.isEmpty(),
+        "Invalid partition values");
     // map partition values to spec
     ImmutableMap.Builder<String, String> partitionValueMapBuilder = ImmutableMap.builder();
     ImmutableMap<String, String> partitionValueMap;

--- a/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableActionResult.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/BaseSnapshotHudiTableActionResult.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+public class BaseSnapshotHudiTableActionResult implements SnapshotHudiTable.Result {
+
+  private final long snapshotFilesCount;
+
+  public BaseSnapshotHudiTableActionResult(long snapshotFilesCount) {
+    this.snapshotFilesCount = snapshotFilesCount;
+  }
+
+  @Override
+  public long snapshotFilesCount() {
+    return snapshotFilesCount;
+  }
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/HudiDataTypeToType.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/HudiDataTypeToType.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.util.List;
+import org.apache.hudi.internal.schema.Types;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+
+public class HudiDataTypeToType extends HudiDataTypeVisitor<Type> {
+  private final Types.RecordType root;
+  private int nextId = 0;
+
+  HudiDataTypeToType() {
+    this.root = null;
+  }
+
+  HudiDataTypeToType(Types.RecordType root) {
+    this.root = root;
+    this.nextId = root.fields().size();
+  }
+
+  private int getNextId() {
+    int next = nextId;
+    nextId += 1;
+    return next;
+  }
+
+  @SuppressWarnings("ReferenceEquality")
+  @Override
+  public Type record(Types.RecordType record, List<Type> fieldResults) {
+    List<Types.Field> fields = record.fields();
+    List<org.apache.iceberg.types.Types.NestedField> newFields =
+        Lists.newArrayListWithExpectedSize(fields.size());
+    boolean isRoot = root == record;
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.Field field = fields.get(i);
+      Type type = fieldResults.get(i);
+      int id;
+      if (isRoot) {
+        id = i;
+      } else {
+        id = getNextId();
+      }
+
+      String doc = field.doc();
+      if (field.isOptional()) {
+        newFields.add(
+            org.apache.iceberg.types.Types.NestedField.optional(id, field.name(), type, doc));
+      } else {
+        newFields.add(
+            org.apache.iceberg.types.Types.NestedField.required(id, field.name(), type, doc));
+      }
+    }
+
+    return org.apache.iceberg.types.Types.StructType.of(newFields);
+  }
+
+  @Override
+  public Type field(Types.Field field, Type typeResult) {
+    return typeResult;
+  }
+
+  @Override
+  public Type map(Types.MapType map, Type keyResult, Type valueResult) {
+    if (map.isValueOptional()) {
+      return org.apache.iceberg.types.Types.MapType.ofOptional(
+          getNextId(), getNextId(), keyResult, valueResult);
+    } else {
+      return org.apache.iceberg.types.Types.MapType.ofRequired(
+          getNextId(), getNextId(), keyResult, valueResult);
+    }
+  }
+
+  @Override
+  public Type array(Types.ArrayType array, Type elementResult) {
+    if (array.isElementOptional()) {
+      return org.apache.iceberg.types.Types.ListType.ofOptional(getNextId(), elementResult);
+    } else {
+      return org.apache.iceberg.types.Types.ListType.ofRequired(getNextId(), elementResult);
+    }
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @Override
+  public Type atomic(org.apache.hudi.internal.schema.Type atomic) {
+    if (atomic instanceof Types.BooleanType) {
+      return org.apache.iceberg.types.Types.BooleanType.get();
+    } else if (atomic instanceof Types.IntType) {
+      return org.apache.iceberg.types.Types.IntegerType.get();
+    } else if (atomic instanceof Types.LongType) {
+      return org.apache.iceberg.types.Types.LongType.get();
+    } else if (atomic instanceof Types.FloatType) {
+      return org.apache.iceberg.types.Types.FloatType.get();
+    } else if (atomic instanceof Types.DoubleType) {
+      return org.apache.iceberg.types.Types.DoubleType.get();
+    } else if (atomic instanceof Types.DateType) {
+      return org.apache.iceberg.types.Types.DateType.get();
+    } else if (atomic instanceof Types.TimestampType) {
+      return org.apache.iceberg.types.Types.TimestampType.withZone();
+    } else if (atomic instanceof Types.StringType) {
+      return org.apache.iceberg.types.Types.StringType.get();
+    } else if (atomic instanceof Types.BinaryType) {
+      return org.apache.iceberg.types.Types.BinaryType.get();
+    } else if (atomic instanceof Types.UUIDType) {
+      return org.apache.iceberg.types.Types.UUIDType.get();
+    } else if (atomic instanceof Types.DecimalType) {
+      return org.apache.iceberg.types.Types.DecimalType.of(
+          ((Types.DecimalType) atomic).precision(), ((Types.DecimalType) atomic).scale());
+    } else if (atomic instanceof Types.FixedType) {
+      return org.apache.iceberg.types.Types.FixedType.ofLength(
+          ((Types.FixedType) atomic).getFixedSize());
+    } else if (atomic instanceof Types.TimeType) {
+      return org.apache.iceberg.types.Types.TimeType.get();
+    }
+
+    throw new ValidationException("Not a supported type: %s", atomic.getClass().getName());
+  }
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/HudiDataTypeVisitor.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/HudiDataTypeVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.util.List;
+import org.apache.hudi.internal.schema.Type;
+import org.apache.hudi.internal.schema.Types;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public abstract class HudiDataTypeVisitor<T> {
+
+  public static <T> T visit(Type type, HudiDataTypeVisitor<T> visitor) {
+    if (type instanceof Types.RecordType) {
+      List<Types.Field> fields = ((Types.RecordType) type).fields();
+      List<T> fieldResults = Lists.newArrayListWithExpectedSize(fields.size());
+
+      for (Types.Field field : fields) {
+        fieldResults.add(visitor.field(field, visit(field.type(), visitor)));
+      }
+
+      return visitor.record((Types.RecordType) type, fieldResults);
+    } else if (type instanceof Types.MapType) {
+      return visitor.map(
+          (Types.MapType) type,
+          visit(((Types.MapType) type).keyType(), visitor),
+          visit(((Types.MapType) type).valueType(), visitor));
+    } else if (type instanceof Types.ArrayType) {
+      return visitor.array(
+          (Types.ArrayType) type, visit(((Types.ArrayType) type).elementType(), visitor));
+    }
+    return visitor.atomic(type);
+  }
+
+  public abstract T record(Types.RecordType record, List<T> fieldResults);
+
+  public abstract T field(Types.Field field, T typeResult);
+
+  public abstract T array(Types.ArrayType array, T elementResult);
+
+  public abstract T map(Types.MapType map, T keyResult, T valueResult);
+
+  public abstract T atomic(Type atomic);
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/HudiToIcebergMigrationActionsProvider.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/HudiToIcebergMigrationActionsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+public interface HudiToIcebergMigrationActionsProvider {
+
+  default SnapshotHudiTable snapshotHudiTable() {
+    throw new UnsupportedOperationException("snapshotHudiTable is not supported");
+  }
+
+  static HudiToIcebergMigrationActionsProvider defaultProvider() {
+    return DefaultHudiToIcebergMigrationActions.defaultMigrationActions();
+  }
+
+  class DefaultHudiToIcebergMigrationActions implements HudiToIcebergMigrationActionsProvider {
+    private static final DefaultHudiToIcebergMigrationActions INSTANCE =
+        new DefaultHudiToIcebergMigrationActions();
+
+    private DefaultHudiToIcebergMigrationActions() {}
+
+    public static DefaultHudiToIcebergMigrationActions defaultMigrationActions() {
+      return INSTANCE;
+    }
+  }
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/HudiToIcebergMigrationActionsProvider.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/HudiToIcebergMigrationActionsProvider.java
@@ -18,12 +18,28 @@
  */
 package org.apache.iceberg.hudi;
 
+/**
+ * An API that provide actions for migration from an Apache Hudi table to an Iceberg table. Query
+ * engines can use {@code defaultActions()} to access default action implementations, or implement
+ * this provider to supply a different implementation if necessary.
+ */
 public interface HudiToIcebergMigrationActionsProvider {
 
-  default SnapshotHudiTable snapshotHudiTable() {
-    throw new UnsupportedOperationException("snapshotHudiTable is not supported");
+  /**
+   * Initiates an action to snapshot an existing Delta Lake table to an Iceberg table.
+   *
+   * @param sourceTableLocation the location of the Delta Lake table
+   * @return a {@link SnapshotHudiTable} action
+   */
+  default SnapshotHudiTable snapshotHudiTable(String sourceTableLocation) {
+    return new BaseSnapshotHudiTableAction(sourceTableLocation);
   }
 
+  /**
+   * Get the default implementation of {@link HudiToIcebergMigrationActionsProvider}
+   *
+   * @return an instance with access to all default actions
+   */
   static HudiToIcebergMigrationActionsProvider defaultProvider() {
     return DefaultHudiToIcebergMigrationActions.defaultMigrationActions();
   }

--- a/hudi/src/main/java/org/apache/iceberg/hudi/SnapshotHudiTable.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/SnapshotHudiTable.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hudi;
+
+import java.util.Map;
+import org.apache.iceberg.actions.Action;
+
+public interface SnapshotHudiTable extends Action<SnapshotHudiTable, SnapshotHudiTable.Result> {
+
+  SnapshotHudiTable tableProperties(Map<String, String> properties);
+
+  SnapshotHudiTable tableProperty(String key, String value);
+
+  interface Result {
+
+    long snapshotFilesCount();
+  }
+}

--- a/hudi/src/main/java/org/apache/iceberg/hudi/SnapshotHudiTable.java
+++ b/hudi/src/main/java/org/apache/iceberg/hudi/SnapshotHudiTable.java
@@ -19,16 +19,69 @@
 package org.apache.iceberg.hudi;
 
 import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.actions.Action;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
 
 public interface SnapshotHudiTable extends Action<SnapshotHudiTable, SnapshotHudiTable.Result> {
 
+  /**
+   * Sets table properties in the newly created Iceberg table. Any properties with the same key name
+   * will be overwritten.
+   *
+   * @param properties a map of properties to set
+   * @return this for method chaining
+   */
   SnapshotHudiTable tableProperties(Map<String, String> properties);
 
-  SnapshotHudiTable tableProperty(String key, String value);
+  /**
+   * Sets a table property in the newly created Iceberg table. Any properties with the same key will
+   * be overwritten.
+   *
+   * @param name a table property name
+   * @param value a table property value
+   * @return this for method chaining
+   */
+  SnapshotHudiTable tableProperty(String name, String value);
 
+  /**
+   * Sets the location of the newly created Iceberg table. Default location is the same as the Hudi
+   * table.
+   *
+   * @param location a path to the new table location
+   * @return this for method chaining
+   */
+  SnapshotHudiTable tableLocation(String location);
+
+  /**
+   * Sets the identifier of the newly created Iceberg table. This is required to be set before
+   * execute the action.
+   *
+   * @param identifier a table identifier (namespace, name) @Returns this for method chaining
+   */
+  SnapshotHudiTable as(TableIdentifier identifier);
+
+  /**
+   * Sets the catalog of the newly created Iceberg table. This is required to be set before execute
+   * the action
+   *
+   * @param catalog a catalog @Returns this for method chaining
+   */
+  SnapshotHudiTable icebergCatalog(Catalog catalog);
+
+  /**
+   * Sets the Hadoop configuration used to access hudi table's timeline and file groups. This is
+   * required to be set before execute the action.
+   *
+   * @param conf a Hadoop configuration @Returns this for method chaining
+   */
+  SnapshotHudiTable hoodieConfiguration(Configuration conf);
+
+  /** The action result that contains a summary of the execution. */
   interface Result {
 
+    /** Returns the number of snapshot data files. */
     long snapshotFilesCount();
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ include 'nessie'
 include 'gcp'
 include 'dell'
 include 'snowflake'
+include 'hudi'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -53,6 +54,7 @@ project(':nessie').name = 'iceberg-nessie'
 project(':gcp').name = 'iceberg-gcp'
 project(':dell').name = 'iceberg-dell'
 project(':snowflake').name = 'iceberg-snowflake'
+project(':hudi').name = 'iceberg-hudi'
 
 if (null != System.getProperty("allVersions")) {
   System.setProperty("flinkVersions", System.getProperty("knownFlinkVersions"))

--- a/versions.props
+++ b/versions.props
@@ -29,6 +29,7 @@ org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
 org.immutables:value = 2.9.2
 net.snowflake:snowflake-jdbc = 3.13.22
+org.apache.hudi:* = 0.12.0
 
 # test deps
 org.junit.vintage:junit-vintage-engine = 5.8.2


### PR DESCRIPTION
This PR is under construction, but I want to put it here for some initial feedback and discussion about the conversion from Apache Hudi to Apache Iceberg

## Overview
This PR aims to add a module called `iceberg-hudi` which contains public API and a base implementation to snapshot a hudi table to iceberg table. In expectation, the base implementation should rely on `hudi-common` module to extract metadata, timeline, locations of datafiles, and other information necessary for the conversion. 

`copy-on-write`(COW) and `merge-on-read` (MOR) are two types of hudi table. As the initial implementation, this PR will focus on the conversion logic for COW tables. 

The overall structure of the module is expected to be similar to #6449 . However, things may change as hudi is different from the delta lake. Also, due to the complexity of the conversion, I may make a proposal later for further discussion in the community.

## High-level Ideas
The base implementation of the snapshot action involves schema conversion and timeline replay. The idea here is to map every completed `COMMIT` action on the timeline to an iceberg snapshot. The conception of `COW` can be mapped to the `overwrite` operation in iceberg. In other words, for every update of a datafile, we will `delete` the previous version datafile and `add` the newly created datafile to the iceberg table. 

## Need Further Investigations:
1. Handle [`COMPACTION`] action on the timeline
2. We may take advantage of column_stats stored in Hudi's metadata table rather than using FileIO to extract metrics from datafiles.

## Dependency Issue
1. `hudi-common:0.12.2` has [dependency conflict](https://github.com/apache/hudi/issues/7409) with the `hudi-spark-bundle:0.12.2`, which is intended to be used for integration test. Currently use version 0.12.0 to work it around 


If you have some comments or suggestions on how to convert hudi to iceberg, please feel free to share them here. Thank you in advance.