### PR TITLE
Add REST catalog spec to iceberg-core.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,11 @@ project(':iceberg-core') {
     testImplementation "com.esotericsoftware:kryo"
     testImplementation "com.google.guava:guava-testlib"
   }
+  tasks.named("jar", Jar).configure {
+    into("META-INF/openapi") {
+      from("$rootDir/open-api")
+    }
+  }
 }
 
 project(':iceberg-data') {


### PR DESCRIPTION
Having the OpenAPI spec file used by a specific iceberg-core jar helps a lot.
This enables generating code from the spec by using the spec in the iceberg-core jar, without having to pull it "manually" from GH.