### PR TITLE
Pin openapi-spec-validator version

### DIFF
--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: 3.9
       - name: Install
         working-directory: ./open-api
-        run: pip install openapi-spec-validator
+        run: pip install openapi-spec-validator==0.5.2
       - name: Validate
         working-directory: ./open-api
         run: openapi-spec-validator rest-catalog-open-api.yaml


### PR DESCRIPTION
0.5.3 of openapi-spec-validator was recently released (https://pypi.org/project/openapi-spec-validator/#history) and it fails with the below error:

```
openapi-spec-validator open-api/rest-catalog-open-api.yaml

maximum recursion depth exceeded
```