### PR TITLE
Spark 3.3: Return partition stats for AddFiles procedure

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -87,12 +87,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -154,11 +154,11 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     String createIceberg = "CREATE TABLE %s (id Long, data String) USING iceberg";
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`avro`.`%s`')",
             catalogName, tableName, outputFile.getPath());
-    Assert.assertEquals(1L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(1L, 1L)), result);
 
     List<Object[]> expected = Lists.newArrayList(new Object[] {1L, "a"}, new Object[] {2L, "b"});
 
@@ -209,10 +209,10 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
+    List<Object[]> result =
+        sql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -229,12 +229,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -250,12 +250,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -272,12 +272,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(8L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(8L, 4L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -294,12 +294,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(8L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(8L, 4L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -361,10 +361,10 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
+    List<Object[]> result =
+        sql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(8L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(8L, 4L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -381,12 +381,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('id', 1))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -403,12 +403,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('date', '2021-01-01'))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -428,12 +428,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('id', 1))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -451,12 +451,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('dept', 'hr'))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(6L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(6L, 3L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -476,12 +476,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('id', 1))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -499,12 +499,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`', map('dept', 'hr'))",
             catalogName, tableName, fileTableDir.getAbsolutePath());
 
-    Assert.assertEquals(6L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(6L, 3L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -524,12 +524,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '%s', map('naMe', 'John Doe'))",
             catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     /*
     While we would like to use
@@ -574,12 +574,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result =
-        scalarSql(
+    List<Object[]> result =
+        sql(
             "CALL %s.system.add_files('%s', '%s', map('id', 1))",
             catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(2L, result);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -652,23 +652,23 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result1 =
-        scalarSql(
+    List<Object[]> result1 =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
                 + "partition_filter => map('id', 1))",
             catalogName, tableName, sourceTableName);
-    Assert.assertEquals(2L, result1);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result1);
 
-    Object result2 =
-        scalarSql(
+    List<Object[]> result2 =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
                 + "partition_filter => map('id', 2))",
             catalogName, tableName, sourceTableName);
-    Assert.assertEquals(2L, result2);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result2);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -689,7 +689,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    scalarSql(
+    sql(
         "CALL %s.system.add_files("
             + "table => '%s', "
             + "source_table => '%s', "
@@ -719,18 +719,18 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result1 =
-        scalarSql(
+    List<Object[]> result1 =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
                 + "partition_filter => map('id', 1))",
             catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(2L, result1);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result1);
 
-    Object result2 =
-        scalarSql(
+    List<Object[]> result2 =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
@@ -738,7 +738,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
                 + "check_duplicate_files => false)",
             catalogName, tableName, sourceTableName);
 
-    Assert.assertEquals(2L, result2);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result2);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -758,7 +758,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    scalarSql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
+    sql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
 
     AssertHelpers.assertThrows(
         "Should not allow adding duplicate files",
@@ -779,18 +779,18 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object result1 =
-        scalarSql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
-    Assert.assertEquals(2L, result1);
+    List<Object[]> result1 =
+        sql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result1);
 
-    Object result2 =
-        scalarSql(
+    List<Object[]> result2 =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s',"
                 + "check_duplicate_files => false)",
             catalogName, tableName, sourceTableName);
-    Assert.assertEquals(2L, result2);
+    assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result2);
 
     assertEquals(
         "Iceberg table contains correct data",
@@ -808,11 +808,11 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     sql(createIceberg, tableName);
 
     // Empty path based import
-    Object pathResult =
-        scalarSql(
+    List<Object[]> pathResult =
+        sql(
             "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
             catalogName, tableName, fileTableDir.getAbsolutePath());
-    Assert.assertEquals(0L, pathResult);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L)), pathResult);
     assertEquals(
         "Iceberg table contains no added data when importing from an empty path",
         emptyQueryResult,
@@ -823,9 +823,9 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         "CREATE TABLE %s (id Integer, name String, dept String, subdept String) STORED AS parquet";
     sql(createHive, sourceTableName);
 
-    Object tableResult =
-        scalarSql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
-    Assert.assertEquals(0L, tableResult);
+    List<Object[]> tableResult =
+        sql("CALL %s.system.add_files('%s', '%s')", catalogName, tableName, sourceTableName);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L)), tableResult);
     assertEquals(
         "Iceberg table contains no added data when importing from an empty table",
         emptyQueryResult,
@@ -847,15 +847,15 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     sql(createIceberg, tableName);
 
-    Object tableResult =
-        scalarSql(
+    List<Object[]> tableResult =
+        sql(
             "CALL %s.system.add_files("
                 + "table => '%s', "
                 + "source_table => '%s', "
                 + "partition_filter => map('id', %d))",
             catalogName, tableName, sourceTableName, emptyPartitionId);
 
-    Assert.assertEquals(0L, tableResult);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L)), tableResult);
     assertEquals(
         "Iceberg table contains no added data when importing from an empty table",
         emptyQueryResult,


### PR DESCRIPTION
Close #6794 

This add `changed_partition_count` as results from Spark AddFilesProcedure. Before this change, spark only return `added_files_count` when adding external files to iceberg table using AddFilesProcedure. 

- For unpartitioned table, the `changed_partition_count` returned is 1
- For partitioned table, the `changed_partition_count` return number of partition updated (sourced from snapshot summary)
- If number of files being added is empty (either because of no valid parquet files or because of incorrectly configured partition filter), the `changed_partition_count` return is 0

This only impact the Spark 3.3 and only adds a new result in returned DF

CC @RussellSpitzer @szehon-ho