### PR TITLE
Delta Migration: Handle delta lake's automatic log clean and VACUUM

### DIFF
--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/SparkDeltaLakeSnapshotTestBase.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/SparkDeltaLakeSnapshotTestBase.java
@@ -47,7 +47,6 @@ public abstract class SparkDeltaLakeSnapshotTestBase {
                 hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname))
             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
             .config("spark.databricks.delta.retentionDurationCheck.enabled", "false")
-            .config("spark.databricks.delta.logRetentionDuration", "interval 0 days")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .enableHiveSupport()
             .getOrCreate();

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/SparkDeltaLakeSnapshotTestBase.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/SparkDeltaLakeSnapshotTestBase.java
@@ -46,6 +46,8 @@ public abstract class SparkDeltaLakeSnapshotTestBase {
                 "spark.hadoop." + HiveConf.ConfVars.METASTOREURIS.varname,
                 hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname))
             .config("spark.sql.legacy.respectNullabilityInTextDatasetConversion", "true")
+            .config("spark.databricks.delta.retentionDurationCheck.enabled", "false")
+            .config("spark.databricks.delta.logRetentionDuration", "interval 0 days")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .enableHiveSupport()
             .getOrCreate();

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -68,30 +68,23 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
   private static final String NAMESPACE = "delta_conversion_test";
   private static final String defaultSparkCatalog = "spark_catalog";
   private static final String icebergCatalogName = "iceberg_hive";
-  private final String partitionedTableName = "partitioned_table";
-  private final String unpartitionedTableName = "unpartitioned_table";
-  private final String externalDataFilesTableName = "external_data_files_table";
-  private final String typeTestTableName = "type_test_table";
-  private final String vacuumTestTableName = "vacuum_test_table";
-  private final String logCleanTestTableName = "log_clean_test_table";
-  private final String snapshotPartitionedTableName = "iceberg_partitioned_table";
-  private final String snapshotUnpartitionedTableName = "iceberg_unpartitioned_table";
-  private final String snapshotExternalDataFilesTableName = "iceberg_external_data_files_table";
-  private final String snapshotNewTableLocationTableName = "iceberg_new_table_location_table";
-  private final String snapshotAdditionalPropertiesTableName =
+  private static final String partitionedTableName = "partitioned_table";
+  private static final String unpartitionedTableName = "unpartitioned_table";
+  private static final String externalDataFilesTableName = "external_data_files_table";
+  private static final String typeTestTableName = "type_test_table";
+  private static final String vacuumTestTableName = "vacuum_test_table";
+  private static final String logCleanTestTableName = "log_clean_test_table";
+  private static final String snapshotPartitionedTableName = "iceberg_partitioned_table";
+  private static final String snapshotUnpartitionedTableName = "iceberg_unpartitioned_table";
+  private static final String snapshotExternalDataFilesTableName =
+      "iceberg_external_data_files_table";
+  private static final String snapshotNewTableLocationTableName =
+      "iceberg_new_table_location_table";
+  private static final String snapshotAdditionalPropertiesTableName =
       "iceberg_additional_properties_table";
-  private final String snapshotVacuumTableName = "iceberg_vacuum_table";
-  private final String snapshotTypeTestTableName = "iceberg_type_test_table";
-  private final String snapshotLogCleanTableName = "iceberg_log_clean_table";
-  private final String partitionedIdentifier = destName(defaultSparkCatalog, partitionedTableName);
-  private final String unpartitionedIdentifier =
-      destName(defaultSparkCatalog, unpartitionedTableName);
-  private final String externalDataFilesIdentifier =
-      destName(defaultSparkCatalog, externalDataFilesTableName);
-  private final String typeTestIdentifier = destName(defaultSparkCatalog, typeTestTableName);
-  private final String vacuumTestIdentifier = destName(defaultSparkCatalog, vacuumTestTableName);
-  private final String logCleanTestIdentifier =
-      destName(defaultSparkCatalog, logCleanTestTableName);
+  private static final String snapshotVacuumTableName = "iceberg_vacuum_table";
+  private static final String snapshotTypeTestTableName = "iceberg_type_test_table";
+  private static final String snapshotLogCleanTableName = "iceberg_log_clean_table";
   private Dataset<Row> typeTestDataFrame;
   private Dataset<Row> nestedDataFrame;
 
@@ -139,6 +132,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testBasicSnapshotPartitioned() throws IOException {
+    String partitionedIdentifier = destName(defaultSparkCatalog, partitionedTableName);
     String partitionedLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(nestedDataFrame, partitionedIdentifier, partitionedLocation, "id");
@@ -157,6 +151,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testBasicSnapshotUnpartitioned() throws IOException {
+    String unpartitionedIdentifier = destName(defaultSparkCatalog, unpartitionedTableName);
     String unpartitionedLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(nestedDataFrame, unpartitionedIdentifier, unpartitionedLocation, null);
@@ -176,6 +171,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotWithNewLocation() throws IOException {
+    String partitionedIdentifier = destName(defaultSparkCatalog, partitionedTableName);
     String partitionedLocation = temp.newFolder().toURI().toString();
     String newIcebergTableLocation = temp.newFolder().toURI().toString();
 
@@ -196,6 +192,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotWithAdditionalProperties() throws IOException {
+    String unpartitionedIdentifier = destName(defaultSparkCatalog, unpartitionedTableName);
     String unpartitionedLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(nestedDataFrame, unpartitionedIdentifier, unpartitionedLocation, null);
@@ -231,6 +228,8 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotTableWithExternalDataFiles() throws IOException {
+    String unpartitionedIdentifier = destName(defaultSparkCatalog, unpartitionedTableName);
+    String externalDataFilesIdentifier = destName(defaultSparkCatalog, externalDataFilesTableName);
     String unpartitionedLocation = temp.newFolder().toURI().toString();
     String externalDataFilesTableLocation = temp.newFolder().toURI().toString();
 
@@ -257,6 +256,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotSupportedTypes() throws IOException {
+    String typeTestIdentifier = destName(defaultSparkCatalog, typeTestTableName);
     String typeTestTableLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(typeTestDataFrame, typeTestIdentifier, typeTestTableLocation, "stringCol");
@@ -276,6 +276,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotVacuumTable() throws IOException {
+    String vacuumTestIdentifier = destName(defaultSparkCatalog, vacuumTestTableName);
     String vacuumTestTableLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(nestedDataFrame, vacuumTestIdentifier, vacuumTestTableLocation, null);
@@ -309,6 +310,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Test
   public void testSnapshotLogCleanTable() throws IOException {
+    String logCleanTestIdentifier = destName(defaultSparkCatalog, logCleanTestTableName);
     String logCleanTestTableLocation = temp.newFolder().toURI().toString();
 
     writeDeltaTable(nestedDataFrame, logCleanTestIdentifier, logCleanTestTableLocation, "id");
@@ -354,8 +356,8 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     Assertions.assertThat(deltaTableContents).hasSize(icebergTableContents.size());
     Assertions.assertThat(deltaLog.update().getAllFiles())
         .hasSize((int) snapshotReport.snapshotDataFilesCount());
-    Assertions.assertThat(icebergTableContents).containsAll(deltaTableContents);
-    Assertions.assertThat(deltaTableContents).containsAll(icebergTableContents);
+    Assertions.assertThat(icebergTableContents)
+        .containsExactlyInAnyOrderElementsOf(deltaTableContents);
   }
 
   private void checkIcebergTableLocation(String icebergTableIdentifier, String expectedLocation) {

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -31,9 +31,15 @@ import io.delta.standalone.exceptions.DeltaConcurrentModificationException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.net.URLCodec;
 import org.apache.iceberg.Table;
@@ -56,9 +62,13 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(Parameterized.class)
 public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestSnapshotDeltaLakeTable.class.getName());
   private static final String SNAPSHOT_SOURCE_PROP = "snapshot_source";
   private static final String DELTA_SOURCE_VALUE = "delta";
   private static final String ORIGINAL_LOCATION_PROP = "original_location";
@@ -69,22 +79,26 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
   private String unpartitionedIdentifier;
   private String externalDataFilesIdentifier;
   private String typeTestIdentifier;
+  private String vacuumTestIdentifier;
   private final String partitionedTableName = "partitioned_table";
   private final String unpartitionedTableName = "unpartitioned_table";
   private final String externalDataFilesTableName = "external_data_files_table";
   private final String typeTestTableName = "type_test_table";
+  private final String vacuumTestTableName = "vacuum_test_table";
   private final String snapshotPartitionedTableName = "iceberg_partitioned_table";
   private final String snapshotUnpartitionedTableName = "iceberg_unpartitioned_table";
   private final String snapshotExternalDataFilesTableName = "iceberg_external_data_files_table";
   private final String snapshotNewTableLocationTableName = "iceberg_new_table_location_table";
   private final String snapshotAdditionalPropertiesTableName =
       "iceberg_additional_properties_table";
+  private final String snapshotVacuumTableName = "iceberg_vacuum_table";
   private final String snapshotTypeTestTableName = "iceberg_type_test_table";
   private String partitionedLocation;
   private String unpartitionedLocation;
   private String newIcebergTableLocation;
   private String externalDataFilesTableLocation;
   private String typeTestTableLocation;
+  private String vacuumTestTableLocation;
   private Dataset<Row> typeTestDataFrame;
   private Dataset<Row> nestedDataFrame;
 
@@ -113,6 +127,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
   @Rule public TemporaryFolder temp3 = new TemporaryFolder();
   @Rule public TemporaryFolder temp4 = new TemporaryFolder();
   @Rule public TemporaryFolder temp5 = new TemporaryFolder();
+  @Rule public TemporaryFolder temp6 = new TemporaryFolder();
 
   public TestSnapshotDeltaLakeTable(
       String catalogName, String implementation, Map<String, String> config) {
@@ -127,11 +142,13 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     File newIcebergTableFolder = temp3.newFolder();
     File externalDataFilesTableFolder = temp4.newFolder();
     File typeTestTableFolder = temp5.newFolder();
+    File vacuumTestTableFolder = temp6.newFolder();
     partitionedLocation = partitionedFolder.toURI().toString();
     unpartitionedLocation = unpartitionedFolder.toURI().toString();
     newIcebergTableLocation = newIcebergTableFolder.toURI().toString();
     externalDataFilesTableLocation = externalDataFilesTableFolder.toURI().toString();
     typeTestTableLocation = typeTestTableFolder.toURI().toString();
+    vacuumTestTableLocation = vacuumTestTableFolder.toURI().toString();
 
     spark.sql(String.format("CREATE DATABASE IF NOT EXISTS %s", NAMESPACE));
 
@@ -139,11 +156,13 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     unpartitionedIdentifier = destName(defaultSparkCatalog, unpartitionedTableName);
     externalDataFilesIdentifier = destName(defaultSparkCatalog, externalDataFilesTableName);
     typeTestIdentifier = destName(defaultSparkCatalog, typeTestTableName);
+    vacuumTestIdentifier = destName(defaultSparkCatalog, vacuumTestTableName);
 
     spark.sql(String.format("DROP TABLE IF EXISTS %s", partitionedIdentifier));
     spark.sql(String.format("DROP TABLE IF EXISTS %s", unpartitionedIdentifier));
     spark.sql(String.format("DROP TABLE IF EXISTS %s", externalDataFilesIdentifier));
     spark.sql(String.format("DROP TABLE IF EXISTS %s", typeTestIdentifier));
+    spark.sql(String.format("DROP TABLE IF EXISTS %s", vacuumTestIdentifier));
 
     // generate the dataframe
     nestedDataFrame = nestedDataFrame();
@@ -176,6 +195,9 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             "DROP TABLE IF EXISTS %s", destName(defaultSparkCatalog, externalDataFilesTableName)));
     spark.sql(
         String.format("DROP TABLE IF EXISTS %s", destName(defaultSparkCatalog, typeTestTableName)));
+    spark.sql(
+        String.format(
+            "DROP TABLE IF EXISTS %s", destName(defaultSparkCatalog, vacuumTestTableName)));
 
     // Drop iceberg tables.
     spark.sql(
@@ -200,6 +222,9 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     spark.sql(
         String.format(
             "DROP TABLE IF EXISTS %s", destName(icebergCatalogName, snapshotTypeTestTableName)));
+    spark.sql(
+        String.format(
+            "DROP TABLE IF EXISTS %s", destName(icebergCatalogName, snapshotVacuumTableName)));
 
     spark.sql(String.format("DROP DATABASE IF EXISTS %s", NAMESPACE));
   }
@@ -305,6 +330,76 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
         newTableIdentifier,
         ImmutableMap.of(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false"),
         typeTestTableLocation);
+  }
+
+  @Test
+  public void testSnapshotVacuumTable() throws IOException {
+    writeDeltaTable(nestedDataFrame, vacuumTestIdentifier, vacuumTestTableLocation, null);
+    Random random = new Random();
+    for (int i = 0; i < 13; i++) {
+      spark.sql(
+          "UPDATE "
+              + vacuumTestIdentifier
+              + " SET magic_number = "
+              + random.nextDouble()
+              + " WHERE id = 1");
+    }
+
+    DeltaLog deltaLog =
+        DeltaLog.forTable(spark.sessionState().newHadoopConf(), vacuumTestTableLocation);
+    Set<String> testLogFiles =
+        listFilesUsingFilesList(URI.create(vacuumTestTableLocation.concat("/_delta_log")));
+    Set<String> testDataFiles = listFilesUsingFilesList(URI.create(vacuumTestTableLocation));
+    LOG.info("testDeltaLogs: {}", testLogFiles);
+    LOG.info("testDataFiles: {}", testDataFiles);
+    spark.sql("VACUUM " + vacuumTestIdentifier + " RETAIN 0 HOURS");
+    testLogFiles =
+        listFilesUsingFilesList(URI.create(vacuumTestTableLocation.concat("/_delta_log")));
+    testDataFiles = listFilesUsingFilesList(URI.create(vacuumTestTableLocation));
+    LOG.info("testDeltaLogs2: {}", testLogFiles);
+    LOG.info("testDataFiles: {}", testDataFiles);
+
+    String newTableIdentifier = destName(icebergCatalogName, snapshotVacuumTableName);
+    SnapshotDeltaLakeTable.Result result =
+        DeltaLakeToIcebergMigrationSparkIntegration.snapshotDeltaLakeTable(
+                spark, newTableIdentifier, vacuumTestTableLocation)
+            .execute();
+    checkSnapshotIntegrity(
+        vacuumTestTableLocation, vacuumTestIdentifier, newTableIdentifier, result);
+  }
+
+  @Test
+  public void testSnapshotVacuumTable2() throws IOException {
+    writeDeltaTable(nestedDataFrame, vacuumTestIdentifier, vacuumTestTableLocation, null);
+    Random random = new Random();
+    for (int i = 0; i < 13; i++) {
+      spark.sql(
+          "UPDATE "
+              + vacuumTestIdentifier
+              + " SET magic_number = "
+              + random.nextDouble()
+              + " WHERE id = 1");
+    }
+
+    DeltaLog deltaLog =
+        DeltaLog.forTable(spark.sessionState().newHadoopConf(), vacuumTestTableLocation);
+    Set<String> testLogFiles =
+        listFilesUsingFilesList(URI.create(vacuumTestTableLocation.concat("/_delta_log")));
+    Set<String> testDataFiles = listFilesUsingFilesList(URI.create(vacuumTestTableLocation));
+    LOG.info("testDeltaLogs: {}", testLogFiles);
+    LOG.info("testDataFiles: {}", testDataFiles);
+    boolean result =
+        Files.deleteIfExists(
+            Paths.get(
+                URI.create(
+                    vacuumTestTableLocation.concat("/_delta_log/00000000000000000000.json"))));
+    spark.sql("VACUUM " + vacuumTestIdentifier + " RETAIN 0 HOURS");
+    LOG.info("Deleted ? {}", result);
+    testLogFiles =
+        listFilesUsingFilesList(URI.create(vacuumTestTableLocation.concat("/_delta_log")));
+    testDataFiles = listFilesUsingFilesList(URI.create(vacuumTestTableLocation));
+    LOG.info("testDeltaLogs2: {}", testLogFiles);
+    LOG.info("testDataFiles: {}", testDataFiles);
   }
 
   private void checkSnapshotIntegrity(
@@ -496,6 +591,16 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
           .saveAsTable(identifier);
     } else {
       df.write().format("delta").mode(SaveMode.Append).option("path", path).saveAsTable(identifier);
+    }
+  }
+
+  public Set<String> listFilesUsingFilesList(URI dir) throws IOException {
+    try (Stream<Path> stream = Files.list(Paths.get(dir))) {
+      return stream
+          .filter(file -> !Files.isDirectory(file))
+          .map(Path::getFileName)
+          .map(Path::toString)
+          .collect(Collectors.toSet());
     }
   }
 }

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -119,13 +119,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     };
   }
 
-  @Rule public TemporaryFolder temp1 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp2 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp3 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp4 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp5 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp6 = new TemporaryFolder();
-  @Rule public TemporaryFolder temp7 = new TemporaryFolder();
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
 
   public TestSnapshotDeltaLakeTable(
       String catalogName, String implementation, Map<String, String> config) {
@@ -135,13 +129,13 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
   @Before
   public void before() throws IOException {
-    File partitionedFolder = temp1.newFolder();
-    File unpartitionedFolder = temp2.newFolder();
-    File newIcebergTableFolder = temp3.newFolder();
-    File externalDataFilesTableFolder = temp4.newFolder();
-    File typeTestTableFolder = temp5.newFolder();
-    File vacuumTestTableFolder = temp6.newFolder();
-    File logCleanTestTableFolder = temp7.newFolder();
+    File partitionedFolder = temp.newFolder();
+    File unpartitionedFolder = temp.newFolder();
+    File newIcebergTableFolder = temp.newFolder();
+    File externalDataFilesTableFolder = temp.newFolder();
+    File typeTestTableFolder = temp.newFolder();
+    File vacuumTestTableFolder = temp.newFolder();
+    File logCleanTestTableFolder = temp.newFolder();
     partitionedLocation = partitionedFolder.toURI().toString();
     unpartitionedLocation = unpartitionedFolder.toURI().toString();
     newIcebergTableLocation = newIcebergTableFolder.toURI().toString();

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -152,7 +152,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
         "Make sure to configure the action with a valid deltaLakeConfiguration");
     Preconditions.checkArgument(
         deltaLog.tableExists(),
-        "Delta lake table does not exist at the given location: %s",
+        "Delta Lake table does not exist at the given location: %s",
         deltaTableLocation);
     io.delta.standalone.Snapshot updatedSnapshot = deltaLog.update();
     Schema schema = convertDeltaLakeSchema(updatedSnapshot.getMetadata().getSchema());
@@ -191,7 +191,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
 
     icebergTransaction.commitTransaction();
     LOG.info(
-        "Successfully created Iceberg table {} from delta lake table at {}, total data file count: {}",
+        "Successfully created Iceberg table {} from Delta Lake table at {}, total data file count: {}",
         newTableIdentifier,
         deltaTableLocation,
         totalDataFiles);
@@ -261,7 +261,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
     }
 
     throw new ValidationException(
-        "Delta table at %s contains no constructable snapshot", deltaTableLocation);
+        "Delta Lake table at %s contains no constructable snapshot", deltaTableLocation);
   }
 
   /**
@@ -351,6 +351,11 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
 
     FileFormat format = determineFileFormatFromPath(fullFilePath);
     InputFile file = deltaLakeFileIO.newInputFile(fullFilePath);
+    if (!file.exists()) {
+      throw new NotFoundException(
+          "The file %s does not exist in the Delta Lake table at %s",
+          fullFilePath, deltaTableLocation);
+    }
 
     // If the file size is not specified, the size should be read from the file
     if (nullableFileSize != null) {

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -353,7 +353,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
     InputFile file = deltaLakeFileIO.newInputFile(fullFilePath);
     if (!file.exists()) {
       throw new NotFoundException(
-          "File %s is referenced in the metadata of Delta Lake table at %s, but cannot be found in the storage",
+          "File %s is referenced in the logs of Delta Lake table at %s, but cannot be found in the storage",
           fullFilePath, deltaTableLocation);
     }
 

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -353,7 +353,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
     InputFile file = deltaLakeFileIO.newInputFile(fullFilePath);
     if (!file.exists()) {
       throw new NotFoundException(
-          "The file %s does not exist in the Delta Lake table at %s",
+          "File %s is referenced in the metadata of Delta Lake table at %s, but cannot be found in the storage",
           fullFilePath, deltaTableLocation);
     }
 

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -218,6 +218,24 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
     return builder.build();
   }
 
+  /**
+   * Commit the initial delta snapshot to iceberg transaction. It tries the snapshot starting from
+   * {@code deltaStartVersion} to {@code latestVersion} and commit the first constructable one.
+   *
+   * <p>There are two cases that the delta snapshot is not constructable:
+   *
+   * <ul>
+   *   <li>the version is earlier than the earliest checkpoint
+   *   <li>the corresponding data files are deleted by {@code VACUUM}
+   * </ul>
+   *
+   * <p>For more information, please refer to delta lake's <a
+   * href="https://docs.delta.io/latest/delta-batch.html#-data-retention">Data Retention</a>
+   *
+   * @param latestVersion the latest version of the delta lake table
+   * @param transaction the iceberg transaction
+   * @return the initial version of the delta lake table that is successfully committed to iceberg
+   */
   private long commitInitialDeltaSnapshotToIcebergTransaction(
       long latestVersion, Transaction transaction) {
     long constructableStartVersion = deltaStartVersion;

--- a/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
@@ -98,7 +98,7 @@ public class TestBaseSnapshotDeltaLakeTableAction {
     Assertions.assertThatThrownBy(testAction::execute)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Delta lake table does not exist at the given location: %s", sourceTableLocation);
+            "Delta Lake table does not exist at the given location: %s", sourceTableLocation);
   }
 
   private static class TestCatalog extends BaseMetastoreCatalog {


### PR DESCRIPTION
## Issue Fixed
This PR fixes #6781 .

The automatic log clean whenever a new checkpoint is created and the manual data file clean by `VACUUM` sometimes lead to inconsistency between the first constructable delta lake version and the earliest delta lake version in the table. The inconsistency will cause file not found errors during the migration.

This PR fix the issue by forcing the snapshot delta lake action to start from the first constructable delta lake version instead of the earliest version.

## Test
Added Integration tests to mock the file clean scenario.

