### PR TITLE
Parquet: Make row-group filters cooperate to filter

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -84,6 +84,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -942,7 +943,7 @@ public class TestMetricsRowGroupFilter {
 
   @Test
   public void testParquetFindsResidual() {
-    Assume.assumeTrue("Only valid for Parquet", format == FileFormat.PARQUET);
+    Assumptions.assumeTrue(format == FileFormat.PARQUET, "Only valid for Parquet");
 
     Expression mightMatch = notEqual("some_nulls", "some");
     Expression cannotMatch = equal("id", INT_MIN_VALUE - 25);
@@ -952,17 +953,15 @@ public class TestMetricsRowGroupFilter {
         new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.or(mightMatch, cannotMatch), true);
     Expression actual = filter.residualFor(parquetSchema, rowGroupMetadata);
 
-    Assert.assertTrue(
-        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
-        actual.isEquivalentTo(expected));
+    Assertions.assertThat(actual.isEquivalentTo(expected))
+        .overridingErrorMessage("Expected: %s, actual: %s", expected, actual);
 
     filter =
         new ParquetMetricsRowGroupFilter(SCHEMA, Expressions.and(mightMatch, cannotMatch), true);
     expected = Expressions.alwaysFalse();
     actual = filter.residualFor(parquetSchema, rowGroupMetadata);
-    Assert.assertTrue(
-        String.format("Expected actual: %s, actual: %s", expected.toString(), actual.toString()),
-        actual.isEquivalentTo(expected));
+    Assertions.assertThat(actual.isEquivalentTo(expected))
+        .overridingErrorMessage("Expected: %s, actual: %s", expected, actual);
   }
 
   private boolean shouldRead(Expression expression) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -23,12 +23,13 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
-import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
+import org.apache.iceberg.expressions.ExpressionVisitors.FindsResidualVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -53,14 +54,19 @@ public class ParquetBloomRowGroupFilter {
   private final Expression expr;
   private final boolean caseSensitive;
 
-  public ParquetBloomRowGroupFilter(Schema schema, Expression unbound) {
-    this(schema, unbound, true);
+  public ParquetBloomRowGroupFilter(Schema schema, Expression expr) {
+    this(schema, expr, true);
   }
 
-  public ParquetBloomRowGroupFilter(Schema schema, Expression unbound, boolean caseSensitive) {
+  public ParquetBloomRowGroupFilter(Schema schema, Expression expr, boolean caseSensitive) {
     this.schema = schema;
     StructType struct = schema.asStruct();
-    this.expr = Binder.bind(struct, Expressions.rewriteNot(unbound), caseSensitive);
+    if (Binder.isBound(expr)) {
+      this.expr = Expressions.rewriteNot(expr);
+    } else {
+      this.expr = Binder.bind(struct, Expressions.rewriteNot(expr), caseSensitive);
+    }
+
     this.caseSensitive = caseSensitive;
   }
 
@@ -74,13 +80,15 @@ public class ParquetBloomRowGroupFilter {
    */
   public boolean shouldRead(
       MessageType fileSchema, BlockMetaData rowGroup, BloomFilterReader bloomReader) {
+    return residualFor(fileSchema, rowGroup, bloomReader) != Expressions.alwaysFalse();
+  }
+
+  public Expression residualFor(
+      MessageType fileSchema, BlockMetaData rowGroup, BloomFilterReader bloomReader) {
     return new BloomEvalVisitor().eval(fileSchema, rowGroup, bloomReader);
   }
 
-  private static final boolean ROWS_MIGHT_MATCH = true;
-  private static final boolean ROWS_CANNOT_MATCH = false;
-
-  private class BloomEvalVisitor extends BoundExpressionVisitor<Boolean> {
+  private class BloomEvalVisitor extends FindsResidualVisitor {
     private BloomFilterReader bloomReader;
     private Set<Integer> fieldsWithBloomFilter = null;
     private Map<Integer, ColumnChunkMetaData> columnMetaMap = null;
@@ -88,7 +96,7 @@ public class ParquetBloomRowGroupFilter {
     private Map<Integer, PrimitiveType> parquetPrimitiveTypes = null;
     private Map<Integer, Type> types = null;
 
-    private boolean eval(
+    private Expression eval(
         MessageType fileSchema, BlockMetaData rowGroup, BloomFilterReader bloomFilterReader) {
       this.bloomReader = bloomFilterReader;
       this.fieldsWithBloomFilter = Sets.newHashSet();
@@ -116,89 +124,99 @@ public class ParquetBloomRowGroupFilter {
       // If the filter's column set doesn't overlap with any bloom filter columns, exit early with
       // ROWS_MIGHT_MATCH
       if (filterRefs.size() > 0 && Sets.intersection(fieldsWithBloomFilter, filterRefs).isEmpty()) {
-        return ROWS_MIGHT_MATCH;
+        return expr;
       }
 
-      return ExpressionVisitors.visitEvaluator(expr, this);
+      return ExpressionVisitors.visit(expr, this);
     }
 
     @Override
-    public Boolean alwaysTrue() {
-      return ROWS_MIGHT_MATCH; // all rows match
+    public Expression alwaysTrue() {
+      return ROWS_ALL_MATCH; // all rows match
     }
 
     @Override
-    public Boolean alwaysFalse() {
+    public Expression alwaysFalse() {
       return ROWS_CANNOT_MATCH; // all rows fail
     }
 
     @Override
-    public Boolean not(Boolean result) {
+    public Expression not(Expression result) {
       // not() should be rewritten by RewriteNot
       // bloom filter is based on hash and cannot eliminate based on not
       throw new UnsupportedOperationException("This path shouldn't be reached.");
     }
 
     @Override
-    public Boolean and(Boolean leftResult, Boolean rightResult) {
-      return leftResult && rightResult;
+    public Expression and(Supplier<Expression> left, Supplier<Expression> right) {
+      Expression leftResult = left.get();
+      if (leftResult == ROWS_CANNOT_MATCH) {
+        return leftResult;
+      }
+
+      return Expressions.and(leftResult, right.get());
     }
 
     @Override
-    public Boolean or(Boolean leftResult, Boolean rightResult) {
-      return leftResult || rightResult;
+    public Expression or(Supplier<Expression> left, Supplier<Expression> right) {
+      Expression leftResult = left.get();
+      if (leftResult == ROWS_ALL_MATCH) {
+        return leftResult;
+      }
+
+      return Expressions.or(leftResult, right.get());
     }
 
     @Override
-    public <T> Boolean isNull(BoundReference<T> ref) {
+    public <T> Expression isNull(BoundReference<T> ref) {
       // bloom filter only contain non-nulls and cannot eliminate based on isNull or NotNull
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean notNull(BoundReference<T> ref) {
+    public <T> Expression notNull(BoundReference<T> ref) {
       // bloom filter only contain non-nulls and cannot eliminate based on isNull or NotNull
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean isNaN(BoundReference<T> ref) {
+    public <T> Expression isNaN(BoundReference<T> ref) {
       // bloom filter is based on hash and cannot eliminate based on isNaN or notNaN
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean notNaN(BoundReference<T> ref) {
+    public <T> Expression notNaN(BoundReference<T> ref) {
       // bloom filter is based on hash and cannot eliminate based on isNaN or notNaN
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression lt(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on lt or ltEq or gt or gtEq
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression ltEq(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on lt or ltEq or gt or gtEq
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression gt(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on lt or ltEq or gt or gtEq
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression gtEq(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on lt or ltEq or gt or gtEq
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean eq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression eq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
       if (!fieldsWithBloomFilter.contains(id)) { // no bloom filter
         return ROWS_MIGHT_MATCH;
@@ -207,17 +225,19 @@ public class ParquetBloomRowGroupFilter {
       BloomFilter bloom = loadBloomFilter(id);
       Type type = types.get(id);
       T value = lit.value();
-      return shouldRead(parquetPrimitiveTypes.get(id), value, bloom, type);
+      return shouldRead(parquetPrimitiveTypes.get(id), value, bloom, type)
+          ? ROWS_MIGHT_MATCH
+          : ROWS_CANNOT_MATCH;
     }
 
     @Override
-    public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression notEq(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on notEq
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
+    public <T> Expression in(BoundReference<T> ref, Set<T> literalSet) {
       int id = ref.fieldId();
       if (!fieldsWithBloomFilter.contains(id)) { // no bloom filter
         return ROWS_MIGHT_MATCH;
@@ -233,19 +253,19 @@ public class ParquetBloomRowGroupFilter {
     }
 
     @Override
-    public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
+    public <T> Expression notIn(BoundReference<T> ref, Set<T> literalSet) {
       // bloom filter is based on hash and cannot eliminate based on notIn
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression startsWith(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on startsWith
       return ROWS_MIGHT_MATCH;
     }
 
     @Override
-    public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
+    public <T> Expression notStartsWith(BoundReference<T> ref, Literal<T> lit) {
       // bloom filter is based on hash and cannot eliminate based on startsWith
       return ROWS_MIGHT_MATCH;
     }
@@ -281,7 +301,7 @@ public class ParquetBloomRowGroupFilter {
               hashValue = bloom.hash(((Number) value).intValue());
               return bloom.findHash(hashValue);
             default:
-              return ROWS_MIGHT_MATCH;
+              return true;
           }
         case INT64:
           switch (type.typeId()) {
@@ -295,7 +315,7 @@ public class ParquetBloomRowGroupFilter {
               hashValue = bloom.hash(((Number) value).longValue());
               return bloom.findHash(hashValue);
             default:
-              return ROWS_MIGHT_MATCH;
+              return true;
           }
         case FLOAT:
           hashValue = bloom.hash(((Number) value).floatValue());
@@ -327,10 +347,10 @@ public class ParquetBloomRowGroupFilter {
               hashValue = bloom.hash(Binary.fromConstantByteArray(UUIDUtil.convert((UUID) value)));
               return bloom.findHash(hashValue);
             default:
-              return ROWS_MIGHT_MATCH;
+              return true;
           }
         default:
-          return ROWS_MIGHT_MATCH;
+          return true;
       }
     }
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -99,15 +100,6 @@ class ReadConf<T> {
     // Fetch all row groups starting positions to compute the row offsets of the filtered row groups
     Map<Long, Long> offsetToStartPos = generateOffsetToStartPos(expectedSchema);
 
-    ParquetMetricsRowGroupFilter statsFilter = null;
-    ParquetDictionaryRowGroupFilter dictFilter = null;
-    ParquetBloomRowGroupFilter bloomFilter = null;
-    if (filter != null) {
-      statsFilter = new ParquetMetricsRowGroupFilter(expectedSchema, filter, caseSensitive);
-      dictFilter = new ParquetDictionaryRowGroupFilter(expectedSchema, filter, caseSensitive);
-      bloomFilter = new ParquetBloomRowGroupFilter(expectedSchema, filter, caseSensitive);
-    }
-
     long computedTotalValues = 0L;
     for (int i = 0; i < shouldSkip.length; i += 1) {
       BlockMetaData rowGroup = rowGroups.get(i);
@@ -115,11 +107,9 @@ class ReadConf<T> {
           offsetToStartPos == null ? 0 : offsetToStartPos.get(rowGroup.getStartingPos());
       boolean shouldRead =
           filter == null
-              || (statsFilter.shouldRead(typeWithIds, rowGroup)
-                  && dictFilter.shouldRead(
-                      typeWithIds, rowGroup, reader.getDictionaryReader(rowGroup))
-                  && bloomFilter.shouldRead(
-                      typeWithIds, rowGroup, reader.getBloomFilterDataReader(rowGroup)));
+              || (findsResidual(filter, expectedSchema, typeWithIds, rowGroup, caseSensitive)
+                  != Expressions.alwaysFalse());
+
       this.shouldSkip[i] = !shouldRead;
       if (shouldRead) {
         computedTotalValues += rowGroup.getRowCount();
@@ -256,5 +246,32 @@ class ReadConf<T> {
       }
     }
     return listBuilder.build();
+  }
+
+  private Expression findsResidual(
+      Expression expr,
+      Schema expectedSchema,
+      MessageType typeWithIds,
+      BlockMetaData rowGroup,
+      boolean caseSensitive) {
+    ParquetMetricsRowGroupFilter metricFilter =
+        new ParquetMetricsRowGroupFilter(expectedSchema, expr, caseSensitive);
+    Expression metricResidual = metricFilter.residualFor(typeWithIds, rowGroup);
+    if (metricResidual == Expressions.alwaysFalse() || metricResidual == Expressions.alwaysTrue()) {
+      return metricResidual;
+    }
+
+    ParquetDictionaryRowGroupFilter dictFilter =
+        new ParquetDictionaryRowGroupFilter(expectedSchema, metricResidual, caseSensitive);
+    Expression dictResidual =
+        dictFilter.residualFor(typeWithIds, rowGroup, reader.getDictionaryReader(rowGroup));
+    if (dictResidual == Expressions.alwaysFalse() || dictResidual == Expressions.alwaysTrue()) {
+      return dictResidual;
+    }
+
+    ParquetBloomRowGroupFilter bloomFilter =
+        new ParquetBloomRowGroupFilter(expectedSchema, dictResidual, caseSensitive);
+    return bloomFilter.residualFor(
+        typeWithIds, rowGroup, reader.getBloomFilterDataReader(rowGroup));
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
@@ -75,6 +75,7 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.schema.MessageType;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1180,9 +1181,9 @@ public class TestBloomRowGroupFilter {
     Expression expected = Binder.bind(SCHEMA.asStruct(), Expressions.or(bloom, dict), true);
     ParquetMetricsRowGroupFilter metricFilter = new ParquetMetricsRowGroupFilter(SCHEMA, expr);
     Expression metricResidual = metricFilter.residualFor(parquetSchema, rowGroupMetadata);
-    Assert.assertTrue(
-        String.format("Expected residual: %s, actual residual: %s", expected, metricResidual),
-        expected.isEquivalentTo(metricResidual));
+    Assertions.assertThat(expected.isEquivalentTo(metricResidual))
+        .overridingErrorMessage(
+            "Expected residual: %s, actual residual: %s", expected, metricResidual);
 
     expected = Binder.bind(SCHEMA.asStruct(), bloom, true);
     ParquetDictionaryRowGroupFilter dictFilter =
@@ -1190,17 +1191,17 @@ public class TestBloomRowGroupFilter {
     Expression dictResidual =
         dictFilter.residualFor(
             parquetSchema, rowGroupMetadata, reader.getDictionaryReader(rowGroupMetadata));
-    Assert.assertTrue(
-        String.format("Expected residual: %s, actual residual: %s", expected, dictResidual),
-        expected.isEquivalentTo(dictResidual));
+    Assertions.assertThat(expected.isEquivalentTo(dictResidual))
+        .overridingErrorMessage(
+            "Expected residual: %s, actual residual: %s", expected, dictResidual);
 
     expected = Expressions.alwaysFalse();
     ParquetBloomRowGroupFilter bloomFilter = new ParquetBloomRowGroupFilter(SCHEMA, dictResidual);
     Expression bloomResidual =
         bloomFilter.residualFor(
             parquetSchema, rowGroupMetadata, reader.getBloomFilterDataReader(rowGroupMetadata));
-    Assert.assertTrue(
-        String.format("Expected residual: %s, actual residual: %s", expected, bloomResidual),
-        expected.isEquivalentTo(bloomResidual));
+    Assertions.assertThat(expected.isEquivalentTo(bloomResidual))
+        .overridingErrorMessage(
+            "Expected residual: %s, actual residual: %s", expected, bloomResidual);
   }
 }


### PR DESCRIPTION
We found that Parquet row-group filters may not work well sometimes, specifically, when evaluating expressions connected by OR and if the child expressions of this OR expression can only be evaluated by different row-group filters. 

For example, suppose we have a sorted column `foo`, its null values are all clustered together after sorting，so queries like `foo IS NULL` can filter out most of the data. But when we want to combine other conditions to query, for example: `bar IN (x, y, z) OR foo IS NULL`(column `bar` is not sorted), row group filters can't work well, we found this is because that `ParquetMetricRowGroupFilter` has poor effect on evaluating `bar IN (x, y, z)` while at the same time `ParquetDictionaryRowGroupFilter` cannot answer `foo IS NULL` because Parquet dictionary has no nulls stats.  This also happens when one child node of OR can only be answered by `ParquetBloomRowGroupFilter` but the other can only be answered by `ParquetMetricRowGroupFilter` or `ParquetDictionaryRowGroupFilter`. 

This PR tries to solve this kind of issue. It borrows the idea of `ResidualEvaluator`, allowing row-group filters to eliminate those predicates that can get ROWS_CANNOT_MATCH / ROWS_ALL_MATCH conclusions during the evaluation process, so that an expression can be evaluated for residuals, which is then passed to the next row-group filter for evaluation. In this way, it makes three row-group filters to work together to evaluate an expression. 

UPDATE: 
I tested this part of the code and the result shows that it does improve the kind of queries mentioned above, filtering out a lot of files. Another minor benefit of this I can think of is that when an expression can be eliminated in the metric filter, there is no need to load its dictionary in the subsequent dictionary filter.
