### PR TITLE
Flink: fix compiling error from PR #6954

### DIFF
--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.util.List;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
@@ -27,6 +28,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.HadoopCatalogResource;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
@@ -156,11 +158,6 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
   }
 
   @Test
-  public void testChangeLogOnDataKey() throws Exception {
-    testChangeLogOnDataKey(SnapshotRef.MAIN_BRANCH);
-  }
-
-  @Test
   public void testUpsertOnlyDeletesOnDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint =
         ImmutableList.of(
@@ -175,7 +172,13 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         row -> row.getField(ROW_DATA_POS),
         true,
         elementsPerCheckpoint,
-        expectedRecords);
+        expectedRecords,
+        SnapshotRef.MAIN_BRANCH);
+  }
+
+  @Test
+  public void testChangeLogOnDataKey() throws Exception {
+    testChangeLogOnDataKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.sink;
 
+import java.util.List;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
@@ -27,6 +28,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.HadoopCatalogResource;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
@@ -156,16 +158,6 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
   }
 
   @Test
-  public void testChangeLogOnDataKey() throws Exception {
-    testChangeLogOnDataKey(SnapshotRef.MAIN_BRANCH);
-  }
-
-  @Test
-  public void testChangeLogOnIdDataKey() throws Exception {
-    testChangeLogOnIdDataKey(SnapshotRef.MAIN_BRANCH);
-  }
-
-  @Test
   public void testUpsertOnlyDeletesOnDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint =
         ImmutableList.of(
@@ -180,7 +172,18 @@ public class TestFlinkIcebergSinkV2 extends TestFlinkIcebergSinkV2Base {
         row -> row.getField(ROW_DATA_POS),
         true,
         elementsPerCheckpoint,
-        expectedRecords);
+        expectedRecords,
+        SnapshotRef.MAIN_BRANCH);
+  }
+
+  @Test
+  public void testChangeLogOnDataKey() throws Exception {
+    testChangeLogOnDataKey(SnapshotRef.MAIN_BRANCH);
+  }
+
+  @Test
+  public void testChangeLogOnIdDataKey() throws Exception {
+    testChangeLogOnIdDataKey(SnapshotRef.MAIN_BRANCH);
   }
 
   @Test


### PR DESCRIPTION
this fix is by directly copying the test file from 1.16 to 1.14 and 1.15 folder.

we probably need to look into why CI build didn't catch it.