### PR TITLE
Add support for special characters in snowflake identifiers for Snowflake Catalog

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
@@ -178,9 +178,9 @@ class JdbcSnowflakeClient implements SnowflakeClient {
 
     final String finalQuery = "SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1";
 
-    List<SnowflakeIdentifier> schemas;
+    List<SnowflakeIdentifier> tables;
     try {
-      schemas =
+      tables =
           connectionPool.run(
               conn ->
                   queryHarness.query(

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
@@ -136,30 +136,6 @@ class JdbcSnowflakeClient implements SnowflakeClient {
     this.queryHarness = queryHarness;
   }
 
-  /**
-   * For rare cases where PreparedStatements aren't supported for user-supplied identifiers intended
-   * for use in special LIKE clauses, we can sanitize by "broadening" the identifier with
-   * single-character wildcards and manually post-filter client-side.
-   *
-   * <p>Note: This sanitization approach intentionally "broadens" the scope of matching results;
-   * callers must be able to handle this method returning an all-wildcard expression; i.e. the
-   * caller must treat the usage of the LIKE clause as only an optional optimization, and should
-   * post-filter for correctness as if the LIKE clause wasn't present in the query at all.
-   */
-  @VisibleForTesting
-  String sanitizeIdentifierWithWildcardForLikeClause(String identifier) {
-    // Restrict identifiers to the "Unquoted object identifiers" synax documented at
-    // https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html
-    //
-    // Use a strict allowlist of characters, replace everything *not* matching the character set
-    // with "_", which is used as a single-character wildcard in Snowflake.
-    String sanitized = identifier.replaceAll("[^a-zA-Z0-9_$]", "_");
-    if (sanitized.startsWith("$")) {
-      sanitized = "_" + sanitized.substring(1);
-    }
-    return sanitized;
-  }
-
   @Override
   public boolean databaseExists(SnowflakeIdentifier database) {
     Preconditions.checkArgument(
@@ -167,29 +143,26 @@ class JdbcSnowflakeClient implements SnowflakeClient {
         "databaseExists requires a DATABASE identifier, got '%s'",
         database);
 
-    // Due to current limitations in PreparedStatement parameters for the LIKE clause in
-    // SHOW DATABASES queries, we'll use a fairly limited allowlist for identifier characters,
-    // using wildcards for non-allowed characters, and post-filter for matching.
-    final String finalQuery =
-        String.format(
-            "SHOW DATABASES LIKE '%s' IN ACCOUNT",
-            sanitizeIdentifierWithWildcardForLikeClause(database.databaseName()));
-    List<SnowflakeIdentifier> databases;
+    final String finalQuery = "SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1";
+
+    List<SnowflakeIdentifier> schemas;
     try {
-      databases =
+      schemas =
           connectionPool.run(
-              conn -> queryHarness.query(conn, finalQuery, DATABASE_RESULT_SET_HANDLER));
+              conn ->
+                  queryHarness.query(
+                      conn, finalQuery, SCHEMA_RESULT_SET_HANDLER, database.databaseName()));
     } catch (SQLException e) {
+      if (e.getErrorCode() == 2003 && e.getMessage().contains("does not exist")) {
+        return false;
+      }
       throw new UncheckedSQLException(e, "Failed to check if database '%s' exists", database);
     } catch (InterruptedException e) {
       throw new UncheckedInterruptedException(
           e, "Interrupted while checking if database '%s' exists", database);
     }
 
-    // Filter to handle the edge case of '_' appearing as a wildcard that can't be remapped the way
-    // it can for predicates in SELECT statements.
-    databases.removeIf(db -> !database.databaseName().equalsIgnoreCase(db.databaseName()));
-    return !databases.isEmpty();
+    return !schemas.isEmpty();
   }
 
   @Override
@@ -203,31 +176,26 @@ class JdbcSnowflakeClient implements SnowflakeClient {
       return false;
     }
 
-    // Due to current limitations in PreparedStatement parameters for the LIKE clause in
-    // SHOW SCHEMAS queries, we'll use a fairly limited allowlist for identifier characters,
-    // using wildcards for non-allowed characters, and post-filter for matching.
-    final String finalQuery =
-        String.format(
-            "SHOW SCHEMAS LIKE '%s' IN DATABASE IDENTIFIER(?)",
-            sanitizeIdentifierWithWildcardForLikeClause(schema.schemaName()));
+    final String finalQuery = "SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1";
+
     List<SnowflakeIdentifier> schemas;
     try {
       schemas =
           connectionPool.run(
               conn ->
                   queryHarness.query(
-                      conn, finalQuery, SCHEMA_RESULT_SET_HANDLER, schema.databaseName()));
+                      conn, finalQuery, TABLE_RESULT_SET_HANDLER, schema.toIdentifierString()));
     } catch (SQLException e) {
+      if (e.getErrorCode() == 2003 && e.getMessage().contains("does not exist")) {
+        return false;
+      }
       throw new UncheckedSQLException(e, "Failed to check if schema '%s' exists", schema);
     } catch (InterruptedException e) {
       throw new UncheckedInterruptedException(
           e, "Interrupted while checking if schema '%s' exists", schema);
     }
 
-    // Filter to handle the edge case of '_' appearing as a wildcard that can't be remapped the way
-    // it can for predicates in SELECT statements.
-    schemas.removeIf(sc -> !schema.schemaName().equalsIgnoreCase(sc.schemaName()));
-    return !schemas.isEmpty();
+    return true;
   }
 
   @Override

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -45,7 +45,6 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     implements Closeable, SupportsNamespaces, Configurable<Object> {
   private static final String DEFAULT_CATALOG_NAME = "snowflake_catalog";
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
-  private static final String APP_IDENTIFIER = "iceberg-SDK";
 
   // Injectable factory for testing purposes.
   static class FileIOFactory {
@@ -110,10 +109,6 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
               + " JDBC driver to your jars/packages",
           cnfe);
     }
-
-    // Populate application identifier in jdbc client
-    properties.put("application", APP_IDENTIFIER);
-
     JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
 
     initialize(name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), properties);

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -45,6 +45,7 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     implements Closeable, SupportsNamespaces, Configurable<Object> {
   private static final String DEFAULT_CATALOG_NAME = "snowflake_catalog";
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
+  private static final String APP_IDENTIFIER = "iceberg-SDK";
 
   // Injectable factory for testing purposes.
   static class FileIOFactory {
@@ -109,6 +110,10 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
               + " JDBC driver to your jars/packages",
           cnfe);
     }
+
+    // Populate application identifier in jdbc client
+    properties.put("application", APP_IDENTIFIER);
+
     JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
 
     initialize(name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), properties);

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
@@ -79,7 +79,8 @@ public class JdbcSnowflakeClientTest {
   @Test
   public void testDatabaseExists() throws SQLException {
     when(mockResultSet.next()).thenReturn(true).thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DB_1");
+    when(mockResultSet.getString("database_name")).thenReturn("DB_1");
+    when(mockResultSet.getString("name")).thenReturn("SCHEMA_1");
 
     Assertions.assertThat(snowflakeClient.databaseExists(SnowflakeIdentifier.ofDatabase("DB_1")))
         .isTrue();
@@ -87,38 +88,15 @@ public class JdbcSnowflakeClientTest {
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW DATABASES LIKE 'DB_1' IN ACCOUNT"),
-            any(JdbcSnowflakeClient.ResultSetParser.class));
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
+            any(JdbcSnowflakeClient.ResultSetParser.class),
+            eq("DB_1"));
   }
 
   @Test
-  public void testDatabaseExistsSpecialCharacters() throws SQLException {
-    when(mockResultSet.next()).thenReturn(true).thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("$DB_1$.'!@#%^&*");
-
-    Assertions.assertThat(
-            snowflakeClient.databaseExists(SnowflakeIdentifier.ofDatabase("$DB_1$.'!@#%^&*")))
-        .isTrue();
-
-    verify(mockQueryHarness)
-        .query(
-            eq(mockConnection),
-            eq("SHOW DATABASES LIKE '_DB_1$_________' IN ACCOUNT"),
-            any(JdbcSnowflakeClient.ResultSetParser.class));
-  }
-
-  @Test
-  public void testDatabaseDoesntExistNoResults() throws SQLException {
-    when(mockResultSet.next()).thenReturn(false);
-
-    Assertions.assertThat(snowflakeClient.databaseExists(SnowflakeIdentifier.ofDatabase("DB_1")))
-        .isFalse();
-  }
-
-  @Test
-  public void testDatabaseDoesntExistMismatchedResults() throws SQLException {
-    when(mockResultSet.next()).thenReturn(true).thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DBZ1");
+  public void testDatabaseDoesntExist() throws SQLException {
+    when(mockResultSet.next())
+        .thenThrow(new SQLException("Database does not exists", "2000", 2003, null));
 
     Assertions.assertThat(snowflakeClient.databaseExists(SnowflakeIdentifier.ofDatabase("DB_1")))
         .isFalse();
@@ -131,87 +109,45 @@ public class JdbcSnowflakeClientTest {
         .thenReturn(false)
         .thenReturn(true)
         .thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DB_1").thenReturn("SCHEMA_1");
-    when(mockResultSet.getString("database_name")).thenReturn("DB_1");
+    when(mockResultSet.getString("name")).thenReturn("DB1").thenReturn("SCHEMA1");
+    when(mockResultSet.getString("database_name")).thenReturn("DB1");
+    when(mockResultSet.getString("schema_name")).thenReturn("SCHEMA1");
 
     Assertions.assertThat(
-            snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")))
+            snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB1", "SCHEMA1")))
         .isTrue();
 
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW DATABASES LIKE 'DB_1' IN ACCOUNT"),
-            any(JdbcSnowflakeClient.ResultSetParser.class));
-    verify(mockQueryHarness)
-        .query(
-            eq(mockConnection),
-            eq("SHOW SCHEMAS LIKE 'SCHEMA_1' IN DATABASE IDENTIFIER(?)"),
+            eq("SHOW SCHEMAS IN DATABASE IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
-            eq("DB_1"));
-  }
-
-  @Test
-  public void testSchemaExistsSpecialCharacters() throws SQLException {
-    when(mockResultSet.next())
-        .thenReturn(true)
-        .thenReturn(false)
-        .thenReturn(true)
-        .thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DB_1").thenReturn("$SCHEMA_1$.'!@#%^&*");
-    when(mockResultSet.getString("database_name")).thenReturn("DB_1");
-
-    Assertions.assertThat(
-            snowflakeClient.schemaExists(
-                SnowflakeIdentifier.ofSchema("DB_1", "$SCHEMA_1$.'!@#%^&*")))
-        .isTrue();
-
+            eq("DB1"));
     verify(mockQueryHarness)
         .query(
             eq(mockConnection),
-            eq("SHOW DATABASES LIKE 'DB_1' IN ACCOUNT"),
-            any(JdbcSnowflakeClient.ResultSetParser.class));
-    verify(mockQueryHarness)
-        .query(
-            eq(mockConnection),
-            eq("SHOW SCHEMAS LIKE '_SCHEMA_1$_________' IN DATABASE IDENTIFIER(?)"),
+            eq("SHOW TABLES IN SCHEMA IDENTIFIER(?) LIMIT 1"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
-            eq("DB_1"));
+            eq("DB1.SCHEMA1"));
   }
 
   @Test
-  public void testSchemaDoesntExistMismatchDatabase() throws SQLException {
-    when(mockResultSet.next()).thenReturn(true).thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DBZ1");
-
-    Assertions.assertThat(
-            snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")))
-        .isFalse();
-  }
-
-  @Test
-  public void testSchemaDoesntExistNoSchemaFound() throws SQLException {
-    when(mockResultSet.next()).thenReturn(true).thenReturn(false).thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DB_1");
-
-    Assertions.assertThat(
-            snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")))
-        .isFalse();
-  }
-
-  @Test
-  public void testSchemaDoesntExistSchemaMismatch() throws SQLException {
+  public void testSchemaDoesntExistNoSchemaFoundException() throws SQLException {
     when(mockResultSet.next())
-        .thenReturn(true)
-        .thenReturn(false)
-        .thenReturn(true)
-        .thenReturn(false);
-    when(mockResultSet.getString("name")).thenReturn("DB_1").thenReturn("SCHEMAZ1");
-    when(mockResultSet.getString("database_name")).thenReturn("DB_1");
+        .thenThrow(new SQLException("Schema does not exists", "2000", 2003, null));
 
     Assertions.assertThat(
             snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")))
         .isFalse();
+  }
+
+  @Test
+  public void testSchemaFailureWithOtherException() throws SQLException {
+    when(mockResultSet.next()).thenThrow(new SQLException("Some other exception", "2000", 2, null));
+
+    Assertions.assertThatExceptionOfType(UncheckedSQLException.class)
+        .isThrownBy(
+            () -> snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")));
   }
 
   @Test
@@ -421,7 +357,7 @@ public class JdbcSnowflakeClientTest {
             eq(mockConnection),
             eq("SHOW ICEBERG TABLES IN SCHEMA IDENTIFIER(?)"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
-            eq("DB_1.SCHEMA_1"));
+            eq("" + "DB_1.SCHEMA_1"));
 
     Assertions.assertThat(actualList)
         .containsExactly(

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/JdbcSnowflakeClientTest.java
@@ -96,7 +96,7 @@ public class JdbcSnowflakeClientTest {
   @Test
   public void testDatabaseDoesntExist() throws SQLException {
     when(mockResultSet.next())
-        .thenThrow(new SQLException("Database does not exists", "2000", 2003, null));
+        .thenThrow(new SQLException("Database does not exist", "2000", 2003, null));
 
     Assertions.assertThat(snowflakeClient.databaseExists(SnowflakeIdentifier.ofDatabase("DB_1")))
         .isFalse();
@@ -134,7 +134,7 @@ public class JdbcSnowflakeClientTest {
   @Test
   public void testSchemaDoesntExistNoSchemaFoundException() throws SQLException {
     when(mockResultSet.next())
-        .thenThrow(new SQLException("Schema does not exists", "2000", 2003, null));
+        .thenThrow(new SQLException("Schema does not exist", "2000", 2003, null));
 
     Assertions.assertThat(
             snowflakeClient.schemaExists(SnowflakeIdentifier.ofSchema("DB_1", "SCHEMA_1")))
@@ -357,7 +357,7 @@ public class JdbcSnowflakeClientTest {
             eq(mockConnection),
             eq("SHOW ICEBERG TABLES IN SCHEMA IDENTIFIER(?)"),
             any(JdbcSnowflakeClient.ResultSetParser.class),
-            eq("" + "DB_1.SCHEMA_1"));
+            eq("DB_1.SCHEMA_1"));
 
     Assertions.assertThat(actualList)
         .containsExactly(


### PR DESCRIPTION
Currently the catalog is unable to handle databases or schema or table names (snowflake identifiers) with special characters. This limitation is due to sanitizing of the parameter for the like clause of SQL statements (which is not well supported by Snowflake JDBC's PreparedStatement) to determine if a database or schema exists (eg: SHOW DATABASES LIKE '%s' IN ACCOUNT). The alternative proposal is to list sub-namespace (eg: list schemas within a database (SHOW SCHEMAS/TABLES IN IDENTIFIER(?) LIMIT 1) or list tables within schema) and rely on the exception being thrown if the database/schema would not exist. This avoids using the like statement (while still being performant) and allows passing in the snowflake identifiers with special characters as quoted identifiers (more details at https://docs.snowflake.com/en/sql-reference/identifiers-syntax.html). The table shows the corresponding commands for creating and accessing database/schema objects in snowflake and spark. The column "Quoted" refers to whether the identifier (database/schema name) is quoted as per snowflake's identifier convention.

```
+----+------------------------------------+-------------------+--------------------------------------------------+
| Row| Snowflake                          | Quoted?| Spark(3.3.1)                                                |
+----+------------------------------------+-------------------+--------------------------------------------------+
| 1  | create database "$peci@al"         | Yes    | spark.sql("use database `\"$peci@l\"`").show()                |
| 2  | create database """doubleQouted""" | Yes    | spark.sql("use database `\"\"\"doubleQuoted\"\"\""`).show()   |
| 3  | create database "Dot.ted"          | Yes    | spark.sql("use database `\"Dot.ted\"`").show()                |
| 4  | create schema "under_Score"        | Yes    | spark.sql("use database `\"Dot.ted\"`.`\"under_Score\"`").show()|
| 5  | create database lower              | No     | spark.sql("use database lower").show()                      |
| -  |                                    |        | spark.sql("use database LOWER").show()                      |
| -  |                                    |        | spark.sql("use database LoWeR").show()                      |
| 6  | create database dollar$            | No     | spark.sql("use database DOLLAR$").show()                    |
| -  |                                    |        | spark.sql("use database dollar$").show()                    |
| -  |                                    |        | spark.sql("use database DOllar$").show()                    |
| 7  | create database "lowerq"           | Yes    | spark.sql("use database `\"lowerq\"`").show()               |
+----+------------------------------------+--------+-------------------------------------------------------------+
```