### PR TITLE
Properly use TypeVar for bounding TableScan return

### DIFF
--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -30,8 +30,8 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Union,
     TypeVar,
+    Union,
 )
 
 from pydantic import Field
@@ -187,7 +187,7 @@ def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
 
 
 
-S = TypeVar("S", bound="TableScan", covariant=True)  # type: ignore
+S = TypeVar("S", bound="TableScan", covariant=True)
 
 
 class TableScan(ABC):

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -186,7 +186,6 @@ def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
     return parser.parse(expr) if isinstance(expr, str) else expr
 
 
-
 S = TypeVar("S", bound="TableScan", covariant=True)
 
 

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -26,13 +26,12 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generic,
     Iterator,
     List,
     Optional,
     Tuple,
-    TypeVar,
     Union,
+    TypeVar,
 )
 
 from pydantic import Field
@@ -101,7 +100,7 @@ class Table:
         case_sensitive: bool = True,
         snapshot_id: Optional[int] = None,
         options: Properties = EMPTY_DICT,
-    ) -> TableScan[Any]:
+    ) -> DataScan:
         return DataScan(
             table=self,
             row_filter=row_filter,
@@ -174,9 +173,6 @@ class Table:
         )
 
 
-S = TypeVar("S", bound="TableScan", covariant=True)  # type: ignore
-
-
 def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
     """Accepts an expression in the form of a BooleanExpression or a string
 
@@ -190,7 +186,11 @@ def _parse_row_filter(expr: Union[str, BooleanExpression]) -> BooleanExpression:
     return parser.parse(expr) if isinstance(expr, str) else expr
 
 
-class TableScan(Generic[S], ABC):
+
+S = TypeVar("S", bound="TableScan", covariant=True)  # type: ignore
+
+
+class TableScan(ABC):
     table: Table
     row_filter: BooleanExpression
     selected_fields: Tuple[str]
@@ -246,7 +246,7 @@ class TableScan(Generic[S], ABC):
         """Creates a copy of this table scan with updated fields."""
         return type(self)(**{**self.__dict__, **overrides})
 
-    def use_ref(self, name: str) -> S:
+    def use_ref(self: S, name: str) -> S:
         if self.snapshot_id:
             raise ValueError(f"Cannot override ref, already set snapshot id={self.snapshot_id}")
         if snapshot := self.table.snapshot_by_name(name):
@@ -254,15 +254,15 @@ class TableScan(Generic[S], ABC):
 
         raise ValueError(f"Cannot scan unknown ref={name}")
 
-    def select(self, *field_names: str) -> S:
+    def select(self: S, *field_names: str) -> S:
         if "*" in self.selected_fields:
             return self.update(selected_fields=field_names)
         return self.update(selected_fields=tuple(set(self.selected_fields).intersection(set(field_names))))
 
-    def filter(self, expr: Union[str, BooleanExpression]) -> S:
+    def filter(self: S, expr: Union[str, BooleanExpression]) -> S:
         return self.update(row_filter=And(self.row_filter, _parse_row_filter(expr)))
 
-    def with_case_sensitive(self, case_sensitive: bool = True) -> S:
+    def with_case_sensitive(self: S, case_sensitive: bool = True) -> S:
         return self.update(case_sensitive=case_sensitive)
 
 
@@ -299,7 +299,7 @@ def _open_manifest(io: FileIO, manifest: ManifestFile, partition_filter: Callabl
     return [FileScanTask(file) for file in matching_partition_data_files]
 
 
-class DataScan(TableScan["DataScan"]):
+class DataScan(TableScan):
     def __init__(
         self,
         table: Table,


### PR DESCRIPTION
Since `TypeVar` S typining bound can be specified in the methods definition, TableScan should not be generic.

Previously using this syntax (see example below), was missleading `mypy` making it thinkg that everything after the `filter` was an `Any` type.

```python
df = (
    table.scan()
    .filter(EqualTo("uuid", "...."))
    .select("rt", "cs1", "in")
    .to_arrow()
)
```

Removing the `TableScan` generic, mypy succeds with the type inference