### PR TITLE
[Spark] add extraSnapshotMetadata using sql conf

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
+import scala.collection.JavaConverters;
 
 /**
  * A class for common Iceberg configs for Spark writes.
@@ -55,6 +56,7 @@ import org.apache.spark.sql.internal.SQLConf;
  */
 public class SparkWriteConf {
 
+  private static final String SESSION_CONF_PREFIX = "spark.iceberg.";
   private final Table table;
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
@@ -191,6 +193,18 @@ public class SparkWriteConf {
                 key.substring(SnapshotSummary.EXTRA_METADATA_PREFIX.length()), value);
           }
         });
+
+    JavaConverters.mapAsJavaMapConverter(sessionConf.getAll())
+        .asJava()
+        .forEach(
+            (key, value) -> {
+              if (key.startsWith(SESSION_CONF_PREFIX + SnapshotSummary.EXTRA_METADATA_PREFIX)) {
+                extraSnapshotMetadata.put(
+                    key.substring(
+                        (SESSION_CONF_PREFIX + SnapshotSummary.EXTRA_METADATA_PREFIX).length()),
+                    value);
+              }
+            });
 
     return extraSnapshotMetadata;
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -448,4 +448,40 @@ public class TestDataSourceOptions {
     Assert.assertTrue(threadNames.contains(null));
     Assert.assertTrue(threadNames.contains("test-extra-commit-message-writer-thread"));
   }
+
+  @Test
+  public void testExtraSnapshotMetadataForSqlInPySpark() throws IOException {
+    String tableLocation = temp.newFolder("iceberg-table").toString();
+    HadoopTables tables = new HadoopTables(CONF);
+
+    Table table =
+        tables.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), tableLocation);
+
+    List<SimpleRecord> expectedRecords =
+        Lists.newArrayList(new SimpleRecord(1, "a"), new SimpleRecord(2, "b"));
+    Dataset<Row> originalDf = spark.createDataFrame(expectedRecords, SimpleRecord.class);
+    originalDf.select("id", "data").write().format("iceberg").mode("append").save(tableLocation);
+    spark.read().format("iceberg").load(tableLocation).createOrReplaceTempView("target");
+    spark.conf().set("spark.iceberg.snapshot-property.extra-key", "someValue");
+    spark.conf().set("spark.iceberg.snapshot-property.another-key", "anotherValue");
+    try {
+      spark.sql("INSERT INTO target VALUES (3, 'c'), (4, 'd')");
+
+      Set<String> extraKeys = Sets.newHashSet();
+      Set<String> anotherKeys = Sets.newHashSet();
+      for (Snapshot snapshot : table.snapshots()) {
+        extraKeys.add(snapshot.summary().get("extra-key"));
+        anotherKeys.add(snapshot.summary().get("another-key"));
+      }
+      Assert.assertEquals(2, extraKeys.size());
+      Assert.assertTrue(extraKeys.contains(null));
+      Assert.assertTrue(extraKeys.contains("someValue"));
+      Assert.assertEquals(2, anotherKeys.size());
+      Assert.assertTrue(anotherKeys.contains(null));
+      Assert.assertTrue(anotherKeys.contains("anotherValue"));
+    } finally {
+      spark.conf().unset("spark.iceberg.snapshot-property.extra-key");
+      spark.conf().unset("spark.iceberg.snapshot-property.another-key");
+    }
+  }
 }


### PR DESCRIPTION
Currently if you are using pyspark and sql statement you can not set extra snapshot metadata as it's only possible using a java lambda.
But we can use spark sql conf to retrieve metadata.
It will also simplify scala and spark usage of this feature.
 
 Fix : https://github.com/apache/iceberg/issues/6754