### PR TITLE
Core: Make Iceberg version in EnvironmentContext by default

### DIFF
--- a/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
+++ b/core/src/main/java/org/apache/iceberg/EnvironmentContext.java
@@ -26,11 +26,13 @@ public class EnvironmentContext {
   public static final String ENGINE_NAME = "engine-name";
   public static final String ENGINE_VERSION = "engine-version";
 
-  private EnvironmentContext() {
-    PROPERTIES.put("iceberg-version", IcebergBuild.fullVersion());
-  }
+  private EnvironmentContext() {}
 
   private static final Map<String, String> PROPERTIES = Maps.newConcurrentMap();
+
+  static {
+    PROPERTIES.put("iceberg-version", IcebergBuild.fullVersion());
+  }
 
   /**
    * Returns a {@link Map} of all properties.

--- a/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
+++ b/core/src/test/java/org/apache/iceberg/TestEnvironmentContext.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestEnvironmentContext {
+
+  @Test
+  public void testDefaultValue() {
+    Assertions.assertThat(EnvironmentContext.get().get("iceberg-version"))
+        .isEqualTo(IcebergBuild.fullVersion());
+  }
+}


### PR DESCRIPTION
Make Iceberg version in EnvironmentContext by default