### PR TITLE
Parquet: Optimize dictionary filter evaluation on notIn and notEq

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -300,12 +300,12 @@ public class ParquetDictionaryRowGroupFilter {
       int id = ref.fieldId();
 
       Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
+      if (hasNonDictPage == null || hasNonDictPage || mayContainNulls.get(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
       Set<T> dictionary = dict(id, lit.comparator());
-      if (dictionary.size() > 1 || mayContainNulls.get(id)) {
+      if (dictionary.size() > 1) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -351,12 +351,12 @@ public class ParquetDictionaryRowGroupFilter {
       int id = ref.fieldId();
 
       Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
+      if (hasNonDictPage == null || hasNonDictPage || mayContainNulls.get(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
       Set<T> dictionary = dict(id, ref.comparator());
-      if (dictionary.size() > literalSet.size() || mayContainNulls.get(id)) {
+      if (dictionary.size() > literalSet.size()) {
         return ROWS_MIGHT_MATCH;
       }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -1030,7 +1030,7 @@ public class TestDictionaryRowGroupFilter {
         IllegalStateException.class,
         "Failed to read required dictionary page for id: 5",
         () ->
-            new ParquetDictionaryRowGroupFilter(SCHEMA, notEqual("some_nulls", "some"))
+            new ParquetDictionaryRowGroupFilter(SCHEMA, equal("some_nulls", "some"))
                 .shouldRead(parquetSchema, rowGroupMetadata, descriptor -> null));
   }
 


### PR DESCRIPTION
This moves the null check forward in `notIn` and `notEq` so that we can avoid reading the dictionary when the column might contain null values.