### PR TITLE
Spark: Fix isIcebergCommand check and style issues from #6638

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -206,9 +206,11 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
             normalized.contains("write unordered") ||
             normalized.contains("set identifier fields") ||
             normalized.contains("drop identifier fields") ||
-            normalized.contains("create branch"))) ||
-            normalized.contains("replace branch")
+            isSnapshotRefDdl(normalized)))
+  }
 
+  private def isSnapshotRefDdl(normalized: String): Boolean = {
+    normalized.contains("create branch") || normalized.contains("replace branch")
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -92,6 +92,9 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
       typedVisit[Transform](ctx.transform))
   }
 
+  /**
+   * Create a CREATE OR REPLACE BRANCH logical command.
+   */
   override def visitCreateOrReplaceBranch(ctx: CreateOrReplaceBranchContext): CreateOrReplaceBranch = withOrigin(ctx) {
     val createOrReplaceBranchClause = ctx.createReplaceBranchClause()
 
@@ -99,7 +102,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     val branchOptionsContext = Option(createOrReplaceBranchClause.branchOptions())
     val snapshotId = branchOptionsContext.flatMap(branchOptions => Option(branchOptions.snapshotId()))
       .map(_.getText.toLong)
-    val snapshotRetention =  branchOptionsContext.flatMap(branchOptions => Option(branchOptions.snapshotRetention()))
+    val snapshotRetention = branchOptionsContext.flatMap(branchOptions => Option(branchOptions.snapshotRetention()))
     val minSnapshotsToKeep = snapshotRetention.flatMap(retention => Option(retention.minSnapshotsToKeep()))
       .map(minSnapshots => minSnapshots.number().getText.toLong)
     val maxSnapshotAgeMs = snapshotRetention
@@ -125,7 +128,6 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
       branchOptions,
       replace,
       ifNotExists)
-
   }
 
   /**

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateBranch.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateBranch.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.extensions;
 
-import java.util.IllegalFormatConversionException;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -193,9 +192,9 @@ public class TestCreateBranch extends SparkExtensionsTestBase {
 
     AssertHelpers.assertThrows(
         "Illegal statement",
-        IllegalFormatConversionException.class,
-        "d != java.lang.String",
-        () -> sql("ALTER TABLE %s CREATE BRANCH %s RETAIN %d DAYS", tableName, branchName, "abc"));
+        IcebergParseException.class,
+        "mismatched input",
+        () -> sql("ALTER TABLE %s CREATE BRANCH %s RETAIN %s DAYS", tableName, branchName, "abc"));
 
     AssertHelpers.assertThrows(
         "Illegal statement",

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceBranch.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceBranch.java
@@ -111,7 +111,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
     table.refresh();
     SnapshotRef ref = table.refs().get(branchName);
     Assert.assertNotNull(ref);
-    Assert.assertEquals(ref.snapshotId(), second);
+    Assert.assertEquals(second, ref.snapshotId());
     Assert.assertEquals(expectedMinSnapshotsToKeep, ref.minSnapshotsToKeep().intValue());
     Assert.assertEquals(expectedMaxSnapshotAgeMs, ref.maxSnapshotAgeMs().longValue());
     Assert.assertEquals(expectedMaxRefAgeMs, ref.maxRefAgeMs().longValue());
@@ -163,7 +163,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
       Assert.assertNotNull(ref);
-      Assert.assertEquals(ref.snapshotId(), second);
+      Assert.assertEquals(second, ref.snapshotId());
       Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
       Assert.assertEquals(maxSnapshotAgeMs, ref.maxSnapshotAgeMs());
       Assert.assertEquals(
@@ -196,7 +196,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
       Assert.assertNotNull(ref);
-      Assert.assertEquals(ref.snapshotId(), second);
+      Assert.assertEquals(second, ref.snapshotId());
       Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
       Assert.assertEquals(
           TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
@@ -237,7 +237,7 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
       table.refresh();
       SnapshotRef ref = table.refs().get(branchName);
       Assert.assertNotNull(ref);
-      Assert.assertEquals(ref.snapshotId(), second);
+      Assert.assertEquals(second, ref.snapshotId());
       Assert.assertEquals(minSnapshotsToKeep, ref.minSnapshotsToKeep());
       Assert.assertEquals(
           TimeUnit.valueOf(timeUnit).toMillis(maxSnapshotAge), ref.maxSnapshotAgeMs().longValue());
@@ -268,6 +268,6 @@ public class TestReplaceBranch extends SparkExtensionsTestBase {
     table.refresh();
     SnapshotRef ref = table.refs().get(branchName);
     Assert.assertNotNull(ref);
-    Assert.assertEquals(ref.snapshotId(), first);
+    Assert.assertEquals(first, ref.snapshotId());
   }
 }


### PR DESCRIPTION
@hililiwei @jackye1995 @flyrain  @yyanyy  When working on the drop branch implementation, I noticed that the "or" condition for replace branch wasn't placed right in https://github.com/apache/iceberg/pull/6638 . It should be within the startsWith("alter table") condition, but currently its outside. The Iceberg DDL will still work, but the check should be more specific to match the alter table condition to prevent any future spark sql syntax change from being bypassed in the `isIcebergCommand` check.

Just raising this PR separately since it's a bugfix (albeit for an unlikely case)