### PR TITLE
Flink: Set up EnvironmentContext for Flink(Both JM and TM)

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -53,7 +53,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -71,7 +70,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -122,8 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -53,7 +53,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -71,7 +70,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -122,8 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -53,7 +53,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -71,7 +70,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -122,8 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 


### PR DESCRIPTION
#6184 has add engine name and version  to `EnvironmentContext` in `FlinkCatalog` ,  but the FlinkCatalog works in the job manager not task manager, when `IcebergFilesCommiter` commit a snapshot, there is no engine name and version in the commit metrics report. So I add them again when table is loaded.

Please take a look this pr, thanks @nastra 