### PR TITLE
add max_concurrent_adds argument to add_files procedure

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -195,7 +195,6 @@ public class TableMigrationUtil {
     return MoreExecutors.getExitingExecutorService(
         (ThreadPoolExecutor)
             Executors.newFixedThreadPool(
-                nThreads,
-                new ThreadFactoryBuilder().setNameFormat("table-migration-%d").build()));
+                nThreads, new ThreadFactoryBuilder().setNameFormat("table-migration-%d").build()));
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -191,11 +191,11 @@ public class TableMigrationUtil {
         .build();
   }
 
-  private static ExecutorService migrationService(int concurrentDeletes) {
+  private static ExecutorService migrationService(int nThreads) {
     return MoreExecutors.getExitingExecutorService(
         (ThreadPoolExecutor)
             Executors.newFixedThreadPool(
-                concurrentDeletes,
+                nThreads,
                 new ThreadFactoryBuilder().setNameFormat("table-migration-%d").build()));
   }
 }

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -462,11 +462,12 @@ will then treat these files as if they are part of the set of files  owned by Ic
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Table which will have files added to|
-| `source_table`| ✔️  | string | Table where files should come from, paths are also possible in the form of \`file_format\`.\`path\` |
-| `partition_filter`  | ️   | map<string, string> | A map of partitions in the source table to import from |
+| Argument Name            | Required? | Type                | Description                                                                                         |
+|--------------------------|-----------|---------------------|-----------------------------------------------------------------------------------------------------|
+| `table`                  | ✔️  | string              | Table which will have files added to                                                                |
+| `source_table`           | ✔️  | string              | Table where files should come from, paths are also possible in the form of \`file_format\`.\`path\` |
+| `partition_filter`       | ️   | map<string, string> | A map of partitions in the source table to import from                                              |
+| `max_concurrent_adds`    |    | int                 | Size of the thread pool used for add file actions (by default, no thread pool is used)              |
 
 Warning : Schema is not validated, adding files with different schema to the Iceberg table will cause issues.
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -100,6 +100,64 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
+  @Test
+  public void addDataUnpartitionedConcurrently() {
+    createUnpartitionedFileTable("parquet");
+
+    String createIceberg =
+            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+
+    sql(createIceberg, tableName);
+
+    Object result =
+            scalarSql(
+                    "CALL %s.system.add_files("
+                            + "table => '%s', "
+                            + "source_table => '`parquet`.`%s`',"
+                            + "max_concurrent_adds => 5)",
+                    catalogName, tableName, fileTableDir.getAbsolutePath());
+
+    Assert.assertEquals(2L, result);
+
+    assertEquals(
+            "Iceberg table contains correct data after concurrent unpartitioned data add",
+            sql("SELECT * FROM %s ORDER BY id", sourceTableName),
+            sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testConcurrentAddDataWithInvalidInput() {
+
+    String createIceberg =
+            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+
+    sql(createIceberg, tableName);
+
+    AssertHelpers.assertThrows(
+            "Should throw an error when max_concurrent_adds=0",
+            IllegalArgumentException.class,
+            "max_concurrent_adds should have value > 0, value:",
+            () ->
+                    scalarSql(
+                            "CALL %s.system.add_files("
+                                    + "table => '%s', "
+                                    + "source_table => '`parquet`.`%s`',"
+                                    + "max_concurrent_adds => 0)",
+                            catalogName, tableName, fileTableDir.getAbsolutePath()));
+
+    AssertHelpers.assertThrows(
+            "Should throw an error when max_concurrent_adds less than 0",
+            IllegalArgumentException.class,
+            "max_concurrent_adds should have value > 0, value:",
+            () ->
+                    scalarSql(
+                            "CALL %s.system.add_files("
+                                    + "table => '%s', "
+                                    + "source_table => '`parquet`.`%s`',"
+                                    + "max_concurrent_adds => -1)",
+                            catalogName, tableName, fileTableDir.getAbsolutePath()));
+  }
+
   @Ignore // TODO Classpath issues prevent us from actually writing to a Spark ORC table
   public void addDataUnpartitionedOrc() {
     createUnpartitionedFileTable("orc");
@@ -305,6 +363,31 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         "Iceberg table contains correct data",
         sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", sourceTableName),
         sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void addDataPartitionedConcurrently() {
+    createPartitionedFileTable("parquet");
+
+    String createIceberg =
+            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+
+    sql(createIceberg, tableName);
+
+    Object result =
+            scalarSql(
+                    "CALL %s.system.add_files("
+                            + "table => '%s', "
+                            + "source_table => '`parquet`.`%s`',"
+                            + "max_concurrent_adds => 5)",
+                    catalogName, tableName, fileTableDir.getAbsolutePath());
+
+    Assert.assertEquals(8L, result);
+
+    assertEquals(
+            "Iceberg table contains correct data after concurrent partitioned data was added",
+            sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", sourceTableName),
+            sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
   }
 
   @Ignore // TODO Classpath issues prevent us from actually writing to a Spark ORC table

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -105,57 +105,57 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     createUnpartitionedFileTable("parquet");
 
     String createIceberg =
-            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
 
     sql(createIceberg, tableName);
 
     Object result =
-            scalarSql(
-                    "CALL %s.system.add_files("
-                            + "table => '%s', "
-                            + "source_table => '`parquet`.`%s`',"
-                            + "max_concurrent_adds => 5)",
-                    catalogName, tableName, fileTableDir.getAbsolutePath());
+        scalarSql(
+            "CALL %s.system.add_files("
+                + "table => '%s', "
+                + "source_table => '`parquet`.`%s`',"
+                + "max_concurrent_adds => 5)",
+            catalogName, tableName, fileTableDir.getAbsolutePath());
 
     Assert.assertEquals(2L, result);
 
     assertEquals(
-            "Iceberg table contains correct data after concurrent unpartitioned data add",
-            sql("SELECT * FROM %s ORDER BY id", sourceTableName),
-            sql("SELECT * FROM %s ORDER BY id", tableName));
+        "Iceberg table contains correct data after concurrent unpartitioned data add",
+        sql("SELECT * FROM %s ORDER BY id", sourceTableName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
   @Test
   public void testConcurrentAddDataWithInvalidInput() {
 
     String createIceberg =
-            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
 
     sql(createIceberg, tableName);
 
     AssertHelpers.assertThrows(
-            "Should throw an error when max_concurrent_adds=0",
-            IllegalArgumentException.class,
-            "max_concurrent_adds should have value > 0, value:",
-            () ->
-                    scalarSql(
-                            "CALL %s.system.add_files("
-                                    + "table => '%s', "
-                                    + "source_table => '`parquet`.`%s`',"
-                                    + "max_concurrent_adds => 0)",
-                            catalogName, tableName, fileTableDir.getAbsolutePath()));
+        "Should throw an error when max_concurrent_adds=0",
+        IllegalArgumentException.class,
+        "max_concurrent_adds should have value > 0, value:",
+        () ->
+            scalarSql(
+                "CALL %s.system.add_files("
+                    + "table => '%s', "
+                    + "source_table => '`parquet`.`%s`',"
+                    + "max_concurrent_adds => 0)",
+                catalogName, tableName, fileTableDir.getAbsolutePath()));
 
     AssertHelpers.assertThrows(
-            "Should throw an error when max_concurrent_adds less than 0",
-            IllegalArgumentException.class,
-            "max_concurrent_adds should have value > 0, value:",
-            () ->
-                    scalarSql(
-                            "CALL %s.system.add_files("
-                                    + "table => '%s', "
-                                    + "source_table => '`parquet`.`%s`',"
-                                    + "max_concurrent_adds => -1)",
-                            catalogName, tableName, fileTableDir.getAbsolutePath()));
+        "Should throw an error when max_concurrent_adds less than 0",
+        IllegalArgumentException.class,
+        "max_concurrent_adds should have value > 0, value:",
+        () ->
+            scalarSql(
+                "CALL %s.system.add_files("
+                    + "table => '%s', "
+                    + "source_table => '`parquet`.`%s`',"
+                    + "max_concurrent_adds => -1)",
+                catalogName, tableName, fileTableDir.getAbsolutePath()));
   }
 
   @Ignore // TODO Classpath issues prevent us from actually writing to a Spark ORC table
@@ -370,24 +370,24 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     createPartitionedFileTable("parquet");
 
     String createIceberg =
-            "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
 
     sql(createIceberg, tableName);
 
     Object result =
-            scalarSql(
-                    "CALL %s.system.add_files("
-                            + "table => '%s', "
-                            + "source_table => '`parquet`.`%s`',"
-                            + "max_concurrent_adds => 5)",
-                    catalogName, tableName, fileTableDir.getAbsolutePath());
+        scalarSql(
+            "CALL %s.system.add_files("
+                + "table => '%s', "
+                + "source_table => '`parquet`.`%s`',"
+                + "max_concurrent_adds => 5)",
+            catalogName, tableName, fileTableDir.getAbsolutePath());
 
     Assert.assertEquals(8L, result);
 
     assertEquals(
-            "Iceberg table contains correct data after concurrent partitioned data was added",
-            sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", sourceTableName),
-            sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
+        "Iceberg table contains correct data after concurrent partitioned data was added",
+        sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", sourceTableName),
+        sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
   }
 
   @Ignore // TODO Classpath issues prevent us from actually writing to a Spark ORC table

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -63,7 +63,7 @@ class AddFilesProcedure extends BaseProcedure {
         ProcedureParameter.optional("partition_filter", STRING_MAP),
         ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType),
         ProcedureParameter.optional("max_concurrent_adds", DataTypes.IntegerType),
-  };
+      };
 
   private static final StructType OUTPUT_TYPE =
       new StructType(
@@ -123,12 +123,13 @@ class AddFilesProcedure extends BaseProcedure {
 
     int maxConcurrentAdds = args.isNullAt(4) ? 1 : args.getInt(4);
     Preconditions.checkArgument(
-            maxConcurrentAdds > 0,
-            "max_concurrent_adds should have value > 0, value: %s",
-            maxConcurrentAdds);
+        maxConcurrentAdds > 0,
+        "max_concurrent_adds should have value > 0, value: %s",
+        maxConcurrentAdds);
 
     long addedFilesCount =
-        importToIceberg(tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
+        importToIceberg(
+            tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
     return new InternalRow[] {newInternalRow(addedFilesCount)};
   }
 
@@ -141,11 +142,11 @@ class AddFilesProcedure extends BaseProcedure {
   }
 
   private long importToIceberg(
-          Identifier destIdent,
-          Identifier sourceIdent,
-          Map<String, String> partitionFilter,
-          boolean checkDuplicateFiles,
-          Integer maxConcurrentAdds) {
+      Identifier destIdent,
+      Identifier sourceIdent,
+      Map<String, String> partitionFilter,
+      boolean checkDuplicateFiles,
+      Integer maxConcurrentAdds) {
     return modifyIcebergTable(
         destIdent,
         table -> {
@@ -155,9 +156,11 @@ class AddFilesProcedure extends BaseProcedure {
           if (isFileIdentifier(sourceIdent)) {
             Path sourcePath = new Path(sourceIdent.name());
             String format = sourceIdent.namespace()[0];
-            importFileTable(table, sourcePath, format, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
+            importFileTable(
+                table, sourcePath, format, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
           } else {
-            importCatalogTable(table, sourceIdent, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
+            importCatalogTable(
+                table, sourceIdent, partitionFilter, checkDuplicateFiles, maxConcurrentAdds);
           }
 
           Snapshot snapshot = table.currentSnapshot();
@@ -176,12 +179,12 @@ class AddFilesProcedure extends BaseProcedure {
   }
 
   private void importFileTable(
-          Table table,
-          Path tableLocation,
-          String format,
-          Map<String, String> partitionFilter,
-          boolean checkDuplicateFiles,
-          Integer maxConcurrentAdds) {
+      Table table,
+      Path tableLocation,
+      String format,
+      Map<String, String> partitionFilter,
+      boolean checkDuplicateFiles,
+      Integer maxConcurrentAdds) {
     // List Partitions via Spark InMemory file search interface
     List<SparkPartition> partitions =
         Spark3Util.getPartitions(spark(), tableLocation, format, partitionFilter);
@@ -205,11 +208,11 @@ class AddFilesProcedure extends BaseProcedure {
   }
 
   private void importCatalogTable(
-          Table table,
-          Identifier sourceIdent,
-          Map<String, String> partitionFilter,
-          boolean checkDuplicateFiles,
-          Integer maxConcurrentAdds) {
+      Table table,
+      Identifier sourceIdent,
+      Map<String, String> partitionFilter,
+      boolean checkDuplicateFiles,
+      Integer maxConcurrentAdds) {
     String stagingLocation = getMetadataLocation(table);
     TableIdentifier sourceTableIdentifier = Spark3Util.toV1TableIdentifier(sourceIdent);
     SparkTableUtil.importSparkTable(
@@ -223,10 +226,19 @@ class AddFilesProcedure extends BaseProcedure {
   }
 
   private void importPartitions(
-          Table table, List<SparkPartition> partitions, boolean checkDuplicateFiles, Integer maxConcurrentAdds) {
+      Table table,
+      List<SparkPartition> partitions,
+      boolean checkDuplicateFiles,
+      Integer maxConcurrentAdds) {
     String stagingLocation = getMetadataLocation(table);
     SparkTableUtil.importSparkPartitions(
-        spark(), partitions, table, table.spec(), stagingLocation, checkDuplicateFiles, maxConcurrentAdds);
+        spark(),
+        partitions,
+        table,
+        table.spec(),
+        stagingLocation,
+        checkDuplicateFiles,
+        maxConcurrentAdds);
   }
 
   private String getMetadataLocation(Table table) {


### PR DESCRIPTION
max_concurrent_adds argument allows users of add_files procedure to concurrently add data files. Today the parallelism defaults to 1 and there is no way to configure.