### PR TITLE
Build: Fix compile warning with Immutables subtype

### DIFF
--- a/api/src/main/java/org/apache/iceberg/view/ViewRepresentation.java
+++ b/api/src/main/java/org/apache/iceberg/view/ViewRepresentation.java
@@ -18,9 +18,6 @@
  */
 package org.apache.iceberg.view;
 
-import org.immutables.value.Value;
-
-@Value.Immutable
 public interface ViewRepresentation {
 
   class Type {


### PR DESCRIPTION
Warning before fix:

```
../iceberg/api/src/main/java/org/apache/iceberg/view/SQLViewRepresentation.java:27: warning: (immutables:subtype) Should not inherit org.apache.iceberg.view.ViewRepresentation which is a value type itself. Avoid extending from another abstract value type. Better to share common abstract class or interface which are not carrying @Immutable annotation. If still extending from immutable abstract type be ready to face some incoherences in generated types.
public interface SQLViewRepresentation extends ViewRepresentation {
       ^
```