### PR TITLE
Spark: Handle ResolvingFileIO while determining LocalityPreference

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -103,19 +103,6 @@ public class Util {
     return false;
   }
 
-  public static boolean usesHadoopFileIO(FileIO io, String location) {
-    if (io instanceof HadoopFileIO) {
-      return true;
-
-    } else if (io instanceof ResolvingFileIO) {
-      ResolvingFileIO resolvingFileIO = (ResolvingFileIO) io;
-      return HadoopFileIO.class.isAssignableFrom(resolvingFileIO.ioClass(location));
-
-    } else {
-      return false;
-    }
-  }
-
   private static String[] blockLocations(FileIO io, ContentScanTask<?> task) {
     String location = task.file().path().toString();
     if (usesHadoopFileIO(io, location)) {
@@ -128,6 +115,19 @@ public class Util {
       }
     } else {
       return HadoopInputFile.NO_LOCATION_PREFERENCE;
+    }
+  }
+
+  private static boolean usesHadoopFileIO(FileIO io, String location) {
+    if (io instanceof HadoopFileIO) {
+      return true;
+
+    } else if (io instanceof ResolvingFileIO) {
+      ResolvingFileIO resolvingFileIO = (ResolvingFileIO) io;
+      return HadoopFileIO.class.isAssignableFrom(resolvingFileIO.ioClass(location));
+
+    } else {
+      return false;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -168,8 +169,12 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
     return SCHEME_TO_FILE_IO.getOrDefault(scheme(location), FALLBACK_IMPL);
   }
 
-  public Class<? extends FileIO> ioClass(String location) {
-    return io(location).getClass();
+  public Class<?> ioClass(String location) {
+    try {
+      return Class.forName(implFromLocation(location));
+    } catch (ClassNotFoundException e) {
+      throw new ValidationException(e.getMessage());
+    }
   }
 
   private static String scheme(String location) {

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -164,8 +164,12 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
     return io;
   }
 
-  public static String implFromLocation(String location) {
+  private static String implFromLocation(String location) {
     return SCHEME_TO_FILE_IO.getOrDefault(scheme(location), FALLBACK_IMPL);
+  }
+
+  public Class<? extends FileIO> ioClass(String location) {
+    return io(location).getClass();
   }
 
   private static String scheme(String location) {

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -164,7 +164,7 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
     return io;
   }
 
-  private static String implFromLocation(String location) {
+  public static String implFromLocation(String location) {
     return SCHEME_TO_FILE_IO.getOrDefault(scheme(location), FALLBACK_IMPL);
   }
 

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -170,10 +170,11 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
   }
 
   public Class<?> ioClass(String location) {
+    String fileIOClassName = implFromLocation(location);
     try {
-      return Class.forName(implFromLocation(location));
+      return Class.forName(fileIOClassName);
     } catch (ClassNotFoundException e) {
-      throw new ValidationException(e.getMessage());
+      throw new ValidationException("Class %s not found : %s", fileIOClassName, e.getMessage());
     }
   }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/SourceUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/SourceUtil.java
@@ -18,24 +18,16 @@
  */
 package org.apache.iceberg.flink.source;
 
-import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.FlinkConfigOptions;
-import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class SourceUtil {
   private SourceUtil() {}
-
-  private static final Logger LOG = LoggerFactory.getLogger(SourceUtil.class);
-  private static final Set<String> FILE_SYSTEM_SUPPORT_LOCALITY = ImmutableSet.of("hdfs");
 
   static boolean isLocalityEnabled(
       Table table, ReadableConfig readableConfig, Boolean exposeLocality) {
@@ -48,13 +40,7 @@ class SourceUtil {
       return false;
     }
 
-    if (Util.isHDFSLocation(table.io(), table.location())) {
-      HadoopInputFile file = (HadoopInputFile) table.io().newInputFile(table.location());
-      String scheme = file.getFileSystem().getScheme();
-      return FILE_SYSTEM_SUPPORT_LOCALITY.contains(scheme);
-    }
-
-    return false;
+    return Util.mayHaveBlockLocations(table.io(), table.location());
   }
 
   /**

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -62,13 +62,8 @@ public class SparkReadConf {
   }
 
   public boolean localityEnabled() {
-    if (Util.usesHadoopFileIO(table.io(), table.location())) {
-      boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-      return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
-
-    } else {
-      return false;
-    }
+    boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
+    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
   }
 
   public Long snapshotId() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -22,10 +22,8 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.HadoopInputFile;
-import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.io.ResolvingFileIO;
+import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.SparkSession;
@@ -69,15 +67,11 @@ public class SparkReadConf {
   }
 
   public boolean localityEnabled() {
-    if (table.io() instanceof HadoopFileIO || table.io() instanceof ResolvingFileIO) {
-      InputFile file = table.io().newInputFile(table.location());
-      if (file instanceof HadoopInputFile) {
-        String scheme = ((HadoopInputFile) file).getFileSystem().getScheme();
-        boolean defaultValue = LOCALITY_WHITELIST_FS.contains(scheme);
-        return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
-      } else {
-        return false;
-      }
+    if (Util.isHDFSLocation(table.io(), table.location())) {
+      HadoopInputFile file = (HadoopInputFile) table.io().newInputFile(table.location());
+      String scheme = file.getFileSystem().getScheme();
+      boolean defaultValue = LOCALITY_WHITELIST_FS.contains(scheme);
+      return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
     }
 
     return false;


### PR DESCRIPTION
### About the change

Presently when determining the locality preference we check if the fileIO if it's Hadoop file IO and then only we perform subsequent checks to determine locality but we may also be using ResolvingFileIO which might be wrapping HadoopFileIO inside it and hence in that case, we might actually wanna proceed with inputFile creation and checking the scheme etc to determine locality enabled.


### Testing 

TODO