### PR TITLE
Nessie: Update the outdated javadoc

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -265,7 +265,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
    * Load the given namespace and return its properties.
    *
    * @param namespace a namespace. {@link Namespace}
-   * @return an empty map
+   * @return properties map
    * @throws NoSuchNamespaceException If the namespace does not exist
    */
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -265,7 +265,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
    * Load the given namespace and return its properties.
    *
    * @param namespace a namespace. {@link Namespace}
-   * @return properties map
+   * @return a string map of properties for the given namespace
    * @throws NoSuchNamespaceException If the namespace does not exist
    */
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -262,8 +262,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
   }
 
   /**
-   * Load the given namespace but return an empty map because namespace properties are currently not
-   * supported.
+   * Load the given namespace and return its properties.
    *
    * @param namespace a namespace. {@link Namespace}
    * @return an empty map


### PR DESCRIPTION
Nessie catalog supports namespace properties. Test cases can be found [here](https://github.com/apache/iceberg/blob/038091f6b65bf63d028af175dbbbc7285815d6be/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java#L111-L146).

But the  javadoc of `loadNamespaceMetadata` is incorrect (maybe not updated when Nessie supported namespace properties)