### PR TITLE
API: Revert to using stephenc findbugs dependency for Nullable

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
+++ b/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.view;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.iceberg.catalog.Namespace;
 import org.immutables.value.Value;
 

--- a/build.gradle
+++ b/build.gradle
@@ -249,7 +249,6 @@ project(':iceberg-api') {
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly "com.google.errorprone:error_prone_annotations"
-    compileOnly 'com.google.code.findbugs:jsr305'
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value"
     testImplementation "org.apache.avro:avro"

--- a/versions.props
+++ b/versions.props
@@ -8,7 +8,6 @@ org.apache.orc:* = 1.8.2
 org.apache.parquet:* = 1.12.3
 org.apache.pig:pig = 0.14.0
 com.fasterxml.jackson.*:* = 2.14.1
-com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:error_prone_annotations = 2.3.3
 com.google.guava:* = 31.1-jre
 com.github.ben-manes.caffeine:caffeine = 2.9.3


### PR DESCRIPTION
Reverts to using stephenc findbugs dependency for Nullable based on @rdblue comment here: https://github.com/apache/iceberg/pull/6598/files#r1103888557

cc @danielcweeks since there is a differing view based off of https://github.com/apache/iceberg/pull/6598#discussion_r1096213570 . In the current PR, we're reverting back to using the stephenc dependency, because it appears the javax one from com.google.code.findbugs:jsr305 is banned. Let me know your thoughts on reverting this! 

To add a third option: It seems like the stephenc findbugs dependency has Nullable marked as deprecated, and based off https://stackoverflow.com/questions/19030954/cant-find-nullable-inside-javax-annotation spotbugs is the newer reccomended library to get the javax.annotation but this still just has a dependency on com.google.code.findbugs:jsr305.

CC: @jackye1995 who is managing the release for 1.2.0. 