### PR TITLE
Spark 3.1: Relocate all Netty classes

### DIFF
--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -92,6 +92,9 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
 
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
+      // to make sure netty libs only come from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
     }
     testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -67,6 +67,9 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.apache.parquet'
+      // to make sure netty libs only come from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
       exclude group: 'org.roaringbitmap'
     }
 
@@ -143,6 +146,9 @@ project(":iceberg-spark:iceberg-spark-extensions-3.1_2.12") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.apache.parquet'
+      // to make sure netty libs only come from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
+      exclude group: 'io.netty', module: 'netty-common'
       exclude group: 'org.roaringbitmap'
     }
 
@@ -255,7 +261,7 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     relocate 'org.apache.httpcomponents.client5', 'org.apache.iceberg.shaded.org.apache.httpcomponents.client5'
     // relocate Arrow and related deps to shade Iceberg specific version
-    relocate 'io.netty.buffer', 'org.apache.iceberg.shaded.io.netty.buffer'
+    relocate 'io.netty', 'org.apache.iceberg.shaded.io.netty'
     relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
     relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
     relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'


### PR DESCRIPTION
Spark 3.1: Relocate all Netty classes 
 #6107