### PR TITLE
Fix OpenAPI types `CreateNamespaceRequest` + `GetNamespaceResponse`

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -937,9 +937,9 @@ components:
         updates:
           uniqueItems: true
           type: object
-          items:
-            type: string
           example: { "owner": "Hank Bendickson" }
+          additionalProperties:
+            type: string
 
     RenameTableRequest:
       type: object
@@ -2157,12 +2157,12 @@ components:
                 $ref: '#/components/schemas/Namespace'
               properties:
                 type: object
-                additionalProperties:
-                  type: string
                 description:
                   Properties stored on the namespace, if supported by the server.
                   If the server does not support namespace properties, it should return null for this field.
                   If namespace properties are supported, but none are set, it should return an empty object.
+                additionalProperties:
+                  type: string
                 example: { "owner": "Ralph", 'transient_lastDdlTime': '1452120468' }
                 default: { }
                 nullable: true

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -922,6 +922,8 @@ components:
           description: Configured string to string map of properties for the namespace
           example: { "owner": "Hank Bendickson" }
           default: { }
+          additionalProperties:
+            type: string
 
     UpdateNamespacePropertiesRequest:
       type: object
@@ -2155,6 +2157,8 @@ components:
                 $ref: '#/components/schemas/Namespace'
               properties:
                 type: object
+                additionalProperties:
+                  type: string
                 description:
                   Properties stored on the namespace, if supported by the server.
                   If the server does not support namespace properties, it should return null for this field.


### PR DESCRIPTION
Both types define some map of string to string as their `properties` property. The current spec would generate Java code like `private @Valid Object properties = { };` for these fields (using the common OpenAPI Generators), which leads to compile errors. I suspect, both are missing this:
```
          additionalProperties:
            type: string
```