### PR TITLE
Nessie: Use latest hash for catalog APIs

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -195,7 +195,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
         ContentKey.of(
             org.projectnessie.model.Namespace.of(tableIdentifier.namespace().levels()),
             tr.getName()),
-        refreshedClient().withReference(tr.getReference(), tr.getHash()),
+        client().withReference(tr.getReference(), tr.getHash()),
         fileIO,
         catalogOptions);
   }
@@ -224,13 +224,13 @@ public class NessieCatalog extends BaseMetastoreCatalog
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    return refreshedClient().listTables(namespace);
+    return client().listTables(namespace);
   }
 
   @Override
   public boolean dropTable(TableIdentifier identifier, boolean purge) {
     TableReference tableReference = parseTableReference(identifier);
-    return refreshedClient()
+    return client()
         .withReference(tableReference.getReference(), tableReference.getHash())
         .dropTable(identifierWithoutTableReference(identifier, tableReference), purge);
   }
@@ -239,7 +239,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     TableReference fromTableReference = parseTableReference(from);
     TableReference toTableReference = parseTableReference(to);
-    NessieIcebergClient nessieIcebergClient = refreshedClient();
+    NessieIcebergClient nessieIcebergClient = client();
     String fromReference =
         fromTableReference.hasReference()
             ? fromTableReference.getReference()
@@ -264,12 +264,12 @@ public class NessieCatalog extends BaseMetastoreCatalog
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
-    refreshedClient().createNamespace(namespace, metadata);
+    client().createNamespace(namespace, metadata);
   }
 
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
-    return refreshedClient().listNamespaces(namespace);
+    return client().listNamespaces(namespace);
   }
 
   /**
@@ -282,22 +282,22 @@ public class NessieCatalog extends BaseMetastoreCatalog
   @Override
   public Map<String, String> loadNamespaceMetadata(Namespace namespace)
       throws NoSuchNamespaceException {
-    return refreshedClient().loadNamespaceMetadata(namespace);
+    return client().loadNamespaceMetadata(namespace);
   }
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    return refreshedClient().dropNamespace(namespace);
+    return client().dropNamespace(namespace);
   }
 
   @Override
   public boolean setProperties(Namespace namespace, Map<String, String> properties) {
-    return refreshedClient().setProperties(namespace, properties);
+    return client().setProperties(namespace, properties);
   }
 
   @Override
   public boolean removeProperties(Namespace namespace, Set<String> properties) {
-    return refreshedClient().removeProperties(namespace, properties);
+    return client().removeProperties(namespace, properties);
   }
 
   @Override
@@ -312,12 +312,12 @@ public class NessieCatalog extends BaseMetastoreCatalog
 
   @VisibleForTesting
   String currentHash() {
-    return refreshedClient().getRef().getHash();
+    return client().getRef().getHash();
   }
 
   @VisibleForTesting
   String currentRefName() {
-    return refreshedClient().getRef().getName();
+    return client().getRef().getName();
   }
 
   @VisibleForTesting
@@ -325,7 +325,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
     return fileIO;
   }
 
-  private NessieIcebergClient refreshedClient() {
+  private NessieIcebergClient client() {
     try {
       client.refresh();
     } catch (NessieNotFoundException e) {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -60,26 +60,8 @@ class UpdateableReference {
     return reference.getHash();
   }
 
-  /** @deprecated will be removed in 1.3.0 */
-  @Deprecated
-  public Branch getAsBranch() {
-    if (!isBranch()) {
-      throw new IllegalArgumentException("Reference is not a branch");
-    }
-    return (Branch) reference;
-  }
-
   public Reference getReference() {
     return reference;
-  }
-
-  public Reference getReferenceForApiRequest() {
-    if (!mutable) {
-      return reference;
-    }
-    // setting hash to null in client's request,
-    // So that server uses the latest commit hash for that branch.
-    return Branch.of(reference.getName(), null);
   }
 
   public void checkMutable() {
@@ -89,5 +71,9 @@ class UpdateableReference {
 
   public String getName() {
     return reference.getName();
+  }
+
+  public boolean isMutable() {
+    return mutable;
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -52,10 +52,6 @@ class UpdateableReference {
     this.reference = Preconditions.checkNotNull(ref, "ref is null");
   }
 
-  public boolean isBranch() {
-    return reference instanceof Branch;
-  }
-
   public String getHash() {
     return reference.getHash();
   }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -60,6 +60,8 @@ class UpdateableReference {
     return reference.getHash();
   }
 
+  /** @deprecated will be removed in 1.3.0 */
+  @Deprecated
   public Branch getAsBranch() {
     if (!isBranch()) {
       throw new IllegalArgumentException("Reference is not a branch");
@@ -69,6 +71,15 @@ class UpdateableReference {
 
   public Reference getReference() {
     return reference;
+  }
+
+  public Reference getReferenceForApiRequest() {
+    if (!mutable) {
+      return reference;
+    }
+    // setting hash to null in client's request,
+    // So that server uses the latest commit hash for that branch.
+    return Branch.of(reference.getName(), null);
   }
 
   public void checkMutable() {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestMultipleClients.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.nessie;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.AbstractMap;
+import java.util.Collections;
+import org.apache.commons.io.FileUtils;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.ext.NessieClientFactory;
+import org.projectnessie.client.ext.NessieClientUri;
+
+public class TestMultipleClients extends BaseTestIceberg {
+
+  private static final String BRANCH = "multiple-clients-test";
+  private static final Schema schema =
+      new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
+
+  public TestMultipleClients() {
+    super(BRANCH);
+  }
+
+  // another client that connects to the same nessie server.
+  NessieCatalog anotherCatalog;
+
+  @Override
+  @BeforeEach
+  public void beforeEach(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws IOException {
+    super.beforeEach(clientFactory, nessieUri);
+    anotherCatalog = initCatalog(branch);
+  }
+
+  @Override
+  @AfterEach
+  public void afterEach() throws Exception {
+    dropTables(catalog);
+    dropTables(anotherCatalog);
+
+    super.afterEach();
+    anotherCatalog.close();
+  }
+
+  @Test
+  public void testListNamespaces() {
+    catalog.createNamespace(Namespace.of("db1"), Collections.emptyMap());
+    Assertions.assertThat(catalog.listNamespaces()).containsExactlyInAnyOrder(Namespace.of("db1"));
+
+    // another client creates a namespace with the same nessie server
+    anotherCatalog.createNamespace(Namespace.of("db2"), Collections.emptyMap());
+    Assertions.assertThat(anotherCatalog.listNamespaces())
+        .containsExactlyInAnyOrder(Namespace.of("db1"), Namespace.of("db2"));
+
+    Assertions.assertThat(catalog.listNamespaces())
+        .containsExactlyInAnyOrder(Namespace.of("db1"), Namespace.of("db2"));
+  }
+
+  @Test
+  public void testLoadNamespaceMetadata() {
+    catalog.createNamespace(Namespace.of("namespace1"), Collections.emptyMap());
+    Assertions.assertThat(catalog.listNamespaces())
+        .containsExactlyInAnyOrder(Namespace.of("namespace1"));
+
+    // another client adds a metadata to the same namespace
+    anotherCatalog.setProperties(Namespace.of("namespace1"), Collections.singletonMap("k1", "v1"));
+    AbstractMap.SimpleEntry<String, String> entry = new AbstractMap.SimpleEntry<>("k1", "v1");
+    Assertions.assertThat(anotherCatalog.loadNamespaceMetadata(Namespace.of("namespace1")))
+        .containsExactly(entry);
+
+    Assertions.assertThat(catalog.loadNamespaceMetadata(Namespace.of("namespace1")))
+        .containsExactly(entry);
+  }
+
+  @Test
+  public void testListTables() {
+    catalog.createTable(TableIdentifier.parse("foo.tbl1"), schema);
+    Assertions.assertThat(catalog.listTables(Namespace.of("foo")))
+        .containsExactlyInAnyOrder(TableIdentifier.parse("foo.tbl1"));
+
+    // another client creates a table with the same nessie server
+    anotherCatalog.createTable(TableIdentifier.parse("foo.tbl2"), schema);
+    Assertions.assertThat(anotherCatalog.listTables(Namespace.of("foo")))
+        .containsExactlyInAnyOrder(
+            TableIdentifier.parse("foo.tbl1"), TableIdentifier.parse("foo.tbl2"));
+
+    Assertions.assertThat(catalog.listTables(Namespace.of("foo")))
+        .containsExactlyInAnyOrder(
+            TableIdentifier.parse("foo.tbl1"), TableIdentifier.parse("foo.tbl2"));
+  }
+
+  private static void dropTables(NessieCatalog nessieCatalog) {
+    nessieCatalog
+        .listNamespaces()
+        .forEach(
+            namespace ->
+                nessieCatalog
+                    .listTables(namespace)
+                    .forEach(identifier -> dropTable(nessieCatalog, identifier)));
+  }
+
+  private static void dropTable(NessieCatalog nessieCatalog, TableIdentifier identifier) {
+    Table table = nessieCatalog.loadTable(identifier);
+    File tableLocation = tableLocation(table);
+    nessieCatalog.dropTable(identifier, false);
+    try {
+      FileUtils.deleteDirectory(tableLocation);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static File tableLocation(Table table) {
+    return new File(table.location().replaceFirst("file:", ""));
+  }
+}


### PR DESCRIPTION
Consider the scenario,
a) client1 - java Nessie catalog client creates a table1
b) client2 - spark + iceberg+ Nessie creates a table2
c) client3 - another java Nessie catalog client creates a table3

where all the 3 clients are connected to the same Nessie server. 

Now for the first client (client1), list tables show only one table even though all 3 clients are connected to the same Nessie server. 
The reason is only the catalog APIs that involves table operations (like `loadTable()`, `commit()`, etc) refresh the `NessieIcebergClient`. The APIs like `listTables()`, `listNamespaces()` use the old state as it doesn't use table operations. 

Changes:
- Pass null for the reference hash in api request for immutable references. So that server will use the latest hash

Other scenarios can be two concurrent spark sessions.  