### PR TITLE
Hive: add retry for metastore permission error

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -261,6 +261,24 @@ acceptedBreaks:
         \ T) throws java.io.IOException, com.fasterxml.jackson.core.JacksonException\
         \ @ org.apache.iceberg.rest.RESTSerializers.UpdateRequirementDeserializer"
       justification: "False positive - JacksonException is a subclass of IOException"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method <R> R org.apache.iceberg.ClientPool<C, E extends java.lang.Exception>::run(org.apache.iceberg.ClientPool.Action<R,\
+        \ C, E>, boolean) throws E, java.lang.InterruptedException"
+      new: "method <R> R org.apache.iceberg.ClientPool<C, E extends java.lang.Exception>::run(org.apache.iceberg.ClientPool.Action<R,\
+        \ C, E>, int, long) throws E, java.lang.InterruptedException"
+      justification: "Add retry limit and delay time instead of retry flag"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method <R> R org.apache.iceberg.ClientPoolImpl<C, E extends java.lang.Exception>::run(org.apache.iceberg.ClientPool.Action<R,\
+        \ C, E>, boolean) throws E, java.lang.InterruptedException"
+      new: "method <R> R org.apache.iceberg.ClientPoolImpl<C, E extends java.lang.Exception>::run(org.apache.iceberg.ClientPool.Action<R,\
+        \ C, E>, int, long) throws E, java.lang.InterruptedException"
+      justification: "Add retry limit and delay time instead of retry flag"
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter void org.apache.iceberg.ClientPoolImpl<C, E extends java.lang.Exception>::<init>(int,\
+        \ java.lang.Class<? extends E>, ===boolean===)"
+      new: "parameter void org.apache.iceberg.ClientPoolImpl<C, E extends java.lang.Exception>::<init>(int,\
+        \ java.lang.Class<? extends E>, ===java.util.Map<java.lang.String, java.lang.String>===)"
+      justification: "Add retry limit and delay time instead of retry flag"
     - code: "java.method.removed"
       old: "method <T> org.apache.iceberg.io.CloseableIterable<T> org.apache.iceberg.deletes.Deletes::filterDeleted(org.apache.iceberg.io.CloseableIterable<T>,\
         \ java.util.function.Predicate<T>)"
@@ -350,10 +368,6 @@ acceptedBreaks:
         \ @ org.apache.iceberg.StreamingDelete"
       justification: "Removing deprecations for 1.2.0"
     - code: "java.method.returnTypeChangedCovariantly"
-      old: "method org.apache.iceberg.Table org.apache.iceberg.BaseMetadataTable::table()"
-      new: "method org.apache.iceberg.BaseTable org.apache.iceberg.BaseMetadataTable::table()"
-      justification: "Returning more specific subclass"
-    - code: "java.method.returnTypeChangedCovariantly"
       old: "method ThisT org.apache.iceberg.SnapshotUpdate<ThisT>::toBranch(java.lang.String)\
         \ @ org.apache.iceberg.BaseOverwriteFiles"
       new: "method org.apache.iceberg.BaseOverwriteFiles org.apache.iceberg.BaseOverwriteFiles::toBranch(java.lang.String)"
@@ -363,6 +377,10 @@ acceptedBreaks:
         \ @ org.apache.iceberg.BaseReplacePartitions"
       new: "method org.apache.iceberg.BaseReplacePartitions org.apache.iceberg.BaseReplacePartitions::toBranch(java.lang.String)"
       justification: "Introducing branch snapshot operations for BaseReplacePartitions"
+    - code: "java.method.returnTypeChangedCovariantly"
+      old: "method org.apache.iceberg.Table org.apache.iceberg.BaseMetadataTable::table()"
+      new: "method org.apache.iceberg.BaseTable org.apache.iceberg.BaseMetadataTable::table()"
+      justification: "Returning more specific subclass"
     org.apache.iceberg:iceberg-orc:
     - code: "java.method.removed"
       old: "method org.apache.iceberg.orc.ORC.WriteBuilder org.apache.iceberg.orc.ORC.WriteBuilder::config(java.lang.String,\

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -147,4 +147,10 @@ public class CatalogProperties {
 
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);
+
+  public static final String RETRY_LIMIT = "retry.limit";
+  public static final int RETRY_LIMIT_DEFAULT = 2;
+
+  public static final String RETRY_DELAY_MS = "retry.delay-ms";
+  public static final long RETRY_DELAY_MS_DEFAULT = 2000;
 }

--- a/core/src/main/java/org/apache/iceberg/ClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/ClientPool.java
@@ -25,5 +25,6 @@ public interface ClientPool<C, E extends Exception> {
 
   <R> R run(Action<R, C, E> action) throws E, InterruptedException;
 
-  <R> R run(Action<R, C, E> action, boolean retry) throws E, InterruptedException;
+  <R> R run(Action<R, C, E> action, int retryLimit, long retryDelayMillis)
+      throws E, InterruptedException;
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -43,7 +43,7 @@ public class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
   }
 
   public JdbcClientPool(int poolSize, String dbUrl, Map<String, String> props) {
-    super(poolSize, SQLNonTransientConnectionException.class, true);
+    super(poolSize, SQLNonTransientConnectionException.class, props);
     properties = props;
     this.dbUrl = dbUrl;
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -50,8 +50,8 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
   private final HiveConf hiveConf;
 
   public HiveClientPool(int poolSize, Configuration conf) {
-    // Do not allow retry by default as we rely on RetryingHiveClient
-    super(poolSize, TTransportException.class, false);
+    // Allow retry for a case of failure in RetryingHiveClient if impersonation is enabled.
+    super(poolSize, TTransportException.class, true);
     this.hiveConf = new HiveConf(conf, HiveClientPool.class);
     this.hiveConf.addResource(conf);
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.AfterClass;
@@ -96,7 +97,7 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
 
     // Set up the spy clients as static variables instead of before every test.
     // The spy clients are reused between methods and closed at the end of all tests in this class.
-    spyClientPool = spy(new HiveClientPool(1, overriddenHiveConf));
+    spyClientPool = spy(new HiveClientPool(1, overriddenHiveConf, Maps.newHashMap()));
     when(spyClientPool.newClient())
         .thenAnswer(
             invocation -> {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.hadoop.Util;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
@@ -168,7 +169,7 @@ public class TestHiveMetastore {
           HiveConf.ConfVars.METASTOREURIS.varname,
           hiveConf.getVar(HiveConf.ConfVars.METASTOREURIS));
 
-      this.clientPool = new HiveClientPool(1, hiveConf);
+      this.clientPool = new HiveClientPool(1, hiveConf, Maps.newHashMap());
     } catch (Exception e) {
       throw new RuntimeException("Cannot start TestHiveMetastore", e);
     }


### PR DESCRIPTION
FIx : https://github.com/apache/iceberg/issues/6750

## Situation

1. `A user` create `RetryingMetaStoreClient` instance, use it, and release.
2. `B user` get `RetryingMetaStoreClient` created from 1, try to use it for query to a table that doesn't allowed to access from `A user`.
3. Permission error is occured while getting table info from metastore server.

## Changes

- Retry once outside of RetryingMetaStoreClient if `isConnectionException`
- Add condition for `AccessControlException` in `isConnectionException`
- Add retry limits and delay.