### PR TITLE
Python: Add `default-catalog` option to the config

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -146,7 +146,7 @@ def infer_catalog_type(name: str, catalog_properties: RecursiveDict) -> Optional
     )
 
 
-def load_catalog(name: str, **properties: Optional[str]) -> Catalog:
+def load_catalog(name: Optional[str], **properties: Optional[str]) -> Catalog:
     """Load the catalog based on the properties
 
     Will look up the properties from the config, based on the name
@@ -162,6 +162,10 @@ def load_catalog(name: str, **properties: Optional[str]) -> Catalog:
         ValueError: Raises a ValueError in case properties are missing or malformed,
             or if it could not determine the catalog based on the properties
     """
+
+    if name is None:
+        name = _ENV_CONFIG.get_default_catalog_name()
+
     env = _ENV_CONFIG.get_catalog_config(name)
     conf: RecursiveDict = merge_config(env or {}, cast(RecursiveDict, properties))
 

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -50,13 +50,13 @@ def catch_exception() -> Callable:  # type: ignore
 
 
 @click.group()
-@click.option("--catalog", default="default")
+@click.option("--catalog")
 @click.option("--verbose", type=click.BOOL)
 @click.option("--output", type=click.Choice(["text", "json"]), default="text")
 @click.option("--uri")
 @click.option("--credential")
 @click.pass_context
-def run(ctx: Context, catalog: str, verbose: bool, output: str, uri: Optional[str], credential: Optional[str]) -> None:
+def run(ctx: Context, catalog: Optional[str], verbose: bool, output: str, uri: Optional[str], credential: Optional[str]) -> None:
     properties = {}
     if uri:
         properties["uri"] = uri

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -23,7 +23,9 @@ import yaml
 from pyiceberg.typedef import FrozenDict, RecursiveDict
 
 PYICEBERG = "pyiceberg_"
+DEFAULT = "default"
 CATALOG = "catalog"
+DEFAULT_CATALOG = f"{DEFAULT}-{CATALOG}"
 HOME = "HOME"
 PYICEBERG_HOME = "PYICEBERG_HOME"
 PYICEBERG_YML = ".pyiceberg.yaml"
@@ -128,6 +130,20 @@ class Config:
                 set_property(config, parts_normalized, config_value)
 
         return config
+
+    def get_default_catalog_name(self) -> str:
+        """
+        Looks into the configuration file for `default-catalog`
+        and returns the name as the default catalog
+
+        Returns: The name of the default catalog in `default-catalog`
+                 Returns `default` when the key cannot be found.
+        """
+        if default_catalog_name := self.config.get(DEFAULT_CATALOG):
+            if not isinstance(default_catalog_name, str):
+                raise ValueError(f"Default catalog name should be a str: {default_catalog_name}")
+            return default_catalog_name
+        return DEFAULT
 
     def get_catalog_config(self, catalog_name: str) -> Optional[RecursiveDict]:
         if CATALOG in self.config:


### PR DESCRIPTION
If you set `default-catalog` it will default to that catalog.

```yaml
default-catalog: rest

catalog:
    hive:
        uri: thrift://127.0.0.1:9083
        s3.endpoint: http://127.0.0.1:9000
        s3.access-key-id: admin
        s3.secret-access-key: password

    rest:
        uri: https://...
        py-io-impl: pyiceberg.io.pyarrow.PyArrowFileIO
```

This will use the rest catalog as set using `default-catalog`.