### PR TITLE
API: Replace special case of deprecated RuntimeIOException

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -24,8 +24,8 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Paths;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.exceptions.NotFoundException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
@@ -57,7 +57,7 @@ public class Files {
       }
 
       if (!file.getParentFile().isDirectory() && !file.getParentFile().mkdirs()) {
-        throw new RuntimeIOException(
+        throw new FileHandlingException(
             "Failed to create the file's directory at %s.", file.getParentFile().getAbsolutePath());
       }
 
@@ -72,7 +72,7 @@ public class Files {
     public PositionOutputStream createOrOverwrite() {
       if (file.exists()) {
         if (!file.delete()) {
-          throw new RuntimeIOException("Failed to delete: %s", file);
+          throw new FileHandlingException("Failed to delete: %s", file);
         }
       }
       return create();

--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -56,10 +56,7 @@ public class Files {
         throw new AlreadyExistsException("File already exists: %s", file);
       }
 
-      if (!file.getParentFile().isDirectory() && !file.getParentFile().mkdirs()) {
-        throw new FileHandlingException(
-            "Failed to create the file's directory at %s.", file.getParentFile().getAbsolutePath());
-      }
+      file.getParentFile().mkdirs();
 
       try {
         return new PositionFileOutputStream(file, new RandomAccessFile(file, "rw"));

--- a/api/src/main/java/org/apache/iceberg/exceptions/FileHandlingException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/FileHandlingException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.exceptions;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+/** Exception raised when unexpected behaviour happens in file operations. */
+public class FileHandlingException extends RuntimeException {
+  @FormatMethod
+  public FileHandlingException(String message, Object... args) {
+    super(String.format(message, args));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -27,7 +27,6 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
@@ -79,14 +78,13 @@ class AvroFileAppender<D> implements FileAppender<D> {
 
   @Override
   public long length() {
-    if (stream != null) {
-      try {
-        return stream.getPos();
-      } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to get stream length");
-      }
+    Preconditions.checkNotNull(stream, "Failed to get stream length: no open stream");
+
+    try {
+      return stream.getPos();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to get stream length");
     }
-    throw new FileHandlingException("Failed to get stream length: no open stream");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -78,7 +78,7 @@ class AvroFileAppender<D> implements FileAppender<D> {
 
   @Override
   public long length() {
-    Preconditions.checkNotNull(stream, "Failed to get stream length: no open stream");
+    Preconditions.checkState(null != stream, "Failed to get stream length: no open stream");
 
     try {
       return stream.getPos();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -27,6 +27,7 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
@@ -85,7 +86,7 @@ class AvroFileAppender<D> implements FileAppender<D> {
         throw new RuntimeIOException(e, "Failed to get stream length");
       }
     }
-    throw new RuntimeIOException("Failed to get stream length: no open stream");
+    throw new FileHandlingException("Failed to get stream length: no open stream");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
@@ -30,6 +30,7 @@ import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.DelegatingInputStream;
 import org.apache.iceberg.io.SeekableInputStream;
@@ -178,7 +179,7 @@ class AvroIO {
           SYNC_READER.read(decoder, blockSync);
 
           if (!Arrays.equals(fileSync, blockSync)) {
-            throw new RuntimeIOException("Invalid sync at %s", nextSyncPos);
+            throw new FileHandlingException("Invalid sync at %s", nextSyncPos);
           }
         }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
@@ -30,7 +30,6 @@ import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.DelegatingInputStream;
 import org.apache.iceberg.io.SeekableInputStream;
@@ -179,7 +178,7 @@ class AvroIO {
           SYNC_READER.read(decoder, blockSync);
 
           if (!Arrays.equals(fileSync, blockSync)) {
-            throw new FileHandlingException("Invalid sync at %s", nextSyncPos);
+            throw new IOException(String.format("Invalid sync at %s", nextSyncPos));
           }
         }
 

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -316,7 +317,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
           if (currentRows == 0L) {
             try {
               io.deleteFile(currentFile.encryptingOutputFile());
-            } catch (UncheckedIOException e) {
+            } catch (UncheckedIOException | FileHandlingException e) {
               // the file may not have been created, and it isn't worth failing the job to clean up,
               // skip deleting
             }

--- a/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
@@ -127,7 +128,7 @@ abstract class RollingFileWriter<T, W extends FileWriter<T, R>, R> implements Fi
       if (currentFileRows == 0L) {
         try {
           io.deleteFile(currentFile.encryptingOutputFile());
-        } catch (UncheckedIOException e) {
+        } catch (UncheckedIOException | FileHandlingException e) {
           // the file may not have been created, and it isn't worth failing the job to clean up,
           // skip deleting
         }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
@@ -315,7 +315,7 @@ public class TestTables {
     @Override
     public void deleteFile(String path) {
       if (!new File(path).delete()) {
-        throw new RuntimeIOException("Failed to delete file: " + path);
+        throw new FileHandlingException("Failed to delete file: " + path);
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
@@ -202,7 +202,7 @@ class TestTables {
     @Override
     public void deleteFile(String path) {
       if (!new File(path).delete()) {
-        throw new RuntimeIOException("Failed to delete file: " + path);
+        throw new FileHandlingException("Failed to delete file: " + path);
       }
     }
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
@@ -202,7 +202,7 @@ class TestTables {
     @Override
     public void deleteFile(String path) {
       if (!new File(path).delete()) {
-        throw new RuntimeIOException("Failed to delete file: " + path);
+        throw new FileHandlingException("Failed to delete file: " + path);
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
@@ -202,7 +202,7 @@ class TestTables {
     @Override
     public void deleteFile(String path) {
       if (!new File(path).delete()) {
-        throw new RuntimeIOException("Failed to delete file: " + path);
+        throw new FileHandlingException("Failed to delete file: " + path);
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.FileHandlingException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.LocationProvider;
@@ -202,7 +202,7 @@ class TestTables {
     @Override
     public void deleteFile(String path) {
       if (!new File(path).delete()) {
-        throw new RuntimeIOException("Failed to delete file: " + path);
+        throw new FileHandlingException("Failed to delete file: " + path);
       }
     }
   }


### PR DESCRIPTION
9 places in the code use deprecated `RuntimeIOException` without an actual `IOException` cause (which are considered as special case).

- Introduce `FileHandlingException` which extends `RuntimeException` and replace 6 (out of 9) places with `FileHandlingException`
- Use `IOException`, `RuntimeException` directly for 2 cases where new `FileHandlingException` is unnecessary
- Remove throwing `RuntimeIOException` from one place where throwing this exception was unnecessary.

This PR partly helps in removing the deprecated `RuntimeIOException`

Derived from an end-to-end PR: https://github.com/apache/iceberg/pull/4776
