### PR TITLE
API:add try catch on ExpressionUtils.sanitizeString

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -412,18 +412,25 @@ public class ExpressionUtil {
   }
 
   private static String sanitizeString(CharSequence value, long now, int today) {
-    if (DATE.matcher(value).matches()) {
-      Literal<Integer> date = Literal.of(value).to(Types.DateType.get());
-      return sanitizeDate(date.value(), today);
-    } else if (TIMESTAMP.matcher(value).matches()) {
-      Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withoutZone());
-      return sanitizeTimestamp(ts.value(), now);
-    } else if (TIMESTAMPTZ.matcher(value).matches()) {
-      Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withZone());
-      return sanitizeTimestamp(ts.value(), now);
-    } else if (TIME.matcher(value).matches()) {
-      return "(time)";
-    } else {
+    try {
+      if (DATE.matcher(value).matches()) {
+        Literal<Integer> date = Literal.of(value).to(Types.DateType.get());
+        return sanitizeDate(date.value(), today);
+      } else if (TIMESTAMP.matcher(value).matches()) {
+        Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withoutZone());
+        return sanitizeTimestamp(ts.value(), now);
+      } else if (TIMESTAMPTZ.matcher(value).matches()) {
+        Literal<Long> ts = Literal.of(value).to(Types.TimestampType.withZone());
+        return sanitizeTimestamp(ts.value(), now);
+      } else if (TIME.matcher(value).matches()) {
+        return "(time)";
+      } else {
+        return sanitizeSimpleString(value);
+      }
+    } catch (Exception ex) {
+      // Don't throw when parsing failed in sanitizeString
+      // because user could provide an invalid integer/date/timestamp string
+      // and expect them to be treated as a string instead of specific type
       return sanitizeSimpleString(value);
     }
   }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -24,6 +24,7 @@ import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -594,6 +595,22 @@ public class TestExpressionUtil {
         "Sanitized string should be identical except for descriptive literal",
         "test = (date-7-days-from-now)",
         ExpressionUtil.toSanitizedString(Expressions.equal("test", nextWeek)));
+  }
+
+  @Test
+  public void testSanitizeStringFallback() {
+    Pattern filterPattern = Pattern.compile("^test = \\(hash-[0-9a-fA-F]{8}\\)$");
+    for (String filter :
+        Lists.newArrayList(
+            "2022-20-29",
+            "2022-04-29T40:49:51.123456",
+            "2022-04-29T23:70:51-07:00",
+            "2022-04-29T23:49:51.123456+100:00")) {
+      String sanitizedFilter = ExpressionUtil.toSanitizedString(Expressions.equal("test", filter));
+      Assert.assertTrue(
+          "Invalid date time string should use default sanitize method",
+          filterPattern.matcher(sanitizedFilter).matches());
+    }
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -607,9 +607,7 @@ public class TestExpressionUtil {
             "2022-04-29T23:70:51-07:00",
             "2022-04-29T23:49:51.123456+100:00")) {
       String sanitizedFilter = ExpressionUtil.toSanitizedString(Expressions.equal("test", filter));
-      Assert.assertTrue(
-          "Invalid date time string should use default sanitize method",
-          filterPattern.matcher(sanitizedFilter).matches());
+      Assertions.assertThat(filterPattern.matcher(sanitizedFilter)).matches();
     }
   }
 


### PR DESCRIPTION
Don't throw in sanitizeString because it will fail planFiles when reading with a string filter that matches any of the specific types like Date/Timestamp with parsing failure.
Closes #6911 