### PR TITLE
Python: Pass location when recreating the FileIO

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -250,8 +250,8 @@ class Catalog(ABC):
         self.name = name
         self.properties = properties
 
-    def _load_file_io(self, properties: Properties = EMPTY_DICT) -> FileIO:
-        return load_file_io({**self.properties, **properties})
+    def _load_file_io(self, properties: Properties = EMPTY_DICT, location: Optional[str] = None) -> FileIO:
+        return load_file_io({**self.properties, **properties}, location)
 
     @abstractmethod
     def create_table(

--- a/python/pyiceberg/catalog/dynamodb.py
+++ b/python/pyiceberg/catalog/dynamodb.py
@@ -579,7 +579,7 @@ class DynamoDbCatalog(Catalog):
             identifier=(self.name, database_name, table_name),
             metadata=metadata,
             metadata_location=metadata_location,
-            io=self._load_file_io(metadata.properties),
+            io=self._load_file_io(metadata.properties, metadata_location),
         )
 
 

--- a/python/pyiceberg/catalog/glue.py
+++ b/python/pyiceberg/catalog/glue.py
@@ -163,7 +163,7 @@ class GlueCatalog(Catalog):
             identifier=(glue_table[PROP_GLUE_TABLE_DATABASE_NAME], glue_table[PROP_GLUE_TABLE_NAME]),
             metadata=metadata,
             metadata_location=metadata_location,
-            io=self._load_file_io(metadata.properties),
+            io=self._load_file_io(metadata.properties, metadata_location),
         )
 
     def _create_glue_table(self, database_name: str, table_name: str, table_input: Dict[str, Any]) -> None:

--- a/python/pyiceberg/catalog/hive.py
+++ b/python/pyiceberg/catalog/hive.py
@@ -242,7 +242,7 @@ class HiveCatalog(Catalog):
             identifier=(table.dbName, table.tableName),
             metadata=metadata,
             metadata_location=metadata_location,
-            io=self._load_file_io(metadata.properties),
+            io=self._load_file_io(metadata.properties, metadata_location),
         )
 
     def create_table(

--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -369,7 +369,9 @@ class RestCatalog(Catalog):
             identifier=(self.name,) + self.identifier_to_tuple(identifier),
             metadata_location=table_response.metadata_location,
             metadata=table_response.metadata,
-            io=self._load_file_io({**table_response.metadata.properties, **table_response.config}),
+            io=self._load_file_io(
+                {**table_response.metadata.properties, **table_response.config}, table_response.metadata_location
+            ),
         )
 
     def list_tables(self, namespace: Union[str, Identifier]) -> List[Identifier]:
@@ -399,7 +401,9 @@ class RestCatalog(Catalog):
             identifier=(self.name,) + identifier_tuple if self.name else identifier_tuple,
             metadata_location=table_response.metadata_location,
             metadata=table_response.metadata,
-            io=self._load_file_io({**table_response.metadata.properties, **table_response.config}),
+            io=self._load_file_io(
+                {**table_response.metadata.properties, **table_response.config}, table_response.metadata_location
+            ),
         )
 
     def drop_table(self, identifier: Union[str, Identifier], purge_requested: bool = False) -> None:


### PR DESCRIPTION
We need to pass in the metadata location when we recreate the file io for the table. We re-create the table because there can be new configuration, but we don't supply the location.

This can cause issues when you have both PyArrow and FSspec installed, you don't have the FileIO set explicitly in your config:

```yaml
catalog:
    default:
...
        py-io-impl: pyiceberg.io.fsspec.FsspecFileIO
```

When you fetch the metadata from ADLS using FSSpec, but then the re-created FileIO is PyArrow.
When we pass in the url, the schema gets taken into account and PyArrow won't be considered for ADLS.