### PR TITLE
AWS: Remove unused validateTableIdentifier method in IcebergToGlueConverter

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -204,16 +204,6 @@ class IcebergToGlueConverter {
   }
 
   /**
-   * Validate Iceberg TableIdentifier is valid in Glue
-   *
-   * @param tableIdentifier Iceberg table identifier
-   */
-  static void validateTableIdentifier(TableIdentifier tableIdentifier) {
-    validateNamespace(tableIdentifier.namespace());
-    validateTableName(tableIdentifier.name());
-  }
-
-  /**
    * Set Glue table input information based on Iceberg table metadata.
    *
    * <p>A best-effort conversion of Iceberg metadata to Glue table is performed to display Iceberg


### PR DESCRIPTION
Was going through GlueCatalog code and saw IcebergToGlueConverter.validateTableIdentifier is unused and since IcebergToGlueConverter is package private we should be good to remove it.

CC: @jackye1995 @singhpk234 @yyanyy 