### PR TITLE
Python: Publish the docs by hand

### DIFF
--- a/.github/workflows/python-ci-docs.yml
+++ b/.github/workflows/python-ci-docs.yml
@@ -19,12 +19,7 @@
 
 name: "Python Docs"
 on:
-  push:
-    branches:
-      - 'master'
-    paths:
-      - 'python/mkdocs/**'
-      - '.github/workflows/python-ci-docs.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/python/mkdocs/docs/how-to-release.md
+++ b/python/mkdocs/docs/how-to-release.md
@@ -162,3 +162,7 @@ This Python release can be downloaded from: https://pypi.org/project/pyiceberg/<
 
 Thanks to everyone for contributing!
 ```
+
+## Release the docs
+
+A committer triggers the `Python Docs` Github Actions through the UI by selecting the branch that just has been released. This will publish the new docs.


### PR DESCRIPTION
Backport to 0.3.0

Currently everything that goes into master will directly be pushed to Github Pages. This was fine for a while, but now we have PRs that publish new functionality, but then it isn't available in the release for example: https://github.com/apache/iceberg/pull/6644

I think we should now publish by hand, and move to multi version docs once PyIceberg stabilizes a bit.