### PR TITLE
spark 3.3 read by snapshot ref schema

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
@@ -165,10 +165,11 @@ public class SparkCachedTableCatalog implements TableCatalog {
 
     Preconditions.checkArgument(
         Stream.of(snapshotId, asOfTimestamp, branch, tag).filter(Objects::nonNull).count() <= 1,
-        "Can specify at most one of snapshot-id (%s), as-of-timestamp (%s), and snapshot-ref (%s)",
+        "Can specify only one of snapshot-id (%s), as-of-timestamp (%s), branch (%s), tag (%s)",
         snapshotId,
         asOfTimestamp,
-        branch);
+        branch,
+        tag);
 
     Table table = TABLE_CACHE.get(key);
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
@@ -190,9 +190,9 @@ public class SparkCachedTableCatalog implements TableCatalog {
       Preconditions.checkArgument(
           tagSnapshot != null, "Cannot find snapshot associated with tag name: %s", tag);
       return Pair.of(table, tagSnapshot.snapshotId());
+    } else {
+      return Pair.of(table, null);
     }
-
-    return Pair.of(table, null);
   }
 
   private Pair<String, List<String>> parseIdent(Identifier ident) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCachedTableCatalog.java
@@ -150,11 +150,13 @@ public class SparkCachedTableCatalog implements TableCatalog {
       Matcher snapshotBasedMatcher = SNAPSHOT_ID.matcher(meta);
       if (snapshotBasedMatcher.matches()) {
         snapshotId = Long.parseLong(snapshotBasedMatcher.group(1));
+        continue;
       }
 
       Matcher branchBasedMatcher = BRANCH.matcher(meta);
       if (branchBasedMatcher.matches()) {
         branch = branchBasedMatcher.group(1);
+        continue;
       }
 
       Matcher tagBasedMatcher = TAG.matcher(meta);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -723,11 +723,13 @@ public class SparkCatalog extends BaseCatalog {
       Matcher id = SNAPSHOT_ID.matcher(meta);
       if (id.matches()) {
         snapshotId = Long.parseLong(id.group(1));
+        continue;
       }
 
       Matcher branchRef = BRANCH.matcher(meta);
       if (branchRef.matches()) {
         branch = branchRef.group(1);
+        continue;
       }
 
       Matcher tagRef = TAG.matcher(meta);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -756,6 +756,7 @@ public class SparkCatalog extends BaseCatalog {
     } else if (asOfTimestamp != null) {
       long snapshotIdAsOfTime = SnapshotUtil.snapshotIdAsOfTime(table, asOfTimestamp);
       return new SparkTable(table, snapshotIdAsOfTime, !cacheEnabled);
+
     } else if (branch != null) {
       Snapshot branchSnapshot = table.snapshot(branch);
       Preconditions.checkArgument(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -674,6 +674,7 @@ public class SparkCatalog extends BaseCatalog {
           return new SparkTable(table, tagSnapshot.snapshotId(), !cacheEnabled);
         }
       }
+
       // the name wasn't a valid snapshot selector and did not point to the changelog
       // throw the original exception
       throw e;
@@ -737,7 +738,7 @@ public class SparkCatalog extends BaseCatalog {
 
     Preconditions.checkArgument(
         Stream.of(snapshotId, asOfTimestamp, branch, tag).filter(Objects::nonNull).count() <= 1,
-        "Can specify at most one of snapshot-id (%s), as-of-timestamp (%s), branch (%s) and tag (%s)",
+        "Can specify only one of snapshot-id (%s), as-of-timestamp (%s), branch (%s), tag (%s)",
         snapshotId,
         asOfTimestamp,
         branch,
@@ -762,11 +763,13 @@ public class SparkCatalog extends BaseCatalog {
       Preconditions.checkArgument(
           branchSnapshot != null, "Cannot find snapshot associated with branch name: %s", branch);
       return new SparkTable(table, branchSnapshot.snapshotId(), !cacheEnabled);
+
     } else if (tag != null) {
       Snapshot tagSnapshot = table.snapshot(tag);
       Preconditions.checkArgument(
           tagSnapshot != null, "Cannot find snapshot associated with tag name: %s", tag);
       return new SparkTable(table, tagSnapshot.snapshotId(), !cacheEnabled);
+
     } else {
       return new SparkTable(table, snapshotId, !cacheEnabled);
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -767,9 +767,9 @@ public class SparkCatalog extends BaseCatalog {
       Preconditions.checkArgument(
           tagSnapshot != null, "Cannot find snapshot associated with tag name: %s", tag);
       return new SparkTable(table, tagSnapshot.snapshotId(), !cacheEnabled);
+    } else {
+      return new SparkTable(table, snapshotId, !cacheEnabled);
     }
-
-    return new SparkTable(table, snapshotId, !cacheEnabled);
   }
 
   private Identifier namespaceToIdentifier(String[] namespace) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -765,7 +765,12 @@ public class SparkCatalog extends BaseCatalog {
       Preconditions.checkArgument(
           table.snapshot(branch) != null, "branch not associated with a snapshot");
       snapshotIdFromTimeTravel = table.snapshot(branch).snapshotId();
+    } else if (tag != null) {
+      Preconditions.checkArgument(
+          table.snapshot(tag) != null, "tag not associated with a snapshot");
+      snapshotIdFromTimeTravel = table.snapshot(tag).snapshotId();
     }
+
     if (snapshotIdFromTimeTravel != -1L) {
       return new SparkTable(table, snapshotIdFromTimeTravel, !cacheEnabled);
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -69,8 +69,8 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
       "spark.sql.catalog." + DEFAULT_CACHE_CATALOG_NAME;
   private static final String AT_TIMESTAMP = "at_timestamp_";
   private static final String SNAPSHOT_ID = "snapshot_id_";
-  private static final String BRANCH = "branch_";
-  private static final String TAG = "tag_";
+  private static final String BRANCH_PREFIX = "branch_";
+  private static final String TAG_PREFIX = "tag_";
   private static final String[] EMPTY_NAMESPACE = new String[0];
 
   private static final SparkTableCache TABLE_CACHE = SparkTableCache.get();
@@ -132,7 +132,7 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
     String tag = options.get(SparkReadOptions.TAG);
     Preconditions.checkArgument(
         Stream.of(snapshotId, asOfTimestamp, branch, tag).filter(Objects::nonNull).count() <= 1,
-        "Can specify at most one of snapshot-id (%s), as-of-timestamp (%s), branch (%s) and tag (%s)",
+        "Can specify only one of snapshot-id (%s), as-of-timestamp (%s), branch (%s), tag (%s)",
         snapshotId,
         asOfTimestamp,
         branch,
@@ -149,11 +149,11 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
     }
 
     if (branch != null) {
-      selector = BRANCH + branch;
+      selector = BRANCH_PREFIX + branch;
     }
 
     if (tag != null) {
-      selector = TAG + tag;
+      selector = TAG_PREFIX + tag;
     }
 
     CatalogManager catalogManager = spark.sessionState().catalogManager();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -67,6 +67,7 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
       "spark.sql.catalog." + DEFAULT_CACHE_CATALOG_NAME;
   private static final String AT_TIMESTAMP = "at_timestamp_";
   private static final String SNAPSHOT_ID = "snapshot_id_";
+  private static final String BRANCH = "branch_";
   private static final String[] EMPTY_NAMESPACE = new String[0];
 
   private static final SparkTableCache TABLE_CACHE = SparkTableCache.get();
@@ -124,6 +125,7 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
 
     Long snapshotId = propertyAsLong(options, SparkReadOptions.SNAPSHOT_ID);
     Long asOfTimestamp = propertyAsLong(options, SparkReadOptions.AS_OF_TIMESTAMP);
+    String branch = options.get(SparkReadOptions.BRANCH);
     Preconditions.checkArgument(
         asOfTimestamp == null || snapshotId == null,
         "Cannot specify both snapshot-id (%s) and as-of-timestamp (%s)",
@@ -138,6 +140,10 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
 
     if (asOfTimestamp != null) {
       selector = AT_TIMESTAMP + asOfTimestamp;
+    }
+
+    if (branch != null) {
+      selector = BRANCH + branch;
     }
 
     CatalogManager catalogManager = spark.sessionState().catalogManager();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -368,7 +368,9 @@ public class SparkTable
       scanOptions.putAll(options.asCaseSensitiveMap());
       scanOptions.put(SparkReadOptions.SNAPSHOT_ID, value);
       scanOptions.remove(SparkReadOptions.AS_OF_TIMESTAMP);
+
       scanOptions.remove(SparkReadOptions.BRANCH);
+      scanOptions.remove(SparkReadOptions.TAG);
       return new CaseInsensitiveStringMap(scanOptions);
     }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -368,7 +368,7 @@ public class SparkTable
       scanOptions.putAll(options.asCaseSensitiveMap());
       scanOptions.put(SparkReadOptions.SNAPSHOT_ID, value);
       scanOptions.remove(SparkReadOptions.AS_OF_TIMESTAMP);
-
+      scanOptions.remove(SparkReadOptions.BRANCH);
       return new CaseInsensitiveStringMap(scanOptions);
     }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -368,9 +368,9 @@ public class SparkTable
       scanOptions.putAll(options.asCaseSensitiveMap());
       scanOptions.put(SparkReadOptions.SNAPSHOT_ID, value);
       scanOptions.remove(SparkReadOptions.AS_OF_TIMESTAMP);
-
       scanOptions.remove(SparkReadOptions.BRANCH);
       scanOptions.remove(SparkReadOptions.TAG);
+
       return new CaseInsensitiveStringMap(scanOptions);
     }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -223,7 +223,7 @@ public class TestSnapshotSelection {
                     .option(SparkReadOptions.AS_OF_TIMESTAMP, timestamp)
                     .load(tableLocation))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Can specify at most one of snapshot-id")
+        .hasMessageContaining("Can specify only one of snapshot-id")
         .hasMessageContaining("as-of-timestamp")
         .hasMessageContaining("branch")
         .hasMessageContaining("tag");
@@ -327,7 +327,7 @@ public class TestSnapshotSelection {
                     .load(tableLocation)
                     .show())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Can specify at most one of snapshot-id");
+        .hasMessageStartingWith("Can specify only one of snapshot-id");
   }
 
   @Test
@@ -358,7 +358,7 @@ public class TestSnapshotSelection {
                     .load(tableLocation)
                     .show())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Can specify at most one of snapshot-id");
+        .hasMessageStartingWith("Can specify only one of snapshot-id");
 
     Assertions.assertThatThrownBy(
             () ->
@@ -370,7 +370,7 @@ public class TestSnapshotSelection {
                     .load(tableLocation)
                     .show())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith("Can specify at most one of snapshot-id");
+        .hasMessageStartingWith("Can specify only one of snapshot-id");
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -394,18 +394,17 @@ public class TestSnapshotSelection {
     Dataset<Row> branchSnapshotResult =
         spark.read().format("iceberg").option("branch", "branch").load(tableLocation);
     List<SimpleRecord> branchSnapshotRecords =
-            branchSnapshotResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+        branchSnapshotResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(firstBatchRecords);
     Assert.assertEquals(
         "Current snapshot rows should match", expectedRecords, branchSnapshotRecords);
 
     Dataset<Row> tagSnapshotResult =
-            spark.read().format("iceberg").option("tag", "tag").load(tableLocation);
+        spark.read().format("iceberg").option("tag", "tag").load(tableLocation);
     List<SimpleRecord> tagSnapshotRecords =
-            tagSnapshotResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
-    Assert.assertEquals(
-            "Current snapshot rows should match", expectedRecords, tagSnapshotRecords);
+        tagSnapshotResult.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    Assert.assertEquals("Current snapshot rows should match", expectedRecords, tagSnapshotRecords);
 
     // Deleting a column to indicate schema change
     table.updateSchema().deleteColumn("data").commit();
@@ -419,16 +418,16 @@ public class TestSnapshotSelection {
             .as(Encoders.bean(SimpleRecord.class))
             .collectAsList();
     Assert.assertEquals(
-            "Current snapshot rows should match", expectedRecords, deletedColumnBranchSnapshotRecords);
+        "Current snapshot rows should match", expectedRecords, deletedColumnBranchSnapshotRecords);
 
     Dataset<Row> deletedColumnTagSnapshotResult =
-            spark.read().format("iceberg").option("branch", "branch").load(tableLocation);
+        spark.read().format("iceberg").option("branch", "branch").load(tableLocation);
     List<SimpleRecord> deletedColumnTagSnapshotRecords =
-            deletedColumnTagSnapshotResult
-                    .orderBy("id")
-                    .as(Encoders.bean(SimpleRecord.class))
-                    .collectAsList();
+        deletedColumnTagSnapshotResult
+            .orderBy("id")
+            .as(Encoders.bean(SimpleRecord.class))
+            .collectAsList();
     Assert.assertEquals(
-            "Current snapshot rows should match", expectedRecords, deletedColumnTagSnapshotRecords);
+        "Current snapshot rows should match", expectedRecords, deletedColumnTagSnapshotRecords);
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -441,7 +441,8 @@ public class TestSelect extends SparkCatalogTestBase {
         "Should not be able to specify both snapshot id and timestamp",
         IllegalArgumentException.class,
         String.format(
-            "Cannot specify both snapshot-id (%s) and as-of-timestamp (%s)", snapshotId, timestamp),
+            "Can specify at most one of snapshot-id (%s), as-of-timestamp (%s)",
+            snapshotId, timestamp),
         () -> {
           spark
               .read()

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -441,7 +441,7 @@ public class TestSelect extends SparkCatalogTestBase {
         "Should not be able to specify both snapshot id and timestamp",
         IllegalArgumentException.class,
         String.format(
-            "Can specify at most one of snapshot-id (%s), as-of-timestamp (%s)",
+            "Can specify only one of snapshot-id (%s), as-of-timestamp (%s)",
             snapshotId, timestamp),
         () -> {
           spark


### PR DESCRIPTION
In PR https://github.com/apache/iceberg/pull/5150 we introduced read from branch or tag. There is a bug where **we cannot read the snapshot specific schema changes** when doing 

`spark.read().option("branch", <branch_name>)`. The fix in this PR is applied similar to https://github.com/apache/iceberg/pull/3722

Still yet to add support for tag. If given a heads up for branch, will go ahead with tag 
cc  @jackieo168

@rdblue @jackye1995 @amogh-jahagirdar @wypoon Let me know what you think 