### PR TITLE
Spark 3.3: Improve log messages in scans

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -142,7 +142,7 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
               .collect(Collectors.toList());
 
       LOG.info(
-          "{}/{} tasks for table {} matched runtime filter {}",
+          "{} of {} task(s) for table {} matched runtime filter {}",
           filteredTasks.size(),
           tasks().size(),
           table().name(),

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -132,11 +132,6 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
         evaluatorsBySpecId.put(spec.specId(), inclusive);
       }
 
-      LOG.info(
-          "Trying to filter {} tasks using runtime filter {}",
-          tasks().size(),
-          ExpressionUtil.toSanitizedString(runtimeFilterExpr));
-
       List<PartitionScanTask> filteredTasks =
           tasks().stream()
               .filter(
@@ -147,9 +142,10 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
               .collect(Collectors.toList());
 
       LOG.info(
-          "{}/{} tasks matched runtime filter {}",
+          "{}/{} tasks for table {} matched runtime filter {}",
           filteredTasks.size(),
           tasks().size(),
+          table().name(),
           ExpressionUtil.toSanitizedString(runtimeFilterExpr));
 
       // don't invalidate tasks if the runtime filter had no effect to avoid planning splits again

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -40,9 +40,13 @@ import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.sources.In;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
     implements SupportsRuntimeFiltering {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkCopyOnWriteScan.class);
 
   private final Snapshot snapshot;
   private Set<String> filteredLocations = null;
@@ -123,8 +127,17 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
               tasks().stream()
                   .filter(file -> fileLocations.contains(file.file().path().toString()))
                   .collect(Collectors.toList());
+
+          LOG.info(
+              "{}/{} tasks for table {} matched runtime file filter",
+              filteredTasks.size(),
+              tasks().size(),
+              table().name());
+
           resetTasks(filteredTasks);
         }
+      } else {
+        LOG.warn("Unsupported runtime filter {}", filter);
       }
     }
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -129,10 +129,11 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
                   .collect(Collectors.toList());
 
           LOG.info(
-              "{}/{} tasks for table {} matched runtime file filter",
+              "{} of {} task(s) for table {} matched runtime file filter with {} location(s)",
               filteredTasks.size(),
               tasks().size(),
-              table().name());
+              table().name(),
+              fileLocations.size());
 
           resetTasks(filteredTasks);
         }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitioningAwareScan.java
@@ -99,13 +99,17 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
   @Override
   public Partitioning outputPartitioning() {
     if (groupingKeyType().fields().isEmpty()) {
-      LOG.info("Reporting UnknownPartitioning with {} partition(s)", taskGroups().size());
+      LOG.info(
+          "Reporting UnknownPartitioning with {} partition(s) for table {}",
+          taskGroups().size(),
+          table().name());
       return new UnknownPartitioning(taskGroups().size());
     } else {
       LOG.info(
-          "Reporting KeyGroupedPartitioning by {} with {} partition(s)",
+          "Reporting KeyGroupedPartitioning by {} with {} partition(s) for table {}",
           groupingKeyTransforms(),
-          taskGroups().size());
+          taskGroups().size(),
+          table().name());
       return new KeyGroupedPartitioning(groupingKeyTransforms(), taskGroups().size());
     }
   }
@@ -200,7 +204,10 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
                 scan.splitOpenFileCost());
         this.taskGroups = Lists.newArrayList(plannedTaskGroups);
 
-        LOG.debug("Planned {} task group(s) without data grouping", taskGroups.size());
+        LOG.debug(
+            "Planned {} task group(s) without data grouping for table {}",
+            taskGroups.size(),
+            table().name());
 
       } else {
         List<ScanTaskGroup<T>> plannedTaskGroups =
@@ -213,10 +220,11 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
         StructLikeSet plannedGroupingKeys = collectGroupingKeys(plannedTaskGroups);
 
         LOG.debug(
-            "Planned {} task group(s) with {} grouping key type and {} unique grouping key(s)",
+            "Planned {} task group(s) with {} grouping key type and {} unique grouping key(s) for table {}",
             plannedTaskGroups.size(),
             groupingKeyType(),
-            plannedGroupingKeys.size());
+            plannedGroupingKeys.size(),
+            table().name());
 
         // task groups may be planned multiple times because of runtime filtering
         // the number of task groups may change but the set of grouping keys must stay same
@@ -236,7 +244,10 @@ abstract class SparkPartitioningAwareScan<T extends PartitionScanTask> extends S
             }
           }
 
-          LOG.debug("{} grouping key(s) were filtered out at runtime", missingGroupingKeys.size());
+          LOG.debug(
+              "{} grouping key(s) were filtered out at runtime for table {}",
+              missingGroupingKeys.size(),
+              table().name());
 
           for (StructLike groupingKey : missingGroupingKeys) {
             plannedTaskGroups.add(new BaseScanTaskGroup<>(groupingKey, Collections.emptyList()));

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -140,7 +140,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     // estimate stats using snapshot summary only for partitioned tables
     // (metadata tables are unpartitioned)
     if (!table.spec().isUnpartitioned() && filterExpressions.isEmpty()) {
-      LOG.debug("Using table metadata to estimate table statistics");
+      LOG.debug("Using snapshot metadata to estimate statistics for table {}", table.name());
       long totalRecords = totalRecords(snapshot);
       return new Stats(SparkSchemaUtil.estimateSize(readSchema(), totalRecords), totalRecords);
     }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -140,7 +140,10 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     // estimate stats using snapshot summary only for partitioned tables
     // (metadata tables are unpartitioned)
     if (!table.spec().isUnpartitioned() && filterExpressions.isEmpty()) {
-      LOG.debug("Using snapshot metadata to estimate statistics for table {}", table.name());
+      LOG.debug(
+          "Using snapshot {} metadata to estimate statistics for table {}",
+          snapshot.snapshotId(),
+          table.name());
       long totalRecords = totalRecords(snapshot);
       return new Stats(SparkSchemaUtil.estimateSize(readSchema(), totalRecords), totalRecords);
     }


### PR DESCRIPTION
While debugging storage-partitions joins, I realized our log messages in scans don't include table names. It makes hard to match log messages with tables if queries touch multiple tables. This PR slightly improves log messages in scans.