### PR TITLE
Spark 3.3: Change the default dest catalog name for TableSnapshot

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -234,10 +234,11 @@ public class TestSnapshotTableProcedure extends SparkExtensionsTestBase {
     String destWithDBAndTable = "default.table";
     String location = temp.newFolder().toString();
     sql(
-            "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
-            sourceName, location);
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        sourceName, location);
     Object result =
-            scalarSql("CALL %s.system.snapshot('%s', '%s')", catalogName, sourceName, destWithDBAndTable);
+        scalarSql(
+            "CALL %s.system.snapshot('%s', '%s')", catalogName, sourceName, destWithDBAndTable);
     Assert.assertEquals("Should have added no file with snapshot success", 0L, result);
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -228,4 +228,16 @@ public class TestSnapshotTableProcedure extends SparkExtensionsTestBase {
         "Cannot handle an empty identifier",
         () -> sql("CALL %s.system.snapshot('src', '')", catalogName));
   }
+
+  @Test
+  public void testSnapshotWithoutCatalogNameForDest() throws IOException {
+    String destWithDBAndTable = "default.table";
+    String location = temp.newFolder().toString();
+    sql(
+            "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+            sourceName, location);
+    Object result =
+            scalarSql("CALL %s.system.snapshot('%s', '%s')", catalogName, sourceName, destWithDBAndTable);
+    Assert.assertEquals("Should have added no file with snapshot success", 0L, result);
+  }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -92,11 +92,9 @@ class SnapshotTableProcedure extends BaseProcedure {
                 return BoxedUnit.UNIT;
               });
     }
-
     // add the catalog name if dest name is like `db.table`
-    dest = dest.split("\\.").length == 2
-            ? String.format("%s.%s", tableCatalog().name(), dest)
-            : dest;
+    dest =
+        dest.split("\\.").length == 2 ? String.format("%s.%s", tableCatalog().name(), dest) : dest;
 
     Preconditions.checkArgument(
         !source.equals(dest),

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -93,6 +93,11 @@ class SnapshotTableProcedure extends BaseProcedure {
               });
     }
 
+    // add the catalog name if dest name is like `db.table`
+    dest = dest.split("\\.").length == 2
+            ? String.format("%s.%s", tableCatalog().name(), dest)
+            : dest;
+
     Preconditions.checkArgument(
         !source.equals(dest),
         "Cannot create a snapshot with the same name as the source of the snapshot.");


### PR DESCRIPTION
## Change
By default, in Spark, the destination catalog name for table snapshot is specified spark default catalog name like `spark_catalog` based on [SparkActions.java#L53](https://github.com/apache/iceberg/blob/370c135144ce2d1b00e9938e267548e78ee6edaf/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkActions.java#L53) and [SnapshotTableSparkAction.java#L81](https://github.com/apache/iceberg/blob/370c135144ce2d1b00e9938e267548e78ee6edaf/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java#L81) (the issue that is caused by this specification is described in ***Issue*** section below). 

This commit changes this destination catalog name to the user specified catalog name that comes from `CALL <catalog>.system.snapshot(...)` in the table snapshot procedure.


## Issue
Currently, in Spark, if we don't specify any catalog for the destination table (e.g. `CALL catalog.system.snapshot('db.src', 'db.dest')`), it fails because of the following exception in [checkDestinationCatalog](https://github.com/apache/iceberg/blob/370c135144ce2d1b00e9938e267548e78ee6edaf/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java#L84). This means if we don't specify the catalog name in the destination table, `spark_catalog` (that is `V2SessionCatalog`) is passed to the `SnapshotTableSparkAction.java`. Therefore, this commit tries passing the first catalog name in the procedure query to the destination as the destination catalog name.

```
java.lang.IllegalArgumentException: Cannot create Iceberg table in non-Iceberg Catalog. Catalog 'spark_catalog' was of class 'org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog' but 'org.apache.iceberg.spark.SparkSessionCatalog' or 'org.apache.iceberg.spark.SparkCatalog' are required
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:472) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.BaseTableCreationSparkAction.checkDestinationCatalog(BaseTableCreationSparkAction.java:142) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.SnapshotTableSparkAction.as(SnapshotTableSparkAction.java:84) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.procedures.SnapshotTableProcedure.call(SnapshotTableProcedure.java:99) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.spark.sql.execution.datasources.v2.CallExec.run(CallExec.scala:34) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:43) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:43) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
	at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:49) ~[spark-sql_2.12-3.3.0-amzn-1.jar:3.3.0-amzn-1]
... // omitted ...
```

Additionally, the document that describes the table snapshot procedure show a query example such as `CALL catalog_name.system.snapshot('db.sample', 'db.snap')`. However, if users run this query on Spark, it fails with the same error above. To solve this, as one of the solutions, they need to run `CALL catalog_name.system.snapshot('db.sample', 'catalog_name.db.snap')` because the `spark_catalog` is passed to the second destination part.

---
### investigation
I tested the snapshot procedure on emr-6.9.0 (Spark 3.3.0) with the latest Iceberg jar that was built from the source:

```
[hadoop@ip-172-31-23-5 ~]$ spark-sql --jars iceberg-jars/bundle-2.17.257.jar,iceberg-jars/iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar,iceberg-jars/url-connection-client-2.17.257.jpark.sql.catalog.glue_catalog=org.apache.iceberg.spark.SparkCatalog --conf spark.sql.catalog.glue_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog --conf spark.sql.catalog.glue_catalog.warehouse=s3://bucket/path --conf spark.sql.catalog.glue_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions

// Iceberg table to Iceberg table (this pattern only works if the src table has input/output formats and serdelib)
spark-sql> CALL glue_catalog.system.snapshot('db.iceberg_tablemig_emr', 'db.dest_snap');
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
23/02/10 18:42:11 ERROR SparkSQLDriver: Failed in [CALL glue_catalog.system.snapshot('garbagedb.iceberg_tablemig_emr', 'garbagedb.dest_snap')]
java.lang.IllegalArgumentException: Cannot create Iceberg table in non-Iceberg Catalog. Catalog 'spark_catalog' was of class 'org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog' but 'org.apache.iceberg.spark.SparkSessionCatalog' or 'org.apache.iceberg.spark.SparkCatalog' are required
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:472) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.BaseTableCreationSparkAction.checkDestinationCatalog(BaseTableCreationSparkAction.java:140) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.SnapshotTableSparkAction.as(SnapshotTableSparkAction.java:84) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.procedures.SnapshotTableProcedure.call(SnapshotTableProcedure.java:99) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.spark.sql.execution.datasources.v2.CallExec.run(CallExec.scala:34) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
...


// catalog name is specified for the dest
spark-sql> CALL glue_catalog.system.snapshot('db.iceberg_tablemig_emr', 'glue_catalog.db.dest_snap');
0


// Hive table to Iceberg table
spark-sql> CALL glue_catalog.system.snapshot('db.non_iceberg_emr', 'db.dest_snap_2');
23/02/10 18:45:31 ERROR SparkSQLDriver: Failed in [CALL glue_catalog.system.snapshot('garbagedb.non_iceberg_emr', 'garbagedb.dest_snap_2')]
java.lang.IllegalArgumentException: Cannot create Iceberg table in non-Iceberg Catalog. Catalog 'spark_catalog' was of class 'org.apache.spark.sql.execution.datasources.v2.V2SessionCatalog' but 'org.apache.iceberg.spark.SparkSessionCatalog' or 'org.apache.iceberg.spark.SparkCatalog' are required
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:472) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.BaseTableCreationSparkAction.checkDestinationCatalog(BaseTableCreationSparkAction.java:140) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.actions.SnapshotTableSparkAction.as(SnapshotTableSparkAction.java:84) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
	at org.apache.iceberg.spark.procedures.SnapshotTableProcedure.call(SnapshotTableProcedure.java:99) ~[iceberg-spark-runtime-3.3_2.12-1.2.0-SNAPSHOT.jar:?]
...

// catalog name is specified for the dest
spark-sql> CALL glue_catalog.system.snapshot('db.non_iceberg_emr', 'glue_catalog.db.dest_snap_2');
0
```