### PR TITLE
Core: Refactor validation in TableScanUtil

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -71,7 +71,7 @@ public class TableScanUtil {
 
   public static CloseableIterable<FileScanTask> splitFiles(
       CloseableIterable<FileScanTask> tasks, long splitSize) {
-    Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative or 0): %s", splitSize);
+    Preconditions.checkArgument(splitSize > 0, "Split size must be > 0: %s", splitSize);
 
     Iterable<FileScanTask> splitTasks =
         FluentIterable.from(tasks).transformAndConcat(input -> input.split(splitSize));
@@ -81,11 +81,8 @@ public class TableScanUtil {
 
   public static CloseableIterable<CombinedScanTask> planTasks(
       CloseableIterable<FileScanTask> splitFiles, long splitSize, int lookback, long openFileCost) {
-    Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative or 0): %s", splitSize);
-    Preconditions.checkArgument(
-        lookback > 0, "Invalid split planning lookback (negative or 0): %s", lookback);
-    Preconditions.checkArgument(
-        openFileCost >= 0, "Invalid file open cost (negative): %s", openFileCost);
+
+    validatePlanningArguments(splitSize, lookback, openFileCost);
 
     // Check the size of delete file as well to avoid unbalanced bin-packing
     Function<FileScanTask, Long> weightFunc =
@@ -106,11 +103,7 @@ public class TableScanUtil {
   public static <T extends ScanTask> CloseableIterable<ScanTaskGroup<T>> planTaskGroups(
       CloseableIterable<T> tasks, long splitSize, int lookback, long openFileCost) {
 
-    Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative or 0): %s", splitSize);
-    Preconditions.checkArgument(
-        lookback > 0, "Invalid split planning lookback (negative or 0): %s", lookback);
-    Preconditions.checkArgument(
-        openFileCost >= 0, "Invalid file open cost (negative): %s", openFileCost);
+    validatePlanningArguments(splitSize, lookback, openFileCost);
 
     // capture manifests which can be closed after scan planning
     CloseableIterable<T> splitTasks =
@@ -144,11 +137,7 @@ public class TableScanUtil {
       long openFileCost,
       Types.StructType groupingKeyType) {
 
-    Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative or 0): %s", splitSize);
-    Preconditions.checkArgument(
-        lookback > 0, "Invalid split planning lookback (negative or 0): %s", lookback);
-    Preconditions.checkArgument(
-        openFileCost >= 0, "Invalid file open cost (negative): %s", openFileCost);
+    validatePlanningArguments(splitSize, lookback, openFileCost);
 
     Function<T, Long> weightFunc =
         task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
@@ -249,5 +238,11 @@ public class TableScanUtil {
     }
 
     return mergedTasks;
+  }
+
+  private static void validatePlanningArguments(long splitSize, int lookback, long openFileCost) {
+    Preconditions.checkArgument(splitSize > 0, "Split size must be > 0: %s", splitSize);
+    Preconditions.checkArgument(lookback > 0, "Split planning lookback must be > 0: %s", lookback);
+    Preconditions.checkArgument(openFileCost >= 0, "File open cost must be >= 0: %s", openFileCost);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -180,7 +180,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split size should be validated",
         IllegalArgumentException.class,
-        "Invalid split size (negative or 0): -10",
+        "Split size must be > 0: -10",
         () -> {
           table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(-10)).planTasks();
         });
@@ -188,7 +188,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split planning lookback should be validated",
         IllegalArgumentException.class,
-        "Invalid split planning lookback (negative or 0): -10",
+        "Split planning lookback must be > 0: -10",
         () -> {
           table.newScan().option(TableProperties.SPLIT_LOOKBACK, String.valueOf(-10)).planTasks();
         });
@@ -196,7 +196,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split open file cost should be validated",
         IllegalArgumentException.class,
-        "Invalid file open cost (negative): -10",
+        "File open cost must be >= 0: -10",
         () -> {
           table
               .newScan()


### PR DESCRIPTION
This PR refactors validation in `TableScanUtil` into a separate method as the same logic is currently used in 3 different methods. In addition, it switches to shorter messages to stay on one line with the new line limit.