### PR TITLE
Nessie: Support ApiV2 for Nessie client

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -96,16 +96,15 @@ public class NessieCatalog extends BaseMetastoreCatalog
             .fromConfig(x -> options.get(removePrefix.apply(x)));
     final String apiVersion = options.get(NessieUtil.CLIENT_API_VERSION);
     NessieApiV1 api;
-    if (apiVersion == null || apiVersion.equalsIgnoreCase("v1")) {
+    if (apiVersion == null || apiVersion.equalsIgnoreCase("1")) {
       // default version is set to v1.
       api = nessieClientBuilder.build(NessieApiV1.class);
-    } else if (apiVersion.equalsIgnoreCase("v2")) {
+    } else if (apiVersion.equalsIgnoreCase("2")) {
       api = nessieClientBuilder.build(NessieApiV2.class);
     } else {
       throw new IllegalArgumentException(
           String.format(
-              "Unsupported %s: %s. Can only be v1 or v2",
-              NessieUtil.CLIENT_API_VERSION, apiVersion));
+              "Unsupported %s: %s. Can only be 1 or 2", NessieUtil.CLIENT_API_VERSION, apiVersion));
     }
 
     initialize(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -94,17 +94,21 @@ public class NessieCatalog extends BaseMetastoreCatalog
         createNessieClientBuilder(
                 options.get(NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL))
             .fromConfig(x -> options.get(removePrefix.apply(x)));
-    final String apiVersion = options.get(NessieUtil.CLIENT_API_VERSION);
+    // default version is set to v1.
+    final String apiVersion = options.getOrDefault(NessieUtil.CLIENT_API_VERSION, "1");
     NessieApiV1 api;
-    if (apiVersion == null || apiVersion.equalsIgnoreCase("1")) {
-      // default version is set to v1.
-      api = nessieClientBuilder.build(NessieApiV1.class);
-    } else if (apiVersion.equalsIgnoreCase("2")) {
-      api = nessieClientBuilder.build(NessieApiV2.class);
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Unsupported %s: %s. Can only be 1 or 2", NessieUtil.CLIENT_API_VERSION, apiVersion));
+    switch (apiVersion) {
+      case "1":
+        api = nessieClientBuilder.build(NessieApiV1.class);
+        break;
+      case "2":
+        api = nessieClientBuilder.build(NessieApiV2.class);
+        break;
+      default:
+        throw new IllegalArgumentException(
+            String.format(
+                "Unsupported %s: %s. Can only be 1 or 2",
+                NessieUtil.CLIENT_API_VERSION, apiVersion));
     }
 
     initialize(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -95,7 +95,8 @@ public class NessieCatalog extends BaseMetastoreCatalog
                 options.get(NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL))
             .fromConfig(x -> options.get(removePrefix.apply(x)));
     // default version is set to v1.
-    final String apiVersion = options.getOrDefault(NessieUtil.CLIENT_API_VERSION, "1");
+    final String apiVersion =
+        options.getOrDefault(removePrefix.apply(NessieUtil.CLIENT_API_VERSION), "1");
     NessieApiV1 api;
     switch (apiVersion) {
       case "1":
@@ -108,7 +109,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
         throw new IllegalArgumentException(
             String.format(
                 "Unsupported %s: %s. Can only be 1 or 2",
-                NessieUtil.CLIENT_API_VERSION, apiVersion));
+                removePrefix.apply(NessieUtil.CLIENT_API_VERSION), apiVersion));
     }
 
     initialize(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -37,7 +37,7 @@ public final class NessieUtil {
   public static final String NESSIE_CONFIG_PREFIX = "nessie.";
   static final String APPLICATION_TYPE = "application-type";
 
-  public static final String CLIENT_API_VERSION = "client-api-version";
+  public static final String CLIENT_API_VERSION = "nessie.client-api-version";
 
   private NessieUtil() {}
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -37,6 +37,8 @@ public final class NessieUtil {
   public static final String NESSIE_CONFIG_PREFIX = "nessie.";
   static final String APPLICATION_TYPE = "application-type";
 
+  public static final String CLIENT_API_VERSION = "client-api-version";
+
   private NessieUtil() {}
 
   static TableIdentifier removeCatalogName(TableIdentifier to, String name) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.client.ext.NessieApiVersion;
 import org.projectnessie.client.ext.NessieApiVersions;
 import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
@@ -88,6 +88,7 @@ public abstract class BaseTestIceberg {
 
   protected NessieCatalog catalog;
   protected NessieApiV1 api;
+  private NessieApiVersion apiVersion;
   protected Configuration hadoopConfig;
   protected final String branch;
   private String initialHashOfDefaultBranch;
@@ -122,6 +123,7 @@ public abstract class BaseTestIceberg {
       throws IOException {
     this.uri = nessieUri.toASCIIString();
     this.api = clientFactory.make();
+    this.apiVersion = clientFactory.apiVersion();
 
     Branch defaultBranch = api.getDefaultBranch();
     initialHashOfDefaultBranch = defaultBranch.getHash();
@@ -146,8 +148,8 @@ public abstract class BaseTestIceberg {
             .put(CatalogProperties.URI, uri)
             .put("auth-type", "NONE")
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
-    if (api instanceof NessieApiV2) {
-      options.put(NessieUtil.CLIENT_API_VERSION, "v2");
+    if (apiVersion == NessieApiVersion.V2) {
+      options.put(NessieUtil.CLIENT_API_VERSION, "2");
     }
     if (null != hash) {
       options.put("ref.hash", hash);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.client.ext.NessieApiVersions;
 import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
@@ -73,7 +73,7 @@ import org.slf4j.LoggerFactory;
 @ExtendWith(DatabaseAdapterExtension.class)
 @NessieDbAdapterName(InmemoryDatabaseAdapterFactory.NAME)
 @NessieExternalDatabase(InmemoryTestConnectionProviderSource.class)
-@NessieApiVersions(versions = NessieApiVersion.V1)
+@NessieApiVersions // test all versions
 public abstract class BaseTestIceberg {
 
   @NessieDbAdapter static DatabaseAdapter databaseAdapter;
@@ -146,6 +146,9 @@ public abstract class BaseTestIceberg {
             .put(CatalogProperties.URI, uri)
             .put("auth-type", "NONE")
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
+    if (api instanceof NessieApiV2) {
+      options.put(NessieUtil.CLIENT_API_VERSION, "v2");
+    }
     if (null != hash) {
       options.put("ref.hash", hash);
     }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -88,7 +88,7 @@ public abstract class BaseTestIceberg {
 
   protected NessieCatalog catalog;
   protected NessieApiV1 api;
-  private NessieApiVersion apiVersion;
+  protected String apiVersion;
   protected Configuration hadoopConfig;
   protected final String branch;
   private String initialHashOfDefaultBranch;
@@ -123,7 +123,7 @@ public abstract class BaseTestIceberg {
       throws IOException {
     this.uri = nessieUri.toASCIIString();
     this.api = clientFactory.make();
-    this.apiVersion = clientFactory.apiVersion();
+    this.apiVersion = clientFactory.apiVersion() == NessieApiVersion.V2 ? "2" : "1";
 
     Branch defaultBranch = api.getDefaultBranch();
     initialHashOfDefaultBranch = defaultBranch.getHash();
@@ -147,10 +147,8 @@ public abstract class BaseTestIceberg {
             .put("ref", ref)
             .put(CatalogProperties.URI, uri)
             .put("auth-type", "NONE")
-            .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
-    if (apiVersion == NessieApiVersion.V2) {
-      options.put(NessieUtil.CLIENT_API_VERSION, "2");
-    }
+            .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString())
+            .put("client-api-version", apiVersion);
     if (null != hash) {
       options.put("ref.hash", hash);
     }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
@@ -48,7 +48,9 @@ public class TestCustomNessieClient extends BaseTestIceberg {
             CatalogProperties.WAREHOUSE_LOCATION,
             temp.toUri().toString(),
             CatalogProperties.URI,
-            uri));
+            uri,
+            "client-api-version",
+            apiVersion));
   }
 
   @Test
@@ -62,7 +64,9 @@ public class TestCustomNessieClient extends BaseTestIceberg {
             CatalogProperties.URI,
             uri,
             NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL,
-            HttpClientBuilder.class.getName()));
+            HttpClientBuilder.class.getName(),
+            "client-api-version",
+            apiVersion));
   }
 
   @Test

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.api.NessieApiV2;
+import org.projectnessie.client.ext.NessieApiVersion;
 import org.projectnessie.client.ext.NessieApiVersions;
 import org.projectnessie.client.ext.NessieClientFactory;
 import org.projectnessie.client.ext.NessieClientUri;
@@ -67,6 +67,7 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
 
   private NessieCatalog catalog;
   private NessieApiV1 api;
+  private NessieApiVersion apiVersion;
   private Configuration hadoopConfig;
   private String initialHashOfDefaultBranch;
   private String uri;
@@ -75,6 +76,7 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
   public void setUp(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
       throws NessieNotFoundException {
     api = clientFactory.make();
+    apiVersion = clientFactory.apiVersion();
     initialHashOfDefaultBranch = api.getDefaultBranch().getHash();
     uri = nessieUri.toASCIIString();
     hadoopConfig = new Configuration();
@@ -121,8 +123,8 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
             .put(CatalogProperties.URI, uri)
             .put("auth-type", "NONE")
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
-    if (api instanceof NessieApiV2) {
-      options.put(NessieUtil.CLIENT_API_VERSION, "v2");
+    if (apiVersion == NessieApiVersion.V2) {
+      options.put(NessieUtil.CLIENT_API_VERSION, "2");
     }
     newCatalog.initialize("nessie", options.buildOrThrow());
     return newCatalog;

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -124,7 +124,7 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
             .put("auth-type", "NONE")
             .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
     if (apiVersion == NessieApiVersion.V2) {
-      options.put(NessieUtil.CLIENT_API_VERSION, "2");
+      options.put("client-api-version", "2");
     }
     newCatalog.initialize("nessie", options.buildOrThrow());
     return newCatalog;

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -117,16 +117,17 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
   private NessieCatalog initNessieCatalog(String ref) {
     NessieCatalog newCatalog = new NessieCatalog();
     newCatalog.setConf(hadoopConfig);
-    ImmutableMap.Builder<String, String> options =
-        ImmutableMap.<String, String>builder()
-            .put("ref", ref)
-            .put(CatalogProperties.URI, uri)
-            .put("auth-type", "NONE")
-            .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
-    if (apiVersion == NessieApiVersion.V2) {
-      options.put("client-api-version", "2");
-    }
-    newCatalog.initialize("nessie", options.buildOrThrow());
+    ImmutableMap<String, String> options =
+        ImmutableMap.of(
+            "ref",
+            ref,
+            CatalogProperties.URI,
+            uri,
+            CatalogProperties.WAREHOUSE_LOCATION,
+            temp.toUri().toString(),
+            "client-api-version",
+            apiVersion == NessieApiVersion.V2 ? "2" : "1");
+    newCatalog.initialize("nessie", options);
     return newCatalog;
   }
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.nessie;
 
+import java.io.IOException;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
@@ -88,5 +89,17 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
     Assertions.assertThat(client.withReference(branch, null).getRef().getReference())
         .isEqualTo(ref);
     Assertions.assertThat(client.withReference(branch, null)).isNotEqualTo(client);
+  }
+
+  @Test
+  public void testInvalidClientApiVersion() throws IOException {
+    try (NessieCatalog newCatalog = new NessieCatalog()) {
+      newCatalog.setConf(hadoopConfig);
+      ImmutableMap.Builder<String, String> options =
+          ImmutableMap.<String, String>builder().put(NessieUtil.CLIENT_API_VERSION, "v3");
+      Assertions.assertThatThrownBy(() -> newCatalog.initialize("nessie", options.buildOrThrow()))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Unsupported client-api-version: v3. Can only be v1 or v2");
+    }
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -96,10 +96,10 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
     try (NessieCatalog newCatalog = new NessieCatalog()) {
       newCatalog.setConf(hadoopConfig);
       ImmutableMap.Builder<String, String> options =
-          ImmutableMap.<String, String>builder().put(NessieUtil.CLIENT_API_VERSION, "v3");
+          ImmutableMap.<String, String>builder().put(NessieUtil.CLIENT_API_VERSION, "3");
       Assertions.assertThatThrownBy(() -> newCatalog.initialize("nessie", options.buildOrThrow()))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Unsupported client-api-version: v3. Can only be v1 or v2");
+          .hasMessage("Unsupported client-api-version: 3. Can only be 1 or 2");
     }
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -96,10 +96,10 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
     try (NessieCatalog newCatalog = new NessieCatalog()) {
       newCatalog.setConf(hadoopConfig);
       ImmutableMap.Builder<String, String> options =
-          ImmutableMap.<String, String>builder().put(NessieUtil.CLIENT_API_VERSION, "3");
+          ImmutableMap.<String, String>builder().put("client-api-version", "3");
       Assertions.assertThatThrownBy(() -> newCatalog.initialize("nessie", options.buildOrThrow()))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Unsupported nessie.client-api-version: 3. Can only be 1 or 2");
+          .hasMessage("Unsupported client-api-version: 3. Can only be 1 or 2");
     }
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -99,7 +99,7 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
           ImmutableMap.<String, String>builder().put(NessieUtil.CLIENT_API_VERSION, "3");
       Assertions.assertThatThrownBy(() -> newCatalog.initialize("nessie", options.buildOrThrow()))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Unsupported client-api-version: 3. Can only be 1 or 2");
+          .hasMessage("Unsupported nessie.client-api-version: 3. Can only be 1 or 2");
     }
   }
 }


### PR DESCRIPTION
- The default version is v1 to avoid forcing users to change their URI in the existing jobs.
- "client-api-version" catalog property is added to specify the API version in-case the user wants to use v2.
