### PR TITLE
Spec: Fix OpenAPI types for CatalogConfig (ConfigResponse)

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -903,10 +903,14 @@ components:
       properties:
         overrides:
           type: object
+          additionalProperties:
+            type: string
           description:
             Properties that should be used to override client configuration; applied after defaults and client configuration.
         defaults:
           type: object
+          additionalProperties:
+            type: string
           description:
             Properties that should be used as default configuration; applied before client configuration.
 


### PR DESCRIPTION
This is a follow-up to https://github.com/apache/iceberg/pull/6663. 
According to https://github.com/apache/iceberg/blob/c07f2aabc0a1d02f068ecf1514d2479c0fbdd3b0/core/src/main/java/org/apache/iceberg/rest/responses/ConfigResponse.java#L46-L47 those need to be `Map<String, String>`