### PR TITLE
Flink: Support writes to branches in FlinkSink

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -172,4 +172,12 @@ public class FlinkWriteConf {
         .defaultValue(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE.defaultValue())
         .parse();
   }
+
+  public String branch() {
+    return confParser
+        .stringConf()
+        .option(FlinkWriteOptions.BRANCH.key())
+        .defaultValue(FlinkWriteOptions.BRANCH.defaultValue())
+        .parse();
+  }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.iceberg.SnapshotRef;
 
 /** Flink sink write options */
 public class FlinkWriteOptions {
@@ -56,4 +57,8 @@ public class FlinkWriteOptions {
   // Overrides the table's write.distribution-mode
   public static final ConfigOption<String> DISTRIBUTION_MODE =
       ConfigOptions.key("distribution-mode").stringType().noDefaultValue();
+
+  // Branch to write to
+  public static final ConfigOption<String> BRANCH =
+      ConfigOptions.key("branch").stringType().defaultValue(SnapshotRef.MAIN_BRANCH);
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -316,6 +316,11 @@ public class FlinkSink {
       return this;
     }
 
+    public Builder toBranch(String branch) {
+      writeOptions.put(FlinkWriteOptions.BRANCH.key(), branch);
+      return this;
+    }
+
     private <T> DataStreamSink<T> chainIcebergOperators() {
       Preconditions.checkArgument(
           inputCreator != null,
@@ -422,7 +427,8 @@ public class FlinkSink {
               tableLoader,
               flinkWriteConf.overwriteMode(),
               snapshotProperties,
-              flinkWriteConf.workerPoolSize());
+              flinkWriteConf.workerPoolSize(),
+              flinkWriteConf.branch());
       SingleOutputStreamOperator<Void> committerStream =
           writerStream
               .transform(operatorName(ICEBERG_FILES_COMMITTER_NAME), Types.VOID, filesCommitter)

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -95,6 +95,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // The completed files cache for current checkpoint. Once the snapshot barrier received, it will
   // be flushed to the 'dataFilesPerCheckpoint'.
   private final List<WriteResult> writeResultsOfCurrentCkpt = Lists.newArrayList();
+  private final String branch;
 
   // It will have an unique identifier for one job.
   private transient String flinkJobId;
@@ -125,11 +126,13 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       TableLoader tableLoader,
       boolean replacePartitions,
       Map<String, String> snapshotProperties,
-      Integer workerPoolSize) {
+      Integer workerPoolSize,
+      String branch) {
     this.tableLoader = tableLoader;
     this.replacePartitions = replacePartitions;
     this.snapshotProperties = snapshotProperties;
     this.workerPoolSize = workerPoolSize;
+    this.branch = branch;
   }
 
   @Override
@@ -179,7 +182,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       // it's safe to assign the max committed checkpoint id from restored flink job to the current
       // flink job.
       this.maxCommittedCheckpointId =
-          getMaxCommittedCheckpointId(table, restoredFlinkJobId, operatorUniqueId);
+          getMaxCommittedCheckpointId(table, restoredFlinkJobId, operatorUniqueId, branch);
 
       NavigableMap<Long, byte[]> uncommittedDataFiles =
           Maps.newTreeMap(checkpointsState.get().iterator().next())
@@ -383,10 +386,11 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       String operatorId,
       long checkpointId) {
     LOG.info(
-        "Committing {} for checkpoint {} to table {} with summary: {}",
+        "Committing {} for checkpoint {} to table {} branch {} with summary: {}",
         description,
         checkpointId,
         table.name(),
+        branch,
         summary);
     snapshotProperties.forEach(operation::set);
     // custom snapshot metadata properties will be overridden if they conflict with internal ones
@@ -394,6 +398,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
     operation.set(FLINK_JOB_ID, newFlinkJobId);
     operation.set(OPERATOR_ID, operatorId);
+    operation.toBranch(branch);
 
     long startNano = System.nanoTime();
     operation.commit(); // abort is automatically called if this fails.
@@ -471,8 +476,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     return new ListStateDescriptor<>("iceberg-files-committer-state", sortedMapTypeInfo);
   }
 
-  static long getMaxCommittedCheckpointId(Table table, String flinkJobId, String operatorId) {
-    Snapshot snapshot = table.currentSnapshot();
+  static long getMaxCommittedCheckpointId(
+      Table table, String flinkJobId, String operatorId, String branch) {
+    Snapshot snapshot = table.snapshot(branch);
     long lastCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
     while (snapshot != null) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBase.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.source.BoundedTestSource;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class TestFlinkIcebergSinkBase {
+
+  protected Table table;
+  protected StreamExecutionEnvironment env;
+  protected static final TypeInformation<Row> ROW_TYPE_INFO =
+      new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
+
+  protected static final DataFormatConverters.RowConverter CONVERTER =
+      new DataFormatConverters.RowConverter(SimpleDataUtil.FLINK_SCHEMA.getFieldDataTypes());
+
+  protected BoundedTestSource<Row> createBoundedSource(List<Row> rows) {
+    return new BoundedTestSource<>(rows.toArray(new Row[0]));
+  }
+
+  protected List<Row> createRows(String prefix) {
+    return Lists.newArrayList(
+        Row.of(1, prefix + "aaa"),
+        Row.of(1, prefix + "bbb"),
+        Row.of(1, prefix + "ccc"),
+        Row.of(2, prefix + "aaa"),
+        Row.of(2, prefix + "bbb"),
+        Row.of(2, prefix + "ccc"),
+        Row.of(3, prefix + "aaa"),
+        Row.of(3, prefix + "bbb"),
+        Row.of(3, prefix + "ccc"));
+  }
+
+  protected List<RowData> convertToRowData(List<Row> rows) {
+    return rows.stream().map(CONVERTER::toInternal).collect(Collectors.toList());
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBranch.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBranch.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.flink.HadoopCatalogResource;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestFlinkIcebergSinkBranch extends TestFlinkIcebergSinkBase {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Rule
+  public final HadoopCatalogResource catalogResource =
+      new HadoopCatalogResource(TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE);
+
+  private final String branch;
+  private TableLoader tableLoader;
+
+  @Parameterized.Parameters(name = "formatVersion = {0}, branch = {1}")
+  public static Object[] parameters() {
+    return new Object[] {"main", "testBranch"};
+  }
+
+  public TestFlinkIcebergSinkBranch(String branch) {
+    this.branch = branch;
+  }
+
+  @Before
+  public void before() throws IOException {
+    table =
+        catalogResource
+            .catalog()
+            .createTable(
+                TestFixtures.TABLE_IDENTIFIER,
+                SimpleDataUtil.SCHEMA,
+                PartitionSpec.unpartitioned(),
+                ImmutableMap.of(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.AVRO.name(),
+                    TableProperties.FORMAT_VERSION,
+                    "1"));
+
+    env =
+        StreamExecutionEnvironment.getExecutionEnvironment(
+                MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG)
+            .enableCheckpointing(100);
+
+    tableLoader = catalogResource.tableLoader();
+  }
+
+  @Test
+  public void testWriteRowWithTableSchema() throws Exception {
+    testWriteRow(SimpleDataUtil.FLINK_SCHEMA, DistributionMode.NONE);
+    verifyOtherBranchUnmodified();
+  }
+
+  private void testWriteRow(TableSchema tableSchema, DistributionMode distributionMode)
+      throws Exception {
+    List<Row> rows = createRows("");
+    DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);
+
+    FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+        .table(table)
+        .tableLoader(tableLoader)
+        .tableSchema(tableSchema)
+        .toBranch(branch)
+        .distributionMode(distributionMode)
+        .append();
+
+    // Execute the program.
+    env.execute("Test Iceberg DataStream.");
+
+    SimpleDataUtil.assertTableRows(table, convertToRowData(rows), branch);
+    SimpleDataUtil.assertTableRows(
+        table,
+        ImmutableList.of(),
+        branch.equals(SnapshotRef.MAIN_BRANCH) ? "test-branch" : SnapshotRef.MAIN_BRANCH);
+
+    verifyOtherBranchUnmodified();
+  }
+
+  private void verifyOtherBranchUnmodified() {
+    String otherBranch =
+        branch.equals(SnapshotRef.MAIN_BRANCH) ? "test-branch" : SnapshotRef.MAIN_BRANCH;
+    if (otherBranch.equals(SnapshotRef.MAIN_BRANCH)) {
+      Assert.assertNull(table.currentSnapshot());
+    }
+
+    Assert.assertTrue(table.snapshot(otherBranch) == null);
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -18,38 +18,25 @@
  */
 package org.apache.iceberg.flink.sink;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Row;
-import org.apache.flink.types.RowKind;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.Table;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.data.IcebergGenerics;
-import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.HadoopCatalogResource;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
-import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.BoundedTestSource;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -60,7 +47,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class TestFlinkIcebergSinkV2 {
+public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
 
   @ClassRule
   public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
@@ -71,29 +58,6 @@ public class TestFlinkIcebergSinkV2 {
   @Rule
   public final HadoopCatalogResource catalogResource =
       new HadoopCatalogResource(TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE);
-
-  private static final int FORMAT_V2 = 2;
-  private static final TypeInformation<Row> ROW_TYPE_INFO =
-      new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
-
-  private static final Map<String, RowKind> ROW_KIND_MAP =
-      ImmutableMap.of(
-          "+I", RowKind.INSERT,
-          "-D", RowKind.DELETE,
-          "-U", RowKind.UPDATE_BEFORE,
-          "+U", RowKind.UPDATE_AFTER);
-
-  private static final int ROW_ID_POS = 0;
-  private static final int ROW_DATA_POS = 1;
-
-  private final FileFormat format;
-  private final int parallelism;
-  private final boolean partitioned;
-  private final String writeDistributionMode;
-
-  private Table table;
-  private StreamExecutionEnvironment env;
-  private TableLoader tableLoader;
 
   @Parameterized.Parameters(
       name = "FileFormat = {0}, Parallelism = {1}, Partitioned={2}, WriteDistributionMode ={3}")
@@ -155,67 +119,6 @@ public class TestFlinkIcebergSinkV2 {
     tableLoader = catalogResource.tableLoader();
   }
 
-  private List<Snapshot> findValidSnapshots() {
-    List<Snapshot> validSnapshots = Lists.newArrayList();
-    for (Snapshot snapshot : table.snapshots()) {
-      if (snapshot.allManifests(table.io()).stream()
-          .anyMatch(m -> snapshot.snapshotId() == m.snapshotId())) {
-        validSnapshots.add(snapshot);
-      }
-    }
-    return validSnapshots;
-  }
-
-  private void testChangeLogs(
-      List<String> equalityFieldColumns,
-      KeySelector<Row, Object> keySelector,
-      boolean insertAsUpsert,
-      List<List<Row>> elementsPerCheckpoint,
-      List<List<Record>> expectedRecordsPerCheckpoint)
-      throws Exception {
-    DataStream<Row> dataStream =
-        env.addSource(new BoundedTestSource<>(elementsPerCheckpoint), ROW_TYPE_INFO);
-
-    FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
-        .tableLoader(tableLoader)
-        .tableSchema(SimpleDataUtil.FLINK_SCHEMA)
-        .writeParallelism(parallelism)
-        .equalityFieldColumns(equalityFieldColumns)
-        .upsert(insertAsUpsert)
-        .append();
-
-    // Execute the program.
-    env.execute("Test Iceberg Change-Log DataStream.");
-
-    table.refresh();
-    List<Snapshot> snapshots = findValidSnapshots();
-    int expectedSnapshotNum = expectedRecordsPerCheckpoint.size();
-    Assert.assertEquals(
-        "Should have the expected snapshot number", expectedSnapshotNum, snapshots.size());
-
-    for (int i = 0; i < expectedSnapshotNum; i++) {
-      long snapshotId = snapshots.get(i).snapshotId();
-      List<Record> expectedRecords = expectedRecordsPerCheckpoint.get(i);
-      Assert.assertEquals(
-          "Should have the expected records for the checkpoint#" + i,
-          expectedRowSet(expectedRecords.toArray(new Record[0])),
-          actualRowSet(snapshotId, "*"));
-    }
-  }
-
-  private Row row(String rowKind, int id, String data) {
-    RowKind kind = ROW_KIND_MAP.get(rowKind);
-    if (kind == null) {
-      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
-    }
-
-    return Row.ofKind(kind, id, data);
-  }
-
-  private Record record(int id, String data) {
-    return SimpleDataUtil.createRecord(id, data);
-  }
-
   @Test
   public void testCheckAndGetEqualityFieldIds() {
     table
@@ -249,136 +152,22 @@ public class TestFlinkIcebergSinkV2 {
 
   @Test
   public void testChangeLogOnIdKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(
-                row("+I", 1, "aaa"),
-                row("-D", 1, "aaa"),
-                row("+I", 1, "bbb"),
-                row("+I", 2, "aaa"),
-                row("-D", 2, "aaa"),
-                row("+I", 2, "bbb")),
-            ImmutableList.of(
-                row("-U", 2, "bbb"), row("+U", 2, "ccc"), row("-D", 2, "ccc"), row("+I", 2, "ddd")),
-            ImmutableList.of(
-                row("-D", 1, "bbb"),
-                row("+I", 1, "ccc"),
-                row("-D", 1, "ccc"),
-                row("+I", 1, "ddd")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "bbb"), record(2, "bbb")),
-            ImmutableList.of(record(1, "bbb"), record(2, "ddd")),
-            ImmutableList.of(record(1, "ddd"), record(2, "ddd")));
-
-    if (partitioned && writeDistributionMode.equals(TableProperties.WRITE_DISTRIBUTION_MODE_HASH)) {
-      AssertHelpers.assertThrows(
-          "Should be error because equality field columns don't include all partition keys",
-          IllegalStateException.class,
-          "should be included in equality fields",
-          () -> {
-            testChangeLogs(
-                ImmutableList.of("id"),
-                row -> row.getField(ROW_ID_POS),
-                false,
-                elementsPerCheckpoint,
-                expectedRecords);
-            return null;
-          });
-    } else {
-      testChangeLogs(
-          ImmutableList.of("id"),
-          row -> row.getField(ROW_ID_POS),
-          false,
-          elementsPerCheckpoint,
-          expectedRecords);
-    }
+    testChangeLogOnIdKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
   public void testChangeLogOnDataKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(
-                row("+I", 1, "aaa"),
-                row("-D", 1, "aaa"),
-                row("+I", 2, "bbb"),
-                row("+I", 1, "bbb"),
-                row("+I", 2, "aaa")),
-            ImmutableList.of(row("-U", 2, "aaa"), row("+U", 1, "ccc"), row("+I", 1, "aaa")),
-            ImmutableList.of(row("-D", 1, "bbb"), row("+I", 2, "aaa"), row("+I", 2, "ccc")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "bbb"), record(2, "aaa")),
-            ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc")),
-            ImmutableList.of(
-                record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "ccc")));
-
-    testChangeLogs(
-        ImmutableList.of("data"),
-        row -> row.getField(ROW_DATA_POS),
-        false,
-        elementsPerCheckpoint,
-        expectedRecords);
+    testChangeLogOnDataKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
   public void testChangeLogOnIdDataKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(
-                row("+I", 1, "aaa"),
-                row("-D", 1, "aaa"),
-                row("+I", 2, "bbb"),
-                row("+I", 1, "bbb"),
-                row("+I", 2, "aaa")),
-            ImmutableList.of(row("-U", 2, "aaa"), row("+U", 1, "ccc"), row("+I", 1, "aaa")),
-            ImmutableList.of(row("-D", 1, "bbb"), row("+I", 2, "aaa")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "bbb"), record(2, "aaa"), record(2, "bbb")),
-            ImmutableList.of(
-                record(1, "aaa"), record(1, "bbb"), record(1, "ccc"), record(2, "bbb")),
-            ImmutableList.of(
-                record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "bbb")));
-
-    testChangeLogs(
-        ImmutableList.of("data", "id"),
-        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
-        false,
-        elementsPerCheckpoint,
-        expectedRecords);
+    testChangeLogOnIdDataKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
   public void testChangeLogOnSameKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            // Checkpoint #1
-            ImmutableList.of(row("+I", 1, "aaa"), row("-D", 1, "aaa"), row("+I", 1, "aaa")),
-            // Checkpoint #2
-            ImmutableList.of(row("-U", 1, "aaa"), row("+U", 1, "aaa")),
-            // Checkpoint #3
-            ImmutableList.of(row("-D", 1, "aaa"), row("+I", 1, "aaa")),
-            // Checkpoint #4
-            ImmutableList.of(row("-U", 1, "aaa"), row("+U", 1, "aaa"), row("+I", 1, "aaa")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "aaa")),
-            ImmutableList.of(record(1, "aaa")),
-            ImmutableList.of(record(1, "aaa")),
-            ImmutableList.of(record(1, "aaa"), record(1, "aaa")));
-
-    testChangeLogs(
-        ImmutableList.of("id", "data"),
-        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
-        false,
-        elementsPerCheckpoint,
-        expectedRecords);
+    testChangeLogOnSameKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
@@ -408,97 +197,16 @@ public class TestFlinkIcebergSinkV2 {
 
   @Test
   public void testUpsertOnIdKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(row("+I", 1, "aaa"), row("+U", 1, "bbb")),
-            ImmutableList.of(row("+I", 1, "ccc")),
-            ImmutableList.of(row("+U", 1, "ddd"), row("+I", 1, "eee")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "bbb")),
-            ImmutableList.of(record(1, "ccc")),
-            ImmutableList.of(record(1, "eee")));
-
-    if (!partitioned) {
-      testChangeLogs(
-          ImmutableList.of("id"),
-          row -> row.getField(ROW_ID_POS),
-          true,
-          elementsPerCheckpoint,
-          expectedRecords);
-    } else {
-      AssertHelpers.assertThrows(
-          "Should be error because equality field columns don't include all partition keys",
-          IllegalStateException.class,
-          "should be included in equality fields",
-          () -> {
-            testChangeLogs(
-                ImmutableList.of("id"),
-                row -> row.getField(ROW_ID_POS),
-                true,
-                elementsPerCheckpoint,
-                expectedRecords);
-            return null;
-          });
-    }
+    testUpsertOnIdKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
   public void testUpsertOnDataKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(row("+I", 1, "aaa"), row("+I", 2, "aaa"), row("+I", 3, "bbb")),
-            ImmutableList.of(row("+U", 4, "aaa"), row("-U", 3, "bbb"), row("+U", 5, "bbb")),
-            ImmutableList.of(row("+I", 6, "aaa"), row("+U", 7, "bbb")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(2, "aaa"), record(3, "bbb")),
-            ImmutableList.of(record(4, "aaa"), record(5, "bbb")),
-            ImmutableList.of(record(6, "aaa"), record(7, "bbb")));
-
-    testChangeLogs(
-        ImmutableList.of("data"),
-        row -> row.getField(ROW_DATA_POS),
-        true,
-        elementsPerCheckpoint,
-        expectedRecords);
+    testUpsertOnDataKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test
   public void testUpsertOnIdDataKey() throws Exception {
-    List<List<Row>> elementsPerCheckpoint =
-        ImmutableList.of(
-            ImmutableList.of(row("+I", 1, "aaa"), row("+U", 1, "aaa"), row("+I", 2, "bbb")),
-            ImmutableList.of(row("+I", 1, "aaa"), row("-D", 2, "bbb"), row("+I", 2, "ccc")),
-            ImmutableList.of(row("+U", 1, "bbb"), row("-U", 1, "ccc"), row("-D", 1, "aaa")));
-
-    List<List<Record>> expectedRecords =
-        ImmutableList.of(
-            ImmutableList.of(record(1, "aaa"), record(2, "bbb")),
-            ImmutableList.of(record(1, "aaa"), record(2, "ccc")),
-            ImmutableList.of(record(1, "bbb"), record(2, "ccc")));
-
-    testChangeLogs(
-        ImmutableList.of("id", "data"),
-        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
-        true,
-        elementsPerCheckpoint,
-        expectedRecords);
-  }
-
-  private StructLikeSet expectedRowSet(Record... records) {
-    return SimpleDataUtil.expectedRowSet(table, records);
-  }
-
-  private StructLikeSet actualRowSet(long snapshotId, String... columns) throws IOException {
-    table.refresh();
-    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
-    try (CloseableIterable<Record> reader =
-        IcebergGenerics.read(table).useSnapshot(snapshotId).select(columns).build()) {
-      reader.forEach(set::add);
-    }
-    return set;
+    testUpsertOnIdDataKey(SnapshotRef.MAIN_BRANCH);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Base.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Base.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.source.BoundedTestSource;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+
+public class TestFlinkIcebergSinkV2Base {
+
+  protected static final int FORMAT_V2 = 2;
+  protected static final TypeInformation<Row> ROW_TYPE_INFO =
+      new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
+
+  protected static final int ROW_ID_POS = 0;
+  protected static final int ROW_DATA_POS = 1;
+
+  protected int parallelism = 1;
+  protected TableLoader tableLoader;
+  protected Table table;
+  protected StreamExecutionEnvironment env;
+  protected FileFormat format;
+  protected boolean partitioned;
+  protected String writeDistributionMode;
+
+  protected static final Map<String, RowKind> ROW_KIND_MAP =
+      ImmutableMap.of(
+          "+I", RowKind.INSERT,
+          "-D", RowKind.DELETE,
+          "-U", RowKind.UPDATE_BEFORE,
+          "+U", RowKind.UPDATE_AFTER);
+
+  protected Row row(String rowKind, int id, String data) {
+    RowKind kind = ROW_KIND_MAP.get(rowKind);
+    if (kind == null) {
+      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
+    }
+
+    return Row.ofKind(kind, id, data);
+  }
+
+  protected void testUpsertOnIdDataKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(row("+I", 1, "aaa"), row("+U", 1, "aaa"), row("+I", 2, "bbb")),
+            ImmutableList.of(row("+I", 1, "aaa"), row("-D", 2, "bbb"), row("+I", 2, "ccc")),
+            ImmutableList.of(row("+U", 1, "bbb"), row("-U", 1, "ccc"), row("-D", 1, "aaa")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "aaa"), record(2, "bbb")),
+            ImmutableList.of(record(1, "aaa"), record(2, "ccc")),
+            ImmutableList.of(record(1, "bbb"), record(2, "ccc")));
+    testChangeLogs(
+        ImmutableList.of("id", "data"),
+        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
+        true,
+        elementsPerCheckpoint,
+        expectedRecords,
+        branch);
+  }
+
+  protected void testChangeLogOnIdDataKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(
+                row("+I", 1, "aaa"),
+                row("-D", 1, "aaa"),
+                row("+I", 2, "bbb"),
+                row("+I", 1, "bbb"),
+                row("+I", 2, "aaa")),
+            ImmutableList.of(row("-U", 2, "aaa"), row("+U", 1, "ccc"), row("+I", 1, "aaa")),
+            ImmutableList.of(row("-D", 1, "bbb"), row("+I", 2, "aaa")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "bbb"), record(2, "aaa"), record(2, "bbb")),
+            ImmutableList.of(
+                record(1, "aaa"), record(1, "bbb"), record(1, "ccc"), record(2, "bbb")),
+            ImmutableList.of(
+                record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "bbb")));
+
+    testChangeLogs(
+        ImmutableList.of("data", "id"),
+        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
+        false,
+        elementsPerCheckpoint,
+        expectedRecords,
+        branch);
+  }
+
+  protected void testChangeLogOnSameKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            // Checkpoint #1
+            ImmutableList.of(row("+I", 1, "aaa"), row("-D", 1, "aaa"), row("+I", 1, "aaa")),
+            // Checkpoint #2
+            ImmutableList.of(row("-U", 1, "aaa"), row("+U", 1, "aaa")),
+            // Checkpoint #3
+            ImmutableList.of(row("-D", 1, "aaa"), row("+I", 1, "aaa")),
+            // Checkpoint #4
+            ImmutableList.of(row("-U", 1, "aaa"), row("+U", 1, "aaa"), row("+I", 1, "aaa")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "aaa")),
+            ImmutableList.of(record(1, "aaa")),
+            ImmutableList.of(record(1, "aaa")),
+            ImmutableList.of(record(1, "aaa"), record(1, "aaa")));
+
+    testChangeLogs(
+        ImmutableList.of("id", "data"),
+        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
+        false,
+        elementsPerCheckpoint,
+        expectedRecords,
+        branch);
+  }
+
+  protected void testChangeLogOnDataKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(
+                row("+I", 1, "aaa"),
+                row("-D", 1, "aaa"),
+                row("+I", 2, "bbb"),
+                row("+I", 1, "bbb"),
+                row("+I", 2, "aaa")),
+            ImmutableList.of(row("-U", 2, "aaa"), row("+U", 1, "ccc"), row("+I", 1, "aaa")),
+            ImmutableList.of(row("-D", 1, "bbb"), row("+I", 2, "aaa"), row("+I", 2, "ccc")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "bbb"), record(2, "aaa")),
+            ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc")),
+            ImmutableList.of(
+                record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "ccc")));
+
+    testChangeLogs(
+        ImmutableList.of("data"),
+        row -> row.getField(ROW_DATA_POS),
+        false,
+        elementsPerCheckpoint,
+        expectedRecords,
+        branch);
+  }
+
+  protected void testUpsertOnDataKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(row("+I", 1, "aaa"), row("+I", 2, "aaa"), row("+I", 3, "bbb")),
+            ImmutableList.of(row("+U", 4, "aaa"), row("-U", 3, "bbb"), row("+U", 5, "bbb")),
+            ImmutableList.of(row("+I", 6, "aaa"), row("+U", 7, "bbb")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(2, "aaa"), record(3, "bbb")),
+            ImmutableList.of(record(4, "aaa"), record(5, "bbb")),
+            ImmutableList.of(record(6, "aaa"), record(7, "bbb")));
+
+    testChangeLogs(
+        ImmutableList.of("data"),
+        row -> row.getField(ROW_DATA_POS),
+        true,
+        elementsPerCheckpoint,
+        expectedRecords,
+        branch);
+  }
+
+  protected void testChangeLogOnIdKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(
+                row("+I", 1, "aaa"),
+                row("-D", 1, "aaa"),
+                row("+I", 1, "bbb"),
+                row("+I", 2, "aaa"),
+                row("-D", 2, "aaa"),
+                row("+I", 2, "bbb")),
+            ImmutableList.of(
+                row("-U", 2, "bbb"), row("+U", 2, "ccc"), row("-D", 2, "ccc"), row("+I", 2, "ddd")),
+            ImmutableList.of(
+                row("-D", 1, "bbb"),
+                row("+I", 1, "ccc"),
+                row("-D", 1, "ccc"),
+                row("+I", 1, "ddd")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "bbb"), record(2, "bbb")),
+            ImmutableList.of(record(1, "bbb"), record(2, "ddd")),
+            ImmutableList.of(record(1, "ddd"), record(2, "ddd")));
+
+    if (partitioned && writeDistributionMode.equals(TableProperties.WRITE_DISTRIBUTION_MODE_HASH)) {
+      AssertHelpers.assertThrows(
+          "Should be error because equality field columns don't include all partition keys",
+          IllegalStateException.class,
+          "should be included in equality fields",
+          () -> {
+            testChangeLogs(
+                ImmutableList.of("id"),
+                row -> row.getField(ROW_ID_POS),
+                false,
+                elementsPerCheckpoint,
+                expectedRecords,
+                branch);
+            return null;
+          });
+    } else {
+      testChangeLogs(
+          ImmutableList.of("id"),
+          row -> row.getField(ROW_ID_POS),
+          false,
+          elementsPerCheckpoint,
+          expectedRecords,
+          branch);
+    }
+  }
+
+  protected void testUpsertOnIdKey(String branch) throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(row("+I", 1, "aaa"), row("+U", 1, "bbb")),
+            ImmutableList.of(row("+I", 1, "ccc")),
+            ImmutableList.of(row("+U", 1, "ddd"), row("+I", 1, "eee")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(
+            ImmutableList.of(record(1, "bbb")),
+            ImmutableList.of(record(1, "ccc")),
+            ImmutableList.of(record(1, "eee")));
+
+    if (!partitioned) {
+      testChangeLogs(
+          ImmutableList.of("id"),
+          row -> row.getField(ROW_ID_POS),
+          true,
+          elementsPerCheckpoint,
+          expectedRecords,
+          branch);
+    } else {
+      AssertHelpers.assertThrows(
+          "Should be error because equality field columns don't include all partition keys",
+          IllegalStateException.class,
+          "should be included in equality fields",
+          () -> {
+            testChangeLogs(
+                ImmutableList.of("id"),
+                row -> row.getField(ROW_ID_POS),
+                true,
+                elementsPerCheckpoint,
+                expectedRecords,
+                branch);
+            return null;
+          });
+    }
+  }
+
+  protected void testChangeLogs(
+      List<String> equalityFieldColumns,
+      KeySelector<Row, Object> keySelector,
+      boolean insertAsUpsert,
+      List<List<Row>> elementsPerCheckpoint,
+      List<List<Record>> expectedRecordsPerCheckpoint,
+      String branch)
+      throws Exception {
+    DataStream<Row> dataStream =
+        env.addSource(new BoundedTestSource<>(elementsPerCheckpoint), ROW_TYPE_INFO);
+
+    FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+        .tableLoader(tableLoader)
+        .tableSchema(SimpleDataUtil.FLINK_SCHEMA)
+        .writeParallelism(parallelism)
+        .equalityFieldColumns(equalityFieldColumns)
+        .upsert(insertAsUpsert)
+        .toBranch(branch)
+        .append();
+
+    // Execute the program.
+    env.execute("Test Iceberg Change-Log DataStream.");
+
+    table.refresh();
+    List<Snapshot> snapshots = findValidSnapshots();
+    int expectedSnapshotNum = expectedRecordsPerCheckpoint.size();
+    Assert.assertEquals(
+        "Should have the expected snapshot number", expectedSnapshotNum, snapshots.size());
+
+    for (int i = 0; i < expectedSnapshotNum; i++) {
+      long snapshotId = snapshots.get(i).snapshotId();
+      List<Record> expectedRecords = expectedRecordsPerCheckpoint.get(i);
+      Assert.assertEquals(
+          "Should have the expected records for the checkpoint#" + i,
+          expectedRowSet(expectedRecords.toArray(new Record[0])),
+          actualRowSet(snapshotId, "*"));
+    }
+  }
+
+  protected Record record(int id, String data) {
+    return SimpleDataUtil.createRecord(id, data);
+  }
+
+  private List<Snapshot> findValidSnapshots() {
+    List<Snapshot> validSnapshots = Lists.newArrayList();
+    for (Snapshot snapshot : table.snapshots()) {
+      if (snapshot.allManifests(table.io()).stream()
+          .anyMatch(m -> snapshot.snapshotId() == m.snapshotId())) {
+        validSnapshots.add(snapshot);
+      }
+    }
+    return validSnapshots;
+  }
+
+  private StructLikeSet expectedRowSet(Record... records) {
+    return SimpleDataUtil.expectedRowSet(table, records);
+  }
+
+  private StructLikeSet actualRowSet(long snapshotId, String... columns) throws IOException {
+    table.refresh();
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    try (CloseableIterable<Record> reader =
+        IcebergGenerics.read(table).useSnapshot(snapshotId).select(columns).build()) {
+      reader.forEach(set::add);
+    }
+    return set;
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Branch.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Branch.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.flink.HadoopCatalogResource;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestFlinkIcebergSinkV2Branch extends TestFlinkIcebergSinkV2Base {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Rule
+  public final HadoopCatalogResource catalogResource =
+      new HadoopCatalogResource(TEMPORARY_FOLDER, TestFixtures.DATABASE, TestFixtures.TABLE);
+
+  private final String branch;
+
+  @Parameterized.Parameters(name = "branch = {0}")
+  public static Object[] parameters() {
+    return new Object[] {"main", "testBranch"};
+  }
+
+  public TestFlinkIcebergSinkV2Branch(String branch) {
+    this.branch = branch;
+  }
+
+  @Before
+  public void before() throws IOException {
+    table =
+        catalogResource
+            .catalog()
+            .createTable(
+                TestFixtures.TABLE_IDENTIFIER,
+                SimpleDataUtil.SCHEMA,
+                PartitionSpec.unpartitioned(),
+                ImmutableMap.of(
+                    TableProperties.DEFAULT_FILE_FORMAT,
+                    FileFormat.AVRO.name(),
+                    TableProperties.FORMAT_VERSION,
+                    "2"));
+
+    env =
+        StreamExecutionEnvironment.getExecutionEnvironment(
+                MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG)
+            .enableCheckpointing(100);
+
+    tableLoader = catalogResource.tableLoader();
+  }
+
+  @Test
+  public void testChangeLogOnIdKey() throws Exception {
+    testChangeLogOnIdKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  @Test
+  public void testChangeLogOnDataKey() throws Exception {
+    testChangeLogOnDataKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  @Test
+  public void testChangeLogOnIdDataKey() throws Exception {
+    testChangeLogOnIdDataKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  @Test
+  public void testUpsertOnIdKey() throws Exception {
+    testUpsertOnIdKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  @Test
+  public void testUpsertOnDataKey() throws Exception {
+    testUpsertOnDataKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  @Test
+  public void testUpsertOnIdDataKey() throws Exception {
+    testUpsertOnIdDataKey(branch);
+    verifyOtherBranchUnmodified();
+  }
+
+  private void verifyOtherBranchUnmodified() {
+    String otherBranch =
+        branch.equals(SnapshotRef.MAIN_BRANCH) ? "test-branch" : SnapshotRef.MAIN_BRANCH;
+    if (otherBranch.equals(SnapshotRef.MAIN_BRANCH)) {
+      Assert.assertNull(table.currentSnapshot());
+    }
+
+    Assert.assertTrue(table.snapshot(otherBranch) == null);
+  }
+}


### PR DESCRIPTION
This change adds support to write to branches in Flink Sink via a FlinkWriteOption "branch"