### PR TITLE
Core, AWS: Allow disabling token refresh

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -142,8 +142,20 @@ public class CatalogProperties {
   public static final String APP_ID = "app-id";
   public static final String USER = "user";
 
+  /**
+   * @deprecated Will be removed in 1.3.0; Use {@link
+   *     org.apache.iceberg.rest.auth.OAuth2Properties#TOKEN_REFRESH_ENABLED} to control token
+   *     refresh behavior.
+   */
+  @Deprecated
   public static final String AUTH_DEFAULT_REFRESH_ENABLED = "auth.default-refresh-enabled";
-  public static final boolean AUTH_DEFAULT_REFRESH_ENABLED_DEFAULT = false;
+
+  /**
+   * @deprecated Will be removed in 1.3.0; Use {@link
+   *     org.apache.iceberg.rest.auth.OAuth2Properties#TOKEN_REFRESH_ENABLED_DEFAULT} to control
+   *     default token refresh behavior.
+   */
+  @Deprecated public static final boolean AUTH_DEFAULT_REFRESH_ENABLED_DEFAULT = false;
 
   public static final String AUTH_SESSION_TIMEOUT_MS = "auth.session-timeout-ms";
   public static final long AUTH_SESSION_TIMEOUT_MS_DEFAULT = TimeUnit.HOURS.toMillis(1);

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
@@ -35,6 +35,14 @@ public class OAuth2Properties {
 
   public static final long TOKEN_EXPIRES_IN_MS_DEFAULT = 3_600_000; // 1 hour
 
+  /**
+   * Controls whether a token should be refreshed if information about its expiration time is
+   * available
+   */
+  public static final String TOKEN_REFRESH_ENABLED = "token-refresh-enabled";
+
+  public static final boolean TOKEN_REFRESH_ENABLED_DEFAULT = true;
+
   /** Additional scope for OAuth2. */
   public static final String SCOPE = "scope";
 

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -566,7 +566,7 @@ public class OAuth2Util {
         expiresAtMillis = defaultExpiresAtMillis;
       }
 
-      if (null != expiresAtMillis) {
+      if (null != executor && null != expiresAtMillis) {
         scheduleTokenRefresh(client, executor, session, expiresAtMillis);
       }
 
@@ -614,7 +614,7 @@ public class OAuth2Util {
         expiresAtMillis = startTimeMillis + TimeUnit.SECONDS.toMillis(response.expiresInSeconds());
       }
 
-      if (null != expiresAtMillis) {
+      if (null != executor && null != expiresAtMillis) {
         scheduleTokenRefresh(client, executor, session, expiresAtMillis);
       }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1636,4 +1636,114 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                       any());
             });
   }
+
+  public void testCatalogTokenRefreshDisabledWithToken() {
+    String token = "some-token";
+    Map<String, String> catalogHeaders = ImmutableMap.of("Authorization", "Bearer " + token);
+
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    Answer<OAuthTokenResponse> addOneSecondExpiration =
+        invocation -> {
+          OAuthTokenResponse response = (OAuthTokenResponse) invocation.callRealMethod();
+          return OAuthTokenResponse.builder()
+              .withToken(response.token())
+              .withTokenType(response.tokenType())
+              .withIssuedTokenType(response.issuedTokenType())
+              .addScopes(response.scopes())
+              .setExpirationInSeconds(1)
+              .build();
+        };
+
+    Mockito.doAnswer(addOneSecondExpiration)
+        .when(adapter)
+        .execute(
+            eq(HTTPMethod.POST),
+            eq("v1/oauth/tokens"),
+            any(),
+            any(),
+            eq(OAuthTokenResponse.class),
+            any(),
+            any());
+
+    Map<String, String> contextCredentials = ImmutableMap.of();
+    SessionCatalog.SessionContext context =
+        new SessionCatalog.SessionContext(
+            UUID.randomUUID().toString(), "user", contextCredentials, ImmutableMap.of());
+
+    RESTCatalog catalog = new RESTCatalog(context, (config) -> adapter);
+    catalog.initialize(
+        "prod",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            OAuth2Properties.TOKEN,
+            token,
+            OAuth2Properties.TOKEN_REFRESH_ENABLED,
+            "false"));
+
+    Mockito.verify(adapter)
+        .execute(
+            eq(HTTPMethod.GET),
+            eq("v1/config"),
+            any(),
+            any(),
+            eq(ConfigResponse.class),
+            eq(catalogHeaders),
+            any());
+  }
+
+  @Test
+  public void testCatalogTokenRefreshDisabledWithCredential() {
+    Map<String, String> catalogHeaders =
+        ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=catalog");
+
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    SessionCatalog.SessionContext context =
+        new SessionCatalog.SessionContext(
+            UUID.randomUUID().toString(), "user", ImmutableMap.of(), ImmutableMap.of());
+
+    RESTCatalog catalog = new RESTCatalog(context, (config) -> adapter);
+    catalog.initialize(
+        "prod",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            OAuth2Properties.CREDENTIAL,
+            "catalog:12345",
+            OAuth2Properties.TOKEN_REFRESH_ENABLED,
+            "false"));
+
+    // fetch token from client credential
+    Map<String, String> fetchTokenFromCredential =
+        ImmutableMap.of(
+            "grant_type",
+            "client_credentials",
+            "client_id",
+            "catalog",
+            "client_secret",
+            "12345",
+            "scope",
+            "catalog");
+    Mockito.verify(adapter)
+        .execute(
+            eq(HTTPMethod.POST),
+            eq("v1/oauth/tokens"),
+            any(),
+            Mockito.argThat(fetchTokenFromCredential::equals),
+            eq(OAuthTokenResponse.class),
+            eq(ImmutableMap.of()),
+            any());
+
+    Mockito.verify(adapter)
+        .execute(
+            eq(HTTPMethod.GET),
+            eq("v1/config"),
+            any(),
+            any(),
+            eq(ConfigResponse.class),
+            eq(catalogHeaders),
+            any());
+  }
 }


### PR DESCRIPTION
## Overview

The catalog property `AUTH_DEFAULT_REFRESH_ENABLED` indicates that it controls the token refresh behavior in the REST catalog. It is used in `RESTSessionCatalog` [here](https://github.com/apache/iceberg/blob/0d0d1be81c981488a3ebc0fff429e99e25ae27b7/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L160-L164) and in [expiresAtMillis()](https://github.com/apache/iceberg/blob/0d0d1be81c981488a3ebc0fff429e99e25ae27b7/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L803-L814) to determine whether a token should be refreshed in case it didn't provide the `OAuth2Properties.TOKEN_EXPIRES_IN_MS` property.

With the changes introduced by #6489 we started to look at the [`exp` claim](https://github.com/apache/iceberg/blob/0d0d1be81c981488a3ebc0fff429e99e25ae27b7/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java#L346) on the token itself to determine its expiration time and only use [expiresAtMillis()](https://github.com/apache/iceberg/blob/0d0d1be81c981488a3ebc0fff429e99e25ae27b7/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L803-L814) as a fallback mechanism.

## Current Behavior
`AUTH_DEFAULT_REFRESH_ENABLED` only works in combination with [expiresAtMillis()](https://github.com/apache/iceberg/blob/0d0d1be81c981488a3ebc0fff429e99e25ae27b7/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L803-L814) when there's no `exp` claim on the token. If there is an `exp` claim on the token, then token refreshes will happen, no matter what `AUTH_DEFAULT_REFRESH_ENABLED` is set to. The current default for `AUTH_DEFAULT_REFRESH_ENABLED` is set to `false`.
From a user's perspective, this behavior is unexpected and non-intuitive. A user would expect to control the token refresh behavior via `AUTH_DEFAULT_REFRESH_ENABLED`. 

## New Behavior
Given that a user would expect `AUTH_DEFAULT_REFRESH_ENABLED` to fully control the token refresh behavior and having an option to disable it by providing `AUTH_DEFAULT_REFRESH_ENABLED=false`, I'm proposing the following:

* use `AUTH_DEFAULT_REFRESH_ENABLED` as the only determining factor for token refreshes
* token refreshes should happen by default. The default of `AUTH_DEFAULT_REFRESH_ENABLED` is currently set to `false` and should be changed to `true`. While this introduces a breaking change, I think it is the correct way to do it, simply because the current behavior of `AUTH_DEFAULT_REFRESH_ENABLED` is not what users would expect and we should fix it.

Minor note: I've also introduced an `AuthConfig` class that allows easier control/configuration of `AuthSession`, because it became quite painful to adjust the parameters of the `AuthSession` constructor.

