### PR TITLE
Core, API: BaseReplacePartitions to branch test Refactoring

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -111,7 +111,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
   }
 
   @Override
-  protected void validate(TableMetadata base, Snapshot snapshot) {
+  protected void validate(TableMetadata base, Snapshot parent) {
     if (validateAddedFilesMatchOverwriteFilter) {
       PartitionSpec spec = dataSpec();
       Expression rowFilter = rowFilter();
@@ -139,19 +139,19 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
     }
 
     if (validateNewDataFiles) {
-      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), snapshot);
+      validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter(), parent);
     }
 
     if (validateNewDeletes) {
       if (rowFilter() != Expressions.alwaysFalse()) {
         Expression filter = conflictDetectionFilter != null ? conflictDetectionFilter : rowFilter();
-        validateNoNewDeleteFiles(base, startingSnapshotId, filter, snapshot);
-        validateDeletedDataFiles(base, startingSnapshotId, filter, snapshot);
+        validateNoNewDeleteFiles(base, startingSnapshotId, filter, parent);
+        validateDeletedDataFiles(base, startingSnapshotId, filter, parent);
       }
 
       if (deletedDataFiles.size() > 0) {
         validateNoNewDeletesForDataFiles(
-            base, startingSnapshotId, conflictDetectionFilter, deletedDataFiles, snapshot);
+            base, startingSnapshotId, conflictDetectionFilter, deletedDataFiles, parent);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
@@ -86,25 +86,25 @@ public class BaseReplacePartitions extends MergingSnapshotProducer<ReplacePartit
   }
 
   @Override
-  public void validate(TableMetadata currentMetadata, Snapshot snapshot) {
+  public void validate(TableMetadata currentMetadata, Snapshot parent) {
     if (validateConflictingData) {
       if (dataSpec().isUnpartitioned()) {
         validateAddedDataFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), snapshot);
+            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
       } else {
-        validateAddedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, snapshot);
+        validateAddedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
       }
     }
 
     if (validateConflictingDeletes) {
       if (dataSpec().isUnpartitioned()) {
         validateDeletedDataFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), snapshot);
+            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
         validateNoNewDeleteFiles(
-            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), snapshot);
+            currentMetadata, startingSnapshotId, Expressions.alwaysTrue(), parent);
       } else {
-        validateDeletedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, snapshot);
-        validateNoNewDeleteFiles(currentMetadata, startingSnapshotId, replacedPartitions, snapshot);
+        validateDeletedDataFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
+        validateNoNewDeleteFiles(currentMetadata, startingSnapshotId, replacedPartitions, parent);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -116,11 +116,11 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
-  protected void validate(TableMetadata base, Snapshot snapshot) {
+  protected void validate(TableMetadata base, Snapshot parent) {
     if (replacedDataFiles.size() > 0) {
       // if there are replaced data files, there cannot be any new row-level deletes for those data
       // files
-      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles, snapshot);
+      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles, parent);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -401,8 +401,8 @@ public class SnapshotUtil {
    * Fetch the snapshot at the head of the given branch in the given table.
    *
    * <p>This method calls {@link Table#currentSnapshot()} instead of using branch API {@link
-   * Table#snapshot(String)} for the main branch to ensure existing tests still goes through the old
-   * code path.
+   * Table#snapshot(String)} for the main branch so that existing code still goes through the
+   * old code path to ensure backwards compatibility.
    *
    * @param table a {@link Table}
    * @param branch branch name of the table
@@ -420,8 +420,8 @@ public class SnapshotUtil {
    * Fetch the snapshot at the head of the given branch in the given table.
    *
    * <p>This method calls {@link TableMetadata#currentSnapshot()} instead of using branch API {@link
-   * TableMetadata#ref(String)}} for the main branch to ensure existing tests still goes through the
-   * old code path.
+   * TableMetadata#ref(String)}} for the main branch so that existing code still goes through the
+   * old code path to ensure backwards compatibility.
    *
    * @param metadata a {@link TableMetadata}
    * @param branch branch name of the table metadata

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -27,7 +27,9 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -393,5 +395,43 @@ public class SnapshotUtil {
     }
 
     return table.schema();
+  }
+
+  /**
+   * Fetch the snapshot at the head of the given branch in the given table.
+   *
+   * <p>This method calls {@link Table#currentSnapshot()} instead of using branch API {@link
+   * Table#snapshot(String)} for the main branch to ensure existing tests still goes through the old
+   * code path.
+   *
+   * @param table a {@link Table}
+   * @param branch branch name of the table
+   * @return the latest snapshot for the given branch
+   */
+  public static Snapshot latestSnapshot(Table table, String branch) {
+    if (branch.equals(SnapshotRef.MAIN_BRANCH)) {
+      return table.currentSnapshot();
+    }
+
+    return table.snapshot(branch);
+  }
+
+  /**
+   * Fetch the snapshot at the head of the given branch in the given table.
+   *
+   * <p>This method calls {@link TableMetadata#currentSnapshot()} instead of using branch API {@link
+   * TableMetadata#ref(String)}} for the main branch to ensure existing tests still goes through the
+   * old code path.
+   *
+   * @param metadata a {@link TableMetadata}
+   * @param branch branch name of the table metadata
+   * @return the latest snapshot for the given branch
+   */
+  public static Snapshot latestSnapshot(TableMetadata metadata, String branch) {
+    if (branch.equals(SnapshotRef.MAIN_BRANCH)) {
+      return metadata.currentSnapshot();
+    }
+
+    return metadata.snapshot(metadata.ref(branch).snapshotId());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -401,8 +401,8 @@ public class SnapshotUtil {
    * Fetch the snapshot at the head of the given branch in the given table.
    *
    * <p>This method calls {@link Table#currentSnapshot()} instead of using branch API {@link
-   * Table#snapshot(String)} for the main branch so that existing code still goes through the
-   * old code path to ensure backwards compatibility.
+   * Table#snapshot(String)} for the main branch so that existing code still goes through the old
+   * code path to ensure backwards compatibility.
    *
    * @param table a {@link Table}
    * @param branch branch name of the table

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -384,23 +384,6 @@ public class TableTestBase {
     }
   }
 
-  @SuppressWarnings("checkstyle:HiddenField")
-  Snapshot latestSnapshot(Table table, String branch) {
-    if (branch.equals(SnapshotRef.MAIN_BRANCH)) {
-      return table.currentSnapshot();
-    }
-
-    return table.snapshot(branch);
-  }
-
-  Snapshot latestSnapshot(TableMetadata metadata, String branch) {
-    if (branch.equals(SnapshotRef.MAIN_BRANCH)) {
-      return metadata.currentSnapshot();
-    }
-
-    return metadata.snapshot(metadata.ref(branch).snapshotId());
-  }
-
   void validateSnapshot(Snapshot old, Snapshot snap, Long sequenceNumber, DataFile... newFiles) {
     Assert.assertEquals(
         "Should not change delete manifests",

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.apache.iceberg.ManifestEntry.Status;

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.apache.iceberg.relocated.com.google.common.collect.Iterators.concat;
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
 
 import java.io.File;
 import java.io.IOException;

--- a/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplacePartitions.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
+
 import java.io.File;
 import java.io.IOException;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.util.SnapshotUtil;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -93,26 +94,26 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     commit(table, table.newReplacePartitions().addFile(FILE_E), branch);
 
-    long replaceId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long replaceId = latestSnapshot(readMetadata(), branch).snapshotId();
     Assert.assertNotEquals("Should create a new snapshot", baseId, replaceId);
     Assert.assertEquals(
         "Table should have 2 manifests",
         2,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
 
     // manifest is not merged because it is less than the minimum
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(replaceId),
         files(FILE_E),
         statuses(Status.ADDED));
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(replaceId, baseId),
         files(FILE_A, FILE_B),
         statuses(Status.DELETED, Status.EXISTING));
@@ -126,19 +127,19 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     commit(table, table.newReplacePartitions().addFile(FILE_E), branch);
 
-    long replaceId = SnapshotUtil.latestSnapshot(table, branch).snapshotId();
+    long replaceId = latestSnapshot(table, branch).snapshotId();
     Assert.assertNotEquals("Should create a new snapshot", baseId, replaceId);
     Assert.assertEquals(
         "Table should have 1 manifest",
         1,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(replaceId, replaceId, baseId),
         files(FILE_E, FILE_A, FILE_B),
         statuses(Status.ADDED, Status.DELETED, Status.EXISTING));
@@ -161,9 +162,7 @@ public class TestReplacePartitions extends TableTestBase {
     Assert.assertEquals(
         "Table version should be 1", 1, (long) TestTables.metadataVersion("unpartitioned"));
     validateSnapshot(
-        null,
-        SnapshotUtil.latestSnapshot(TestTables.readMetadata("unpartitioned"), branch),
-        FILE_A);
+        null, latestSnapshot(TestTables.readMetadata("unpartitioned"), branch), FILE_A);
 
     ReplacePartitions replacePartitions = unpartitioned.newReplacePartitions().addFile(FILE_B);
     commit(table, replacePartitions, branch);
@@ -171,27 +170,21 @@ public class TestReplacePartitions extends TableTestBase {
     Assert.assertEquals(
         "Table version should be 2", 2, (long) TestTables.metadataVersion("unpartitioned"));
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     Assert.assertEquals(
         "Table should have 2 manifests",
         2,
-        SnapshotUtil.latestSnapshot(replaceMetadata, branch)
-            .allManifests(unpartitioned.io())
-            .size());
+        latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).size());
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(replaceMetadata, branch)
-            .allManifests(unpartitioned.io())
-            .get(0),
+        latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(0),
         ids(replaceId),
         files(FILE_B),
         statuses(Status.ADDED));
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(replaceMetadata, branch)
-            .allManifests(unpartitioned.io())
-            .get(1),
+        latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(1),
         ids(replaceId),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -219,9 +212,7 @@ public class TestReplacePartitions extends TableTestBase {
     Assert.assertEquals(
         "Table version should be 2", 2, (long) TestTables.metadataVersion("unpartitioned"));
     validateSnapshot(
-        null,
-        SnapshotUtil.latestSnapshot(TestTables.readMetadata("unpartitioned"), branch),
-        FILE_A);
+        null, latestSnapshot(TestTables.readMetadata("unpartitioned"), branch), FILE_A);
 
     ReplacePartitions replacePartitions = unpartitioned.newReplacePartitions().addFile(FILE_B);
     commit(table, replacePartitions, branch);
@@ -229,19 +220,15 @@ public class TestReplacePartitions extends TableTestBase {
     Assert.assertEquals(
         "Table version should be 3", 3, (long) TestTables.metadataVersion("unpartitioned"));
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     Assert.assertEquals(
         "Table should have 1 manifest",
         1,
-        SnapshotUtil.latestSnapshot(replaceMetadata, branch)
-            .allManifests(unpartitioned.io())
-            .size());
+        latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).size());
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(replaceMetadata, branch)
-            .allManifests(unpartitioned.io())
-            .get(0),
+        latestSnapshot(replaceMetadata, branch).allManifests(unpartitioned.io()).get(0),
         ids(replaceId, replaceId),
         files(FILE_B, FILE_A),
         statuses(Status.ADDED, Status.DELETED));
@@ -252,7 +239,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     ReplacePartitions replace =
         table.newReplacePartitions().addFile(FILE_F).addFile(FILE_G).validateAppendOnly();
@@ -266,7 +253,7 @@ public class TestReplacePartitions extends TableTestBase {
     Assert.assertEquals(
         "Should not create a new snapshot",
         baseId,
-        SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId());
+        latestSnapshot(readMetadata(), branch).snapshotId());
   }
 
   @Test
@@ -274,26 +261,26 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     commit(table, table.newReplacePartitions().addFile(FILE_G).validateAppendOnly(), branch);
 
-    long replaceId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long replaceId = latestSnapshot(readMetadata(), branch).snapshotId();
     Assert.assertNotEquals("Should create a new snapshot", baseId, replaceId);
     Assert.assertEquals(
         "Table should have 2 manifests",
         2,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
 
     // manifest is not merged because it is less than the minimum
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(replaceId),
         files(FILE_G),
         statuses(Status.ADDED));
 
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(baseId, baseId),
         files(FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED));
@@ -311,7 +298,7 @@ public class TestReplacePartitions extends TableTestBase {
         table
             .newReplacePartitions()
             .addFile(FILE_E)
-            .validateFromSnapshot(SnapshotUtil.latestSnapshot(base, branch).snapshotId()),
+            .validateFromSnapshot(latestSnapshot(base, branch).snapshotId()),
         branch);
     commit(
         table,
@@ -319,21 +306,21 @@ public class TestReplacePartitions extends TableTestBase {
             .newReplacePartitions()
             .addFile(FILE_A) // Replaces FILE_E which becomes Deleted
             .addFile(FILE_B)
-            .validateFromSnapshot(SnapshotUtil.latestSnapshot(base, branch).snapshotId()),
+            .validateFromSnapshot(latestSnapshot(base, branch).snapshotId()),
         branch);
 
-    long replaceId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long replaceId = latestSnapshot(readMetadata(), branch).snapshotId();
     Assert.assertEquals(
         "Table should have 2 manifest",
         2,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(replaceId, replaceId),
         files(FILE_A, FILE_B),
         statuses(Status.ADDED, Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(replaceId),
         files(FILE_E),
         statuses(Status.DELETED));
@@ -366,7 +353,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Replace Partitions should fail with ValidationException
     commit(table, table.newReplacePartitions().addFile(FILE_A), branch);
@@ -394,11 +381,11 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    long id1 = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long id1 = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Replace Partitions should not fail if concerning different partitions
     commit(table, table.newReplacePartitions().addFile(FILE_A), branch);
-    long id2 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id2 = latestSnapshot(readMetadata(), branch).snapshotId();
 
     commit(
         table,
@@ -410,18 +397,18 @@ public class TestReplacePartitions extends TableTestBase {
             .addFile(FILE_B),
         branch);
 
-    long id3 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id3 = latestSnapshot(readMetadata(), branch).snapshotId();
     Assert.assertEquals(
         "Table should have 2 manifests",
         2,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(id3),
         files(FILE_B),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(id2),
         files(FILE_A),
         statuses(Status.ADDED));
@@ -435,7 +422,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, unpartitioned.newAppend().appendFile(FILE_UNPARTITIONED_A), branch);
 
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceBaseId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceBaseId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     // Concurrent ReplacePartitions should fail with ValidationException
     commit(table, unpartitioned.newReplacePartitions().addFile(FILE_UNPARTITIONED_A), branch);
@@ -462,7 +449,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Append and ReplacePartition should fail with ValidationException
     commit(table, table.newFastAppend().appendFile(FILE_B), branch);
@@ -490,12 +477,12 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    long id1 = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long id1 = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Append and ReplacePartition should not conflict if concerning different partitions
     commit(table, table.newFastAppend().appendFile(FILE_B), branch);
 
-    long id2 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id2 = latestSnapshot(readMetadata(), branch).snapshotId();
 
     commit(
         table,
@@ -507,23 +494,23 @@ public class TestReplacePartitions extends TableTestBase {
             .addFile(FILE_A),
         branch);
 
-    long id3 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id3 = latestSnapshot(readMetadata(), branch).snapshotId();
     Assert.assertEquals(
         "Table should have 3 manifests",
         3,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(id3),
         files(FILE_A),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(id2),
         files(FILE_B),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(2),
+        latestSnapshot(table, branch).allManifests(table.io()).get(2),
         ids(id3),
         files(FILE_A),
         statuses(Status.DELETED));
@@ -537,7 +524,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, unpartitioned.newAppend().appendFile(FILE_UNPARTITIONED_A), branch);
 
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceBaseId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceBaseId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     // Concurrent Append and ReplacePartitions should fail with ValidationException
     commit(table, unpartitioned.newAppend().appendFile(FILE_UNPARTITIONED_A), branch);
@@ -565,7 +552,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Delete and ReplacePartition should fail with ValidationException
     commit(
@@ -598,7 +585,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, unpartitioned.newAppend().appendFile(FILE_A), branch);
 
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceBaseId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceBaseId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     // Concurrent Delete and ReplacePartitions should fail with ValidationException
     commit(table, unpartitioned.newRowDelta().addDeletes(FILE_UNPARTITIONED_A_DELETES), branch);
@@ -624,7 +611,7 @@ public class TestReplacePartitions extends TableTestBase {
   public void testDeleteReplaceNoConflict() {
     Assume.assumeTrue(formatVersion == 2);
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
-    long id1 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id1 = latestSnapshot(readMetadata(), branch).snapshotId();
 
     // Concurrent Delta and ReplacePartition should not conflict if concerning different partitions
     commit(
@@ -638,7 +625,7 @@ public class TestReplacePartitions extends TableTestBase {
             .validateFromSnapshot(id1),
         branch);
 
-    long id2 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id2 = latestSnapshot(readMetadata(), branch).snapshotId();
 
     commit(
         table,
@@ -650,24 +637,24 @@ public class TestReplacePartitions extends TableTestBase {
             .addFile(FILE_B),
         branch);
 
-    long id3 = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long id3 = latestSnapshot(readMetadata(), branch).snapshotId();
 
     Assert.assertEquals(
         "Table should have 3 manifest",
         3,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(id3),
         files(FILE_B),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(id1),
         files(FILE_A),
         statuses(Status.ADDED));
     validateDeleteManifest(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(2),
+        latestSnapshot(table, branch).allManifests(table.io()).get(2),
         dataSeqs(2L),
         fileSeqs(2L),
         ids(id2),
@@ -681,7 +668,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Overwrite and ReplacePartition should fail with ValidationException
     commit(table, table.newOverwrite().deleteFile(FILE_A), branch);
@@ -709,7 +696,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
 
     TableMetadata base = readMetadata();
-    long baseId = SnapshotUtil.latestSnapshot(base, branch).snapshotId();
+    long baseId = latestSnapshot(base, branch).snapshotId();
 
     // Concurrent Overwrite and ReplacePartition should not fail with if concerning different
     // partitions
@@ -725,19 +712,19 @@ public class TestReplacePartitions extends TableTestBase {
             .addFile(FILE_B),
         branch);
 
-    long finalId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long finalId = latestSnapshot(readMetadata(), branch).snapshotId();
 
     Assert.assertEquals(
         "Table should have 2 manifest",
         2,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(finalId),
         files(FILE_B),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(finalId),
         files(FILE_B),
         statuses(Status.DELETED));
@@ -754,7 +741,7 @@ public class TestReplacePartitions extends TableTestBase {
     commit(table, unpartitioned.newAppend().appendFile(FILE_UNPARTITIONED_A), branch);
 
     TableMetadata replaceMetadata = TestTables.readMetadata("unpartitioned");
-    long replaceBaseId = SnapshotUtil.latestSnapshot(replaceMetadata, branch).snapshotId();
+    long replaceBaseId = latestSnapshot(replaceMetadata, branch).snapshotId();
 
     // Concurrent Overwrite and ReplacePartitions should fail with ValidationException
     commit(table, unpartitioned.newOverwrite().deleteFile(FILE_UNPARTITIONED_A), branch);
@@ -779,7 +766,7 @@ public class TestReplacePartitions extends TableTestBase {
   @Test
   public void testValidateOnlyDeletes() {
     commit(table, table.newAppend().appendFile(FILE_A), branch);
-    long baseId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long baseId = latestSnapshot(readMetadata(), branch).snapshotId();
 
     // Snapshot Isolation mode: appends do not conflict with replace
     commit(table, table.newAppend().appendFile(FILE_B), branch);
@@ -792,24 +779,24 @@ public class TestReplacePartitions extends TableTestBase {
             .validateNoConflictingDeletes()
             .addFile(FILE_B),
         branch);
-    long finalId = SnapshotUtil.latestSnapshot(readMetadata(), branch).snapshotId();
+    long finalId = latestSnapshot(readMetadata(), branch).snapshotId();
 
     Assert.assertEquals(
         "Table should have 3 manifest",
         3,
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).size());
+        latestSnapshot(table, branch).allManifests(table.io()).size());
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(0),
+        latestSnapshot(table, branch).allManifests(table.io()).get(0),
         ids(finalId),
         files(FILE_B),
         statuses(Status.ADDED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(1),
+        latestSnapshot(table, branch).allManifests(table.io()).get(1),
         ids(finalId),
         files(FILE_B),
         statuses(Status.DELETED));
     validateManifestEntries(
-        SnapshotUtil.latestSnapshot(table, branch).allManifests(table.io()).get(2),
+        latestSnapshot(table, branch).allManifests(table.io()).get(2),
         ids(baseId),
         files(FILE_A),
         statuses(Status.ADDED));

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.ManifestEntry.Status.ADDED;
 import static org.apache.iceberg.ManifestEntry.Status.DELETED;
 import static org.apache.iceberg.ManifestEntry.Status.EXISTING;
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
 
 import java.io.File;
 import java.util.Collections;

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -26,6 +26,7 @@ import static org.apache.iceberg.SnapshotSummary.CHANGED_PARTITION_PREFIX;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DATA_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_DELETE_FILES_PROP;
 import static org.apache.iceberg.SnapshotSummary.TOTAL_POS_DELETES_PROP;
+import static org.apache.iceberg.util.SnapshotUtil.latestSnapshot;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
follow up from https://github.com/apache/iceberg/pull/5234, to refactoring minor comments left in last PR. @rdblue @amogh-jahagirdar please take a look at this.