### PR TITLE
[Python Legacy] Convert string to boolean if the binding variable is Boolean

### DIFF
--- a/python_legacy/iceberg/api/expressions/literals.py
+++ b/python_legacy/iceberg/api/expressions/literals.py
@@ -382,6 +382,7 @@ class StringLiteral(BaseLiteral):
         super(StringLiteral, self).__init__(value, TypeID.STRING)
 
     def to(self, type_var):  # noqa: C901
+        value_upper = self.value.upper()
         import dateutil.parser
         if type_var.type_id == TypeID.DATE:
             return DateLiteral((dateutil.parser.parse(self.value) - Literals.EPOCH).days)
@@ -414,8 +415,8 @@ class StringLiteral(BaseLiteral):
                     return DecimalLiteral(Decimal(str(self.value))
                                           .quantize(Decimal("." + "".join(["0" for i in range(1, type_var.scale)]) + "1"),
                                                     rounding=ROUND_HALF_UP))
-        elif type_var.type_id == TypeID.BOOLEAN and self.value.upper() in ['TRUE', 'FALSE']:
-            return BooleanLiteral(True if self.value.upper() == 'TRUE' else False)
+        elif type_var.type_id == TypeID.BOOLEAN and value_upper in ['TRUE', 'FALSE']:
+            return BooleanLiteral(value_upper == 'TRUE')
 
     def __eq__(self, other):
         if id(self) == id(other):

--- a/python_legacy/iceberg/api/expressions/literals.py
+++ b/python_legacy/iceberg/api/expressions/literals.py
@@ -415,8 +415,8 @@ class StringLiteral(BaseLiteral):
                     return DecimalLiteral(Decimal(str(self.value))
                                           .quantize(Decimal("." + "".join(["0" for i in range(1, type_var.scale)]) + "1"),
                                                     rounding=ROUND_HALF_UP))
-        elif type_var.type_id == TypeID.BOOLEAN and value_upper in ['TRUE', 'FALSE']:
-            return BooleanLiteral(value_upper == 'TRUE')
+        elif type_var.type_id == TypeID.BOOLEAN and value_upper in ["TRUE", "FALSE"]:
+            return BooleanLiteral(value_upper == "TRUE")
 
     def __eq__(self, other):
         if id(self) == id(other):

--- a/python_legacy/iceberg/api/expressions/literals.py
+++ b/python_legacy/iceberg/api/expressions/literals.py
@@ -414,6 +414,8 @@ class StringLiteral(BaseLiteral):
                     return DecimalLiteral(Decimal(str(self.value))
                                           .quantize(Decimal("." + "".join(["0" for i in range(1, type_var.scale)]) + "1"),
                                                     rounding=ROUND_HALF_UP))
+        elif type_var.type_id == TypeID.BOOLEAN and self.value.upper() in ['TRUE', 'FALSE']:
+            return BooleanLiteral(True if self.value.upper() == 'TRUE' else False)
 
     def __eq__(self, other):
         if id(self) == id(other):

--- a/python_legacy/setup.py
+++ b/python_legacy/setup.py
@@ -36,7 +36,7 @@ setup(
                       'requests',
                       'retrying',
                       'pandas',
-                      'pyarrow'
+                      'pyarrow>=3.0.0,<=4.0.1'
                       ],
     extras_require={
         "dev": [

--- a/python_legacy/setup.py
+++ b/python_legacy/setup.py
@@ -36,7 +36,7 @@ setup(
                       'requests',
                       'retrying',
                       'pandas',
-                      'pyarrow>=3.0.0,<=4.0.1'
+                      'pyarrow'
                       ],
     extras_require={
         "dev": [

--- a/python_legacy/tests/api/expressions/test_string_literal_conversions.py
+++ b/python_legacy/tests/api/expressions/test_string_literal_conversions.py
@@ -22,13 +22,13 @@ import uuid
 import dateutil.parser
 from fastavro.write import LOGICAL_WRITERS as avro_conversion
 from iceberg.api.expressions import Literal
-from iceberg.api.types import (DateType,
+from iceberg.api.types import (BooleanType,
+                               DateType,
                                DecimalType,
                                StringType,
                                TimestampType,
                                TimeType,
-                               UUIDType,
-                               BooleanType)
+                               UUIDType)
 from pytest import raises
 
 

--- a/python_legacy/tests/api/expressions/test_string_literal_conversions.py
+++ b/python_legacy/tests/api/expressions/test_string_literal_conversions.py
@@ -27,7 +27,8 @@ from iceberg.api.types import (DateType,
                                StringType,
                                TimestampType,
                                TimeType,
-                               UUIDType)
+                               UUIDType,
+                               BooleanType)
 from pytest import raises
 
 
@@ -100,3 +101,10 @@ def test_string_to_decimal_literal():
 
     assert decimal_str.to(DecimalType.of(9, 2)) is None
     assert decimal_str.to(DecimalType.of(9, 4)) is None
+
+
+def test_string_to_boolean_literal():
+    assert Literal.of(True) == Literal.of("true").to(BooleanType.get())
+    assert Literal.of(True) == Literal.of("True").to(BooleanType.get())
+    assert Literal.of(False) == Literal.of("false").to(BooleanType.get())
+    assert Literal.of(False) == Literal.of("False").to(BooleanType.get())


### PR DESCRIPTION
In case of `Boolean` binding column (`is_auth_action` column is `Boolean` type) following expression `Expressions.convert_string_to_expr("dt='2023-02-13' and is_auth_action=true")`, throwing below error -

```    file_scan_tasks = list(table.new_scan().filter(Expressions.convert_string_to_expr(partition)).plan_files())
  File "/usr/local/lib/python3.7/dist-packages/iceberg/core/data_table_scan.py", line 72, in plan_files
    return super(DataTableScan, self).plan_files()
  File "/usr/local/lib/python3.7/dist-packages/iceberg/core/base_table_scan.py", line 164, in plan_files
    return self.plan_files(ops, snapshot, row_filter)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/core/data_table_scan.py", line 74, in plan_files
    matching_manifests = [manifest for manifest in snapshot.manifests
  File "/usr/local/lib/python3.7/dist-packages/iceberg/core/data_table_scan.py", line 75, in <listcomp>
    if self.cache_loader(manifest.spec_id).eval(manifest)]
  File "/usr/local/lib/python3.7/dist-packages/iceberg/core/data_table_scan.py", line 105, in cache_loader
    return InclusiveManifestEvaluator(spec, self.row_filter)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/inclusive_manifest_evaluator.py", line 35, in __init__
    .project(row_filter)),
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/projections.py", line 50, in project
    return ExpressionVisitors.visit(ExpressionVisitors.visit(expr, RewriteNot.get()), self)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/expressions.py", line 170, in visit
    ExpressionVisitors.visit(expr.right, visitor))
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/expressions.py", line 160, in visit
    return visitor.predicate(expr)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/projections.py", line 84, in predicate
    return super(InclusiveProjection, self).predicate(pred)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/projections.py", line 68, in predicate
    bound = pred.bind(self.spec.schema.as_struct(), case_sensitive=self.case_sensitive)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/predicate.py", line 228, in bind
    return self.bind_literal_operation(bound)
  File "/usr/local/lib/python3.7/dist-packages/iceberg/api/expressions/predicate.py", line 278, in bind_literal_operation
    (bound_term.type, self.lit, self.lit.__class__.__name__))
  File "/usr/local/lib/python3.7/dist-packages/iceberg/exceptions/exceptions.py", line 44, in check
    raise ValidationException(message, args)
iceberg.exceptions.exceptions.ValidationException: Invalid Value for conversion to type boolean: "true" (StringLiteral)
```

Created the PR to mitigate the issue, this bug is also present in `pyiceberg` api, I will create separate PR to resolve the same. 
All tests are passing after the change.