### PR TITLE
Parquet: fix conversion of enums to strings

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
@@ -85,6 +85,7 @@ class ParquetConversions {
   static Function<Object, Object> converterFromParquet(PrimitiveType type) {
     if (type.getOriginalType() != null) {
       switch (type.getOriginalType()) {
+        case ENUM:
         case UTF8:
           // decode to CharSequence to avoid copying into a new String
           return binary -> StandardCharsets.UTF_8.decode(((Binary) binary).toByteBuffer());

--- a/parquet/src/test/java/org/apache/iceberg/parquet/ParquetConversionsTest.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/ParquetConversionsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParquetConversionsTest {
+  @Test
+  public void fromParquetPrimitive() {
+    Literal<Object> out = ParquetConversions.fromParquetPrimitive(
+        Types.StringType.get(),
+        org.apache.parquet.schema.Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.OPTIONAL)
+            .as(LogicalTypeAnnotation.enumType())
+            .named("enum"),
+        Binary.fromString("value")
+    );
+    Assert.assertEquals(Literal.of("value"), out);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
@@ -27,7 +27,7 @@ import org.apache.parquet.schema.Type;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class ParquetConversionsTest {
+public class TestParquetConversions {
   @Test
   public void fromParquetPrimitive() {
     Literal<Object> out = ParquetConversions.fromParquetPrimitive(


### PR DESCRIPTION
I ran across this when trying to use `ParquetUtils#footerMetrics` on a Parquet file with an enum type. The method in turn calls `ParquetConversions`. It seems Parquet enums aren't supported. It throws an exception:

```
java.nio.HeapByteBuffer cannot be cast to java.lang.CharSequence
java.lang.ClassCastException: java.nio.HeapByteBuffer cannot be cast to java.lang.CharSequence
	at org.apache.iceberg.parquet.ParquetConversions.fromParquetPrimitive(ParquetConversions.java:53)
```

Adds `ENUM` to switch statement when converting strings along with testcase.