### PR TITLE
Python: Use Version Ranges for Various Dependencies

### DIFF
--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -2470,4 +2470,4 @@ snappy = ["python-snappy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "9294e496c5be2025b0ea54dbd1e068730349b47337d459553c0080f41b3a3abd"
+content-hash = "9ed787b3f081bd27cee8c90fa1ad3461d8734f5251edcc0339c62b37c3a275f9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -50,33 +50,33 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8"
 mmhash3 = "3.0.1"
-requests = "2.28.2"
+requests = ">=2.28.1,<=2.28.2"
 click = "8.1.3"
-rich = "13.3.1"
-pyyaml = "6.0.0"
+rich = ">=13.0.0,<=13.3.1"
+pyyaml = ">=5.4.0,<=6.0.0"
 
 pydantic = "1.10.4"
-fsspec = "2023.1.0"
+fsspec = ">=2022.8.2,<=2023.1.0"
 
 pyparsing = "3.0.9"
 
 zstandard = "0.19.0"
 
-pyarrow = { version = "11.0.0", optional = true }
+pyarrow = { version = ">=8.0.0,<=11.0.0", optional = true }
 
-pandas = { version = "1.5.3", optional = true }
+pandas = { version = ">=1.4.4,<=1.5.3", optional = true }
 
-duckdb = { version = "0.6.1", optional = true }
+duckdb = { version = ">=0.6.0,<=0.6.1", optional = true }
 
 python-snappy = { version = "0.6.1", optional = true }
 
 thrift = { version = "0.16.0", optional = true }
 
-boto3 = {version = "1.24.59", optional = true}
+boto3 = { version = "1.24.59", optional = true }
 
 # The versions of the fsspec implementations should run in sync with fsspec above
-s3fs = { version = "2023.1.0", optional = true }
-adlfs = { version = "2023.1.0", optional = true }
+s3fs = { version = ">=2022.8.2,<=2023.1.0", optional = true }
+adlfs = { version = ">=2022.8.2,<=2023.1.0", optional = true }
 
 [tool.poetry.dev-dependencies]
 pytest = "7.2.1"


### PR DESCRIPTION
As discussed in #6620, this PR uses version ranges for some dependencies. This will unfix the versions for certain dependencies and allow users to use older versions when install PyIceberg to use as a library. The dependencies changed are:
- PyArrow from `11.0.0` to `8.0.0-11.0.0`. It is an optional dependency used either for FileIO, conversion from Iceberg to Arrow (schema, expression, table, etc.), or a dep for Pandas or DuckDB. Made sure current tests pass with every major version.
- Pandas from `1.5.3` to `1.4.4-1.5.3`. It is only used to read Iceberg tables out to Pandas, which is current done through PyArrow anyways. Tested 1.4.4. PyIceberg used 1.5.2 until recently
- DuckDB from `0.6.1` to `0.6.0-0.6.1`. Similar to Pandas, and PyIceberg used 0.6.0 until recently
- FsSpec, S3Fs, and ADLSFs from `2023.1.0` to `2022.8.2-2023.1.0`. Used for FileIO, and I believe S3Fs and ADLSFs already depend on the same version of FsSpec. Tested with all major versions with success, and PyIceberg has used `2022.8.2`, `2022.10.0`, and `2022.11.2` in the past
- Requests from `2.28.2` to `2.28.1-2.28.2` since this is only a patch release and PyIceberg used `2.28.1` until recently.
- Rich from `13.3.1` to `13.0.0-13.3.1` since this is minor release changes with no significant differences
- PyYAML from `6.0.0` to `5.4.0-6.0.0` since `5.4` is still used commonly in other tools, and the only change in the major change in the major release was removing Python 2.7 support. Tested with `5.4.0` 
