### PR TITLE
Core: Support delete file stats in partitions metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -168,10 +168,21 @@ public class PartitionsTable extends BaseMetadataTable {
                 CloseableIterable.transform(
                     ManifestFiles.open(manifest, table.io(), table.specs())
                         .caseSensitive(scan.isCaseSensitive())
-                        .select(BaseScan.DELETE_SCAN_COLUMNS), // don't select stats columns
+                        .select(scanColumns(manifest.content())), // don't select stats columns
                     t -> (ContentFile<?>) t));
 
     return new ParallelIterable<>(tasks, scan.planExecutor());
+  }
+
+  private static List<String> scanColumns(ManifestContent content) {
+    switch (content) {
+      case DATA:
+        return BaseScan.SCAN_COLUMNS;
+      case DELETES:
+        return BaseScan.DELETE_SCAN_COLUMNS;
+      default:
+        throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
+    }
   }
 
   private static CloseableIterable<ManifestFile> filteredManifests(

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -20,6 +20,9 @@ package org.apache.iceberg;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -47,7 +50,27 @@ public class PartitionsTable extends BaseMetadataTable {
             Types.NestedField.required(
                 2, "record_count", Types.LongType.get(), "Count of records in data files"),
             Types.NestedField.required(
-                3, "file_count", Types.IntegerType.get(), "Count of data files"));
+                3, "file_count", Types.IntegerType.get(), "Count of data files"),
+            Types.NestedField.required(
+                5,
+                "position_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in position delete files"),
+            Types.NestedField.required(
+                6,
+                "position_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of position delete files"),
+            Types.NestedField.required(
+                7,
+                "equality_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in equality delete files"),
+            Types.NestedField.required(
+                8,
+                "equality_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of equality delete files"));
   }
 
   @Override
@@ -58,7 +81,13 @@ public class PartitionsTable extends BaseMetadataTable {
   @Override
   public Schema schema() {
     if (table().spec().fields().size() < 1) {
-      return schema.select("record_count", "file_count");
+      return schema.select(
+          "record_count",
+          "file_count",
+          "position_delete_record_count",
+          "position_delete_file_count",
+          "equality_delete_record_count",
+          "equality_delete_file_count");
     }
     return schema;
   }
@@ -77,7 +106,14 @@ public class PartitionsTable extends BaseMetadataTable {
           schema(),
           scan.schema(),
           partitions,
-          root -> StaticDataTask.Row.of(root.dataRecordCount, root.dataFileCount));
+          root ->
+              StaticDataTask.Row.of(
+                  root.dataRecordCount,
+                  root.dataFileCount,
+                  root.posDeleteRecordCount,
+                  root.posDeleteFileCount,
+                  root.eqDeleteRecordCount,
+                  root.eqDeleteFileCount));
     } else {
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),
@@ -93,31 +129,55 @@ public class PartitionsTable extends BaseMetadataTable {
         partition.partitionData,
         partition.specId,
         partition.dataRecordCount,
-        partition.dataFileCount);
+        partition.dataFileCount,
+        partition.posDeleteRecordCount,
+        partition.posDeleteFileCount,
+        partition.eqDeleteRecordCount,
+        partition.eqDeleteFileCount);
   }
 
   private static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
     Types.StructType partitionType = Partitioning.partitionType(table);
     PartitionMap partitions = new PartitionMap(partitionType);
 
-    CloseableIterable<DataFile> datafiles = planDataFiles(scan);
-    for (DataFile dataFile : datafiles) {
-      StructLike partition =
-          PartitionUtil.coercePartition(
-              partitionType, table.specs().get(dataFile.specId()), dataFile.partition());
-      partitions.get(partition).update(dataFile);
+    try (CloseableIterable<ContentFile<?>> files = planFiles(scan)) {
+      for (ContentFile<?> file : files) {
+        StructLike partition =
+            PartitionUtil.coercePartition(
+                partitionType, table.specs().get(file.specId()), file.partition());
+        partitions.get(partition).update(file);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
 
     return partitions.all();
   }
 
   @VisibleForTesting
-  static CloseableIterable<DataFile> planDataFiles(StaticTableScan scan) {
+  static CloseableIterable<ContentFile<?>> planFiles(StaticTableScan scan) {
     Table table = scan.table();
-    Snapshot snapshot = scan.snapshot();
 
-    CloseableIterable<ManifestFile> dataManifests =
-        CloseableIterable.withNoopClose(snapshot.dataManifests(table.io()));
+    CloseableIterable<ManifestFile> filteredManifests =
+        filteredManifests(scan, table, scan.snapshot().allManifests(table.io()));
+
+    Iterable<CloseableIterable<ContentFile<?>>> tasks =
+        CloseableIterable.transform(
+            filteredManifests,
+            manifest ->
+                CloseableIterable.transform(
+                    ManifestFiles.open(manifest, table.io(), table.specs())
+                        .caseSensitive(scan.isCaseSensitive())
+                        .select(BaseScan.DELETE_SCAN_COLUMNS), // don't select stats columns
+                    t -> (ContentFile<?>) t));
+
+    return new ParallelIterable<>(tasks, scan.planExecutor());
+  }
+
+  private static CloseableIterable<ManifestFile> filteredManifests(
+      StaticTableScan scan, Table table, List<ManifestFile> manifestFilesList) {
+    CloseableIterable<ManifestFile> manifestFiles =
+        CloseableIterable.withNoopClose(manifestFilesList);
 
     LoadingCache<Integer, ManifestEvaluator> evalCache =
         Caffeine.newBuilder()
@@ -129,19 +189,8 @@ public class PartitionsTable extends BaseMetadataTable {
                       scan.filter(), transformedSpec, scan.isCaseSensitive());
                 });
 
-    CloseableIterable<ManifestFile> filteredManifests =
-        CloseableIterable.filter(
-            dataManifests, manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
-
-    Iterable<CloseableIterable<DataFile>> tasks =
-        CloseableIterable.transform(
-            filteredManifests,
-            manifest ->
-                ManifestFiles.read(manifest, table.io(), table.specs())
-                    .caseSensitive(scan.isCaseSensitive())
-                    .select(BaseScan.SCAN_COLUMNS)); // don't select stats columns
-
-    return new ParallelIterable<>(tasks, scan.planExecutor());
+    return CloseableIterable.filter(
+        manifestFiles, manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
   }
 
   private class PartitionsScan extends StaticTableScan {
@@ -182,18 +231,43 @@ public class PartitionsTable extends BaseMetadataTable {
     private int specId;
     private long dataRecordCount;
     private int dataFileCount;
+    private long posDeleteRecordCount;
+    private int posDeleteFileCount;
+    private long eqDeleteRecordCount;
+    private int eqDeleteFileCount;
 
     Partition(StructLike key, Types.StructType keyType) {
       this.partitionData = toPartitionData(key, keyType);
       this.specId = 0;
       this.dataRecordCount = 0;
       this.dataFileCount = 0;
+      this.posDeleteRecordCount = 0;
+      this.posDeleteFileCount = 0;
+      this.eqDeleteRecordCount = 0;
+      this.eqDeleteFileCount = 0;
     }
 
-    void update(DataFile file) {
-      this.dataRecordCount += file.recordCount();
-      this.dataFileCount += 1;
-      this.specId = file.specId();
+    void update(ContentFile<?> file) {
+      switch (file.content()) {
+        case DATA:
+          this.dataRecordCount += file.recordCount();
+          this.dataFileCount += 1;
+          this.specId = file.specId();
+          break;
+        case POSITION_DELETES:
+          this.posDeleteRecordCount = file.recordCount();
+          this.posDeleteFileCount += 1;
+          this.specId = file.specId();
+          break;
+        case EQUALITY_DELETES:
+          this.eqDeleteRecordCount = file.recordCount();
+          this.eqDeleteFileCount += 1;
+          this.specId = file.specId();
+          break;
+        default:
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
+      }
     }
 
     /** Needed because StructProjection is not serializable */

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -81,18 +81,18 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
   }
 
   protected void validateSingleFieldPartition(
-      CloseableIterable<DataFile> dataFiles, int partitionValue) {
-    validatePartition(dataFiles, 0, partitionValue);
+      CloseableIterable<ContentFile<?>> files, int partitionValue) {
+    validatePartition(files, 0, partitionValue);
   }
 
   protected void validatePartition(
-      CloseableIterable<DataFile> dataFiles, int position, int partitionValue) {
+      CloseableIterable<ContentFile<?>> files, int position, int partitionValue) {
     Assert.assertTrue(
         "File scan tasks do not include correct file",
-        StreamSupport.stream(dataFiles.spliterator(), false)
+        StreamSupport.stream(files.spliterator(), false)
             .anyMatch(
-                dataFile -> {
-                  StructLike partition = dataFile.partition();
+                file -> {
+                  StructLike partition = file.partition();
                   if (position >= partition.size()) {
                     return false;
                   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -317,13 +317,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
 
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
-    validateSingleFieldPartition(dataFiles, 1);
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanNoFilter);
+    if (formatVersion == 2) {
+      Assert.assertEquals(8, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(files, 1);
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -337,13 +342,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanWithProjection);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
-    validateSingleFieldPartition(dataFiles, 1);
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanWithProjection);
+    if (formatVersion == 2) {
+      Assert.assertEquals(8, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(files, 1);
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -351,14 +361,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 
     Table partitionsTable = new PartitionsTable(table);
-    CloseableIterable<DataFile> tasksAndEq =
-        PartitionsTable.planDataFiles((StaticTableScan) partitionsTable.newScan());
-    for (DataFile dataFile : tasksAndEq) {
-      Assert.assertNull(dataFile.columnSizes());
-      Assert.assertNull(dataFile.valueCounts());
-      Assert.assertNull(dataFile.nullValueCounts());
-      Assert.assertNull(dataFile.lowerBounds());
-      Assert.assertNull(dataFile.upperBounds());
+    CloseableIterable<ContentFile<?>> tasksAndEq =
+        PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan());
+    for (ContentFile<?> file : tasksAndEq) {
+      Assert.assertNull(file.columnSizes());
+      Assert.assertNull(file.valueCounts());
+      Assert.assertNull(file.nullValueCounts());
+      Assert.assertNull(file.lowerBounds());
+      Assert.assertNull(file.upperBounds());
     }
   }
 
@@ -373,10 +383,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanAndEq);
+    if (formatVersion == 2) {
+      Assert.assertEquals(2, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(1, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
   }
 
   @Test
@@ -390,11 +405,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.lessThan("partition.data_bucket", 2),
             Expressions.greaterThan("record_count", 0));
     TableScan scanLtAnd = partitionsTable.newScan().filter(ltAnd);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanLtAnd);
-    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
-    validateSingleFieldPartition(dataFiles, 1);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanLtAnd);
+    if (formatVersion == 2) {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(2, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(files, 1);
   }
 
   @Test
@@ -409,12 +429,17 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanOr = partitionsTable.newScan().filter(or);
 
-    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scanOr);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
-    validateSingleFieldPartition(dataFiles, 1);
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanOr);
+    if (formatVersion == 2) {
+      Assert.assertEquals(8, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(files, 1);
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -424,11 +449,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanNot);
-    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanNot);
+    if (formatVersion == 2) {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(2, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -439,11 +468,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanSet);
-    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanSet);
+    if (formatVersion == 2) {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(2, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -454,13 +487,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanUnary);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
-    validateSingleFieldPartition(dataFiles, 1);
-    validateSingleFieldPartition(dataFiles, 2);
-    validateSingleFieldPartition(dataFiles, 3);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanUnary);
+    if (formatVersion == 2) {
+      Assert.assertEquals(8, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    }
+
+    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(files, 1);
+    validateSingleFieldPartition(files, 2);
+    validateSingleFieldPartition(files, 3);
   }
 
   @Test
@@ -663,18 +701,30 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
-    // Four data files of old spec, one new data file of new spec
-    Assert.assertEquals(5, Iterables.size(dataFiles));
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
+    if (formatVersion == 2) {
+      // Four data files and delete files of old spec, one new data file of new spec
+      Assert.assertEquals(9, Iterables.size(files));
+    } else {
+      // Four data files of old spec, one new data file of new spec
+      Assert.assertEquals(5, Iterables.size(files));
+    }
+
     filter =
         Expressions.and(
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
+    files = PartitionsTable.planFiles((StaticTableScan) scan);
 
-    // 1 original data file written by old spec, plus 1 new data file written by new spec
-    Assert.assertEquals(2, Iterables.size(dataFiles));
+    if (formatVersion == 2) {
+      // 1 original data file and delete file written by old spec, plus 1 new data file written by
+      // new spec
+      Assert.assertEquals(3, Iterables.size(files));
+    } else {
+      // 1 original data file written by old spec, plus 1 new data file written by new spec
+      Assert.assertEquals(2, Iterables.size(files));
+    }
   }
 
   @Test
@@ -715,10 +765,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
 
-    // Four original files of original spec, one data file written by new spec
-    Assert.assertEquals(5, Iterables.size(dataFiles));
+    if (formatVersion == 2) {
+      // Four data and delete files of original spec, one data file written by new spec
+      Assert.assertEquals(9, Iterables.size(files));
+    } else {
+      // Four data files of original spec, one data file written by new spec
+      Assert.assertEquals(5, Iterables.size(files));
+    }
 
     // Filter for a dropped partition spec field.  Correct behavior is that only old partitions are
     // returned.
@@ -727,14 +782,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
+    files = PartitionsTable.planFiles((StaticTableScan) scan);
 
     if (formatVersion == 1) {
       // 1 original data file written by old spec
-      Assert.assertEquals(1, Iterables.size(dataFiles));
+      Assert.assertEquals(1, Iterables.size(files));
     } else {
-      // 1 original data/delete files written by old spec, plus both of new data file/delete file
-      // written by new spec
+      // 1 original data and 1 delete files written by old spec, plus both of new data file/delete
+      // file written by new spec
       //
       // Unlike in V1, V2 does not write (data=null) on newer files' partition data, so these cannot
       // be filtered out
@@ -746,7 +801,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
       // schema.
       // The Partition table final schema is a union of fields of all specs, including dropped
       // fields.
-      Assert.assertEquals(3, Iterables.size(dataFiles));
+      Assert.assertEquals(4, Iterables.size(files));
     }
   }
 
@@ -797,10 +852,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.partition", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validateSingleFieldPartition(dataFiles, 0);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanAndEq);
+    Assert.assertEquals(1, Iterators.size(files.iterator()));
+    validateSingleFieldPartition(files, 0);
   }
 
   @Test
@@ -868,8 +923,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
+    if (formatVersion == 2) {
+      Assert.assertEquals(8, Iterators.size(files.iterator()));
+    } else {
+      Assert.assertEquals(4, Iterators.size(files.iterator()));
+    }
+
     Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -152,15 +152,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
-    CloseableIterable<DataFile> dataFiles =
-        PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
-    validatePartition(dataFiles, 1, 2);
-    validatePartition(dataFiles, 1, 3);
+    CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanNoFilter);
+    Assert.assertEquals(4, Iterators.size(files.iterator()));
+    validatePartition(files, 0, 0);
+    validatePartition(files, 0, 1);
+    validatePartition(files, 0, 2);
+    validatePartition(files, 0, 3);
+    validatePartition(files, 1, 2);
+    validatePartition(files, 1, 3);
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1233,7 +1233,27 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Types.StructType expectedSchema =
         Types.StructType.of(
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
+            required(
+                5,
+                "position_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in position delete files"),
+            required(
+                6,
+                "position_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of position delete files"),
+            required(
+                7,
+                "equality_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in equality delete files"),
+            required(
+                8,
+                "equality_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of equality delete files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1244,7 +1264,15 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     GenericRecordBuilder builder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
-    GenericData.Record expectedRow = builder.set("record_count", 1L).set("file_count", 1).build();
+    GenericData.Record expectedRow =
+        builder
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .build();
 
     List<Row> actual =
         spark
@@ -1303,6 +1331,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 1).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
     expected.add(
@@ -1310,6 +1342,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 2).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -36,6 +36,7 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -47,6 +48,9 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1015,16 +1019,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1187,16 +1182,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1252,7 +1238,27 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Types.StructType expectedSchema =
         Types.StructType.of(
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
+            required(
+                5,
+                "position_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in position delete files"),
+            required(
+                6,
+                "position_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of position delete files"),
+            required(
+                7,
+                "equality_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in equality delete files"),
+            required(
+                8,
+                "equality_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of equality delete files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1263,7 +1269,15 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     GenericRecordBuilder builder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
-    GenericData.Record expectedRow = builder.set("record_count", 1L).set("file_count", 1).build();
+    GenericData.Record expectedRow =
+        builder
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .build();
 
     List<Row> actual =
         spark
@@ -1322,6 +1336,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 1).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
     expected.add(
@@ -1329,6 +1347,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 2).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
 
@@ -1373,6 +1395,109 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
     Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableDeleteStats() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "b")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    // test position deletes
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
+    DeleteFile deleteFile = writePosDeleteFile(table);
+    table.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 1L) // should be incremented now
+            .set("position_delete_file_count", 1) // should be incremented now
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // test equality delete
+    DeleteFile eqDeleteFile = writeEqDeleteFile(table);
+    table.newRowDelta().addDeletes(eqDeleteFile).commit();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    expected.remove(0);
+    expected.add(
+        0,
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 1L) // should be incremented now
+            .set("equality_delete_file_count", 1) // should be incremented now
+            .set("spec_id", 0)
+            .build());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1836,5 +1961,34 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
 
     return positionDeleteWriter.toDeleteFile();
+  }
+
+  private DeleteFile writePosDeleteFile(Table table) {
+    DataFile dataFile =
+        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
+    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
+    StructLike dataFilePartition = dataFile.partition();
+
+    PositionDelete<InternalRow> delete = PositionDelete.create();
+    delete.set(dataFile.path(), 0L, null);
+
+    return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+  }
+
+  private DeleteFile writeEqDeleteFile(Table table) {
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("id");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("id", 1));
+    try {
+      return FileHelpers.writeDeleteFile(
+          table,
+          Files.localOutput(temp.newFile()),
+          org.apache.iceberg.TestHelpers.Row.of(1),
+          deletes,
+          deleteRowSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -39,6 +39,7 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -50,6 +51,9 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1020,16 +1024,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1192,16 +1187,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1257,7 +1243,27 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Types.StructType expectedSchema =
         Types.StructType.of(
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
+            required(
+                5,
+                "position_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in position delete files"),
+            required(
+                6,
+                "position_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of position delete files"),
+            required(
+                7,
+                "equality_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in equality delete files"),
+            required(
+                8,
+                "equality_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of equality delete files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1268,7 +1274,15 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     GenericRecordBuilder builder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
-    GenericData.Record expectedRow = builder.set("record_count", 1L).set("file_count", 1).build();
+    GenericData.Record expectedRow =
+        builder
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .build();
 
     List<Row> actual =
         spark
@@ -1327,6 +1341,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 1).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
     expected.add(
@@ -1334,6 +1352,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 2).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
 
@@ -1378,6 +1400,109 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
     Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableDeleteStats() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "b")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    // test position deletes
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
+    DeleteFile deleteFile = writePosDeleteFile(table);
+    table.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 1L) // should be incremented now
+            .set("position_delete_file_count", 1) // should be incremented now
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // test equality delete
+    DeleteFile eqDeleteFile = writeEqDeleteFile(table);
+    table.newRowDelta().addDeletes(eqDeleteFile).commit();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    expected.remove(0);
+    expected.add(
+        0,
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 1L) // should be incremented now
+            .set("equality_delete_file_count", 1) // should be incremented now
+            .set("spec_id", 0)
+            .build());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1904,5 +2029,34 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
 
     return positionDeleteWriter.toDeleteFile();
+  }
+
+  private DeleteFile writePosDeleteFile(Table table) {
+    DataFile dataFile =
+        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
+    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
+    StructLike dataFilePartition = dataFile.partition();
+
+    PositionDelete<InternalRow> delete = PositionDelete.create();
+    delete.set(dataFile.path(), 0L, null);
+
+    return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+  }
+
+  private DeleteFile writeEqDeleteFile(Table table) {
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("id");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("id", 1));
+    try {
+      return FileHelpers.writeDeleteFile(
+          table,
+          Files.localOutput(temp.newFile()),
+          org.apache.iceberg.TestHelpers.Row.of(1),
+          deletes,
+          deleteRowSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -38,6 +38,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -49,6 +50,9 @@ import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
@@ -1019,16 +1023,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1190,16 +1185,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
 
-    DataFile dataFile =
-        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
-    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
-    StructLike dataFilePartition = dataFile.partition();
-
-    PositionDelete<InternalRow> delete = PositionDelete.create();
-    delete.set(dataFile.path(), 0L, null);
-
-    DeleteFile deleteFile =
-        writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+    DeleteFile deleteFile = writePosDeleteFile(table);
 
     table.newRowDelta().addDeletes(deleteFile).commit();
 
@@ -1255,7 +1241,27 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Types.StructType expectedSchema =
         Types.StructType.of(
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
+            required(
+                5,
+                "position_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in position delete files"),
+            required(
+                6,
+                "position_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of position delete files"),
+            required(
+                7,
+                "equality_delete_record_count",
+                Types.LongType.get(),
+                "Count of records in equality delete files"),
+            required(
+                8,
+                "equality_delete_file_count",
+                Types.IntegerType.get(),
+                "Count of equality delete files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1266,7 +1272,15 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     GenericRecordBuilder builder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
-    GenericData.Record expectedRow = builder.set("record_count", 1L).set("file_count", 1).build();
+    GenericData.Record expectedRow =
+        builder
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .build();
 
     List<Row> actual =
         spark
@@ -1325,6 +1339,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 1).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
     expected.add(
@@ -1332,6 +1350,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("partition", partitionBuilder.set("id", 2).build())
             .set("record_count", 1L)
             .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
             .build());
 
@@ -1376,6 +1398,109 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
     Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableDeleteStats() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "b")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    // test position deletes
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
+    DeleteFile deleteFile = writePosDeleteFile(table);
+    table.newRowDelta().addDeletes(deleteFile).commit();
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 1L) // should be incremented now
+            .set("position_delete_file_count", 1) // should be incremented now
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .build());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // test equality delete
+    DeleteFile eqDeleteFile = writeEqDeleteFile(table);
+    table.newRowDelta().addDeletes(eqDeleteFile).commit();
+    actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    expected.remove(0);
+    expected.add(
+        0,
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 1L) // should be incremented now
+            .set("equality_delete_file_count", 1) // should be incremented now
+            .set("spec_id", 0)
+            .build());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1902,5 +2027,34 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
 
     return positionDeleteWriter.toDeleteFile();
+  }
+
+  private DeleteFile writePosDeleteFile(Table table) {
+    DataFile dataFile =
+        Iterables.getFirst(table.currentSnapshot().addedDataFiles(table.io()), null);
+    PartitionSpec dataFileSpec = table.specs().get(dataFile.specId());
+    StructLike dataFilePartition = dataFile.partition();
+
+    PositionDelete<InternalRow> delete = PositionDelete.create();
+    delete.set(dataFile.path(), 0L, null);
+
+    return writePositionDeletes(table, dataFileSpec, dataFilePartition, ImmutableList.of(delete));
+  }
+
+  private DeleteFile writeEqDeleteFile(Table table) {
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("id");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("id", 1));
+    try {
+      return FileHelpers.writeDeleteFile(
+          table,
+          Files.localOutput(temp.newFile()),
+          org.apache.iceberg.TestHelpers.Row.of(1),
+          deletes,
+          deleteRowSchema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
Currently [partitions metadata table](https://iceberg.apache.org/docs/latest/spark-queries/#partitions) only has the data file stats 
```
file_count
record_count
```

When the delete files are present, these stats are inaccurate (as we don't decrement these values). 
So, capture the delete file stats to give a rough idea about why these stats are inaccurate.
**Note that we are not applying the deletes to the data file and computing the effective result as it will be a very expensive operation. Users are suggested to execute rewrite_data_files periodically to apply the delete files to the data files.**

Delete file stats to be added:

```
pos_delete_file_count
pos_delete_record_count
eq_delete_file_count
eq_delete_record_count
```

Note:
- Docs will be updated in a follow-up PR, probably after renaming file_count, and record_count.
- The same schema will also be used for the partition stats feature during implementation.

Fixes #6042 