### PR TITLE
Fix TableScan typing

### DIFF
--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -26,13 +26,12 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generic,
     Iterator,
     List,
     Optional,
     Tuple,
-    TypeVar,
     Union,
+    Self,
 )
 
 from pydantic import Field
@@ -101,7 +100,7 @@ class Table:
         case_sensitive: bool = True,
         snapshot_id: Optional[int] = None,
         options: Properties = EMPTY_DICT,
-    ) -> TableScan[Any]:
+    ) -> DataScan:
         return DataScan(
             table=self,
             row_filter=row_filter,
@@ -174,9 +173,6 @@ class Table:
         )
 
 
-S = TypeVar("S", bound="TableScan", covariant=True)  # type: ignore
-
-
 def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
     """Accepts an expression in the form of a BooleanExpression or a string
 
@@ -190,7 +186,8 @@ def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
     return parser.parse(expr) if isinstance(expr, str) else expr
 
 
-class TableScan(Generic[S], ABC):
+
+class TableScan(ABC):
     table: Table
     row_filter: BooleanExpression
     selected_fields: Tuple[str]
@@ -242,11 +239,11 @@ class TableScan(Generic[S], ABC):
     def to_pandas(self, **kwargs: Any) -> pd.DataFrame:
         ...
 
-    def update(self: S, **overrides: Any) -> S:
+    def update(self, **overrides: Any) -> Self:
         """Creates a copy of this table scan with updated fields."""
         return type(self)(**{**self.__dict__, **overrides})
 
-    def use_ref(self, name: str) -> S:
+    def use_ref(self, name: str) -> Self:
         if self.snapshot_id:
             raise ValueError(f"Cannot override ref, already set snapshot id={self.snapshot_id}")
         if snapshot := self.table.snapshot_by_name(name):
@@ -254,15 +251,15 @@ class TableScan(Generic[S], ABC):
 
         raise ValueError(f"Cannot scan unknown ref={name}")
 
-    def select(self, *field_names: str) -> S:
+    def select(self, *field_names: str) -> Self:
         if "*" in self.selected_fields:
             return self.update(selected_fields=field_names)
         return self.update(selected_fields=tuple(set(self.selected_fields).intersection(set(field_names))))
 
-    def filter(self, expr: Union[str, BooleanExpression]) -> S:
+    def filter(self, expr: Union[str, BooleanExpression]) -> Self:
         return self.update(row_filter=And(self.row_filter, _parse_row_filter(expr)))
 
-    def with_case_sensitive(self, case_sensitive: bool = True) -> S:
+    def with_case_sensitive(self, case_sensitive: bool = True) -> Self:
         return self.update(case_sensitive=case_sensitive)
 
 
@@ -299,7 +296,7 @@ def _open_manifest(io: FileIO, manifest: ManifestFile, partition_filter: Callabl
     return [FileScanTask(file) for file in matching_partition_data_files]
 
 
-class DataScan(TableScan["DataScan"]):
+class DataScan(TableScan):
     def __init__(
         self,
         table: Table,


### PR DESCRIPTION
TableScan is not a generic, to solve the issue of returning an instance of the same or sub-class it's better to use the `Self` new typing.

Previously using this syntax (see example below), was missleading `mypy` making it thinkg that everything after the `filter` was an `Any` type.

```python
df = (
    table.scan()
    .filter(EqualTo("uuid", "...."))
    .select("rt", "cs1", "in")
    .to_arrow()
)
```

With the usage of `Self` it is solved.