### PR TITLE
Core: ReachableFileUtil.versionHintLocation() should not fail for table location with just bucket name

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -45,8 +45,8 @@ public class ReachableFileUtil {
    */
   public static String versionHintLocation(Table table) {
     // only Hadoop tables have a hint file and such tables have a fixed metadata layout
-    Path metadataPath = new Path(table.location(), METADATA_FOLDER_NAME);
-    Path versionHintPath = new Path(metadataPath, Util.VERSION_HINT_FILENAME);
+    Path metadataPath = new Path(table.location() + "/" + METADATA_FOLDER_NAME);
+    Path versionHintPath = new Path(metadataPath + "/" + Util.VERSION_HINT_FILENAME);
     return versionHintPath.toString();
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestReachableFileUtil.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.util;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.List;
@@ -131,6 +133,15 @@ public class TestReachableFileUtil {
 
     String reportedVersionHintLocation = ReachableFileUtil.versionHintLocation(staticTable);
     String expectedVersionHintLocation = ops.metadataFileLocation(Util.VERSION_HINT_FILENAME);
+    Assert.assertEquals(expectedVersionHintLocation, reportedVersionHintLocation);
+  }
+
+  @Test
+  public void testVersionHintWithBucketNameAsLocation() {
+    Table mockTable = mock(Table.class);
+    when(mockTable.location()).thenReturn("s3://bucket1");
+    String reportedVersionHintLocation = ReachableFileUtil.versionHintLocation(mockTable);
+    String expectedVersionHintLocation = "s3://bucket1/metadata/" + Util.VERSION_HINT_FILENAME;
     Assert.assertEquals(expectedVersionHintLocation, reportedVersionHintLocation);
   }
 }


### PR DESCRIPTION
After https://github.com/apache/iceberg/pull/6777 all trailing slashes to table locations are removed. This caused the issue below.

`ReachableFileUtil.versionHintLocation()` concatenates table location with "metadata" and does a hadoop path resolution. The path resolution fails if the first location is just S3 bucket name which is a valid table path. 

```
scala> new org.apache.hadoop.fs.Path("s3a://bucket1", "metadata");
java.lang.IllegalArgumentException: java.net.URISyntaxException: Relative path in absolute URI: s3a://idmsdatabucket1metadata
  at org.apache.hadoop.fs.Path.initialize(Path.java:263)
  at org.apache.hadoop.fs.Path.<init>(Path.java:161)
  at org.apache.hadoop.fs.Path.<init>(Path.java:119)
  ... 47 elided
Caused by: java.net.URISyntaxException: Relative path in absolute URI: s3a://bucket1metadata
  at java.base/java.net.URI.checkPath(URI.java:1940)
  at java.base/java.net.URI.<init>(URI.java:757)
  at org.apache.hadoop.fs.Path.initialize(Path.java:260)
  ... 49 more
```

Having a slash succeeds
```
scala> new org.apache.hadoop.fs.Path("s3a://bucket1", "/metadata");
res3: org.apache.hadoop.fs.Path = s3a://bucket1/metadata
```


Tests:
This happens only with s3 path. I could not find a suitable integration test for this. I just added a hadoop path resolution test. That would fail without a slash.