### PR TITLE
Prevent RESTCatalog AuthSession from expiring

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -191,9 +191,12 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   private AuthSession session(SessionContext context) {
-    return sessions.get(
-        context.sessionId(),
-        id -> newSession(context.credentials(), context.properties(), catalogAuth));
+    AuthSession session =
+        sessions.get(
+            context.sessionId(),
+            id -> newSession(context.credentials(), context.properties(), catalogAuth));
+
+    return session != null ? session : catalogAuth;
   }
 
   private Supplier<Map<String, String>> headers(SessionContext context) {
@@ -728,7 +731,9 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   private AuthSession tableSession(Map<String, String> tableConf, AuthSession parent) {
-    return newSession(tableConf, tableConf, parent);
+    AuthSession session = newSession(tableConf, tableConf, parent);
+
+    return session != null ? session : parent;
   }
 
   private static ConfigResponse fetchConfig(
@@ -784,7 +789,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
       }
     }
 
-    return parent;
+    return null;
   }
 
   private Long expiresAtMillis(Map<String, String> properties) {


### PR DESCRIPTION
When using OAuth with RESTCatalog, the catalog's auth session is returned by `newSession` if credentials are not provided.  This results in the main auth session being cached and eventually expired.

This PR removes the side-effect of returning the original auth from `newSession` and prevents it from being cached.