### PR TITLE
Python: Check if optional Parquet kv metadata is None before reading Iceberg Schema

### DIFF
--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -505,7 +505,9 @@ def project_table(
         # Get the schema
         with fs.open_input_file(path) as fout:
             parquet_schema = pq.read_schema(fout)
-            schema_raw = parquet_schema.metadata.get(ICEBERG_SCHEMA)
+            schema_raw = None
+            if metadata := parquet_schema.metadata:
+                schema_raw = metadata.get(ICEBERG_SCHEMA)
             if schema_raw is None:
                 raise ValueError(
                     "Iceberg schema is not embedded into the Parquet file, see https://github.com/apache/iceberg/issues/6505"


### PR DESCRIPTION
This is an interim solution for https://github.com/apache/iceberg/issues/6647. Parquet file k/v metadata is optional and not required to be written as per the Parquet spec https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L1022

The real fix will be to determine the Iceberg schema from the Parquet file (in this case we don't care about any external definitions, it'll be just from the parquet schema) https://github.com/apache/iceberg/issues/6505

If the real solution is ready for PR soon, we can just close this. But I was thinking in the interim it would be useful so that users know it's a known issue until we release the fix.

CC: @Fokko @JonasJ-ap @rdblue @samredai 

