### PR TITLE
Core: DeleteWithFilter fails on HashCode Collision

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -519,8 +519,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
             new StrictMetricsEvaluator(tableSchema, residual, caseSensitive);
 
         metricsEvaluators.put(
-            partition
-                .copy(), // The partition may be a re-used container so a copy is required
+            partition.copy(), // The partition may be a re-used container so a copy is required
             Pair.of(inclusive, strict));
       }
       return metricsEvaluators.get(partition);

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -510,16 +510,21 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       // in other words, ResidualEvaluator returns a part of the expression that needs to be
       // evaluated
       // for rows in the given partition using metrics
-      return metricsEvaluators.computeIfAbsent(
-          file.partition(),
-          partition -> {
-            Expression residual = residualEvaluator.residualFor(partition);
-            InclusiveMetricsEvaluator inclusive =
-                new InclusiveMetricsEvaluator(tableSchema, residual, caseSensitive);
-            StrictMetricsEvaluator strict =
-                new StrictMetricsEvaluator(tableSchema, residual, caseSensitive);
-            return Pair.of(inclusive, strict);
-          });
+      PartitionData partition = (PartitionData) file.partition();
+      if (!metricsEvaluators.containsKey(partition)) {
+        Expression residual = residualEvaluator.residualFor(partition);
+        InclusiveMetricsEvaluator inclusive =
+            new InclusiveMetricsEvaluator(tableSchema, residual, caseSensitive);
+        StrictMetricsEvaluator strict =
+            new StrictMetricsEvaluator(tableSchema, residual, caseSensitive);
+
+        metricsEvaluators.put(
+            partition
+                .copy(), // We need a new partition object to avoid collision on reading the next
+            // entry
+            Pair.of(inclusive, strict));
+      }
+      return metricsEvaluators.get(partition);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -520,8 +520,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
         metricsEvaluators.put(
             partition
-                .copy(), // We need a new partition object to avoid collision on reading the next
-            // entry
+                .copy(), // The partition may be a re-used container so a copy is required
             Pair.of(inclusive, strict));
       }
       return metricsEvaluators.get(partition);

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -20,12 +20,15 @@ package org.apache.iceberg;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import org.apache.commons.compress.utils.Lists;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -347,6 +350,47 @@ public class TestDeleteFiles extends TableTestBase {
         ids(initialSnapshot.snapshotId(), delete2.snapshotId(), delete2.snapshotId()),
         files(FILE_A, FILE_B, FILE_C),
         statuses(Status.EXISTING, Status.DELETED, Status.DELETED));
+  }
+
+  @Test
+  public void testDeleteWithCollision() {
+    Schema schema = new Schema(Types.NestedField.of(0, false, "x", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("x").build();
+    Table t = TestTables.create(tableDir, "hashcollision", schema, spec, formatVersion);
+
+    PartitionData partitionOne = new PartitionData(spec.partitionType());
+    partitionOne.set(0, "Aa");
+    PartitionData partitionTwo = new PartitionData(spec.partitionType());
+    partitionTwo.set(0, "BB");
+
+    Assert.assertEquals(
+            StructLikeWrapper.forType(spec.partitionType()).set(partitionOne).hashCode(),
+            StructLikeWrapper.forType(spec.partitionType()).set(partitionTwo).hashCode());
+
+    Metrics metrics = new Metrics(1L, null, null, null, null);
+
+    DataFile testFileOne = DataFiles.builder(spec)
+            .withPartition(partitionOne)
+            .withPath("/g1.parquet")
+            .withFileSizeInBytes(100)
+            .withMetrics(metrics)
+            .build();
+    DataFile testFileTwo = DataFiles.builder(spec)
+            .withPartition(partitionTwo)
+            .withMetrics(metrics)
+            .withFileSizeInBytes(100)
+            .withPath("/g2.parquet")
+            .build();
+
+    t.newFastAppend().appendFile(testFileOne).appendFile(testFileTwo).commit();
+
+    Assert.assertEquals("We should have two files", 2, Lists.newArrayList(t.newScan().planFiles().iterator()).size());
+
+    t.newDelete().deleteFromRowFilter(Expressions.equal("x", "BB")).commit();
+
+    Assert.assertEquals("We should have deleted one of them", 1, Lists.newArrayList(t.newScan().planFiles().iterator()).size());
+
+    Lists.newArrayList(t.newScan().planFiles().iterator());
   }
 
   private static ByteBuffer longToBuffer(long value) {

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -20,13 +20,13 @@ package org.apache.iceberg;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import org.apache.commons.compress.utils.Lists;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.Assert;
@@ -356,7 +356,8 @@ public class TestDeleteFiles extends TableTestBase {
   public void testDeleteWithCollision() {
     Schema schema = new Schema(Types.NestedField.of(0, false, "x", Types.StringType.get()));
     PartitionSpec spec = PartitionSpec.builderFor(schema).identity("x").build();
-    Table t = TestTables.create(tableDir, "hashcollision", schema, spec, formatVersion);
+    Table collisionTable =
+        TestTables.create(tableDir, "hashcollision", schema, spec, formatVersion);
 
     PartitionData partitionOne = new PartitionData(spec.partitionType());
     partitionOne.set(0, "Aa");
@@ -364,33 +365,39 @@ public class TestDeleteFiles extends TableTestBase {
     partitionTwo.set(0, "BB");
 
     Assert.assertEquals(
-            StructLikeWrapper.forType(spec.partitionType()).set(partitionOne).hashCode(),
-            StructLikeWrapper.forType(spec.partitionType()).set(partitionTwo).hashCode());
+        StructLikeWrapper.forType(spec.partitionType()).set(partitionOne).hashCode(),
+        StructLikeWrapper.forType(spec.partitionType()).set(partitionTwo).hashCode());
 
     Metrics metrics = new Metrics(1L, null, null, null, null);
 
-    DataFile testFileOne = DataFiles.builder(spec)
+    DataFile testFileOne =
+        DataFiles.builder(spec)
             .withPartition(partitionOne)
             .withPath("/g1.parquet")
             .withFileSizeInBytes(100)
             .withMetrics(metrics)
             .build();
-    DataFile testFileTwo = DataFiles.builder(spec)
+    DataFile testFileTwo =
+        DataFiles.builder(spec)
             .withPartition(partitionTwo)
             .withMetrics(metrics)
             .withFileSizeInBytes(100)
             .withPath("/g2.parquet")
             .build();
 
-    t.newFastAppend().appendFile(testFileOne).appendFile(testFileTwo).commit();
+    collisionTable.newFastAppend().appendFile(testFileOne).appendFile(testFileTwo).commit();
 
-    Assert.assertEquals("We should have two files", 2, Lists.newArrayList(t.newScan().planFiles().iterator()).size());
+    Assert.assertEquals(
+        "We should have two files",
+        2,
+        Lists.newArrayList(collisionTable.newScan().planFiles().iterator()).size());
 
-    t.newDelete().deleteFromRowFilter(Expressions.equal("x", "BB")).commit();
+    collisionTable.newDelete().deleteFromRowFilter(Expressions.equal("x", "BB")).commit();
 
-    Assert.assertEquals("We should have deleted one of them", 1, Lists.newArrayList(t.newScan().planFiles().iterator()).size());
-
-    Lists.newArrayList(t.newScan().planFiles().iterator());
+    Assert.assertEquals(
+        "We should have deleted one of them",
+        1,
+        Lists.newArrayList(collisionTable.newScan().planFiles().iterator()).size());
   }
 
   private static ByteBuffer longToBuffer(long value) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -21,24 +21,18 @@ package org.apache.iceberg.spark.sql;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
-import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-import scala.Tuple2;
 
 public class TestDeleteFrom extends SparkCatalogTestBase {
   public TestDeleteFrom(String catalogName, String implementation, Map<String, String> config) {
@@ -172,47 +166,5 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         "Should have expected rows",
         ImmutableList.of(),
         sql("SELECT * FROM %s ORDER BY id", tableName));
-  }
-
-  @Test
-  public void testDeleteWithCommonPartitionHashCode() throws NoSuchTableException, ParseException {
-    sql(
-        "CREATE TABLE %s (log_dateint int, request_dateint int) USING iceberg "
-            + "PARTITIONED BY (log_dateint, request_dateint)",
-        tableName);
-
-    Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    PartitionData partitionOne = new PartitionData(table.spec().partitionType());
-    partitionOne.set(0, 20220730);
-    partitionOne.set(1, 20220721);
-    PartitionData partitionTwo = new PartitionData(table.spec().partitionType());
-    partitionTwo.set(0, 20220728);
-    partitionTwo.set(1, 20220803);
-
-    Assert.assertEquals(
-        StructLikeWrapper.forType(table.spec().partitionType()).set(partitionOne).hashCode(),
-        StructLikeWrapper.forType(table.spec().partitionType()).set(partitionTwo).hashCode());
-
-    Dataset<Row> df =
-        spark
-            .createDataset(
-                ImmutableList.of(
-                    Tuple2.apply((int) partitionOne.get(0), (int) partitionOne.get(1)),
-                    Tuple2.apply((int) partitionTwo.get(0), (int) partitionTwo.get(1))),
-                Encoders.tuple(Encoders.INT(), Encoders.INT()))
-            .toDF("log_dateint", "request_dateint");
-
-    df.writeTo(tableName).append();
-
-    Assert.assertEquals(
-        1, sql("SELECT * FROM %s WHERE request_dateint == 20220803", tableName).size());
-    Assert.assertEquals(
-        1, sql("SELECT * FROM %s WHERE request_dateint == 20220721", tableName).size());
-
-    sql("DELETE FROM %s WHERE request_dateint == 20220803", tableName);
-    Assert.assertEquals(
-        0, sql("SELECT * FROM %s WHERE request_dateint == 20220803", tableName).size());
-    Assert.assertEquals(
-        1, sql("SELECT * FROM %s WHERE request_dateint == 20220721", tableName).size());
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -21,18 +21,24 @@ package org.apache.iceberg.spark.sql;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.iceberg.util.StructLikeWrapper;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import scala.Tuple2;
 
 public class TestDeleteFrom extends SparkCatalogTestBase {
   public TestDeleteFrom(String catalogName, String implementation, Map<String, String> config) {
@@ -166,5 +172,47 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         "Should have expected rows",
         ImmutableList.of(),
         sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testDeleteWithCommonPartitionHashCode() throws NoSuchTableException, ParseException {
+    sql(
+        "CREATE TABLE %s (log_dateint int, request_dateint int) USING iceberg "
+            + "PARTITIONED BY (log_dateint, request_dateint)",
+        tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    PartitionData partitionOne = new PartitionData(table.spec().partitionType());
+    partitionOne.set(0, 20220730);
+    partitionOne.set(1, 20220721);
+    PartitionData partitionTwo = new PartitionData(table.spec().partitionType());
+    partitionTwo.set(0, 20220728);
+    partitionTwo.set(1, 20220803);
+
+    Assert.assertEquals(
+        StructLikeWrapper.forType(table.spec().partitionType()).set(partitionOne).hashCode(),
+        StructLikeWrapper.forType(table.spec().partitionType()).set(partitionTwo).hashCode());
+
+    Dataset<Row> df =
+        spark
+            .createDataset(
+                ImmutableList.of(
+                    Tuple2.apply((int) partitionOne.get(0), (int) partitionOne.get(1)),
+                    Tuple2.apply((int) partitionTwo.get(0), (int) partitionTwo.get(1))),
+                Encoders.tuple(Encoders.INT(), Encoders.INT()))
+            .toDF("log_dateint", "request_dateint");
+
+    df.writeTo(tableName).append();
+
+    Assert.assertEquals(
+        1, sql("SELECT * FROM %s WHERE request_dateint == 20220803", tableName).size());
+    Assert.assertEquals(
+        1, sql("SELECT * FROM %s WHERE request_dateint == 20220721", tableName).size());
+
+    sql("DELETE FROM %s WHERE request_dateint == 20220803", tableName);
+    Assert.assertEquals(
+        0, sql("SELECT * FROM %s WHERE request_dateint == 20220803", tableName).size());
+    Assert.assertEquals(
+        1, sql("SELECT * FROM %s WHERE request_dateint == 20220721", tableName).size());
   }
 }


### PR DESCRIPTION
Fixes #6670 

When we determine the ResidualEvaluators for manifest entries in file we use a computeIfAbsent method using the file object's PartitionData as a key. The underlying issue here is that when being read using ManifestReader the PartitionData object is reused. This means once placed within the Map the value of the PartitionData changes every time a new entry is read. Because the original hashcode is correct, this isn't a problem until two values collide. Once they do the second key will end up retrieving the value of the first key, the underlying key retrieved will then also be equal because of the ManifestReader Container re-use. If the First Key was "always true" but the second key should be "false" the second key will return true and delete a file it should not.

To fix this we only place a copy of the PartitionData inside the map instead of the PartitionData object itself. We can't use computeIfAbsent unless we want to make a brand new PartitionData object for every entry.


To note the reason this has not been hit frequently before is that we must hit all of following conditions

* There needs to be a conflict of structlikewrapper.wrap(PartitionData) hashcodes
* The two files with the conflicting partition hashcodes MUST be in the same manifest
* They must have different behaviors for the delete condition (eg if both collision values should be delete or not deleted then it isn't a problem)