### PR TITLE
Core: Fix API breakages around scanMetrics()

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -321,38 +321,6 @@ acceptedBreaks:
         \ java.lang.Object, java.lang.Object>)"
       justification: "Removing deprecations for 1.2.0"
     - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.AllDataFilesTable.AllDataFilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.AllDeleteFilesTable.AllDeleteFilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.AllFilesTable.AllFilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.AllManifestsTable.AllManifestsTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.DataFilesTable.DataFilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.DataTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.DeleteFilesTable.DeleteFilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
-      old: "method org.apache.iceberg.metrics.ScanMetrics org.apache.iceberg.BaseTableScan::scanMetrics()\
-        \ @ org.apache.iceberg.FilesTable.FilesTableScan"
-      justification: "Method is still there but moved to parent class"
-    - code: "java.method.removed"
       old: "method void org.apache.iceberg.BaseReplacePartitions::validate(org.apache.iceberg.TableMetadata)"
       justification: "Removing deprecations for 1.2.0"
     - code: "java.method.removed"

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.metrics.ScanMetrics;
 import org.apache.iceberg.metrics.ScanMetricsResult;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.metrics.Timer;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -67,8 +66,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
 
   protected abstract CloseableIterable<T> doPlanFiles();
 
-  @VisibleForTesting
-  ScanMetrics scanMetrics() {
+  protected ScanMetrics scanMetrics() {
     if (scanMetrics == null) {
       this.scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
     }


### PR DESCRIPTION
#6365 moved `scanMetrics()` from `BaseTableScan` higher in the hierarchy to `SnapshotScan` and required RevAPI changes due to making method package-private instead of `protected` (meaning that classes in different packages wouldn't have access to that method anymore). This PR makes sure that we don't need the RevAPI changes and changes visibility back to `protected`.

/cc @szehon-ho @rdblue 