### PR TITLE
Flink: use projection when delete records in upsert mode

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -94,7 +94,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
         writer.delete(row);
         break;
       case DELETE:
-        writer.delete(row);
+        if (upsert) {
+          writer.deleteKey(keyProjection.wrap(row));
+        } else {
+          writer.delete(row);
+        }
         break;
 
       default:

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -297,6 +297,24 @@ public class TestFlinkIcebergSinkV2 {
   }
 
   @Test
+  public void testUpsertOnlyDeletesOnDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint =
+        ImmutableList.of(
+            ImmutableList.of(row("+I", 1, "aaa")),
+            ImmutableList.of(row("-D", 1, "aaa"), row("-D", 2, "bbb")));
+
+    List<List<Record>> expectedRecords =
+        ImmutableList.of(ImmutableList.of(record(1, "aaa")), ImmutableList.of());
+
+    testChangeLogs(
+        ImmutableList.of("data"),
+        row -> row.getField(ROW_DATA_POS),
+        true,
+        elementsPerCheckpoint,
+        expectedRecords);
+  }
+
+  @Test
   public void testChangeLogOnDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint =
         ImmutableList.of(


### PR DESCRIPTION
The equality delete writer is built with projected schema in upsert mode, but now it passes row data to it without projection and thus causes problems in case of the equality column is not the first column.

This change adds projection when deleting records in upsert mode.