### PR TITLE
Spark 3.3: Remove redundant vars in ChangelogRowReader

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/ChangelogRowReader.java
@@ -151,16 +151,14 @@ class ChangelogRowReader extends BaseRowReader<ChangelogScanTask>
   }
 
   private static Stream<ContentFile<?>> deletedDataFileScanTaskFiles(DeletedDataFileScanTask task) {
-    DeletedDataFileScanTask deletedDataFileScanTask = task;
-    DataFile file = deletedDataFileScanTask.file();
-    List<DeleteFile> existingDeletes = deletedDataFileScanTask.existingDeletes();
+    DataFile file = task.file();
+    List<DeleteFile> existingDeletes = task.existingDeletes();
     return Stream.concat(Stream.of(file), existingDeletes.stream());
   }
 
   private static Stream<ContentFile<?>> addedRowsScanTaskFiles(AddedRowsScanTask task) {
-    AddedRowsScanTask addedRowsScanTask = task;
-    DataFile file = addedRowsScanTask.file();
-    List<DeleteFile> deletes = addedRowsScanTask.deletes();
+    DataFile file = task.file();
+    List<DeleteFile> deletes = task.deletes();
     return Stream.concat(Stream.of(file), deletes.stream());
   }
 }


### PR DESCRIPTION
This PR removes redundant variables in `ChangelogRowReader`.