### PR TITLE
Core: Use server URI from REST server instead of manually constructing it

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -170,10 +170,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     restCatalog.initialize(
         "prod",
         ImmutableMap.of(
-            CatalogProperties.URI,
-            "http://localhost:" + localPort() + "/",
-            "credential",
-            "catalog:12345"));
+            CatalogProperties.URI, httpServer.getURI().toString(), "credential", "catalog:12345"));
   }
 
   @SuppressWarnings("unchecked")
@@ -1219,7 +1216,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         "prod",
         ImmutableMap.of(
             CatalogProperties.URI,
-            "http://localhost:" + localPort() + "/",
+            httpServer.getURI().toString(),
             "credential",
             "catalog:12345",
             CatalogProperties.METRICS_REPORTER_IMPL,
@@ -1622,10 +1619,5 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             eq(OAuthTokenResponse.class),
             eq(catalogHeaders),
             any());
-  }
-
-  private int localPort() {
-    assertThat(httpServer.isRunning()).isTrue();
-    return ((ServerConnector) httpServer.getConnectors()[0]).getLocalPort();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -66,7 +66,6 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.types.Types;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;


### PR DESCRIPTION
After reviewing #6895 it occurred to me that we don't need to manually figure out the port and construct the URL from it. We can directly use `httpServer.getURI()` in that case.