### PR TITLE
Python: Assume timezone when it is omitted

### DIFF
--- a/python/mkdocs/docs/configuration.md
+++ b/python/mkdocs/docs/configuration.md
@@ -33,7 +33,12 @@ The configuration file is recommended since that's the most transparent way. If 
 export PYICEBERG_CATALOG__DEFAULT__URI=thrift://localhost:9083
 ```
 
-The environment variable picked up by Iceberg starts with `PYICEBERG_` and then follows the yaml structure below, where a double underscore `__` represents a nested field.
+The environment variable picked up by Iceberg starts with `PYICEBERG_` and then follows the yaml structure below, where a double underscore `__` represents a nested field. Catalog level configuration:
+
+| Key        | Example                          | Default                                      | Description                                                                                     |
+| ---------- | -------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| py-io-impl | pyiceberg.io.fsspec.FsspecFileIO | Preference based on the scheme `s3://`, etc. | Sets the FileIO explicitly to an implementation, and will fail explicitly if it can't be loaded |
+| timezone   | -07:00                           | UTC `+00:00`                                 | For Timestamptz fields, in the case a timezone is omitted, it will use this timezone.           |
 
 ## FileIO
 
@@ -44,14 +49,6 @@ Iceberg works with the concept of a FileIO which is a pluggable module for readi
 - **file**: `PyArrowFileIO`
 - **hdfs**: `PyArrowFileIO`
 - **abfs**, **abfss**: `FsspecFileIO`
-
-You can also set the FileIO explicitly:
-
-| Key        | Example                          | Description                                                                                     |
-| ---------- | -------------------------------- | ----------------------------------------------------------------------------------------------- |
-| py-io-impl | pyiceberg.io.fsspec.FsspecFileIO | Sets the FileIO explicitly to an implementation, and will fail explicitly if it can't be loaded |
-
-For the FileIO there are several configuration options available:
 
 ### S3
 

--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -26,6 +26,8 @@ from datetime import (
     timedelta,
 )
 
+TIMEZONE = "timezone"
+UTC = "+00:00"
 EPOCH_DATE = date.fromisoformat("1970-01-01")
 EPOCH_TIMESTAMP = datetime.fromisoformat("1970-01-01T00:00:00.000000")
 ISO_TIMESTAMP = re.compile(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d{1,6})?")
@@ -85,6 +87,15 @@ def timestamp_to_micros(timestamp_str: str) -> int:
         # When we can match a timestamp without a zone, we can give a more specific error
         raise ValueError(f"Zone offset provided, but not expected: {timestamp_str}")
     raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
+
+
+def iso8601_add_default_timezone(timestamp_str: str, default_tz: str = "+00:00") -> str:
+    if ISO_TIMESTAMPTZ.fullmatch(timestamp_str):
+        return timestamp_str
+    if ISO_TIMESTAMP.fullmatch(timestamp_str):
+        return timestamp_str + default_tz
+    else:
+        raise ValueError(f"Invalid timestamp: {timestamp_str} (must be ISO-8601)")
 
 
 def timestamptz_to_micros(timestamptz_str: str) -> int:


### PR DESCRIPTION
We don't want to throw an error when the timezone is missing and just assume UTC.