### PR TITLE
API: Check redundant partitions when binding

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -558,7 +558,9 @@ public class PartitionSpec implements Serializable {
 
     Builder add(int sourceId, int fieldId, String name, Transform<?, ?> transform) {
       checkAndAddPartitionName(name, sourceId);
-      fields.add(new PartitionField(sourceId, fieldId, name, transform));
+      PartitionField field = new PartitionField(sourceId, fieldId, name, transform);
+      checkForRedundantPartitions(field);
+      fields.add(field);
       lastAssignedFieldId.getAndAccumulate(fieldId, Math::max);
       return this;
     }

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -342,4 +342,19 @@ public class TestPartitionSpecValidation {
     Assert.assertEquals(1006, spec.fields().get(2).fieldId());
     Assert.assertEquals(1006, spec.lastAssignedFieldId());
   }
+
+  @Test
+  public void testBindSchemaRedundancyCheck() {
+    UnboundPartitionSpec spec =
+        UnboundPartitionSpec.builder()
+            .addField("day", 2, "days(ts)")
+            .addField("hour", 2, "hours(ts)")
+            .build();
+
+    AssertHelpers.assertThrows(
+        "Should not allow days(ts) and hours(ts)",
+        IllegalArgumentException.class,
+        "Cannot add redundant partition",
+        () -> spec.bind(SCHEMA));
+  }
 }


### PR DESCRIPTION
We check for redundant partitions when creating a bound partition spec:

```java
PartitionSpec.builderFor(SCHEMA).year("ts").month("ts").build())
```

Raises:

```
IllegalArgumentException:
	Cannot add redundant partition: 1000: ts_year: year(2) conflicts with 1001: ts_month: month(2)
```

However, if you `.bind()` a UnboundPartitionSpec to a PartitionSpec, using `.bind()` this check isn't done, and this allows you to create partitions with redundant partitions:

![image](https://user-images.githubusercontent.com/1134248/219685557-c7d8d4b3-0658-4f34-b387-aa5413b4c147.png)

Ends up with:

```
s3://warehouse/wh/default/iceberg_table/data/ts_year=2019/ts_month=2019-06/ts_day=2019-06-13/00000-12-6a2ee5a1-201c-4ca9-a07c-379940c7f83e-00001.parquet
```