### PR TITLE
AWS: set lastEvaluatedKey for listTables in DynamoDb Catalog

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -329,7 +329,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
     List<TableIdentifier> identifiers = Lists.newArrayList();
-    Map<String, AttributeValue> lastEvaluatedKey;
+    Map<String, AttributeValue> lastEvaluatedKey = null;
     String condition = COL_NAMESPACE + " = :ns";
     Map<String, AttributeValue> conditionValues =
         ImmutableMap.of(":ns", AttributeValue.builder().s(namespace.toString()).build());
@@ -341,6 +341,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
                   .indexName(GSI_NAMESPACE_IDENTIFIER)
                   .keyConditionExpression(condition)
                   .expressionAttributeValues(conditionValues)
+                  .exclusiveStartKey(lastEvaluatedKey)
                   .build());
 
       if (response.hasItems()) {


### PR DESCRIPTION
While working on issue #6763 found that lastEvaluatedKey was not set for subsequent calls in listTables()

@jackye1995 FYI