### PR TITLE
Update REST Spec to include warehouse param

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -70,8 +70,8 @@ paths:
       summary: List all catalog configuration settings
       operationId: getConfig
       parameters:
-        - in: query
-          name: warehouse
+        - name: warehouse
+          in: query
           required: false
           schema:
             type: string

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -69,6 +69,13 @@ paths:
         - Configuration API
       summary: List all catalog configuration settings
       operationId: getConfig
+      parameters:
+        - in: query
+          name: warehouse
+          required: false
+          schema:
+            type: string
+          description: Warehouse location or identifier to request from the service
       description:
         "
         All REST clients should first call this route to get catalog configuration


### PR DESCRIPTION
The warehouse parameter was added to the REST config route, but was not documented in the spec.  This PR adds the relevant definitions.