### PR TITLE
Core: use random port for rest catalog unit tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -38,6 +38,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import javax.net.ServerSocketFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
@@ -79,8 +80,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
-
-import javax.net.ServerSocketFactory;
 
 public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   private static final ObjectMapper MAPPER = RESTObjectMapper.mapper();
@@ -175,11 +174,16 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     restCatalog.initialize(
         "prod",
         ImmutableMap.of(
-            CatalogProperties.URI, "http://localhost:"+port+"/", "credential", "catalog:12345"));
+            CatalogProperties.URI,
+            "http://localhost:" + port + "/",
+            "credential",
+            "catalog:12345"));
   }
 
   private void initializePort() {
-    try(ServerSocket s = ServerSocketFactory.getDefault().createServerSocket(0, 1, InetAddress.getByName("localhost"))){
+    try (ServerSocket s =
+        ServerSocketFactory.getDefault()
+            .createServerSocket(0, 1, InetAddress.getByName("localhost"))) {
       this.port = s.getLocalPort();
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -1229,7 +1233,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         "prod",
         ImmutableMap.of(
             CatalogProperties.URI,
-            "http://localhost:"+port+"/",
+            "http://localhost:" + port + "/",
             "credential",
             "catalog:12345",
             CatalogProperties.METRICS_REPORTER_IMPL,


### PR DESCRIPTION
Rest catalog test uses fixed port 8181, which can cause random test failures on CI.

Fix to use random available port for unit tests. 
Failure on oss https://github.com/apache/iceberg/actions/runs/4229402634/jobs/7345745908
<img width="770" alt="image" src="https://user-images.githubusercontent.com/69539469/220422310-e191cc55-dcc6-4a7c-a593-a8a3c7da84ee.png">
