### PR TITLE
Build: Fix minor errorprone warnings during compile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/AggregateEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/AggregateEvaluator.java
@@ -108,6 +108,7 @@ public class AggregateEvaluator {
       this.values = values;
     }
 
+    @Override
     public int size() {
       return values.length;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ValueAggregate.java
@@ -33,6 +33,7 @@ class ValueAggregate<T> extends BoundAggregate<T, T> {
     return term().eval(struct);
   }
 
+  @Override
   public T eval(DataFile file) {
     valueStruct.setValue(evaluateRef(file));
     return term().eval(valueStruct);

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -86,6 +86,8 @@ subprojects {
           '-Xep:PreferSafeLogger:OFF',
           // Enforce safe string splitting
           '-Xep:StringSplitter:ERROR',
+          // Enforce missing override
+          '-Xep:MissingOverride:ERROR',
       )
     }
   }


### PR DESCRIPTION
Just keeping the build green (`./gradlew build -x test -x javadoc -x integrationTest`)

Before
<img width="790" alt="Screenshot 2023-03-02 at 12 06 39 PM" src="https://user-images.githubusercontent.com/5889404/222351916-2e252d94-52b9-49bf-9486-6d1264ad7344.png">

After
<img width="790" alt="image" src="https://user-images.githubusercontent.com/5889404/222352003-00626610-0d70-4c2e-9d7c-b10ee8ba3553.png">

Note:
ignore the build time in the images. I was playing around with gradle --scan.