### PR TITLE
Nessie-build: add test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -668,6 +668,8 @@ project(':iceberg-nessie') {
     implementation "com.fasterxml.jackson.core:jackson-core"
 
     testImplementation "org.projectnessie:nessie-jaxrs-testextension"
+    testImplementation "org.projectnessie:nessie-versioned-persist-in-memory"
+    testImplementation "org.projectnessie:nessie-versioned-persist-in-memory-test"
     // Need to "pull in" el-api explicitly :(
     testImplementation "jakarta.el:jakarta.el-api"
 


### PR DESCRIPTION
Future change in Nessie requires these test dependencies, which are no longer transitive.

The change hasn't been merged to Nessie yet, but once it's merged, it would break our Nessie/Iceberg integration testing. It's a rather no-op for Iceberg.