### PR TITLE
Build: Enable debugging for java-ci

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         distribution: zulu
         java-version: 8
-    - run: ./gradlew -DallVersions build -x test -x javadoc -x integrationTest
+    - run: ./gradlew -DallVersions build -x test -x javadoc -x integrationTest --info --stacktrace
 
   build-javadoc:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Too many times, I am facing one flaky error (also other people are facing it too). Unable to know the reason. Hence, enabling the `--stacktrace`, `--info` for future debugging.  

```
* What went wrong:
Execution failed for task ':iceberg-spark:iceberg-spark-3.3_2.12:checkstyleMain'.
> A failure occurred while executing org.gradle.api.plugins.quality.internal.CheckstyleAction
   > An unexpected error occurred configuring and executing Checkstyle.
      > java.lang.Error: Error was thrown while processing /home/runner/work/iceberg/iceberg/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
```

Failure details:
https://github.com/apache/iceberg/actions/workflows/java-ci.yml

https://github.com/apache/iceberg/actions/runs/4309428443
https://github.com/apache/iceberg/actions/runs/4310045826
https://github.com/apache/iceberg/actions/runs/4306392493/
and many more