### PR TITLE
cache delete files for repeat reading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,8 @@ project(':iceberg-data') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
 
+    implementation "com.github.ben-manes.caffeine:caffeine"
+
     implementation("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -120,6 +120,15 @@ public class Deletes {
     }
   }
 
+  public static StructLikeSet toEqualitySet(
+      Iterable<StructLikeSet> eqDeleteSets, Types.StructType eqType) {
+    StructLikeSet mergedDeleteSet = StructLikeSet.create(eqType);
+
+    eqDeleteSets.forEach(mergedDeleteSet::addAll);
+
+    return mergedDeleteSet;
+  }
+
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(
       CharSequence dataLocation, List<CloseableIterable<T>> deleteFiles) {
     DataFileFilter<T> locationFilter = new DataFileFilter<>(dataLocation);


### PR DESCRIPTION
Related with the request [6865](https://github.com/apache/iceberg/issues/6865)

I'll add the following update if this proposal makes sense to the team:

- A table property to enable/disable the delete file cache
- unit test to cover the reading from cache
- doc