### PR TITLE
Python: Wrap FsspecFileIO in PyArrowFileIO

### DIFF
--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -31,6 +31,7 @@ import requests
 from botocore import UNSIGNED
 from botocore.awsrequest import AWSRequest
 from fsspec import AbstractFileSystem
+from pyarrow.filesystem import LocalFileSystem
 from requests import HTTPError
 
 from pyiceberg.catalog import TOKEN
@@ -78,6 +79,10 @@ def s3v4_rest_signer(properties: Properties, request: AWSRequest, **_: Any) -> A
 SIGNERS: Dict[str, Callable[[Properties, AWSRequest], AWSRequest]] = {"S3V4RestSigner": s3v4_rest_signer}
 
 
+def _file(_: Properties) -> LocalFileSystem:
+    return LocalFileSystem()
+
+
 def _s3(properties: Properties) -> AbstractFileSystem:
     from s3fs import S3FileSystem
 
@@ -117,6 +122,7 @@ def _adlfs(properties: Properties) -> AbstractFileSystem:
 
 
 SCHEME_TO_FS = {
+    "file": _file,
     "s3": _s3,
     "s3a": _s3,
     "s3n": _s3,

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -548,9 +548,9 @@ def project_table(
                 fs = PyFileSystem(FSSpecHandler(table.io.get_fs(scheme)))
             else:
                 raise ValueError(f"Expected PyArrowFileIO or FsspecFileIO, got: {table.io}")
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as e:
             # When FsSpec is not installed
-            raise ValueError(f"Expected PyArrowFileIO or FsspecFileIO, got: {table.io}")
+            raise ValueError(f"Expected PyArrowFileIO or FsspecFileIO, got: {table.io}") from e
 
     bound_row_filter = bind(table.schema(), row_filter, case_sensitive=case_sensitive)
 

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -529,20 +529,6 @@ def test_expr_not_in_to_pyarrow(bound_reference: BoundReference[str]) -> None:
     )
 
 
-def test_expr_starts_with_to_pyarrow(bound_reference: BoundReference[str]) -> None:
-    assert (
-        repr(expression_to_pyarrow(BoundStartsWith(bound_reference, literal("he"))))
-        == '<pyarrow.compute.Expression starts_with(foo, {pattern="he", ignore_case=false})>'
-    )
-
-
-def test_expr_not_starts_with_to_pyarrow(bound_reference: BoundReference[str]) -> None:
-    assert (
-        repr(expression_to_pyarrow(BoundNotStartsWith(bound_reference, literal("he"))))
-        == '<pyarrow.compute.Expression invert(starts_with(foo, {pattern="he", ignore_case=false}))>'
-    )
-
-
 def test_and_to_pyarrow(bound_reference: BoundReference[str]) -> None:
     assert (
         repr(expression_to_pyarrow(And(BoundEqualTo(bound_reference, literal("hello")), BoundIsNull(bound_reference))))

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -50,7 +50,7 @@ from pyiceberg.expressions import (
     Or,
     literal,
 )
-from pyiceberg.io import InputStream, OutputStream
+from pyiceberg.io import InputStream, OutputStream, load_file_io
 from pyiceberg.io.pyarrow import (
     PyArrowFile,
     PyArrowFileIO,
@@ -526,6 +526,20 @@ def test_expr_not_in_to_pyarrow(bound_reference: BoundReference[str]) -> None:
   "hello",
   "world"
 ], skip_nulls=false}))>""",
+    )
+
+
+def test_expr_starts_with_to_pyarrow(bound_reference: BoundReference[str]) -> None:
+    assert (
+        repr(expression_to_pyarrow(BoundStartsWith(bound_reference, literal("he"))))
+        == '<pyarrow.compute.Expression starts_with(foo, {pattern="he", ignore_case=false})>'
+    )
+
+
+def test_expr_not_starts_with_to_pyarrow(bound_reference: BoundReference[str]) -> None:
+    assert (
+        repr(expression_to_pyarrow(BoundNotStartsWith(bound_reference, literal("he"))))
+        == '<pyarrow.compute.Expression invert(starts_with(foo, {pattern="he", ignore_case=false}))>'
     )
 
 
@@ -1114,3 +1128,38 @@ def test_projection_filter_on_unknown_field(schema_int_str: Schema, file_int_str
         _ = project(schema, [file_int_str], GreaterThan("unknown_field", "1"), schema_int_str)
 
     assert "Could not find field with name unknown_field, case_sensitive=True" in str(exc_info.value)
+
+
+def test_pyarrow_wrap_fsspec(example_task: FileScanTask, table_schema_simple: Schema) -> None:
+    metadata_location = "file://a/b/c.json"
+    projection = project_table(
+        [example_task],
+        Table(
+            ("namespace", "table"),
+            metadata=TableMetadataV2(
+                location=metadata_location,
+                last_column_id=1,
+                format_version=2,
+                current_schema_id=1,
+                schemas=[table_schema_simple],
+                partition_specs=[PartitionSpec()],
+            ),
+            metadata_location=metadata_location,
+            io=load_file_io(properties={"py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO"}, location=metadata_location),
+        ),
+        case_sensitive=True,
+        projected_schema=table_schema_simple,
+        row_filter=AlwaysTrue(),
+    )
+
+    assert (
+        str(projection)
+        == """pyarrow.Table
+foo: string
+bar: int64 not null
+baz: bool
+----
+foo: [["a","b","c"]]
+bar: [[1,2,3]]
+baz: [[true,false,null]]"""
+    )


### PR DESCRIPTION
This allows us to read PyArrow tables using FsspecFileIO. For ADLS users this allows them to pull data from ADLS.