### PR TITLE
Build: add version.txt for build.gradle

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+apache-iceberg-1.1.0-master.dirty


### PR DESCRIPTION
make the gradle build process run without exceptions in absence of git.

[    throw new Exception("Neither version.txt nor git version exists")](https://github.com/ludlows/iceberg/blob/505368ad3f02d490cc969a5949cfcb9e51c00828/build.gradle#L841)

as shown above, in the file build.gradle, which requires either git version or version.txt file to start the build process, 
a error "_Neither version.txt nor git version exists_" is raised in absence of git version .

here I added the file _version.txt_ to make the build process start to run.

