### PR TITLE
Nessie: Avoid usage of deprecated APIs in test

### DIFF
--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -48,8 +48,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
-import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
@@ -69,6 +71,7 @@ import org.slf4j.LoggerFactory;
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+@NessieApiVersions(versions = NessieApiVersion.V1)
 public abstract class BaseTestIceberg {
 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
@@ -113,9 +116,10 @@ public abstract class BaseTestIceberg {
   }
 
   @BeforeEach
-  public void beforeEach(@NessieClientUri URI nessieUri) throws IOException {
-    this.uri = nessieUri.resolve("v1").toASCIIString();
-    this.api = HttpClientBuilder.builder().withUri(this.uri).build(NessieApiV1.class);
+  public void beforeEach(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws IOException {
+    this.uri = nessieUri.toASCIIString();
+    this.api = clientFactory.make();
 
     Branch defaultBranch = api.getDefaultBranch();
     initialHashOfDefaultBranch = defaultBranch.getHash();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -48,15 +48,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
-import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
-import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
@@ -72,11 +71,11 @@ import org.slf4j.LoggerFactory;
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
 public abstract class BaseTestIceberg {
 
-  @NessieDbAdapter(storeWorker = TableCommitMetaStoreWorker.class)
-  static DatabaseAdapter databaseAdapter;
+  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server =
+      NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseTestIceberg.class);
 
@@ -114,8 +113,8 @@ public abstract class BaseTestIceberg {
   }
 
   @BeforeEach
-  public void beforeEach(@NessieUri URI nessieUri) throws IOException {
-    this.uri = nessieUri.toString();
+  public void beforeEach(@NessieClientUri URI nessieUri) throws IOException {
+    this.uri = nessieUri.resolve("v1").toASCIIString();
     this.api = HttpClientBuilder.builder().withUri(this.uri).build(NessieApiV1.class);
 
     Branch defaultBranch = api.getDefaultBranch();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -33,15 +33,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
-import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
-import org.projectnessie.server.store.TableCommitMetaStoreWorker;
 import org.projectnessie.versioned.persist.adapter.DatabaseAdapter;
 import org.projectnessie.versioned.persist.inmem.InmemoryDatabaseAdapterFactory;
 import org.projectnessie.versioned.persist.inmem.InmemoryTestConnectionProviderSource;
@@ -55,11 +54,11 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
 public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
 
-  @NessieDbAdapter(storeWorker = TableCommitMetaStoreWorker.class)
-  static DatabaseAdapter databaseAdapter;
+  @NessieDbAdapter static DatabaseAdapter databaseAdapter;
 
   @RegisterExtension
-  static NessieJaxRsExtension server = new NessieJaxRsExtension(() -> databaseAdapter);
+  static NessieJaxRsExtension server =
+      NessieJaxRsExtension.jaxRsExtensionForDatabaseAdapter(() -> databaseAdapter);
 
   @TempDir public Path temp;
 
@@ -70,8 +69,8 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
   private String uri;
 
   @BeforeEach
-  public void beforeEach(@NessieUri URI nessieUri) throws IOException {
-    this.uri = nessieUri.toString();
+  public void beforeEach(@NessieClientUri URI nessieUri) throws IOException {
+    this.uri = nessieUri.resolve("v1").toASCIIString();
     this.api = HttpClientBuilder.builder().withUri(this.uri).build(NessieApiV1.class);
 
     initialHashOfDefaultBranch = api.getDefaultBranch().getHash();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -33,8 +33,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
-import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
@@ -52,6 +54,7 @@ import org.projectnessie.versioned.persist.tests.extension.NessieExternalDatabas
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
+@NessieApiVersions(versions = NessieApiVersion.V1)
 public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
@@ -69,12 +72,11 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
   private String uri;
 
   @BeforeEach
-  public void beforeEach(@NessieClientUri URI nessieUri) throws IOException {
-    this.uri = nessieUri.resolve("v1").toASCIIString();
-    this.api = HttpClientBuilder.builder().withUri(this.uri).build(NessieApiV1.class);
-
+  public void setUp(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws NessieNotFoundException {
+    api = clientFactory.make();
     initialHashOfDefaultBranch = api.getDefaultBranch().getHash();
-
+    uri = nessieUri.toASCIIString();
     hadoopConfig = new Configuration();
     catalog = initNessieCatalog("main");
   }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -52,6 +52,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -89,8 +90,9 @@ public class TestNessieTable extends BaseTestIceberg {
 
   @Override
   @BeforeEach
-  public void beforeEach(@NessieClientUri URI uri) throws IOException {
-    super.beforeEach(uri);
+  public void beforeEach(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws IOException {
+    super.beforeEach(clientFactory, nessieUri);
     this.tableLocation =
         catalog.createTable(TABLE_IDENTIFIER, schema).location().replaceFirst("file:", "");
   }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -52,9 +52,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.projectnessie.client.ext.NessieClientUri;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.jaxrs.ext.NessieUri;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
@@ -89,7 +89,7 @@ public class TestNessieTable extends BaseTestIceberg {
 
   @Override
   @BeforeEach
-  public void beforeEach(@NessieUri URI uri) throws IOException {
+  public void beforeEach(@NessieClientUri URI uri) throws IOException {
     super.beforeEach(uri);
     this.tableLocation =
         catalog.createTable(TABLE_IDENTIFIER, schema).location().replaceFirst("file:", "");


### PR DESCRIPTION
Deprecated API usage:

<img width="919" alt="image" src="https://user-images.githubusercontent.com/5889404/214542776-2d7e7b65-aa18-46f0-9d05-bea38b5d23d6.png">
