### PR TITLE
Python: Avoid local imports in test

### DIFF
--- a/python/tests/catalog/test_base.py
+++ b/python/tests/catalog/test_base.py
@@ -14,6 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+# pylint:disable=redefined-outer-name
 
 from typing import (
     Dict,
@@ -204,6 +205,11 @@ class InMemoryCatalog(Catalog):
         return PropertiesUpdateSummary(
             removed=list(removed or []), updated=list(updates.keys() if updates else []), missing=list(expected_to_change)
         )
+
+
+@pytest.fixture
+def catalog() -> InMemoryCatalog:
+    return InMemoryCatalog("test.in.memory.catalog", **{"test.key": "test.value"})
 
 
 TEST_TABLE_IDENTIFIER = ("com", "organization", "department", "my_table")

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -112,9 +112,9 @@ def test_create_table_with_strips_bucket_root(
     _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
 ) -> None:
     identifier = (database_name, table_name)
-    test_catalog_strip = GlueCatalog("glue", warehouse=f"s3://{BUCKET_NAME}/")
-    test_catalog_strip.create_namespace(namespace=database_name)
-    table_strip = test_catalog_strip.create_table(identifier, table_schema_nested)
+    test_catalog = GlueCatalog("glue", warehouse=f"s3://{BUCKET_NAME}/")
+    test_catalog.create_namespace(namespace=database_name)
+    table_strip = test_catalog.create_table(identifier, table_schema_nested)
     assert table_strip.identifier == identifier
     assert table_metadata_location_regex.match(table_strip.metadata_location)
 

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -106,8 +106,11 @@ def test_create_table_with_strips(
     table = test_catalog.create_table(identifier, table_schema_nested)
     assert table.identifier == identifier
     assert table_metadata_location_regex.match(table.metadata_location)
-    database_name = f"{database_name}_second"
-    table_name = f"{table_name}_second"
+
+
+def test_create_table_with_strips_bucket_root(
+    _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
+) -> None:
     identifier = (database_name, table_name)
     test_catalog_strip = GlueCatalog("glue", warehouse=f"s3://{BUCKET_NAME}/")
     test_catalog_strip.create_namespace(namespace=database_name)

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -108,6 +108,7 @@ def test_create_table_with_strips(
     assert table_metadata_location_regex.match(table.metadata_location)
 
 
+@mock_glue
 def test_create_table_with_strips_bucket_root(
     _bucket_initialize: None, _patch_aiobotocore: None, table_schema_nested: Schema, database_name: str, table_name: str
 ) -> None:

--- a/python/tests/cli/test_console.py
+++ b/python/tests/cli/test_console.py
@@ -36,7 +36,68 @@ from pyiceberg.table.metadata import TableMetadataV2
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT, Identifier, Properties
 from pyiceberg.utils.config import Config
-from tests.conftest import EXAMPLE_TABLE_METADATA_V2
+
+EXAMPLE_TABLE_METADATA_V2 = {
+    "format-version": 2,
+    "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+    "location": "s3://bucket/test/location",
+    "last-sequence-number": 34,
+    "last-updated-ms": 1602638573590,
+    "last-column-id": 3,
+    "current-schema-id": 1,
+    "schemas": [
+        {"type": "struct", "schema-id": 0, "fields": [{"id": 1, "name": "x", "required": True, "type": "long"}]},
+        {
+            "type": "struct",
+            "schema-id": 1,
+            "identifier-field-ids": [1, 2],
+            "fields": [
+                {"id": 1, "name": "x", "required": True, "type": "long"},
+                {"id": 2, "name": "y", "required": True, "type": "long", "doc": "comment"},
+                {"id": 3, "name": "z", "required": True, "type": "long"},
+            ],
+        },
+    ],
+    "default-spec-id": 0,
+    "partition-specs": [{"spec-id": 0, "fields": [{"name": "x", "transform": "identity", "source-id": 1, "field-id": 1000}]}],
+    "last-partition-id": 1000,
+    "default-sort-order-id": 3,
+    "sort-orders": [
+        {
+            "order-id": 3,
+            "fields": [
+                {"transform": "identity", "source-id": 2, "direction": "asc", "null-order": "nulls-first"},
+                {"transform": "bucket[4]", "source-id": 3, "direction": "desc", "null-order": "nulls-last"},
+            ],
+        }
+    ],
+    "properties": {"read.split.target.size": 134217728},
+    "current-snapshot-id": 3055729675574597004,
+    "snapshots": [
+        {
+            "snapshot-id": 3051729675574597004,
+            "timestamp-ms": 1515100955770,
+            "sequence-number": 0,
+            "summary": {"operation": "append"},
+            "manifest-list": "s3://a/b/1.avro",
+        },
+        {
+            "snapshot-id": 3055729675574597004,
+            "parent-snapshot-id": 3051729675574597004,
+            "timestamp-ms": 1555100955770,
+            "sequence-number": 1,
+            "summary": {"operation": "append"},
+            "manifest-list": "s3://a/b/2.avro",
+            "schema-id": 1,
+        },
+    ],
+    "snapshot-log": [
+        {"snapshot-id": 3051729675574597004, "timestamp-ms": 1515100955770},
+        {"snapshot-id": 3055729675574597004, "timestamp-ms": 1555100955770},
+    ],
+    "metadata-log": [{"metadata-file": "s3://bucket/.../v1.json", "timestamp-ms": 1515100}],
+    "refs": {"test": {"snapshot-id": 3051729675574597004, "type": "tag", "max-ref-age-ms": 10000000}},
+}
 
 
 class MockCatalog(Catalog):

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -25,12 +25,15 @@ and the built-in pytest fixture request should be used as an additional argument
 retrieved using `request.getfixturevalue(fixture_name)`.
 """
 import os
+import string
+from random import choice
 from tempfile import TemporaryDirectory
 from typing import (
     Any,
     Callable,
     Dict,
     Generator,
+    List,
 )
 from unittest.mock import MagicMock
 from urllib.parse import urlparse
@@ -65,7 +68,6 @@ from pyiceberg.types import (
     StringType,
     StructType,
 )
-from tests.catalog.test_base import InMemoryCatalog
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -308,11 +310,6 @@ EXAMPLE_TABLE_METADATA_V2 = {
 @pytest.fixture
 def example_table_metadata_v2() -> Dict[str, Any]:
     return EXAMPLE_TABLE_METADATA_V2
-
-
-@pytest.fixture
-def catalog() -> InMemoryCatalog:
-    return InMemoryCatalog("test.in.memory.catalog", **{"test.key": "test.value"})
 
 
 manifest_entry_records = [
@@ -1271,3 +1268,31 @@ def adlfs_fsspec_fileio(request: pytest.FixtureRequest) -> Generator[FsspecFileI
 def empty_home_dir_path(tmp_path_factory: pytest.TempPathFactory) -> str:
     home_path = str(tmp_path_factory.mktemp("home"))
     return home_path
+
+
+RANDOM_LENGTH = 20
+NUM_TABLES = 2
+
+
+@pytest.fixture()
+def table_name() -> str:
+    prefix = "my_iceberg_table-"
+    random_tag = "".join(choice(string.ascii_letters) for _ in range(RANDOM_LENGTH))
+    return (prefix + random_tag).lower()
+
+
+@pytest.fixture()
+def table_list(table_name: str) -> List[str]:
+    return [f"{table_name}_{idx}" for idx in range(NUM_TABLES)]
+
+
+@pytest.fixture()
+def database_name() -> str:
+    prefix = "my_iceberg_database-"
+    random_tag = "".join(choice(string.ascii_letters) for _ in range(RANDOM_LENGTH))
+    return (prefix + random_tag).lower()
+
+
+@pytest.fixture()
+def database_list(database_name: str) -> List[str]:
+    return [f"{database_name}_{idx}" for idx in range(NUM_TABLES)]


### PR DESCRIPTION
My isort seems to mess up the imports, and it is a good thing to avoid in general. Prefer fixtures over imports. Also because the test folder doesn't have the `__init__.py` files and therefore it isn't a package, this might introduce issues in some situations.