### PR TITLE
Core: TableMetadata Always Strips Trailing Slash From Location

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 
@@ -290,7 +291,7 @@ public class TableMetadata implements Serializable {
     this.metadataFileLocation = metadataFileLocation;
     this.formatVersion = formatVersion;
     this.uuid = uuid;
-    this.location = location;
+    this.location = location != null ? LocationUtil.stripTrailingSlash(location) : null;
     this.lastSequenceNumber = lastSequenceNumber;
     this.lastUpdatedMillis = lastUpdatedMillis;
     this.lastColumnId = lastColumnId;

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -38,6 +38,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -1560,6 +1561,19 @@ public class TestTableMetadata {
                 "/tmp",
                 ImmutableMap.of(TableProperties.UUID, "uuid"),
                 1));
+  }
+
+  @Test
+  public void testNoTrailingLocationSlash() {
+    String locationWithSlash = "/with_trailing_slash/";
+    String locationWithoutSlash = "/with_trailing_slash";
+    TableMetadata meta =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA, SPEC_5, SORT_ORDER_3, locationWithSlash, Collections.emptyMap());
+    Assert.assertEquals(
+        "Metadata should never return a location ending in a slash",
+        locationWithoutSlash,
+        meta.location());
   }
 
   private String createManifestListWithManifestFile(

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
@@ -327,7 +328,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   private void checkIcebergTableLocation(String icebergTableIdentifier, String expectedLocation) {
     Table icebergTable = getIcebergTable(icebergTableIdentifier);
-    Assertions.assertThat(icebergTable.location()).isEqualTo(expectedLocation);
+    Assertions.assertThat(icebergTable.location()).isEqualTo(LocationUtil.stripTrailingSlash(expectedLocation));
   }
 
   private void checkIcebergTableProperties(

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -328,7 +328,8 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   private void checkIcebergTableLocation(String icebergTableIdentifier, String expectedLocation) {
     Table icebergTable = getIcebergTable(icebergTableIdentifier);
-    Assertions.assertThat(icebergTable.location()).isEqualTo(LocationUtil.stripTrailingSlash(expectedLocation));
+    Assertions.assertThat(icebergTable.location())
+        .isEqualTo(LocationUtil.stripTrailingSlash(expectedLocation));
   }
 
   private void checkIcebergTableProperties(

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/SnowflakeCatalogTest.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/SnowflakeCatalogTest.java
@@ -87,7 +87,7 @@ public class SnowflakeCatalogTest {
         "s3://tab1/metadata/v3.metadata.json",
         TableMetadataParser.toJson(
                 TableMetadata.newTableMetadata(
-                    schema, partitionSpec, "s3://tab1/", ImmutableMap.<String, String>of()))
+                    schema, partitionSpec, "s3://tab1", ImmutableMap.<String, String>of()))
             .getBytes());
     fakeFileIO.addFile(
         "wasbs://mycontainer@myaccount.blob.core.windows.net/tab3/metadata/v334.metadata.json",
@@ -216,20 +216,20 @@ public class SnowflakeCatalogTest {
   @Test
   public void testLoadS3Table() {
     Table table = catalog.loadTable(TableIdentifier.of(Namespace.of("DB_1", "SCHEMA_1"), "TAB_1"));
-    Assertions.assertThat(table.location()).isEqualTo("s3://tab1/");
+    Assertions.assertThat(table.location()).isEqualTo("s3://tab1");
   }
 
   @Test
   public void testLoadAzureTable() {
     Table table = catalog.loadTable(TableIdentifier.of(Namespace.of("DB_2", "SCHEMA_2"), "TAB_3"));
     Assertions.assertThat(table.location())
-        .isEqualTo("wasbs://mycontainer@myaccount.blob.core.windows.net/tab1/");
+        .isEqualTo("wasbs://mycontainer@myaccount.blob.core.windows.net/tab1");
   }
 
   @Test
   public void testLoadGcsTable() {
     Table table = catalog.loadTable(TableIdentifier.of(Namespace.of("DB_3", "SCHEMA_3"), "TAB_5"));
-    Assertions.assertThat(table.location()).isEqualTo("gs://tab5/");
+    Assertions.assertThat(table.location()).isEqualTo("gs://tab5");
   }
 
   @Test

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -635,7 +635,7 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     Assert.assertTrue(
         "trash file should be removed",
         StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "data/trashfile")));
+            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -635,7 +635,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Assert.assertTrue(
         "trash file should be removed",
         StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "data/trashfile")));
+            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
   }
 
   @Test

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -737,7 +737,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Assert.assertTrue(
         "trash file should be removed",
         StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "data/trashfile")));
+            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -737,7 +737,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     Assert.assertTrue(
         "trash file should be removed",
         StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "data/trashfile")));
+            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
   }
 
   @Test


### PR DESCRIPTION
Previously we could end up in situations where we unintentionally we would create // in file paths which is an issue with non-POSIX FileIOs.

This is a partial fix for #6758 