### PR TITLE
Core: Minor refactoring of PartitionsTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -47,12 +47,9 @@ public class PartitionsTable extends BaseMetadataTable {
             Types.NestedField.required(1, "partition", Partitioning.partitionType(table)),
             Types.NestedField.required(4, "spec_id", Types.IntegerType.get()),
             Types.NestedField.required(
-                2,
-                "record_count",
-                Types.LongType.get(),
-                "data record count without applying the deletes"),
+                2, "record_count", Types.LongType.get(), "count of records in data files"),
             Types.NestedField.required(
-                3, "file_count", Types.IntegerType.get(), "data file count"));
+                3, "file_count", Types.IntegerType.get(), "count of data files"));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -45,9 +45,14 @@ public class PartitionsTable extends BaseMetadataTable {
     this.schema =
         new Schema(
             Types.NestedField.required(1, "partition", Partitioning.partitionType(table)),
-            Types.NestedField.required(2, "record_count", Types.LongType.get()),
-            Types.NestedField.required(3, "file_count", Types.IntegerType.get()),
-            Types.NestedField.required(4, "spec_id", Types.IntegerType.get()));
+            Types.NestedField.required(4, "spec_id", Types.IntegerType.get()),
+            Types.NestedField.required(
+                2,
+                "record_count",
+                Types.LongType.get(),
+                "data record count without applying the deletes"),
+            Types.NestedField.required(
+                3, "file_count", Types.IntegerType.get(), "data file count"));
   }
 
   @Override
@@ -77,7 +82,7 @@ public class PartitionsTable extends BaseMetadataTable {
           schema(),
           scan.schema(),
           partitions,
-          root -> StaticDataTask.Row.of(root.recordCount, root.fileCount));
+          root -> StaticDataTask.Row.of(root.dataRecordCount, root.dataFileCount));
     } else {
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),
@@ -90,7 +95,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private static StaticDataTask.Row convertPartition(Partition partition) {
     return StaticDataTask.Row.of(
-        partition.key, partition.recordCount, partition.fileCount, partition.specId);
+        partition.key, partition.specId, partition.dataRecordCount, partition.dataFileCount);
   }
 
   private static Iterable<Partition> partitions(Table table, StaticTableScan scan) {
@@ -220,20 +225,20 @@ public class PartitionsTable extends BaseMetadataTable {
 
   static class Partition {
     private final StructLike key;
-    private long recordCount;
-    private int fileCount;
     private int specId;
+    private long dataRecordCount;
+    private int dataFileCount;
 
     Partition(StructLike key) {
       this.key = key;
-      this.recordCount = 0;
-      this.fileCount = 0;
       this.specId = 0;
+      this.dataRecordCount = 0;
+      this.dataFileCount = 0;
     }
 
     void update(DataFile file) {
-      this.recordCount += file.recordCount();
-      this.fileCount += 1;
+      this.dataRecordCount += file.recordCount();
+      this.dataFileCount += 1;
       this.specId = file.specId();
     }
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -47,9 +47,9 @@ public class PartitionsTable extends BaseMetadataTable {
             Types.NestedField.required(1, "partition", Partitioning.partitionType(table)),
             Types.NestedField.required(4, "spec_id", Types.IntegerType.get()),
             Types.NestedField.required(
-                2, "record_count", Types.LongType.get(), "count of records in data files"),
+                2, "record_count", Types.LongType.get(), "Count of records in data files"),
             Types.NestedField.required(
-                3, "file_count", Types.IntegerType.get(), "count of data files"));
+                3, "file_count", Types.IntegerType.get(), "Count of data files"));
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -332,7 +332,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Table partitionsTable = new PartitionsTable(table);
     Types.StructType expected =
-        new Schema(required(3, "file_count", Types.IntegerType.get(), "data file count"))
+        new Schema(required(3, "file_count", Types.IntegerType.get(), "count of data files"))
             .asStruct();
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -332,7 +332,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Table partitionsTable = new PartitionsTable(table);
     Types.StructType expected =
-        new Schema(required(3, "file_count", Types.IntegerType.get(), "count of data files"))
+        new Schema(required(3, "file_count", Types.IntegerType.get(), "Count of data files"))
             .asStruct();
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -332,7 +332,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Table partitionsTable = new PartitionsTable(table);
     Types.StructType expected =
-        new Schema(required(3, "file_count", Types.IntegerType.get())).asStruct();
+        new Schema(required(3, "file_count", Types.IntegerType.get(), "data file count"))
+            .asStruct();
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1234,8 +1234,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
+            required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1234,12 +1234,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
-                2,
-                "record_count",
-                Types.LongType.get(),
-                "data record count without applying the deletes"),
-            required(3, "file_count", Types.IntegerType.get(), "data file count"));
+            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1234,8 +1234,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get()),
-            required(3, "file_count", Types.IntegerType.get()));
+            required(
+                2,
+                "record_count",
+                Types.LongType.get(),
+                "data record count without applying the deletes"),
+            required(3, "file_count", Types.IntegerType.get(), "data file count"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1232,12 +1232,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
-                2,
-                "record_count",
-                Types.LongType.get(),
-                "data record count without applying the deletes"),
-            required(3, "file_count", Types.IntegerType.get(), "data file count"));
+            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1232,8 +1232,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get()),
-            required(3, "file_count", Types.IntegerType.get()));
+            required(
+                2,
+                "record_count",
+                Types.LongType.get(),
+                "data record count without applying the deletes"),
+            required(3, "file_count", Types.IntegerType.get(), "data file count"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1232,8 +1232,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
+            required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1249,8 +1249,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get()),
-            required(3, "file_count", Types.IntegerType.get()));
+            required(
+                2,
+                "record_count",
+                Types.LongType.get(),
+                "data record count without applying the deletes"),
+            required(3, "file_count", Types.IntegerType.get(), "data file count"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1249,12 +1249,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
-                2,
-                "record_count",
-                Types.LongType.get(),
-                "data record count without applying the deletes"),
-            required(3, "file_count", Types.IntegerType.get(), "data file count"));
+            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1249,8 +1249,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
+            required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1252,8 +1252,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
-            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
+            required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "Count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1252,8 +1252,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(2, "record_count", Types.LongType.get()),
-            required(3, "file_count", Types.IntegerType.get()));
+            required(
+                2,
+                "record_count",
+                Types.LongType.get(),
+                "data record count without applying the deletes"),
+            required(3, "file_count", Types.IntegerType.get(), "data file count"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1252,12 +1252,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
-                2,
-                "record_count",
-                Types.LongType.get(),
-                "data record count without applying the deletes"),
-            required(3, "file_count", Types.IntegerType.get(), "data file count"));
+            required(2, "record_count", Types.LongType.get(), "count of records in data files"),
+            required(3, "file_count", Types.IntegerType.get(), "count of data files"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 


### PR DESCRIPTION
Changes:
- schema changes
   - move spec_id (without changing field id) before the counters. Because It looks odd when we add new counters to have spec_id in between.
   - add column docs for `record_count` and `file_count` to clarify that it is only data file counters.
- Rename internal fields `recordCount` to `dataRecordCount` and `fileCount` to `dataFileCount` for better clarity. 

This PR is a prerequisite for #6661  