### PR TITLE
Core: enforce writing POSIX compatible paths for data location

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -250,6 +250,10 @@ public class TableProperties {
   // If not set, defaults to a "metadata" folder underneath the root path of the table.
   public static final String WRITE_METADATA_LOCATION = "write.metadata.path";
 
+  public static final String WRITE_POSIX_PATH_ENFORCED = "write.posix-path-enforced";
+
+  public static final boolean WRITE_POSIX_PATH_ENFORCED_DEFAULT = true;
+
   public static final String WRITE_PARTITION_SUMMARY_LIMIT = "write.summary.partition-limit";
   public static final int WRITE_PARTITION_SUMMARY_LIMIT_DEFAULT = 0;
 

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -18,9 +18,14 @@
  */
 package org.apache.iceberg.util;
 
+import java.nio.file.Paths;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class LocationUtil {
+  private static final String SCHEME_DELIM = "://";
+  private static final String PATH_DELIM = "/";
+
   private LocationUtil() {}
 
   public static String stripTrailingSlash(String path) {
@@ -32,5 +37,18 @@ public class LocationUtil {
       result = result.substring(0, result.length() - 1);
     }
     return result;
+  }
+
+  public static String posixNormalize(String path) {
+    String[] schemeSplit = path.split(SCHEME_DELIM, -1);
+    ValidationException.check(
+        schemeSplit.length <= 2, // length is at least 1 in a split
+        "Invalid path, must only contain at most 1 scheme: %s",
+        path);
+    if (schemeSplit.length == 1) {
+      return Paths.get(path).normalize().toString();
+    }
+
+    return schemeSplit[0] + SCHEME_DELIM + Paths.get(schemeSplit[1]).normalize().toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -48,6 +48,6 @@ public class LocationUtil {
       return Paths.get(path).normalize().toString();
     }
 
-    return schemeSplit[0] + SCHEME_DELIM + Paths.get(schemeSplit[1]).normalize().toString();
+    return schemeSplit[0] + SCHEME_DELIM + Paths.get(schemeSplit[1]).normalize();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -24,7 +24,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class LocationUtil {
   private static final String SCHEME_DELIM = "://";
-  private static final String PATH_DELIM = "/";
 
   private LocationUtil() {}
 

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -297,4 +297,106 @@ public class TestLocationProvider extends TableTestBase {
     Assert.assertEquals(
         "Fourth part should be the file name passed in", "test.parquet", parts.get(3));
   }
+
+  @Test
+  public void testPosixNormalizeCustomDataURILocationWithDoubleSlashPart() {
+    String rootLocation = "s3://some/path/";
+    String nonPosixPart = "foo//bar";
+    String posixPart = "foo/bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path with custom data location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
+
+  @Test
+  public void testPosixNormalizeCustomDataURILocationWithDoubleDotPart() {
+    String rootLocation = "s3://some/path/";
+    String nonPosixPart = "foo/../bar";
+    String posixPart = "bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path with custom data location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
+
+  @Test
+  public void testPosixNormalizeCustomDataURILocationWithSingleDotPart() {
+    String rootLocation = "s3://some/path/";
+    String nonPosixPart = "foo/./bar";
+    String posixPart = "foo/bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path with custom data location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
+
+  @Test
+  public void testPosixNormalizeCustomDataPathLocationWithDoubleSlashPart() {
+    String rootLocation = "/local/some/path/";
+    String nonPosixPart = "foo//bar";
+    String posixPart = "foo/bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path with default table location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
+
+  @Test
+  public void testPosixNormalizeCustomDataPathLocationWithDoubleDotPart() {
+    String rootLocation = "/local/some/path/";
+    String nonPosixPart = "foo/../bar";
+    String posixPart = "bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path with default table location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
+
+  @Test
+  public void testPosixNormalizeCustomDataPathLocationWithSingleDotPart() {
+    String rootLocation = "/local/some/path/";
+    String nonPosixPart = "foo/./bar";
+    String posixPart = "foo/bar";
+    table
+        .updateProperties()
+        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
+        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .commit();
+    table.refresh();
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path with default table location",
+        rootLocation + posixPart,
+        table.locationProvider().newDataLocation(nonPosixPart));
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -300,10 +300,7 @@ public class TestLocationProvider extends TableTestBase {
 
   @Test
   public void testPosixNormalizeWithDefaultLocationProviderAndDefaultDataLocation() {
-    table
-        .updateProperties()
-        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .commit();
+    table.updateProperties().set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true").commit();
     table.updateLocation().setLocation("s3://bucket").commit();
     table.refresh();
     Assert.assertEquals(

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -299,104 +299,58 @@ public class TestLocationProvider extends TableTestBase {
   }
 
   @Test
-  public void testPosixNormalizeCustomDataURILocationWithDoubleSlashPart() {
-    String rootLocation = "s3://some/path/";
-    String nonPosixPart = "foo//bar";
-    String posixPart = "foo/bar";
+  public void testPosixNormalizeWithDefaultLocationProviderAndDefaultDataLocation() {
     table
         .updateProperties()
         .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
         .commit();
+    table.updateLocation().setLocation("s3://bucket").commit();
     table.refresh();
     Assert.assertEquals(
-        "Must change // to / to enforce posix path with custom data location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
+        "Must enforce POSIX standard for path",
+        "s3://bucket/data/foo/bar",
+        table.locationProvider().newDataLocation("foo//bar"));
   }
 
   @Test
-  public void testPosixNormalizeCustomDataURILocationWithDoubleDotPart() {
-    String rootLocation = "s3://some/path/";
-    String nonPosixPart = "foo/../bar";
-    String posixPart = "bar";
+  public void testPosixNormalizeWithDefaultLocationProviderAndCustomDataLocation() {
     table
         .updateProperties()
         .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .set(TableProperties.WRITE_DATA_LOCATION, "s3://bucket")
         .commit();
     table.refresh();
     Assert.assertEquals(
-        "Must resolve .. to previous directory to enforce posix path with custom data location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
+        "Must enforce POSIX standard for path",
+        "s3://bucket/foo/bar",
+        table.locationProvider().newDataLocation("foo//bar"));
   }
 
   @Test
-  public void testPosixNormalizeCustomDataURILocationWithSingleDotPart() {
-    String rootLocation = "s3://some/path/";
-    String nonPosixPart = "foo/./bar";
-    String posixPart = "foo/bar";
+  public void testPosixNormalizeWithObjectStorageLocationProviderAndDefaultDataLocation() {
     table
         .updateProperties()
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
         .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
         .commit();
+    table.updateLocation().setLocation("s3://bucket").commit();
     table.refresh();
-    Assert.assertEquals(
-        "Must resolve . to current directory to enforce posix path with custom data location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
+    Assert.assertTrue(
+        "Must enforce POSIX standard for path",
+        table.locationProvider().newDataLocation("foo//bar").contains("foo/bar"));
   }
 
   @Test
-  public void testPosixNormalizeCustomDataPathLocationWithDoubleSlashPart() {
-    String rootLocation = "/local/some/path/";
-    String nonPosixPart = "foo//bar";
-    String posixPart = "foo/bar";
+  public void testPosixNormalizeWithObjectStorageLocationProviderAndCustomDataLocation() {
     table
         .updateProperties()
         .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
+        .set(TableProperties.WRITE_DATA_LOCATION, "s3://bucket")
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
         .commit();
     table.refresh();
-    Assert.assertEquals(
-        "Must change // to / to enforce posix path with default table location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
-  }
-
-  @Test
-  public void testPosixNormalizeCustomDataPathLocationWithDoubleDotPart() {
-    String rootLocation = "/local/some/path/";
-    String nonPosixPart = "foo/../bar";
-    String posixPart = "bar";
-    table
-        .updateProperties()
-        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
-        .commit();
-    table.refresh();
-    Assert.assertEquals(
-        "Must resolve .. to previous directory to enforce posix path with default table location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
-  }
-
-  @Test
-  public void testPosixNormalizeCustomDataPathLocationWithSingleDotPart() {
-    String rootLocation = "/local/some/path/";
-    String nonPosixPart = "foo/./bar";
-    String posixPart = "foo/bar";
-    table
-        .updateProperties()
-        .set(TableProperties.WRITE_POSIX_PATH_ENFORCED, "true")
-        .set(TableProperties.WRITE_DATA_LOCATION, rootLocation)
-        .commit();
-    table.refresh();
-    Assert.assertEquals(
-        "Must resolve . to current directory to enforce posix path with default table location",
-        rootLocation + posixPart,
-        table.locationProvider().newDataLocation(nonPosixPart));
+    Assert.assertTrue(
+        "Must enforce POSIX standard for path",
+        table.locationProvider().newDataLocation("foo//bar").contains("foo/bar"));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -153,9 +153,7 @@ public class TestLocationUtil {
   @Test
   public void testPosixNormalizeNoSchemePaths() {
     Assert.assertEquals(
-        "Must work with the root directory representation",
-        "/",
-        LocationUtil.posixNormalize("/"));
+        "Must work with the root directory representation", "/", LocationUtil.posixNormalize("/"));
     Assert.assertEquals(
         "Must resolve all root directory representations to /",
         "/",
@@ -165,9 +163,7 @@ public class TestLocationUtil {
         "/dir",
         LocationUtil.posixNormalize("//dir"));
     Assert.assertEquals(
-        "Must remove / from the end of directory",
-        "/dir",
-        LocationUtil.posixNormalize("/dir/"));
+        "Must remove / from the end of directory", "/dir", LocationUtil.posixNormalize("/dir/"));
     Assert.assertEquals(
         "Must change // to / to enforce posix path",
         "/foo/bar",

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -151,7 +151,7 @@ public class TestLocationUtil {
   }
 
   @Test
-  public void testPosixNormalizeNoSchemePaths() {
+  public void testPosixNormalizePathsWithoutScheme() {
     Assert.assertEquals(
         "Must work with the root directory representation", "/", LocationUtil.posixNormalize("/"));
     Assert.assertEquals(

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -61,4 +61,124 @@ public class TestLocationUtil {
           () -> LocationUtil.stripTrailingSlash(invalidPath));
     }
   }
+
+  @Test
+  public void testPosixNormalizePathsWithSchemeAndAuthorityS3Style() {
+    Assert.assertEquals(
+        "Must work with a root authority",
+        "s3://bucket",
+        LocationUtil.posixNormalize("s3://bucket"));
+    Assert.assertEquals(
+        "Must remove / from the end of authority",
+        "s3://bucket",
+        LocationUtil.posixNormalize("s3://bucket/"));
+    Assert.assertEquals(
+        "Must remove / from the end of directory",
+        "s3://bucket/dir",
+        LocationUtil.posixNormalize("s3://bucket/dir/"));
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path",
+        "s3://bucket/foo/bar",
+        LocationUtil.posixNormalize("s3://bucket/foo//bar"));
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path",
+        "s3://bucket/bar",
+        LocationUtil.posixNormalize("s3://bucket/foo/../bar"));
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path",
+        "s3://bucket/foo/bar",
+        LocationUtil.posixNormalize("s3://bucket/foo/.//bar"));
+  }
+
+  @Test
+  public void testPosixNormalizePathsWithSchemeAndAuthorityHdfsStyle() {
+    Assert.assertEquals(
+        "Must work with a root authority",
+        "hdfs://1.2.3.4",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4"));
+    Assert.assertEquals(
+        "Must remove / from the end of authority",
+        "hdfs://1.2.3.4",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4/"));
+    Assert.assertEquals(
+        "Must remove / from the end of directory",
+        "hdfs://1.2.3.4/dir",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4/dir/"));
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path",
+        "hdfs://1.2.3.4/foo/bar",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4/foo//bar"));
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path",
+        "hdfs://1.2.3.4/bar",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4/foo/../bar"));
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path",
+        "hdfs://1.2.3.4/foo/bar",
+        LocationUtil.posixNormalize("hdfs://1.2.3.4/foo/.//bar"));
+  }
+
+  @Test
+  public void testPosixNormalizePathsWithSchemeAndWithoutAuthority() {
+    Assert.assertEquals(
+        "Must work with the root directory representation",
+        "file:///",
+        LocationUtil.posixNormalize("file:///"));
+    Assert.assertEquals(
+        "Must resolve all root directory representations to /",
+        "file:///",
+        LocationUtil.posixNormalize("file:////"));
+    Assert.assertEquals(
+        "Must resolve all root directory representations to / with subdirectory",
+        "file:///dir",
+        LocationUtil.posixNormalize("file:////dir"));
+    Assert.assertEquals(
+        "Must remove / from the end of directory",
+        "file:///dir",
+        LocationUtil.posixNormalize("file:///dir/"));
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path",
+        "file:///foo/bar",
+        LocationUtil.posixNormalize("file:///foo//bar"));
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path",
+        "file:///bar",
+        LocationUtil.posixNormalize("file:///foo/../bar"));
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path",
+        "file:///foo/bar",
+        LocationUtil.posixNormalize("file:///foo/.//bar"));
+  }
+
+  @Test
+  public void testPosixNormalizeNoSchemePaths() {
+    Assert.assertEquals(
+        "Must work with the root directory representation",
+        "/",
+        LocationUtil.posixNormalize("/"));
+    Assert.assertEquals(
+        "Must resolve all root directory representations to /",
+        "/",
+        LocationUtil.posixNormalize("//"));
+    Assert.assertEquals(
+        "Must resolve all root directory representations to / with subdirectory",
+        "/dir",
+        LocationUtil.posixNormalize("//dir"));
+    Assert.assertEquals(
+        "Must remove / from the end of directory",
+        "/dir",
+        LocationUtil.posixNormalize("/dir/"));
+    Assert.assertEquals(
+        "Must change // to / to enforce posix path",
+        "/foo/bar",
+        LocationUtil.posixNormalize("/foo//bar"));
+    Assert.assertEquals(
+        "Must resolve .. to previous directory to enforce posix path",
+        "/bar",
+        LocationUtil.posixNormalize("/foo/../bar"));
+    Assert.assertEquals(
+        "Must resolve . to current directory to enforce posix path",
+        "/foo/bar",
+        LocationUtil.posixNormalize("/foo/.//bar"));
+  }
 }


### PR DESCRIPTION
part of fixes for #6758 