### PR TITLE
Use UGI shortUserName as the default owner of Hive objects

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
@@ -30,12 +30,11 @@ public class HiveHadoopUtil {
   private HiveHadoopUtil() {}
 
   public static String currentUser() {
-    String username = null;
     try {
-      username = UserGroupInformation.getCurrentUser().getShortUserName();
+      return UserGroupInformation.getCurrentUser().getShortUserName();
     } catch (IOException e) {
       LOG.warn("Failed to get Hadoop user", e);
+      return System.getProperty("user.name");
     }
-    return username != null ? username : System.getProperty("user.name");
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
@@ -31,7 +31,12 @@ public class HiveHadoopUtil {
 
   public static String currentUser() {
     try {
-      return UserGroupInformation.getCurrentUser().getShortUserName();
+      String username = UserGroupInformation.getCurrentUser().getShortUserName();
+      if (username != null) {
+        return username;
+      } else {
+        throw new IOException("Hadoop user is null");
+      }
     } catch (IOException e) {
       LOG.warn("Failed to get Hadoop user", e);
       return System.getProperty("user.name");

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
@@ -30,11 +30,12 @@ public class HiveHadoopUtil {
   private HiveHadoopUtil() {}
 
   public static String currentUser() {
+    String username = null;
     try {
-      return UserGroupInformation.getCurrentUser().getUserName();
+      username = UserGroupInformation.getCurrentUser().getShortUserName();
     } catch (IOException e) {
       LOG.warn("Failed to get Hadoop user", e);
-      return System.getProperty("user.name");
     }
+    return username != null ? username : System.getProperty("user.name");
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveHadoopUtil.java
@@ -30,15 +30,17 @@ public class HiveHadoopUtil {
   private HiveHadoopUtil() {}
 
   public static String currentUser() {
+    String username = null;
     try {
-      String username = UserGroupInformation.getCurrentUser().getShortUserName();
-      if (username != null) {
-        return username;
-      } else {
-        throw new IOException("Hadoop user is null");
-      }
+      username = UserGroupInformation.getCurrentUser().getShortUserName();
     } catch (IOException e) {
       LOG.warn("Failed to get Hadoop user", e);
+    }
+
+    if (username != null) {
+      return username;
+    } else {
+      LOG.warn("Hadoop user is null, defaulting to user.name");
       return System.getProperty("user.name");
     }
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -373,7 +373,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     createNamespaceAndVerifyOwnership(
         "default_ownership_1",
         ImmutableMap.of(),
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     createNamespaceAndVerifyOwnership(
@@ -381,7 +381,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         ImmutableMap.of(
             "non_owner_prop1", "value1",
             "non_owner_prop2", "value2"),
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     createNamespaceAndVerifyOwnership(
@@ -684,9 +684,9 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         "set_ownership_noop_3",
         ImmutableMap.of(),
         ImmutableMap.of(),
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER,
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     setNamespaceOwnershipAndVerify(
@@ -752,7 +752,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         ImmutableSet.of(HiveCatalog.HMS_DB_OWNER, HiveCatalog.HMS_DB_OWNER_TYPE),
         "some_owner",
         PrincipalType.USER,
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     removeNamespaceOwnershipAndVerify(
@@ -765,25 +765,25 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         ImmutableSet.of(HiveCatalog.HMS_DB_OWNER, HiveCatalog.HMS_DB_OWNER_TYPE),
         "some_group_owner",
         PrincipalType.GROUP,
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     removeNamespaceOwnershipAndVerify(
         "remove_ownership_on_default_noop_1",
         ImmutableMap.of(),
         ImmutableSet.of(HiveCatalog.HMS_DB_OWNER, HiveCatalog.HMS_DB_OWNER_TYPE),
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER,
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     removeNamespaceOwnershipAndVerify(
         "remove_ownership_on_default_noop_2",
         ImmutableMap.of(),
         ImmutableSet.of(),
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER,
-        UserGroupInformation.getCurrentUser().getUserName(),
+        UserGroupInformation.getCurrentUser().getShortUserName(),
         PrincipalType.USER);
 
     removeNamespaceOwnershipAndVerify(

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -261,7 +261,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         DB_NAME,
         "tbl_default_owner",
         ImmutableMap.of(),
-        UserGroupInformation.getCurrentUser().getUserName());
+        UserGroupInformation.getCurrentUser().getShortUserName());
   }
 
   private void createTableAndVerifyOwner(


### PR DESCRIPTION
In #6324, [HiveCatalog] was changed to use UGI current user as the default owner of Hive db&tbl.
The owner name was from `UserGroupInformation#getUserName`, was the full name of a kerberos principal, eg. "foo/dev@apache.org".

However, in Spark & Hive, owner name is set to `UserGroupInformation#getShortUserName`, eg. "foo".

We should change the owner name to the short user name.

Refs:

- https://issues.apache.org/jira/browse/SPARK-26929
- https://issues.apache.org/jira/browse/HIVE-3807
