### PR TITLE
Push down group by for partition columns

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Binder.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Binder.java
@@ -168,6 +168,16 @@ public class Binder {
     public <T, C> Expression aggregate(BoundAggregate<T, C> agg) {
       throw new IllegalStateException("Found already bound aggregate: " + agg);
     }
+
+    @Override
+    public Expression groupBy(UnboundGroupBy groupBy) {
+      return groupBy.bind(struct, caseSensitive);
+    }
+
+    @Override
+    public Expression groupBy(BoundGroupBy groupBy) {
+      throw new IllegalStateException("Found already bound groupBy: " + groupBy);
+    }
   }
 
   private static class ReferenceVisitor extends ExpressionVisitor<Set<Integer>> {

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundGroupBy.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundGroupBy.java
@@ -18,41 +18,22 @@
  */
 package org.apache.iceberg.expressions;
 
-/**
- * The aggregate functions that can be pushed and evaluated in Iceberg. Currently only three
- * aggregate functions Max, Min and Count are supported.
- */
-public abstract class Aggregate<C extends Term> implements Expression {
-  private final Operation op;
-  private final C term;
+import org.apache.iceberg.StructLike;
 
-  Aggregate(Operation op, C term) {
-    this.op = op;
-    this.term = term;
+public class BoundGroupBy<T, C> extends GroupBy<BoundTerm<T>> implements Bound<C> {
+
+  protected BoundGroupBy(BoundTerm<T> term) {
+    super(term);
   }
 
   @Override
-  public Operation op() {
-    return op;
-  }
-
-  public C term() {
-    return term;
+  public C eval(StructLike struct) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement eval(StructLike)");
   }
 
   @Override
-  public String toString() {
-    switch (op()) {
-      case COUNT:
-        return "count(" + term() + ")";
-      case COUNT_STAR:
-        return "count(*)";
-      case MAX:
-        return "max(" + term() + ")";
-      case MIN:
-        return "min(" + term() + ")";
-      default:
-        throw new UnsupportedOperationException("Unsupported aggregate: " + op());
-    }
+  public BoundReference<?> ref() {
+    return term().ref();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -22,12 +22,14 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -154,6 +156,19 @@ public class ExpressionUtil {
         Projections.strict(spec, caseSensitive).project(expr),
         spec.partitionType(),
         caseSensitive);
+  }
+
+  public static boolean isPartitionCol(BoundGroupBy expr, Table table) {
+    return table.specs().values().stream().allMatch(spec -> isPartitionCol(expr, spec));
+  }
+
+  public static boolean isPartitionCol(BoundGroupBy expr, PartitionSpec spec) {
+    Collection<PartitionField> parts = spec.getFieldsBySourceId(expr.ref().fieldId());
+    if (parts.isEmpty()) {
+      return false;
+    }
+
+    return true;
   }
 
   public static String describe(Term term) {

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -63,6 +63,14 @@ public class ExpressionVisitors {
     public <T> R aggregate(UnboundAggregate<T> agg) {
       throw new UnsupportedOperationException("Cannot visit aggregate expression");
     }
+
+    public <T, C> R groupBy(BoundGroupBy<T, C> groupBy) {
+      throw new UnsupportedOperationException("Cannot visit groupBy expression");
+    }
+
+    public <T> R groupBy(UnboundGroupBy<T> groupBy) {
+      throw new UnsupportedOperationException("Cannot visit groupBy expression");
+    }
   }
 
   public abstract static class BoundExpressionVisitor<R> extends ExpressionVisitor<R> {
@@ -351,6 +359,12 @@ public class ExpressionVisitors {
         return visitor.aggregate((BoundAggregate<?, ?>) expr);
       } else {
         return visitor.aggregate((UnboundAggregate<?>) expr);
+      }
+    } else if (expr instanceof GroupBy) {
+      if (expr instanceof BoundGroupBy) {
+        return visitor.groupBy((BoundGroupBy<?, ?>) expr);
+      } else {
+        return visitor.groupBy((UnboundGroupBy<?>) expr);
       }
     } else {
       switch (expr.op()) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -324,4 +324,8 @@ public class Expressions {
   public static <T> UnboundAggregate<T> min(String name) {
     return new UnboundAggregate<>(Operation.MIN, ref(name));
   }
+
+  public static UnboundGroupBy groupBy(String name) {
+    return new UnboundGroupBy(ref(name));
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/GroupBy.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/GroupBy.java
@@ -18,22 +18,16 @@
  */
 package org.apache.iceberg.expressions;
 
-/**
- * The aggregate functions that can be pushed and evaluated in Iceberg. Currently only three
- * aggregate functions Max, Min and Count are supported.
- */
-public abstract class Aggregate<C extends Term> implements Expression {
-  private final Operation op;
+public abstract class GroupBy<C extends Term> implements Expression {
   private final C term;
 
-  Aggregate(Operation op, C term) {
-    this.op = op;
+  GroupBy(C term) {
     this.term = term;
   }
 
   @Override
   public Operation op() {
-    return op;
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   public C term() {
@@ -42,17 +36,6 @@ public abstract class Aggregate<C extends Term> implements Expression {
 
   @Override
   public String toString() {
-    switch (op()) {
-      case COUNT:
-        return "count(" + term() + ")";
-      case COUNT_STAR:
-        return "count(*)";
-      case MAX:
-        return "max(" + term() + ")";
-      case MIN:
-        return "min(" + term() + ")";
-      default:
-        throw new UnsupportedOperationException("Unsupported aggregate: " + op());
-    }
+    return "group by " + term;
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundGroupBy.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundGroupBy.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Types;
+
+public class UnboundGroupBy<T> extends GroupBy<UnboundTerm<T>> implements Unbound<T, Expression> {
+
+  UnboundGroupBy(UnboundTerm<T> term) {
+    super(term);
+  }
+
+  @Override
+  public NamedReference<?> ref() {
+    return term().ref();
+  }
+
+  /**
+   * Bind this UnboundGroupBy.
+   *
+   * @param struct The {@link Types.StructType struct type} to resolve references by name.
+   * @param caseSensitive A boolean flag to control whether the bind should enforce case
+   *     sensitivity.
+   * @return an {@link Expression}
+   * @throws ValidationException if literals do not match bound references, or if comparison on
+   *     expression is invalid
+   */
+  @Override
+  public Expression bind(Types.StructType struct, boolean caseSensitive) {
+    return new BoundGroupBy(boundTerm(struct, caseSensitive));
+  }
+
+  private BoundTerm<T> boundTerm(Types.StructType struct, boolean caseSensitive) {
+    Preconditions.checkArgument(term() != null, "Invalid group by term: null");
+    return term().bind(struct, caseSensitive);
+  }
+}

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -455,7 +455,8 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
             + " (3, 22, null) ",
         tableName);
 
-    String select = "SELECT id1, MIN(data), MAX(data), COUNT(data), COUNT(*) FROM %s GROUP BY id1";
+    String select =
+        "SELECT id1, MIN(data), MAX(data), COUNT(data), COUNT(*) FROM %s GROUP BY id1 ORDER BY id1";
 
     List<Object[]> explain = sql("EXPLAIN " + select, tableName);
     String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
@@ -471,8 +472,8 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
 
     List<Object[]> actual = sql(select, tableName);
     List<Object[]> expected = Lists.newArrayList();
-    expected.add(new Object[] {3L, 777, 888, 2L, 3L});
     expected.add(new Object[] {2L, 444, 666, 2L, 3L});
+    expected.add(new Object[] {3L, 777, 888, 2L, 3L});
     expected.add(new Object[] {4L, 222, 333, 2L, 3L});
     assertEquals("expected and actual should equal", expected, actual);
   }
@@ -497,7 +498,7 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
         tableName);
 
     String select =
-        "SELECT ts, id, MIN(data), MAX(data), COUNT(data), COUNT(*) FROM %s GROUP BY id, ts";
+        "SELECT ts, id, MIN(data), MAX(data), COUNT(data), COUNT(*) FROM %s GROUP BY id, ts ORDER BY ts, id";
 
     List<Object[]> explain = sql("EXPLAIN " + select, tableName);
     String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
@@ -513,12 +514,12 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
 
     List<Object[]> actual = sql(select, tableName);
     List<Object[]> expected = Lists.newArrayList();
-    expected.add(new Object[] {Timestamp.valueOf("2021-11-11 22:22:22.0"), 3L, 888, 888, 1L, 2L});
-    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 2L, 555, 666, 2L, 2L});
-    expected.add(new Object[] {Timestamp.valueOf("2021-11-11 22:22:22.0"), 4L, 111, 111, 1L, 2L});
-    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 4L, 333, 333, 1L, 1L});
-    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 3L, 999, 999, 1L, 1L});
     expected.add(new Object[] {Timestamp.valueOf("2021-11-11 22:22:22.0"), 2L, 444, 444, 1L, 1L});
+    expected.add(new Object[] {Timestamp.valueOf("2021-11-11 22:22:22.0"), 3L, 888, 888, 1L, 2L});
+    expected.add(new Object[] {Timestamp.valueOf("2021-11-11 22:22:22.0"), 4L, 111, 111, 1L, 2L});
+    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 2L, 555, 666, 2L, 2L});
+    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 3L, 999, 999, 1L, 1L});
+    expected.add(new Object[] {Timestamp.valueOf("2021-11-12 22:22:22.0"), 4L, 333, 333, 1L, 1L});
     assertEquals("expected and actual should equal", expected, actual);
   }
 
@@ -541,7 +542,7 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
             + " (3, 22, null) ",
         tableName);
 
-    String select = "SELECT id1, MIN(data) FROM %s GROUP BY id1, id2";
+    String select = "SELECT id1, MIN(data) FROM %s GROUP BY id1, id2 ORDER BY id1";
 
     List<Object[]> explain = sql("EXPLAIN " + select, tableName);
     String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
@@ -555,10 +556,10 @@ public class TestAggregatePushDown extends SparkCatalogTestBase {
 
     List<Object[]> actual = sql(select, tableName);
     List<Object[]> expected = Lists.newArrayList();
-    expected.add(new Object[] {3L, 777});
-    expected.add(new Object[] {3L, 888});
     expected.add(new Object[] {2L, 444});
     expected.add(new Object[] {2L, 666});
+    expected.add(new Object[] {3L, 777});
+    expected.add(new Object[] {3L, 888});
     expected.add(new Object[] {4L, 222});
     expected.add(new Object[] {4L, 333});
     assertEquals("expected and actual should equal", expected, actual);


### PR DESCRIPTION
Push down min/max/count with group by if group by is on partition columns

For example:
```
CREATE TABLE test (id LONG, ts TIMESTAMP, data INT) USING iceberg PARTITIONED BY (id, ts);
SELECT MIN(data), MAX(data), COUNT(data), COUNT(*) FROM test GROUP BY id, ts;
```


I have the following changes:

1. Added Expression `GroupBy`, `UnboundGroupBy`, `BoundGroupBy`
2. In `Aggregator`, I will take consideration of `GroupBy`. Use `MaxAggregator` as an example:

   - Add `List<BoundGroupBy>` in the constructor
   - Add `private Map<StructLike, T> maxP` which contains max value for each of the partition.
   - The key of the above Map is `AggregateEvaluator.ArrayStructLike`, which contains the partition values.
   - Add `update(R value, StructLike partitionKey)` to update value for specific partitions
   - Add `Map<StructLike, R> currentPartition()` to get current value for each partitions

4. Build the Scan schema to be: group by columns + aggregates (this is what Spark is expecting)
Use `SELECT MIN(data), MAX(data), COUNT(data), COUNT(*) FROM test GROUP BY id, ts` as an example: 
the schema is 
`LONG, TIMESTAMP, INT, INT, LONG, LONG`, 
which corresponds to
`id, ts, MIN(data), MAX(data), COUNT(data), COUNT(*)`


