### PR TITLE
Fix Types from string, allow spaces

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -53,8 +53,9 @@ public class Types {
           .put(BinaryType.get().toString(), BinaryType.get())
           .buildOrThrow();
 
-  private static final Pattern FIXED = Pattern.compile("fixed\\[(\\d+)\\]");
-  private static final Pattern DECIMAL = Pattern.compile("decimal\\((\\d+),\\s+(\\d+)\\)");
+  private static final Pattern FIXED = Pattern.compile("fixed\\[\\s*(\\d+)\\s*\\]");
+  private static final Pattern DECIMAL =
+      Pattern.compile("decimal\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)");
 
   public static PrimitiveType fromPrimitiveString(String typeString) {
     String lowerTypeString = typeString.toLowerCase(Locale.ROOT);

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.types;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTypes {
+
+  @Test
+  public void fromPrimitiveString() {
+    Assert.assertSame(Types.BooleanType.get(), Types.fromPrimitiveString("boolean"));
+    Assert.assertSame(Types.BooleanType.get(), Types.fromPrimitiveString("BooLean"));
+
+    Assert.assertSame(Types.TimestampType.withoutZone(), Types.fromPrimitiveString("timestamp"));
+
+    Assert.assertEquals(Types.FixedType.ofLength(3), Types.fromPrimitiveString("Fixed[ 3 ]"));
+
+    Assert.assertEquals(Types.DecimalType.of(2, 3), Types.fromPrimitiveString("Decimal( 2 , 3 )"));
+
+    Assert.assertEquals(Types.DecimalType.of(2, 3), Types.fromPrimitiveString("Decimal(2,3)"));
+
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class, () -> Types.fromPrimitiveString("Unknown"));
+    Assert.assertTrue(exception.getMessage().contains("Unknown"));
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -18,27 +18,30 @@
  */
 package org.apache.iceberg.types;
 
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestTypes {
 
   @Test
   public void fromPrimitiveString() {
-    Assert.assertSame(Types.BooleanType.get(), Types.fromPrimitiveString("boolean"));
-    Assert.assertSame(Types.BooleanType.get(), Types.fromPrimitiveString("BooLean"));
+    Assertions.assertThat(Types.fromPrimitiveString("boolean")).isSameAs(Types.BooleanType.get());
+    Assertions.assertThat(Types.fromPrimitiveString("BooLean")).isSameAs(Types.BooleanType.get());
 
-    Assert.assertSame(Types.TimestampType.withoutZone(), Types.fromPrimitiveString("timestamp"));
+    Assertions.assertThat(Types.fromPrimitiveString("timestamp"))
+        .isSameAs(Types.TimestampType.withoutZone());
 
-    Assert.assertEquals(Types.FixedType.ofLength(3), Types.fromPrimitiveString("Fixed[ 3 ]"));
+    Assertions.assertThat(Types.fromPrimitiveString("Fixed[ 3 ]"))
+        .isEqualTo(Types.FixedType.ofLength(3));
 
-    Assert.assertEquals(Types.DecimalType.of(2, 3), Types.fromPrimitiveString("Decimal( 2 , 3 )"));
+    Assertions.assertThat(Types.fromPrimitiveString("Decimal( 2 , 3 )"))
+        .isEqualTo(Types.DecimalType.of(2, 3));
 
-    Assert.assertEquals(Types.DecimalType.of(2, 3), Types.fromPrimitiveString("Decimal(2,3)"));
+    Assertions.assertThat(Types.fromPrimitiveString("Decimal(2,3)"))
+        .isEqualTo(Types.DecimalType.of(2, 3));
 
-    IllegalArgumentException exception =
-        Assert.assertThrows(
-            IllegalArgumentException.class, () -> Types.fromPrimitiveString("Unknown"));
-    Assert.assertTrue(exception.getMessage().contains("Unknown"));
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Types.fromPrimitiveString("Unknown"))
+        .withMessageContaining("Unknown");
   }
 }


### PR DESCRIPTION
Fix for [issue 6910](https://github.com/apache/iceberg/issues/6910), accepting space for types Fixed (Fixed[ 2 ]) and decimal.
(Unit test on Types class added)