### PR TITLE
Spark-3.3: Support unregister table procedure

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -125,6 +125,10 @@ public class CachingCatalog implements Catalog {
     }
   }
 
+  public Catalog catalog() {
+    return catalog;
+  }
+
   @Override
   public String name() {
     return catalog.name();

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUnregisterTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUnregisterTableProcedure.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestUnregisterTableProcedure extends SparkExtensionsTestBase {
+
+  public TestUnregisterTableProcedure(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  @After
+  public void dropTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testUnregisterTable() throws NoSuchTableException, IOException {
+    if (catalogName.equals(SparkCatalogConfig.HADOOP.catalogName())) {
+      AssertHelpers.assertThrows(
+          "Should fail for hadoop catalog",
+          UnsupportedOperationException.class,
+          "Unregister table is not supported for Hadoop catalog",
+          () -> sql("CALL %s.system.unregister_table('%s')", catalogName, tableName));
+      return;
+    }
+
+    sql("CREATE TABLE %s (id int, data string) using ICEBERG", tableName);
+    spark
+        .range(0, 10)
+        .withColumn("data", functions.col("id").cast(DataTypes.StringType))
+        .writeTo(tableName)
+        .append();
+
+    Table table = catalog.loadTable(tableIdent);
+
+    // delete the files from storage
+    FileUtils.forceDelete(new File(table.location().replaceFirst("file:", "")));
+
+    List<Object[]> result = sql("CALL %s.system.unregister_table('%s')", catalogName, tableName);
+    Assert.assertTrue("Should be success", (boolean) result.get(0)[0]);
+
+    AssertHelpers.assertThrows(
+        "Entry should not be present in the catalog",
+        org.apache.iceberg.exceptions.NoSuchTableException.class,
+        "Table does not exist: default.table",
+        () -> catalog.loadTable(tableIdent));
+  }
+
+  @Test
+  public void testFailure() {
+    Assume.assumeTrue(!catalogName.equals(SparkCatalogConfig.HADOOP.catalogName()));
+
+    List<Object[]> result = sql("CALL %s.system.unregister_table('foo.bar')", catalogName);
+    Assert.assertFalse("Should be a failure as table does not exist", (boolean) result.get(0)[0]);
+  }
+
+  @Test
+  public void testInvalidInput() {
+    AssertHelpers.assertThrows(
+        "Should fail because of invalid input",
+        AnalysisException.class,
+        "Missing required parameters: [table]",
+        () -> sql("CALL %s.system.unregister_table()", catalogName));
+
+    AssertHelpers.assertThrows(
+        "Should fail because of invalid input",
+        IllegalArgumentException.class,
+        "Cannot handle an empty identifier for argument table",
+        () -> sql("CALL %s.system.unregister_table('')", catalogName));
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -53,6 +53,7 @@ public class SparkProcedures {
     mapBuilder.put("ancestors_of", AncestorsOfProcedure::builder);
     mapBuilder.put("register_table", RegisterTableProcedure::builder);
     mapBuilder.put("publish_changes", PublishChangesProcedure::builder);
+    mapBuilder.put("unregister_table", UnregisterTableProcedure::builder);
     return mapBuilder.build();
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/UnregisterTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/UnregisterTableProcedure.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.iceberg.spark.source.HasIcebergCatalog;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+class UnregisterTableProcedure extends BaseProcedure {
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {ProcedureParameter.required("table", DataTypes.StringType)};
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField("isUnregistered", DataTypes.BooleanType, false, Metadata.empty())
+          });
+
+  private UnregisterTableProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  public static ProcedureBuilder builder() {
+    return new Builder<UnregisterTableProcedure>() {
+      @Override
+      protected UnregisterTableProcedure doBuild() {
+        return new UnregisterTableProcedure(tableCatalog());
+      }
+    };
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    TableIdentifier identifier =
+        Spark3Util.identifierToTableIdentifier(toIdentifier(args.getString(0), "table"));
+    Preconditions.checkArgument(
+        tableCatalog() instanceof HasIcebergCatalog,
+        "Cannot use Unregister Table in a non-Iceberg catalog");
+
+    Catalog icebergCatalog = ((HasIcebergCatalog) tableCatalog()).icebergCatalog();
+    if (isHadoopCatalog(icebergCatalog)) {
+      // even with purge as false, dropTable() will clean the files for hadoop catalog.
+      throw new UnsupportedOperationException(
+          "Unregister table is not supported for Hadoop catalog.");
+    }
+
+    // with purge as false, dropTable() will not load the table metadata.
+    // It just drops the table entry from catalog.
+    boolean isUnregistered = icebergCatalog.dropTable(identifier, false);
+
+    return new InternalRow[] {newInternalRow(isUnregistered)};
+  }
+
+  private boolean isHadoopCatalog(Catalog icebergCatalog) {
+    return icebergCatalog instanceof HadoopCatalog
+        || (icebergCatalog instanceof CachingCatalog
+            && ((CachingCatalog) icebergCatalog).catalog() instanceof HadoopCatalog);
+  }
+
+  @Override
+  public String description() {
+    return "UnregisterTableProcedure";
+  }
+}


### PR DESCRIPTION
CALL Procedure to just remove the table entry from the catalog without looking up the data and metadata files. 

Fixes #6785 

Note: 
Not supporting this feature for hadoop catalog as there is no concept of just removing the table entry from catalog in hadoop as hadoop catalog will always clean the files even with purge=false.

Note: Documentation will be updated in the follow up PR to avoid rework if there are any comments about the procedure.