### PR TITLE
Python: Let pytest know that it shouldn't collect TestType

### DIFF
--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -422,6 +422,7 @@ def test_void_transform() -> None:
 
 class TestType(IcebergBaseModel):
     __root__: Transform[Any, Any]
+    __test__ = False
 
 
 def test_bucket_transform_serialize() -> None:


### PR DESCRIPTION
Because TestType contains test in the name, pytest tries to collect it and run tests on it. Setting `__test__ = False` tells PyTest to ignore it