### PR TITLE
Docs: Add the description of creating a table using DataFrameWriterV2 with a table location

### DIFF
--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -302,6 +302,14 @@ data.writeTo("prod.db.table")
     .createOrReplace()
 ```
 
+You can specify an Iceberg table location such as the `LOCATION` clause in SQL by add the `location` paramter to the `tableProperty`:
+
+```scala
+data.writeTo("prod.db.table")
+    .tableProperty("location", "/path/to/location")
+    .createOrReplace()
+```
+
 ## Writing to partitioned tables
 
 Iceberg requires the data to be sorted according to the partition spec per task (Spark partition) in prior to write


### PR DESCRIPTION
This change adds how to run CTAS using DataFrame V2 API with specifying a table location. As a background, some iceberg users ask how to create an iceberg table by DataFrame V2 with specifying a table location, and it's not easy to find the information about the parameter.