### PR TITLE
API: Fix Transform backward compatibility in PartitionSpec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.transforms.PartitionSpecVisitor;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.transforms.UnknownTransform;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.Pair;
 
 class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
@@ -338,6 +339,12 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     int sourceId = boundTerm.ref().fieldId();
     Transform<?, ?> transform = toTransform(boundTerm);
 
+    Type fieldType = schema.findType(sourceId);
+    if (fieldType != null) {
+      transform = Transforms.fromString(fieldType, transform.toString());
+    } else {
+      transform = Transforms.fromString(transform.toString());
+    }
     return Pair.of(sourceId, transform);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -20,8 +20,10 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.expressions.Expressions.bucket;
 import static org.apache.iceberg.expressions.Expressions.truncate;
+import static org.apache.iceberg.expressions.Expressions.year;
 
 import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,6 +183,44 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         PartitionSpec.builderFor(table.schema())
             .withSpecId(1)
             .add(1, 1001, "id_bucket_8", Transforms.bucket(8))
+            .build(),
+        table.spec());
+
+    Assert.assertEquals(1001, table.spec().lastAssignedFieldId());
+  }
+
+  @Test
+  public void testRemoveAndAddYearField() {
+    table.updateSchema().addColumn("year_field", Types.DateType.get()).commit();
+    table.updateSpec().addField(year("year_field")).commit();
+
+    PartitionSpec evolvedSpec =
+        PartitionSpec.builderFor(table.schema())
+            .withSpecId(1)
+            .bucket("data", 16)
+            .year("year_field")
+            .build();
+
+    Assert.assertEquals("should match evolved spec", evolvedSpec, table.spec());
+    Assert.assertEquals(1001, table.spec().lastAssignedFieldId());
+
+    table.updateSpec().removeField("year_field_year").addField(year("year_field")).commit();
+
+    V1Assert.assertEquals(
+        "Should soft delete id and data buckets",
+        PartitionSpec.builderFor(table.schema())
+            .withSpecId(1)
+            .bucket("data", 16)
+            .year("year_field")
+            .build(),
+        table.spec());
+
+    V2Assert.assertEquals(
+        "Should remove and then add a year field",
+        PartitionSpec.builderFor(table.schema())
+            .withSpecId(1)
+            .bucket("data", 16)
+            .add(3, 1001, "year_field_year", Transforms.year())
             .build(),
         table.spec());
 


### PR DESCRIPTION
BaseUpdatePartitionSpec::addField  is failing with “Cannot add duplicate partition field” for the re-added DATE type field.

existing.transform().equals(sourceTransform.second()) returns FALSE since the types are different: 
````
existing.transform() = {Dates@11599} “year”
sourceTransform.second() = {Years@11603} “year”
````

Test
````
Schema SCHEMA = new Schema(
          required(1, "id", Types.IntegerType.get()),
          required(2, "data", Types.StringType.get()),
          optional(3, "year_field", Types.DateType.get()));

PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).year("year_field").build();
table = create(SCHEMA, SPEC);

table.updateSpec()
    .removeField(Expressions.year("year_field"))
    .addField(Expressions.year("year_field"));
````