### PR TITLE
API: Deprecate AssertHelpers

### DIFF
--- a/api/src/test/java/org/apache/iceberg/AssertHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/AssertHelpers.java
@@ -23,7 +23,22 @@ import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.GenericRecord;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
 
+/**
+ * This class is deprecated. Please use {@link
+ * Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)} directly as shown below:
+ *
+ * <pre>
+ * Assertions.assertThatThrownBy(() -> throwingCallable)
+ *    .isInstanceOf(ExpectedException.class)
+ *    .hasMessage(expectedErrorMsg)
+ * </pre>
+ *
+ * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)} directly
+ *     as it provides a more fluent way of asserting on exceptions.
+ */
+@Deprecated
 public class AssertHelpers {
 
   private AssertHelpers() {}
@@ -35,7 +50,10 @@ public class AssertHelpers {
    * @param expected An Exception class that the Runnable should throw
    * @param containedInMessage A String that should be contained by the thrown exception's message
    * @param callable A Callable that is expected to throw the exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrows(
       String message,
       Class<? extends Exception> expected,
@@ -55,7 +73,10 @@ public class AssertHelpers {
    * @param expected An Exception class that the Runnable should throw
    * @param containedInMessage A String that should be contained by the thrown exception's message
    * @param runnable A Runnable that is expected to throw the runtime exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrows(
       String message,
       Class<? extends Exception> expected,
@@ -74,7 +95,10 @@ public class AssertHelpers {
    * @param message A String message to describe this assertion
    * @param expected An Exception class that the Runnable should throw
    * @param callable A Callable that is expected to throw the exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrows(
       String message, Class<? extends Exception> expected, Callable callable) {
     assertThrows(message, expected, null, callable);
@@ -86,7 +110,10 @@ public class AssertHelpers {
    * @param message A String message to describe this assertion
    * @param expected An Exception class that the Runnable should throw
    * @param runnable A Runnable that is expected to throw the runtime exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrows(
       String message, Class<? extends Exception> expected, Runnable runnable) {
     assertThrows(message, expected, null, runnable);
@@ -100,7 +127,10 @@ public class AssertHelpers {
    * @param containedInMessage A String that should be contained by the cause of the thrown
    *     exception's message
    * @param runnable A Runnable that is expected to throw the runtime exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrowsCause(
       String message,
       Class<? extends Exception> expected,
@@ -124,7 +154,10 @@ public class AssertHelpers {
    * @param causeContainedInMessage A String that should be contained by the cause of the thrown
    *     exception's message, will be skipped if null.
    * @param runnable A Runnable that is expected to throw the runtime exception
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertThrowsWithCause(
       String message,
       Class<? extends Exception> expected,
@@ -150,13 +183,22 @@ public class AssertHelpers {
    *
    * @param record The record to read from
    * @param field The name of the field
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
    */
+  @Deprecated
   public static void assertEmptyAvroField(GenericRecord record, String field) {
     AssertHelpers.assertThrows(
         "Not a valid schema field: " + field, AvroRuntimeException.class, () -> record.get(field));
   }
 
-  /** Same as {@link AssertHelpers#assertThrowsCause}, but this method compares root cause. */
+  /**
+   * Same as {@link AssertHelpers#assertThrowsCause}, but this method compares root cause.
+   *
+   * @deprecated Use {@link Assertions#assertThatThrownBy(ThrowableAssert.ThrowingCallable)}
+   *     directly as it provides a more fluent way of asserting on exceptions.
+   */
+  @Deprecated
   public static void assertThrowsRootCause(
       String message,
       Class<? extends Exception> expected,


### PR DESCRIPTION
I believe we should point people for newly written code to use `Assertions#assertThatThrownBy(..)` as it provides a more fluent way of asserting exceptions