### PR TITLE
Flink: Add branch to successful commit logs

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -407,9 +407,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     operation.commit(); // abort is automatically called if this fails.
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     LOG.info(
-        "Committed {} to table: {}, checkpointId {} in {} ms",
+        "Committed {} to table: {}, branch: {}, checkpointId {} in {} ms",
         description,
         table.name(),
+        branch,
         checkpointId,
         durationMs);
     committerMetrics.commitDuration(durationMs);


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/6660/files, I missed adding branch to the logs after a successful commit. This change is already included in the backport of #6660 to 1.14 and 1.15 https://github.com/apache/iceberg/pull/6949/files

@stevenzwu 