### PR TITLE
AWS: Change GlueCatalog skip archive default to true

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -61,7 +61,6 @@ public class GlueTestBase {
 
   // iceberg
   static GlueCatalog glueCatalog;
-  static GlueCatalog glueCatalogWithSkip;
   static GlueCatalog glueCatalogWithSkipNameValidation;
 
   static Schema schema =
@@ -75,24 +74,15 @@ public class GlueTestBase {
           TableProperties.WRITE_FOLDER_STORAGE_LOCATION,
               "s3://" + testBucketName + "/writeFolderStorageLoc");
 
+  static final String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
+  static final S3FileIO fileIO = new S3FileIO(clientFactory::s3);
+
   @BeforeClass
   public static void beforeClass() {
-    String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
-    S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     glueCatalog = new GlueCatalog();
-    glueCatalog.initialize(
-        catalogName,
-        testBucketPath,
-        new AwsProperties(),
-        glue,
-        LockManagers.defaultLockManager(),
-        fileIO,
-        ImmutableMap.of());
     AwsProperties properties = new AwsProperties();
-    properties.setGlueCatalogSkipArchive(true);
     properties.setS3FileIoDeleteBatchSize(10);
-    glueCatalogWithSkip = new GlueCatalog();
-    glueCatalogWithSkip.initialize(
+    glueCatalog.initialize(
         catalogName,
         testBucketPath,
         properties,
@@ -100,6 +90,7 @@ public class GlueTestBase {
         LockManagers.defaultLockManager(),
         fileIO,
         ImmutableMap.of());
+
     glueCatalogWithSkipNameValidation = new GlueCatalog();
     AwsProperties propertiesSkipNameValidation = new AwsProperties();
     propertiesSkipNameValidation.setGlueCatalogSkipNameValidation(true);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -376,6 +376,16 @@ public class TestGlueCatalogTable extends GlueTestBase {
     Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.StringType.get(), "c1"));
     PartitionSpec partitionSpec = PartitionSpec.builderFor(schema).build();
     String tableName = getRandomName();
+    AwsProperties properties = new AwsProperties();
+    properties.setGlueCatalogSkipArchive(false);
+    glueCatalog.initialize(
+        catalogName,
+        testBucketPath,
+        properties,
+        glue,
+        LockManagers.defaultLockManager(),
+        fileIO,
+        ImmutableMap.of());
     glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
     Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     DataFile dataFile =
@@ -396,9 +406,9 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .size());
     // create table and commit with skip
     tableName = getRandomName();
-    glueCatalogWithSkip.createTable(
-        TableIdentifier.of(namespace, tableName), schema, partitionSpec);
-    table = glueCatalogWithSkip.loadTable(TableIdentifier.of(namespace, tableName));
+    glueCatalog.initialize(catalogName, ImmutableMap.of());
+    glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
+    table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     table.newAppend().appendFile(dataFile).commit();
     Assert.assertEquals(
         "skipArchive should not create new version",

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -129,7 +129,7 @@ public class AwsProperties implements Serializable {
    */
   public static final String GLUE_CATALOG_SKIP_ARCHIVE = "glue.skip-archive";
 
-  public static final boolean GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT = false;
+  public static final boolean GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT = true;
 
   /**
    * If Glue should skip name validations It is recommended to stick to Glue best practice in

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -181,9 +181,10 @@ see more details in [AWS client customization](#aws-client-customization).
 
 #### Skip Archive
 
-By default, Glue stores all the table versions created and user can rollback a table to any historical version if needed.
-However, if you are streaming data to Iceberg, this will easily create a lot of Glue table versions.
-Therefore, it is recommended to turn off the archive feature in Glue by setting `glue.skip-archive` to `true`.
+AWS Glue has the ability to archive older table versions and a user can rollback the table to any historical version if needed.
+By default, the Iceberg Glue Catalog will skip the archival of older table versions.
+If a user wishes to archive older table versions, they can set `glue.skip-archive` to false.
+Do note for streaming ingestion into Iceberg tables, setting `glue.skip-archive` to false will quickly create a lot of Glue table versions.
 For more details, please read [Glue Quotas](https://docs.aws.amazon.com/general/latest/gr/glue.html) and the [UpdateTable API](https://docs.aws.amazon.com/glue/latest/webapi/API_UpdateTable.html).
 
 #### Skip Name Validation


### PR DESCRIPTION
Currently GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT is set to false. This means every glue commit will archive older versions of table, which quickly hits the Glue limit (a max of 100k versions gets maintained) for streaming use cases. After discussing with users of Glue Catalog, came to the conclusion that it's better to change this default behavior.

CC: @jackye1995 @singhpk234 