### PR TITLE
Flink: Replace Flink Tableschema To Resolvedschema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,26 @@ subprojects {
       oldName = project.name
       oldVersion = "1.1.0"
     }
+
+    tasks.register('showDeprecationRulesOnRevApiFailure') {
+      doLast {
+        throw new RuntimeException("==================================================================================" +
+                "\nAPI/ABI breaks detected.\n" +
+                "Adding RevAPI breaks should only be done after going through a deprecation cycle." +
+                "\nPlease make sure to follow the deprecation rules defined in\n" +
+                "https://github.com/apache/iceberg/blob/master/CONTRIBUTING.md#semantic-versioning.\n" +
+                "==================================================================================")
+      }
+      onlyIf {
+        tasks.revapi.state.failure != null
+      }
+    }
+
+    tasks.configureEach { rootTask ->
+      if (rootTask.name == 'revapi') {
+        rootTask.finalizedBy showDeprecationRulesOnRevApiFailure
+      }
+    }
   }
 
   configurations {

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -53,7 +53,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -71,7 +70,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -122,8 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -53,7 +53,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -71,7 +70,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -122,8 +120,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
@@ -36,8 +35,10 @@ import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -407,7 +408,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
   void createIcebergTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
-    validateFlinkTable(table);
+    validateFlinkTable((ResolvedCatalogBaseTable) table);
     Schema icebergSchema = FlinkSchemaUtil.convert(table);
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
 
@@ -431,9 +432,10 @@ public class FlinkCatalog extends AbstractCatalog {
     }
   }
 
-  private static void validateTableSchemaAndPartition(CatalogTable ct1, CatalogTable ct2) {
-    TableSchema ts1 = ct1.getSchema();
-    TableSchema ts2 = ct2.getSchema();
+  private static void validateTableSchemaAndPartition(
+      ResolvedCatalogTable ct1, ResolvedCatalogTable ct2) {
+    ResolvedSchema ts1 = ct1.getResolvedSchema();
+    ResolvedSchema ts2 = ct2.getResolvedSchema();
     boolean equalsPrimary = false;
 
     if (ts1.getPrimaryKey().isPresent() && ts2.getPrimaryKey().isPresent()) {
@@ -445,7 +447,7 @@ public class FlinkCatalog extends AbstractCatalog {
       equalsPrimary = true;
     }
 
-    if (!(Objects.equals(ts1.getTableColumns(), ts2.getTableColumns())
+    if (!(Objects.equals(ts1.getColumns(), ts2.getColumns())
         && Objects.equals(ts1.getWatermarkSpecs(), ts2.getWatermarkSpecs())
         && equalsPrimary)) {
       throw new UnsupportedOperationException("Altering schema is not supported yet.");
@@ -459,7 +461,7 @@ public class FlinkCatalog extends AbstractCatalog {
   @Override
   public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
       throws CatalogException, TableNotExistException {
-    validateFlinkTable(newTable);
+    validateFlinkTable((ResolvedCatalogBaseTable) newTable);
 
     Table icebergTable;
     try {
@@ -472,14 +474,14 @@ public class FlinkCatalog extends AbstractCatalog {
       }
     }
 
-    CatalogTable table = toCatalogTable(icebergTable);
+    ResolvedCatalogTable table = toCatalogTable(icebergTable);
 
     // Currently, Flink SQL only support altering table properties.
 
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by
     // comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    validateTableSchemaAndPartition(table, (CatalogTable) newTable);
+    validateTableSchemaAndPartition(table, (ResolvedCatalogTable) newTable);
 
     Map<String, String> oldProperties = table.getOptions();
     Map<String, String> setProperties = Maps.newHashMap();
@@ -519,13 +521,13 @@ public class FlinkCatalog extends AbstractCatalog {
     commitChanges(icebergTable, setLocation, setSnapshotId, pickSnapshotId, setProperties);
   }
 
-  private static void validateFlinkTable(CatalogBaseTable table) {
+  private static void validateFlinkTable(ResolvedCatalogBaseTable table) {
     Preconditions.checkArgument(
         table instanceof CatalogTable, "The Table should be a CatalogTable.");
 
-    TableSchema schema = table.getSchema();
+    ResolvedSchema schema = table.getResolvedSchema();
     schema
-        .getTableColumns()
+        .getColumns()
         .forEach(
             column -> {
               if (!FlinkCompatibilityUtil.isPhysicalColumn(column)) {
@@ -607,8 +609,8 @@ public class FlinkCatalog extends AbstractCatalog {
     transaction.commitTransaction();
   }
 
-  static CatalogTable toCatalogTable(Table table) {
-    TableSchema schema = FlinkSchemaUtil.toSchema(table.schema());
+  static ResolvedCatalogTable toCatalogTable(Table table) {
+    ResolvedSchema schema = FlinkSchemaUtil.toSchema(table.schema());
     List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
 
     // NOTE: We can not create a IcebergCatalogTable extends CatalogTable, because Flink optimizer
@@ -616,7 +618,14 @@ public class FlinkCatalog extends AbstractCatalog {
     // CatalogTableImpl to copy a new catalog table.
     // Let's re-loading table from Iceberg catalog when creating source/sink operators.
     // Iceberg does not have Table comment, so pass a null (Default comment value in Flink).
-    return new CatalogTableImpl(schema, partitionKeys, table.properties(), null);
+    final CatalogTable origin =
+        CatalogTable.of(
+            org.apache.flink.table.api.Schema.newBuilder().fromResolvedSchema(schema).build(),
+            null,
+            partitionKeys,
+            table.properties());
+
+    return new ResolvedCatalogTable(origin, schema);
   }
 
   @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -408,8 +408,7 @@ public class FlinkCatalog extends AbstractCatalog {
   void createIcebergTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
-
-    Schema icebergSchema = FlinkSchemaUtil.convert(table.getSchema());
+    Schema icebergSchema = FlinkSchemaUtil.convert(table);
     PartitionSpec spec = toPartitionSpec(((CatalogTable) table).getPartitionKeys(), icebergSchema);
 
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -54,7 +54,6 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionField;
@@ -72,7 +71,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
-import org.apache.iceberg.flink.util.FlinkPackage;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -123,8 +121,7 @@ public class FlinkCatalog extends AbstractCatalog {
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;
     closeable = originalCatalog instanceof Closeable ? (Closeable) originalCatalog : null;
 
-    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
-    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+    FlinkEnvironmentContext.init();
   }
 
   @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
@@ -83,7 +83,7 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    ResolvedCatalogBaseTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> tableProps = catalogTable.getOptions();
     ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 
@@ -105,7 +105,7 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    ResolvedCatalogBaseTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> writeProps = catalogTable.getOptions();
     ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -23,19 +23,18 @@ import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -84,9 +83,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    CatalogTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogBaseTable catalogTable = context.getCatalogTable();
     Map<String, String> tableProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 
     TableLoader tableLoader;
     if (catalog != null) {
@@ -106,9 +105,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    CatalogTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogBaseTable catalogTable = context.getCatalogTable();
     Map<String, String> writeProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 
     TableLoader tableLoader;
     if (catalog != null) {

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkEnvironmentContext.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.flink.util.FlinkPackage;
+
+class FlinkEnvironmentContext {
+  private FlinkEnvironmentContext() {}
+
+  public static void init() {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "flink");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, FlinkPackage.version());
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.Column;
-import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -62,8 +62,8 @@ public class FlinkSchemaUtil {
   private FlinkSchemaUtil() {}
 
   public static Schema convert(CatalogBaseTable table) {
-    if (table instanceof ResolvedCatalogBaseTable) {
-      ResolvedCatalogBaseTable catalogBaseTable = (ResolvedCatalogBaseTable) table;
+    if (table instanceof ResolvedCatalogTable) {
+      ResolvedCatalogTable catalogBaseTable = (ResolvedCatalogTable) table;
       return convert(catalogBaseTable.getResolvedSchema());
     }
     throw new IllegalArgumentException("Unknown kind of catalog base table: " + table.getClass());

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
@@ -39,7 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning, SupportsOverwrite {
   private final TableLoader tableLoader;
-  private final TableSchema tableSchema;
+  private final ResolvedSchema tableSchema;
   private final ReadableConfig readableConfig;
   private final Map<String, String> writeProps;
 
@@ -55,7 +55,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
 
   public IcebergTableSink(
       TableLoader tableLoader,
-      TableSchema tableSchema,
+      ResolvedSchema tableSchema,
       ReadableConfig readableConfig,
       Map<String, String> writeProps) {
     this.tableLoader = tableLoader;

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -73,6 +73,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return tables.load(location);
     }
 
@@ -106,6 +107,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
+      FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
     }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.types.DataType;
@@ -106,9 +107,9 @@ public class FlinkSink {
    * @param tableSchema defines the {@link TypeInformation} for input data.
    * @return {@link Builder} to connect the iceberg table.
    */
-  public static Builder forRow(DataStream<Row> input, TableSchema tableSchema) {
-    RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
-    DataType[] fieldDataTypes = tableSchema.getFieldDataTypes();
+  public static Builder forRow(DataStream<Row> input, ResolvedSchema tableSchema) {
+    RowType rowType = (RowType) tableSchema.toPhysicalRowDataType().getLogicalType();
+    DataType[] fieldDataTypes = (DataType[]) tableSchema.getColumnDataTypes().toArray();
 
     DataFormatConverters.RowConverter rowConverter =
         new DataFormatConverters.RowConverter(fieldDataTypes);
@@ -131,7 +132,7 @@ public class FlinkSink {
     private Function<String, DataStream<RowData>> inputCreator = null;
     private TableLoader tableLoader;
     private Table table;
-    private TableSchema tableSchema;
+    private ResolvedSchema tableSchema;
     private Integer writeParallelism = null;
     private List<String> equalityFieldColumns = null;
     private String uidPrefix = null;
@@ -209,7 +210,7 @@ public class FlinkSink {
       return this;
     }
 
-    public Builder tableSchema(TableSchema newTableSchema) {
+    public Builder tableSchema(ResolvedSchema newTableSchema) {
       this.tableSchema = newTableSchema;
       return this;
     }
@@ -549,7 +550,7 @@ public class FlinkSink {
     }
   }
 
-  static RowType toFlinkRowType(Schema schema, TableSchema requestedSchema) {
+  static RowType toFlinkRowType(Schema schema, ResolvedSchema requestedSchema) {
     if (requestedSchema != null) {
       // Convert the flink schema to iceberg schema firstly, then reassign ids to match the existing
       // iceberg schema.
@@ -563,7 +564,7 @@ public class FlinkSink {
       // read 4 bytes rather than 1 byte, it will mess up the byte array in BinaryRowData. So here
       // we must use flink
       // schema.
-      return (RowType) requestedSchema.toRowDataType().getLogicalType();
+      return (RowType) requestedSchema.toPhysicalRowDataType().getLogicalType();
     } else {
       return FlinkSchemaUtil.convert(schema);
     }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -101,7 +101,7 @@ public class FlinkSink {
   /**
    * Initialize a {@link Builder} to export the data from input data stream with {@link Row}s into
    * iceberg table. We use {@link RowData} inside the sink connector, so users need to provide a
-   * {@link TableSchema} for builder to convert those {@link Row}s to a {@link RowData} DataStream.
+   * {@link ResolvedSchema} for builder to convert those {@link Row}s to a {@link RowData} DataStream.
    *
    * @param input the source input data stream with {@link Row}s.
    * @param tableSchema defines the {@link TypeInformation} for input data.

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -41,7 +41,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
@@ -101,7 +100,8 @@ public class FlinkSink {
   /**
    * Initialize a {@link Builder} to export the data from input data stream with {@link Row}s into
    * iceberg table. We use {@link RowData} inside the sink connector, so users need to provide a
-   * {@link ResolvedSchema} for builder to convert those {@link Row}s to a {@link RowData} DataStream.
+   * {@link ResolvedSchema} for builder to convert those {@link Row}s to a {@link RowData}
+   * DataStream.
    *
    * @param input the source input data stream with {@link Row}s.
    * @param tableSchema defines the {@link TypeInformation} for input data.

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -109,7 +109,7 @@ public class FlinkSink {
    */
   public static Builder forRow(DataStream<Row> input, ResolvedSchema tableSchema) {
     RowType rowType = (RowType) tableSchema.toPhysicalRowDataType().getLogicalType();
-    DataType[] fieldDataTypes = (DataType[]) tableSchema.getColumnDataTypes().toArray();
+    DataType[] fieldDataTypes = tableSchema.getColumnDataTypes().toArray(new DataType[0]);
 
     DataFormatConverters.RowConverter rowConverter =
         new DataFormatConverters.RowConverter(fieldDataTypes);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -28,7 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -79,7 +79,7 @@ public class FlinkSource {
     private StreamExecutionEnvironment env;
     private Table table;
     private TableLoader tableLoader;
-    private TableSchema projectedSchema;
+    private ResolvedSchema projectedSchema;
     private ReadableConfig readableConfig = new Configuration();
     private final ScanContext.Builder contextBuilder = ScanContext.builder();
     private Boolean exposeLocality;
@@ -106,7 +106,7 @@ public class FlinkSource {
       return this;
     }
 
-    public Builder project(TableSchema schema) {
+    public Builder project(ResolvedSchema schema) {
       this.projectedSchema = schema;
       return this;
     }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -36,7 +36,7 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.BaseMetadataTable;
@@ -212,7 +212,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
     private ReaderFunction<T> readerFunction;
     private ReadableConfig flinkConfig = new Configuration();
     private final ScanContext.Builder contextBuilder = ScanContext.builder();
-    private TableSchema projectedFlinkSchema;
+    private ResolvedSchema projectedFlinkSchema;
     private Boolean exposeLocality;
 
     private final Map<String, String> readOptions = Maps.newHashMap();
@@ -356,7 +356,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       return this;
     }
 
-    public Builder<T> project(TableSchema newProjectedFlinkSchema) {
+    public Builder<T> project(ResolvedSchema newProjectedFlinkSchema) {
       this.projectedFlinkSchema = newProjectedFlinkSchema;
       return this;
     }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -154,7 +155,8 @@ public class IcebergTableSource
       return schema;
     } else {
       List<Column> columns = schema.getColumns();
-      return ResolvedSchema.of(columns);
+      return ResolvedSchema.of(
+          Arrays.stream(projectedFields).mapToObj(columns::get).toArray(Column[]::new));
     }
   }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkCompatibilityUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/util/FlinkCompatibilityUtil.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink.util;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
@@ -36,7 +36,7 @@ public class FlinkCompatibilityUtil {
     return InternalTypeInfo.of(rowType);
   }
 
-  public static boolean isPhysicalColumn(TableColumn column) {
+  public static boolean isPhysicalColumn(Column column) {
     return column.isPhysical();
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -27,7 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -80,10 +81,12 @@ public class SimpleDataUtil {
           Types.NestedField.optional(1, "id", Types.IntegerType.get()),
           Types.NestedField.optional(2, "data", Types.StringType.get()));
 
-  public static final TableSchema FLINK_SCHEMA =
-      TableSchema.builder().field("id", DataTypes.INT()).field("data", DataTypes.STRING()).build();
+  public static final ResolvedSchema FLINK_SCHEMA =
+      ResolvedSchema.of(
+          Column.physical("id", DataTypes.INT()), Column.physical("data", DataTypes.STRING()));
 
-  public static final RowType ROW_TYPE = (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType();
+  public static final RowType ROW_TYPE =
+      (RowType) FLINK_SCHEMA.toPhysicalRowDataType().getLogicalType();
 
   public static final Record RECORD = GenericRecord.create(SCHEMA);
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
@@ -126,7 +125,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         table.schema().asStruct());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+    ResolvedCatalogTable catalogTable = catalogTable("tl");
 
     Assert.assertEquals(
         ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT())),
@@ -144,7 +143,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         Sets.newHashSet(table.schema().findField("key").fieldId()),
         table.schema().identifierFieldIds());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+    ResolvedCatalogTable catalogTable = catalogTable("tl");
     Optional<UniqueConstraint> uniqueConstraintOptional =
         catalogTable.getResolvedSchema().getPrimaryKey();
     Assert.assertTrue(
@@ -167,7 +166,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
             table.schema().findField("id").fieldId(), table.schema().findField("data").fieldId()),
         table.schema().identifierFieldIds());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+    ResolvedCatalogTable catalogTable = catalogTable("tl");
     Optional<UniqueConstraint> uniqueConstraintOptional =
         catalogTable.getResolvedSchema().getPrimaryKey();
     Assert.assertTrue(
@@ -215,7 +214,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         table.schema().asStruct());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl2");
+    ResolvedCatalogTable catalogTable = catalogTable("tl2");
     ResolvedSchema expectSchema = ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT()));
     Assert.assertEquals(expectSchema, catalogTable.getResolvedSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
@@ -251,14 +250,14 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         PartitionSpec.builderFor(table.schema()).identity("dt").build(), table.spec());
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+    ResolvedCatalogTable catalogTable = catalogTable("tl");
     ResolvedSchema resolvedSchema =
         ResolvedSchema.of(
             Column.physical("id", DataTypes.BIGINT()), Column.physical("dt", DataTypes.STRING()));
     Assert.assertEquals(resolvedSchema, catalogTable.getResolvedSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
-    List<String> keys = catalogTable.getResolvedSchema().getPrimaryKey().get().getColumns();
-    //Assert.assertEquals(Collections.singletonList("dt"), keys);
+    List<String> keys = catalogTable.getPartitionKeys();
+    Assert.assertEquals(Collections.singletonList("dt"), keys);
   }
 
   @Test
@@ -307,11 +306,11 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         schema,
         PartitionSpec.builderFor(schema).bucket("id", 100).build());
 
-    ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+    ResolvedCatalogTable catalogTable = catalogTable("tl");
     ResolvedSchema expectSchema = ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT()));
     Assert.assertEquals(expectSchema, catalogTable.getResolvedSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
-    List<String> keys = catalogTable.getResolvedSchema().getPrimaryKey().get().getColumns();
+    List<String> keys = catalogTable.getPartitionKeys();
     Assert.assertEquals(Collections.emptyList(), keys);
   }
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -128,8 +127,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
     ResolvedCatalogBaseTable catalogTable = catalogTable("tl");
+
     Assert.assertEquals(
-        TableSchema.builder().field("id", DataTypes.BIGINT()).build(),
+        ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT())),
         catalogTable.getResolvedSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
   }
@@ -258,7 +258,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assert.assertEquals(resolvedSchema, catalogTable.getResolvedSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
     List<String> keys = catalogTable.getResolvedSchema().getPrimaryKey().get().getColumns();
-    Assert.assertEquals(Collections.singletonList("dt"), keys);
+    //Assert.assertEquals(Collections.singletonList("dt"), keys);
   }
 
   @Test

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
@@ -29,8 +29,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Expressions;
-import org.apache.flink.table.api.TableColumn;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
@@ -55,21 +55,20 @@ import org.junit.Test;
 
 public class TestFlinkFilters {
 
-  private static final TableSchema TABLE_SCHEMA =
-      TableSchema.builder()
-          .field("field1", DataTypes.INT())
-          .field("field2", DataTypes.BIGINT())
-          .field("field3", DataTypes.FLOAT())
-          .field("field4", DataTypes.DOUBLE())
-          .field("field5", DataTypes.STRING())
-          .field("field6", DataTypes.BOOLEAN())
-          .field("field7", DataTypes.BINARY(2))
-          .field("field8", DataTypes.DECIMAL(10, 2))
-          .field("field9", DataTypes.DATE())
-          .field("field10", DataTypes.TIME())
-          .field("field11", DataTypes.TIMESTAMP())
-          .field("field12", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
-          .build();
+  private static final ResolvedSchema TABLE_SCHEMA =
+      ResolvedSchema.of(
+          Column.physical("field1", DataTypes.INT()),
+          Column.physical("field2", DataTypes.BIGINT()),
+          Column.physical("field3", DataTypes.FLOAT()),
+          Column.physical("field4", DataTypes.DOUBLE()),
+          Column.physical("field5", DataTypes.STRING()),
+          Column.physical("field6", DataTypes.BOOLEAN()),
+          Column.physical("field7", DataTypes.BINARY(2)),
+          Column.physical("field8", DataTypes.DECIMAL(10, 2)),
+          Column.physical("field9", DataTypes.DATE()),
+          Column.physical("field10", DataTypes.TIME()),
+          Column.physical("field11", DataTypes.TIMESTAMP()),
+          Column.physical("field12", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()));
 
   // A map list of fields and values used to verify the conversion of flink expression to iceberg
   // expression
@@ -412,10 +411,10 @@ public class TestFlinkFilters {
           @Override
           public Expression visit(UnresolvedReferenceExpression unresolvedReference) {
             String name = unresolvedReference.getName();
-            Optional<TableColumn> field = TABLE_SCHEMA.getTableColumn(name);
+            Optional<Column> field = TABLE_SCHEMA.getColumn(name);
             if (field.isPresent()) {
-              int index = TABLE_SCHEMA.getTableColumns().indexOf(field.get());
-              return new FieldReferenceExpression(name, field.get().getType(), 0, index);
+              int index = TABLE_SCHEMA.getColumns().indexOf(field.get());
+              return new FieldReferenceExpression(name, field.get().getDataType(), 0, index);
             } else {
               return null;
             }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -18,9 +18,15 @@
  */
 package org.apache.iceberg.flink;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -44,37 +50,36 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testConvertFlinkSchemaToIcebergSchema() {
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field("id", DataTypes.INT().notNull())
-            .field("name", DataTypes.STRING()) /* optional by default */
-            .field("salary", DataTypes.DOUBLE().notNull())
-            .field(
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("id", DataTypes.INT().notNull()),
+            Column.physical("name", DataTypes.STRING()), /* optional by default */
+            Column.physical("salary", DataTypes.DOUBLE().notNull()),
+            Column.physical(
                 "locations",
                 DataTypes.MAP(
                     DataTypes.STRING(),
                     DataTypes.ROW(
                         DataTypes.FIELD("posX", DataTypes.DOUBLE().notNull(), "X field"),
-                        DataTypes.FIELD("posY", DataTypes.DOUBLE().notNull(), "Y field"))))
-            .field("strArray", DataTypes.ARRAY(DataTypes.STRING()).nullable())
-            .field("intArray", DataTypes.ARRAY(DataTypes.INT()).nullable())
-            .field("char", DataTypes.CHAR(10).notNull())
-            .field("varchar", DataTypes.VARCHAR(10).notNull())
-            .field("boolean", DataTypes.BOOLEAN().nullable())
-            .field("tinyint", DataTypes.TINYINT())
-            .field("smallint", DataTypes.SMALLINT())
-            .field("bigint", DataTypes.BIGINT())
-            .field("varbinary", DataTypes.VARBINARY(10))
-            .field("binary", DataTypes.BINARY(10))
-            .field("time", DataTypes.TIME())
-            .field("timestampWithoutZone", DataTypes.TIMESTAMP())
-            .field("timestampWithZone", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())
-            .field("date", DataTypes.DATE())
-            .field("decimal", DataTypes.DECIMAL(2, 2))
-            .field("decimal2", DataTypes.DECIMAL(38, 2))
-            .field("decimal3", DataTypes.DECIMAL(10, 1))
-            .field("multiset", DataTypes.MULTISET(DataTypes.STRING().notNull()))
-            .build();
+                        DataTypes.FIELD("posY", DataTypes.DOUBLE().notNull(), "Y field")))),
+            Column.physical("strArray", DataTypes.ARRAY(DataTypes.STRING()).nullable()),
+            Column.physical("intArray", DataTypes.ARRAY(DataTypes.INT()).nullable()),
+            Column.physical("char", DataTypes.CHAR(10).notNull()),
+            Column.physical("varchar", DataTypes.VARCHAR(10).notNull()),
+            Column.physical("boolean", DataTypes.BOOLEAN().nullable()),
+            Column.physical("tinyint", DataTypes.TINYINT()),
+            Column.physical("smallint", DataTypes.SMALLINT()),
+            Column.physical("bigint", DataTypes.BIGINT()),
+            Column.physical("varbinary", DataTypes.VARBINARY(10)),
+            Column.physical("binary", DataTypes.BINARY(10)),
+            Column.physical("time", DataTypes.TIME()),
+            Column.physical("timestampWithoutZone", DataTypes.TIMESTAMP()),
+            Column.physical("timestampWithZone", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()),
+            Column.physical("date", DataTypes.DATE()),
+            Column.physical("decimal", DataTypes.DECIMAL(2, 2)),
+            Column.physical("decimal2", DataTypes.DECIMAL(38, 2)),
+            Column.physical("decimal3", DataTypes.DECIMAL(10, 1)),
+            Column.physical("multiset", DataTypes.MULTISET(DataTypes.STRING().notNull())));
 
     Schema icebergSchema =
         new Schema(
@@ -122,17 +127,19 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testMapField() {
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field(
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical(
                 "map_int_long",
-                DataTypes.MAP(DataTypes.INT(), DataTypes.BIGINT()).notNull()) /* Required */
-            .field(
+                DataTypes.MAP(DataTypes.INT(), DataTypes.BIGINT())
+                    .notNull()), /* optional by default */
+            Column.physical(
                 "map_int_array_string",
-                DataTypes.MAP(DataTypes.ARRAY(DataTypes.INT()), DataTypes.STRING()))
-            .field(
-                "map_decimal_string", DataTypes.MAP(DataTypes.DECIMAL(10, 2), DataTypes.STRING()))
-            .field(
+                DataTypes.MAP(DataTypes.ARRAY(DataTypes.INT()), DataTypes.STRING())),
+            Column.physical(
+                "map_decimal_string", DataTypes.MAP(DataTypes.DECIMAL(10, 2), DataTypes.STRING())),
+            Column.physical(
                 "map_fields_fields",
                 DataTypes.MAP(
                         DataTypes.ROW(
@@ -145,8 +152,7 @@ public class TestFlinkSchemaUtil {
                                     DataTypes.ARRAY(DataTypes.STRING()),
                                     "doc - array"))
                             .notNull() /* Required */)
-                    .notNull() /* Required */)
-            .build();
+                    .notNull() /* Required */));
 
     Schema icebergSchema =
         new Schema(
@@ -192,9 +198,10 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testStructField() {
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field(
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical(
                 "struct_int_string_decimal",
                 DataTypes.ROW(
                         DataTypes.FIELD("field_int", DataTypes.INT()),
@@ -208,14 +215,13 @@ public class TestFlinkSchemaUtil {
                                         "inner_struct_float_array",
                                         DataTypes.ARRAY(DataTypes.FLOAT())))
                                 .notNull()) /* Row is required */)
-                    .notNull()) /* Required */
-            .field(
+                    .notNull()), /* Required */
+            Column.physical(
                 "struct_map_int_int",
                 DataTypes.ROW(
                         DataTypes.FIELD(
                             "field_map", DataTypes.MAP(DataTypes.INT(), DataTypes.INT())))
-                    .nullable()) /* Optional */
-            .build();
+                    .nullable())); /* Optional */
 
     Schema icebergSchema =
         new Schema(
@@ -251,21 +257,22 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testListField() {
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field(
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical(
                 "list_struct_fields",
                 DataTypes.ARRAY(DataTypes.ROW(DataTypes.FIELD("field_int", DataTypes.INT())))
-                    .notNull()) /* Required */
-            .field(
+                    .notNull()), /* Required */
+            Column.physical(
                 "list_optional_struct_fields",
                 DataTypes.ARRAY(
                         DataTypes.ROW(
                             DataTypes.FIELD(
                                 "field_timestamp_with_local_time_zone",
                                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())))
-                    .nullable()) /* Optional */
-            .field(
+                    .notNull()), /* Required */
+            Column.physical(
                 "list_map_fields",
                 DataTypes.ARRAY(
                         DataTypes.MAP(
@@ -274,8 +281,7 @@ public class TestFlinkSchemaUtil {
                                 DataTypes.ROW(
                                     DataTypes.FIELD("field_0", DataTypes.INT(), "doc - int")))
                             .notNull())
-                    .notNull()) /* Required */
-            .build();
+                    .notNull())); /* Required */
 
     Schema icebergSchema =
         new Schema(
@@ -312,7 +318,7 @@ public class TestFlinkSchemaUtil {
     checkSchema(flinkSchema, icebergSchema);
   }
 
-  private void checkSchema(TableSchema flinkSchema, Schema icebergSchema) {
+  private void checkSchema(ResolvedSchema flinkSchema, Schema icebergSchema) {
     Assert.assertEquals(icebergSchema.asStruct(), FlinkSchemaUtil.convert(flinkSchema).asStruct());
     // The conversion is not a 1:1 mapping, so we just check iceberg types.
     Assert.assertEquals(
@@ -369,13 +375,16 @@ public class TestFlinkSchemaUtil {
                 Types.NestedField.optional(102, "string", Types.StringType.get())),
             Sets.newHashSet(101));
 
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field("int", DataTypes.INT().notNull())
-            .field("string", DataTypes.STRING().nullable())
-            .primaryKey("int")
-            .build();
-    Schema convertedSchema = FlinkSchemaUtil.convert(baseSchema, flinkSchema);
+    List<Column> columns = Lists.newArrayList();
+    Column intColumn = Column.physical("int", DataTypes.INT().notNull());
+    Column stringColumn = Column.physical("string", DataTypes.STRING().notNull());
+    columns.add(intColumn);
+    columns.add(stringColumn);
+    UniqueConstraint primaryKey = UniqueConstraint.primaryKey("name", Arrays.asList("int"));
+    ResolvedSchema projectedSchema =
+        new ResolvedSchema(columns, Collections.emptyList(), primaryKey);
+
+    Schema convertedSchema = FlinkSchemaUtil.convert(baseSchema, projectedSchema);
     Assert.assertEquals(baseSchema.asStruct(), convertedSchema.asStruct());
     Assert.assertEquals(ImmutableSet.of(101), convertedSchema.identifierFieldIds());
   }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -377,9 +376,10 @@ public class TestFlinkSchemaUtil {
 
     List<Column> columns = Lists.newArrayList();
     Column intColumn = Column.physical("int", DataTypes.INT().notNull());
-    Column stringColumn = Column.physical("string", DataTypes.STRING().notNull());
+    Column stringColumn = Column.physical("string", DataTypes.STRING().nullable());
     columns.add(intColumn);
     columns.add(stringColumn);
+
     UniqueConstraint primaryKey = UniqueConstraint.primaryKey("name", Arrays.asList("int"));
     ResolvedSchema projectedSchema =
         new ResolvedSchema(columns, Collections.emptyList(), primaryKey);
@@ -398,7 +398,7 @@ public class TestFlinkSchemaUtil {
                 Types.NestedField.required(2, "string", Types.StringType.get())),
             Sets.newHashSet(1, 2));
 
-    TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
+    ResolvedSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
     Assert.assertTrue(tableSchema.getPrimaryKey().isPresent());
     Assert.assertEquals(
         ImmutableSet.of("int", "string"),

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -270,7 +270,7 @@ public class TestFlinkSchemaUtil {
                             DataTypes.FIELD(
                                 "field_timestamp_with_local_time_zone",
                                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE())))
-                    .notNull()), /* Required */
+                    .nullable()), /* Required */
             Column.physical(
                 "list_map_fields",
                 DataTypes.ARRAY(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -145,7 +145,7 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
             "sourceTable",
             getTableEnv()
                 .fromValues(
-                    SimpleDataUtil.FLINK_SCHEMA.toRowDataType(),
+                    SimpleDataUtil.FLINK_SCHEMA.toPhysicalRowDataType(),
                     Expressions.row(1, "hello"),
                     Expressions.row(2, "world"),
                     Expressions.row(3, (String) null),

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Table;
@@ -208,7 +208,8 @@ public class TestCompressionSettings {
   }
 
   private static OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
-      Table icebergTable, TableSchema flinkSchema, Map<String, String> override) throws Exception {
+      Table icebergTable, ResolvedSchema flinkSchema, Map<String, String> override)
+      throws Exception {
     RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
     FlinkWriteConf flinkWriteConfig =
         new FlinkWriteConf(
@@ -226,7 +227,7 @@ public class TestCompressionSettings {
   }
 
   private static Map<String, String> appenderProperties(
-      Table table, TableSchema schema, Map<String, String> override) throws Exception {
+      Table table, ResolvedSchema schema, Map<String, String> override) throws Exception {
     try (OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness =
         createIcebergStreamWriter(table, schema, override)) {
       testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 1);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Row;
@@ -140,7 +140,7 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
     SimpleDataUtil.assertTableRows(table, convertToRowData(rows));
   }
 
-  private void testWriteRow(TableSchema tableSchema, DistributionMode distributionMode)
+  private void testWriteRow(ResolvedSchema tableSchema, DistributionMode distributionMode)
       throws Exception {
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBase.java
@@ -21,10 +21,12 @@ package org.apache.iceberg.flink.sink;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.SimpleDataUtil;
@@ -36,10 +38,11 @@ public class TestFlinkIcebergSinkBase {
   protected Table table;
   protected StreamExecutionEnvironment env;
   protected static final TypeInformation<Row> ROW_TYPE_INFO =
-      new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
+      new RowTypeInfo(Types.INT, Types.STRING);
 
   protected static final DataFormatConverters.RowConverter CONVERTER =
-      new DataFormatConverters.RowConverter(SimpleDataUtil.FLINK_SCHEMA.getFieldDataTypes());
+      new DataFormatConverters.RowConverter(
+          SimpleDataUtil.FLINK_SCHEMA.getColumnDataTypes().toArray(new DataType[2]));
 
   protected BoundedTestSource<Row> createBoundedSource(List<Row> rows) {
     return new BoundedTestSource<>(rows.toArray(new Row[0]));

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBranch.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkBranch.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.DistributionMode;
@@ -100,7 +100,7 @@ public class TestFlinkIcebergSinkBranch extends TestFlinkIcebergSinkBase {
     verifyOtherBranchUnmodified();
   }
 
-  private void testWriteRow(TableSchema tableSchema, DistributionMode distributionMode)
+  private void testWriteRow(ResolvedSchema tableSchema, DistributionMode distributionMode)
       throws Exception {
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Base.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2Base.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -49,7 +50,7 @@ public class TestFlinkIcebergSinkV2Base {
 
   protected static final int FORMAT_V2 = 2;
   protected static final TypeInformation<Row> ROW_TYPE_INFO =
-      new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
+      new RowTypeInfo(Types.INT, Types.STRING);
 
   protected static final int ROW_ID_POS = 0;
   protected static final int ROW_DATA_POS = 1;

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -27,7 +27,8 @@ import java.util.Set;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -308,12 +309,11 @@ public class TestIcebergStreamWriter {
             Types.NestedField.required(1, "tinyint", Types.IntegerType.get()),
             Types.NestedField.required(2, "smallint", Types.IntegerType.get()),
             Types.NestedField.optional(3, "int", Types.IntegerType.get()));
-    TableSchema flinkSchema =
-        TableSchema.builder()
-            .field("tinyint", DataTypes.TINYINT().notNull())
-            .field("smallint", DataTypes.SMALLINT().notNull())
-            .field("int", DataTypes.INT().nullable())
-            .build();
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("tinyint", DataTypes.TINYINT().notNull()),
+            Column.physical("smallint", DataTypes.SMALLINT().notNull()),
+            Column.physical("int", DataTypes.INT().nullable()));
 
     PartitionSpec spec;
     if (partitioned) {
@@ -369,7 +369,7 @@ public class TestIcebergStreamWriter {
   }
 
   private OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
-      Table icebergTable, TableSchema flinkSchema) throws Exception {
+      Table icebergTable, ResolvedSchema flinkSchema) throws Exception {
     RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
     FlinkWriteConf flinkWriteConfig =
         new FlinkWriteConf(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -231,7 +231,7 @@ public class TestTaskWriters {
     TaskWriterFactory<RowData> taskWriterFactory =
         new RowDataTaskWriterFactory(
             SerializableTable.copyOf(table),
-            (RowType) SimpleDataUtil.FLINK_SCHEMA.toRowDataType().getLogicalType(),
+            (RowType) SimpleDataUtil.FLINK_SCHEMA.toPhysicalRowDataType().getLogicalType(),
             targetFileSize,
             format,
             table.properties(),

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTableFactory.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTableFactory.java
@@ -31,7 +31,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -40,8 +40,9 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
@@ -68,8 +69,7 @@ public class BoundedTableFactory implements DynamicTableSourceFactory {
 
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
-    TableSchema tableSchema =
-        TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+    ResolvedSchema tableSchema = context.getCatalogTable().getResolvedSchema();
 
     Configuration configuration = Configuration.fromMap(context.getCatalogTable().getOptions());
     String dataId = configuration.getString(DATA_ID);
@@ -97,9 +97,9 @@ public class BoundedTableFactory implements DynamicTableSourceFactory {
   private static class BoundedTableSource implements ScanTableSource {
 
     private final List<List<Row>> elementsPerCheckpoint;
-    private final TableSchema tableSchema;
+    private final ResolvedSchema tableSchema;
 
-    private BoundedTableSource(List<List<Row>> elementsPerCheckpoint, TableSchema tableSchema) {
+    private BoundedTableSource(List<List<Row>> elementsPerCheckpoint, ResolvedSchema tableSchema) {
       this.elementsPerCheckpoint = elementsPerCheckpoint;
       this.tableSchema = tableSchema;
     }
@@ -140,13 +140,12 @@ public class BoundedTableFactory implements DynamicTableSourceFactory {
           boolean checkpointEnabled = env.getCheckpointConfig().isCheckpointingEnabled();
           SourceFunction<Row> source =
               new BoundedTestSource<>(elementsPerCheckpoint, checkpointEnabled);
-
-          RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
+          RowType rowType = (RowType) tableSchema.toPhysicalRowDataType().getLogicalType();
           // Converter to convert the Row to RowData.
           DataFormatConverters.RowConverter rowConverter =
-              new DataFormatConverters.RowConverter(tableSchema.getFieldDataTypes());
-
-          return env.addSource(source, new RowTypeInfo(tableSchema.getFieldTypes()))
+              new DataFormatConverters.RowConverter(
+                  tableSchema.getColumnDataTypes().toArray(new DataType[0]));
+          return env.addSource(source, new RowTypeInfo(InternalTypeInfo.of(rowType)))
               .map(rowConverter::toInternal, FlinkCompatibilityUtil.toTypeInfo(rowType));
         }
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
@@ -25,7 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.FileFormat;
@@ -85,11 +86,11 @@ public class TestFlinkInputFormat extends TestFlinkSource {
     // The Flink SQL output: [f2, data]
     // The FlinkInputFormat output: [nested[f2], data]
 
-    TableSchema projectedSchema =
-        TableSchema.builder()
-            .field("nested", DataTypes.ROW(DataTypes.FIELD("f2", DataTypes.STRING())))
-            .field("data", DataTypes.STRING())
-            .build();
+    ResolvedSchema projectedSchema =
+        ResolvedSchema.of(
+            Column.physical("nested", DataTypes.ROW(DataTypes.FIELD("f2", DataTypes.STRING()))),
+            Column.physical("data", DataTypes.STRING()));
+
     List<Row> result =
         runFormat(
             FlinkSource.forRowData()
@@ -120,11 +121,10 @@ public class TestFlinkInputFormat extends TestFlinkSource {
     List<Record> writeRecords = RandomGenericData.generate(writeSchema, 2, 0L);
     new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER).appendToTable(writeRecords);
 
-    TableSchema projectedSchema =
-        TableSchema.builder()
-            .field("id", DataTypes.BIGINT())
-            .field("data", DataTypes.STRING())
-            .build();
+    ResolvedSchema projectedSchema =
+        ResolvedSchema.of(
+            Column.physical("id", DataTypes.BIGINT()), Column.physical("data", DataTypes.STRING()));
+
     List<Row> result =
         runFormat(
             FlinkSource.forRowData()
@@ -166,10 +166,11 @@ public class TestFlinkInputFormat extends TestFlinkSource {
       appender.appendToTable(partition, Collections.singletonList(record));
     }
 
-    TableSchema projectedSchema =
-        TableSchema.builder()
-            .field("struct", DataTypes.ROW(DataTypes.FIELD("innerName", DataTypes.STRING())))
-            .build();
+    ResolvedSchema projectedSchema =
+        ResolvedSchema.of(
+            Column.physical(
+                "struct", DataTypes.ROW(DataTypes.FIELD("innerName", DataTypes.STRING()))));
+
     List<Row> result =
         runFormat(
             FlinkSource.forRowData()

--- a/python/mkdocs/docs/api.md
+++ b/python/mkdocs/docs/api.md
@@ -28,7 +28,7 @@ catalog:
     credential: t-1234:secret
 ```
 
-These info must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` directory or in the `$PYICEBERG_HOME` directory (if var is set).
+This information must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively) or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
 
 For more details on possible configurations refer to the [specific page](https://py.iceberg.apache.org/configuration/).
 

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -26,7 +26,6 @@ PYICEBERG = "pyiceberg_"
 DEFAULT = "default"
 CATALOG = "catalog"
 DEFAULT_CATALOG = f"{DEFAULT}-{CATALOG}"
-HOME = "HOME"
 PYICEBERG_HOME = "PYICEBERG_HOME"
 PYICEBERG_YML = ".pyiceberg.yaml"
 
@@ -75,7 +74,7 @@ class Config:
 
         def _load_yaml(directory: Optional[str]) -> Optional[RecursiveDict]:
             if directory:
-                path = f"{directory.rstrip('/')}/{PYICEBERG_YML}"
+                path = os.path.join(directory, PYICEBERG_YML)
                 if os.path.isfile(path):
                     with open(path, encoding="utf-8") as f:
                         file_config = yaml.safe_load(f)
@@ -87,7 +86,7 @@ class Config:
         if pyiceberg_home_config := _load_yaml(os.environ.get(PYICEBERG_HOME)):
             return pyiceberg_home_config
         # Look into the home directory
-        if pyiceberg_home_config := _load_yaml(os.environ.get(HOME)):
+        if pyiceberg_home_config := _load_yaml(os.path.expanduser("~")):
             return pyiceberg_home_config
         # Didn't find a config
         return None

--- a/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.3/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -160,6 +160,7 @@ transformArgument
 expression
     : constant
     | stringMap
+    | stringArray
     ;
 
 constant
@@ -171,6 +172,10 @@ constant
 
 stringMap
     : MAP '(' constant (',' constant)* ')'
+    ;
+
+stringArray
+    : ARRAY '(' constant (',' constant)* ')'
     ;
 
 booleanValue
@@ -274,6 +279,7 @@ TRUE: 'TRUE';
 FALSE: 'FALSE';
 
 MAP: 'MAP';
+ARRAY: 'ARRAY';
 
 PLUS: '+';
 MINUS: '-';

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCreateChangelogViewProcedure.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.ChangelogOperation;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkReadOptions;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCreateChangelogViewProcedure extends SparkExtensionsTestBase {
+  private static final String DELETE = ChangelogOperation.DELETE.name();
+  private static final String INSERT = ChangelogOperation.INSERT.name();
+  private static final String UPDATE_BEFORE = ChangelogOperation.UPDATE_BEFORE.name();
+  private static final String UPDATE_AFTER = ChangelogOperation.UPDATE_AFTER.name();
+
+  public TestCreateChangelogViewProcedure(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  public void createTableWith2Columns() {
+    sql("CREATE TABLE %s (id INT, data STRING) USING iceberg", tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='%d')", tableName, 1);
+    sql("ALTER TABLE %s ADD PARTITION FIELD data", tableName);
+  }
+
+  private void createTableWith3Columns() {
+    sql("CREATE TABLE %s (id INT, data STRING, age INT) USING iceberg", tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='%d')", tableName, 1);
+    sql("ALTER TABLE %s ADD PARTITION FIELD id", tableName);
+  }
+
+  private void createTableWithIdentifierField() {
+    sql("CREATE TABLE %s (id INT NOT NULL, data STRING) USING iceberg", tableName);
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='%d')", tableName, 1);
+    sql("ALTER TABLE %s SET IDENTIFIER FIELDS id", tableName);
+  }
+
+  @Test
+  public void testCustomizedViewName() {
+    createTableWith2Columns();
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (-2, 'b')", tableName);
+
+    table.refresh();
+
+    Snapshot snap2 = table.currentSnapshot();
+
+    sql(
+        "CALL %s.system.create_changelog_view("
+            + "table => '%s',"
+            + "options => map('%s','%s','%s','%s'),"
+            + "changelog_view => '%s')",
+        catalogName,
+        tableName,
+        SparkReadOptions.START_SNAPSHOT_ID,
+        snap1.snapshotId(),
+        SparkReadOptions.END_SNAPSHOT_ID,
+        snap2.snapshotId(),
+        "cdc_view");
+
+    long rowCount = sql("select * from %s", "cdc_view").stream().count();
+    Assert.assertEquals(2, rowCount);
+  }
+
+  @Test
+  public void testNoSnapshotIdInput() {
+    createTableWith2Columns();
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap0 = table.currentSnapshot();
+
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (-2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(" + "table => '%s')",
+            catalogName, tableName, "cdc_view");
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap0.snapshotId()),
+            row(2, "b", INSERT, 1, snap1.snapshotId()),
+            row(-2, "b", INSERT, 2, snap2.snapshotId()),
+            row(2, "b", DELETE, 2, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id", viewName));
+  }
+
+  @Test
+  public void testTimestampsBasedQuery() {
+    createTableWith2Columns();
+    long beginning = System.currentTimeMillis();
+
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap0 = table.currentSnapshot();
+    long afterFirstInsert = waitUntilAfter(snap0.timestampMillis());
+
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (-2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    long afterInsertOverwrite = waitUntilAfter(snap2.timestampMillis());
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', "
+                + "options => map('%s', '%s','%s', '%s'))",
+            catalogName,
+            tableName,
+            SparkReadOptions.START_TIMESTAMP,
+            beginning,
+            SparkReadOptions.END_TIMESTAMP,
+            afterInsertOverwrite);
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap0.snapshotId()),
+            row(2, "b", INSERT, 1, snap1.snapshotId()),
+            row(-2, "b", INSERT, 2, snap2.snapshotId()),
+            row(2, "b", DELETE, 2, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
+
+    // query the timestamps starting from the second insert
+    returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', "
+                + "options => map('%s', '%s', '%s', '%s'))",
+            catalogName,
+            tableName,
+            SparkReadOptions.START_TIMESTAMP,
+            afterFirstInsert,
+            SparkReadOptions.END_TIMESTAMP,
+            afterInsertOverwrite);
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(-2, "b", INSERT, 1, snap2.snapshotId()),
+            row(2, "b", DELETE, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id", returns.get(0)[0]));
+  }
+
+  @Test
+  public void testWithCarryovers() {
+    createTableWith2Columns();
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap0 = table.currentSnapshot();
+
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (-2, 'b'), (2, 'b'), (2, 'b')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view("
+                + "remove_carryovers => false,"
+                + "table => '%s')",
+            catalogName, tableName, "cdc_view");
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap0.snapshotId()),
+            row(2, "b", INSERT, 1, snap1.snapshotId()),
+            row(-2, "b", INSERT, 2, snap2.snapshotId()),
+            row(2, "b", DELETE, 2, snap2.snapshotId()),
+            row(2, "b", INSERT, 2, snap2.snapshotId()),
+            row(2, "b", INSERT, 2, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, _change_type", viewName));
+  }
+
+  @Test
+  public void testUpdate() {
+    createTableWith2Columns();
+    sql("ALTER TABLE %s DROP PARTITION FIELD data", tableName);
+    sql("ALTER TABLE %s ADD PARTITION FIELD id", tableName);
+
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (3, 'c'), (2, 'd')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', identifier_columns => array('id'))",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", UPDATE_AFTER, 1, snap2.snapshotId()),
+            row(3, "c", INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testUpdateWithIdentifierField() {
+    createTableWithIdentifierField();
+
+    sql("INSERT INTO %s VALUES (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (3, 'c'), (2, 'd')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', compute_updates => true)",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", UPDATE_AFTER, 1, snap2.snapshotId()),
+            row(3, "c", INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testUpdateWithFilter() {
+    createTableWith2Columns();
+    sql("ALTER TABLE %s DROP PARTITION FIELD data", tableName);
+    sql("ALTER TABLE %s ADD PARTITION FIELD id", tableName);
+
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (3, 'c'), (2, 'd')", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view(table => '%s', identifier_columns => array('id'))",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", INSERT, 0, snap1.snapshotId()),
+            row(2, "b", UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", UPDATE_AFTER, 1, snap2.snapshotId())),
+        // the predicate on partition columns will filter out the insert of (3, 'c') at the planning
+        // phase
+        sql("select * from %s where id != 3 order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testUpdateWithMultipleIdentifierColumns() {
+    createTableWith3Columns();
+
+    sql("INSERT INTO %s VALUES (1, 'a', 12), (2, 'b', 11)", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    sql("INSERT OVERWRITE %s VALUES (3, 'c', 13), (2, 'd', 11), (2, 'e', 12)", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view("
+                + "identifier_columns => array('id','age'),"
+                + "table => '%s')",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", 11, UPDATE_AFTER, 1, snap2.snapshotId()),
+            row(2, "e", 12, INSERT, 1, snap2.snapshotId()),
+            row(3, "c", 13, INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testRemoveCarryOvers() {
+    createTableWith3Columns();
+
+    sql("INSERT INTO %s VALUES (1, 'a', 12), (2, 'b', 11), (2, 'e', 12)", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    // carry-over row (2, 'e', 12)
+    sql("INSERT OVERWRITE %s VALUES (3, 'c', 13), (2, 'd', 11), (2, 'e', 12)", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view("
+                + "identifier_columns => array('id','age'), "
+                + "table => '%s')",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+    // the carry-over rows (2, 'e', 12, 'DELETE', 1), (2, 'e', 12, 'INSERT', 1) are removed
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, INSERT, 0, snap1.snapshotId()),
+            row(2, "e", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, UPDATE_BEFORE, 1, snap2.snapshotId()),
+            row(2, "d", 11, UPDATE_AFTER, 1, snap2.snapshotId()),
+            row(3, "c", 13, INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testRemoveCarryOversWithoutUpdatedRows() {
+    createTableWith3Columns();
+
+    sql("INSERT INTO %s VALUES (1, 'a', 12), (2, 'b', 11), (2, 'e', 12)", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    // carry-over row (2, 'e', 12)
+    sql("INSERT OVERWRITE %s VALUES (3, 'c', 13), (2, 'd', 11), (2, 'e', 12)", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql("CALL %s.system.create_changelog_view(table => '%s')", catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+
+    // the carry-over rows (2, 'e', 12, 'DELETE', 1), (2, 'e', 12, 'INSERT', 1) are removed, even
+    // though update-row is not computed
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, INSERT, 0, snap1.snapshotId()),
+            row(2, "e", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, DELETE, 1, snap2.snapshotId()),
+            row(2, "d", 11, INSERT, 1, snap2.snapshotId()),
+            row(3, "c", 13, INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data", viewName));
+  }
+
+  @Test
+  public void testNotRemoveCarryOvers() {
+    createTableWith3Columns();
+
+    sql("INSERT INTO %s VALUES (1, 'a', 12), (2, 'b', 11), (2, 'e', 12)", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snap1 = table.currentSnapshot();
+
+    // carry-over row (2, 'e', 12)
+    sql("INSERT OVERWRITE %s VALUES (3, 'c', 13), (2, 'd', 11), (2, 'e', 12)", tableName);
+    table.refresh();
+    Snapshot snap2 = table.currentSnapshot();
+
+    List<Object[]> returns =
+        sql(
+            "CALL %s.system.create_changelog_view("
+                + "remove_carryovers => false,"
+                + "table => '%s')",
+            catalogName, tableName);
+
+    String viewName = (String) returns.get(0)[0];
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, "a", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, INSERT, 0, snap1.snapshotId()),
+            row(2, "e", 12, INSERT, 0, snap1.snapshotId()),
+            row(2, "b", 11, DELETE, 1, snap2.snapshotId()),
+            row(2, "d", 11, INSERT, 1, snap2.snapshotId()),
+            // the following two rows are carry-over rows
+            row(2, "e", 12, DELETE, 1, snap2.snapshotId()),
+            row(2, "e", 12, INSERT, 1, snap2.snapshotId()),
+            row(3, "c", 13, INSERT, 1, snap2.snapshotId())),
+        sql("select * from %s order by _change_ordinal, id, data, _change_type", viewName));
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.procedures;
 
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -31,6 +32,8 @@ import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -49,6 +52,7 @@ import scala.Option;
 abstract class BaseProcedure implements Procedure {
   protected static final DataType STRING_MAP =
       DataTypes.createMapType(DataTypes.StringType, DataTypes.StringType);
+  protected static final DataType STRING_ARRAY = DataTypes.createArrayType(DataTypes.StringType);
 
   private final SparkSession spark;
   private final TableCatalog tableCatalog;
@@ -142,6 +146,12 @@ abstract class BaseProcedure implements Procedure {
           String.format("Couldn't load table '%s' in catalog '%s'", ident, tableCatalog.name());
       throw new RuntimeException(errMsg, e);
     }
+  }
+
+  protected Dataset<Row> loadDataSetFromTable(Identifier tableIdent, Map<String, String> options) {
+    String tableName = Spark3Util.quotedFullIdentifier(tableCatalog().name(), tableIdent);
+    // no need to validate the read options here since the reader will validate them
+    return spark().read().options(options).table(tableName);
   }
 
   protected void refreshSparkCache(Identifier ident, Table table) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/CreateChangelogViewProcedure.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.procedures;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.ChangelogIterator;
+import org.apache.iceberg.spark.source.SparkChangelogTable;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+import scala.runtime.BoxedUnit;
+
+/**
+ * A procedure that creates a view for changed rows.
+ *
+ * <p>The procedure removes the carry-over rows by default. If you want to keep them, you can set
+ * "remove_carryovers" to be false in the options.
+ *
+ * <p>The procedure doesn't compute the pre/post update images by default. If you want to compute
+ * them, you can set "compute_updates" to be true in the options.
+ *
+ * <p>Carry-over rows are the result of a removal and insertion of the same row within an operation
+ * because of the copy-on-write mechanism. For example, given a file which contains row1 (id=1,
+ * data='a') and row2 (id=2, data='b'). A copy-on-write delete of row2 would require erasing this
+ * file and preserving row1 in a new file. The changelog table would report this as (id=1, data='a',
+ * op='DELETE') and (id=1, data='a', op='INSERT'), despite it not being an actual change to the
+ * table. The procedure finds the carry-over rows and removes them from the result.
+ *
+ * <p>Pre/post update images are converted from a pair of a delete row and an insert row. Identifier
+ * columns are used for determining whether an insert and a delete record refer to the same row. If
+ * the two records share the same values for the identity columns they are considered to be before
+ * and after states of the same row. You can either set identifier fields in the table schema or
+ * input them as the procedure parameters. Here is an example of pre/post update images with an
+ * identifier column(id). A pair of a delete row and an insert row with the same id:
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='DELETE')
+ *   <li>(id=1, data='b', op='INSERT')
+ * </ul>
+ *
+ * <p>will be marked as pre/post update images:
+ *
+ * <ul>
+ *   <li>(id=1, data='a', op='UPDATE_BEFORE')
+ *   <li>(id=1, data='b', op='UPDATE_AFTER')
+ * </ul>
+ */
+public class CreateChangelogViewProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS =
+      new ProcedureParameter[] {
+        ProcedureParameter.required("table", DataTypes.StringType),
+        ProcedureParameter.optional("changelog_view", DataTypes.StringType),
+        ProcedureParameter.optional("options", STRING_MAP),
+        ProcedureParameter.optional("compute_updates", DataTypes.BooleanType),
+        ProcedureParameter.optional("remove_carryovers", DataTypes.BooleanType),
+        ProcedureParameter.optional("identifier_columns", STRING_ARRAY),
+      };
+
+  private static final int TABLE_NAME_ORDINAL = 0;
+  private static final int CHANGELOG_VIEW_NAME_ORDINAL = 1;
+  private static final int OPTIONS_ORDINAL = 2;
+  private static final int COMPUTE_UPDATES_ORDINAL = 3;
+  private static final int REMOVE_CARRYOVERS_ORDINAL = 4;
+  private static final int IDENTIFIER_COLUMNS_ORDINAL = 5;
+
+  private static final StructType OUTPUT_TYPE =
+      new StructType(
+          new StructField[] {
+            new StructField("changelog_view", DataTypes.StringType, false, Metadata.empty())
+          });
+
+  public static SparkProcedures.ProcedureBuilder builder() {
+    return new BaseProcedure.Builder<CreateChangelogViewProcedure>() {
+      @Override
+      protected CreateChangelogViewProcedure doBuild() {
+        return new CreateChangelogViewProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private CreateChangelogViewProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    Identifier tableIdent =
+        toIdentifier(args.getString(TABLE_NAME_ORDINAL), PARAMETERS[TABLE_NAME_ORDINAL].name());
+
+    // load insert and deletes from the changelog table
+    Identifier changelogTableIdent = changelogTableIdent(tableIdent);
+    Dataset<Row> df = loadDataSetFromTable(changelogTableIdent, options(args));
+
+    if (shouldComputeUpdateImages(args)) {
+      df = computeUpdateImages(identifierColumns(args, tableIdent), df);
+    } else if (shouldRemoveCarryoverRows(args)) {
+      df = removeCarryoverRows(df);
+    }
+
+    String viewName = viewName(args, tableIdent.name());
+
+    df.createOrReplaceTempView(viewName);
+
+    return toOutputRows(viewName);
+  }
+
+  private Dataset<Row> computeUpdateImages(String[] identifierColumns, Dataset<Row> df) {
+    Preconditions.checkArgument(
+        identifierColumns.length > 0,
+        "Cannot compute the update-rows because identifier columns are not set");
+
+    Column[] repartitionColumns = new Column[identifierColumns.length + 1];
+    for (int i = 0; i < identifierColumns.length; i++) {
+      repartitionColumns[i] = df.col(identifierColumns[i]);
+    }
+    repartitionColumns[repartitionColumns.length - 1] =
+        df.col(MetadataColumns.CHANGE_ORDINAL.name());
+
+    return applyChangelogIterator(df, repartitionColumns);
+  }
+
+  private boolean shouldComputeUpdateImages(InternalRow args) {
+    if (!args.isNullAt(COMPUTE_UPDATES_ORDINAL)) {
+      return args.getBoolean(COMPUTE_UPDATES_ORDINAL);
+    } else {
+      // If the identifier columns are set, we compute pre/post update images by default.
+      return !args.isNullAt(IDENTIFIER_COLUMNS_ORDINAL);
+    }
+  }
+
+  private boolean shouldRemoveCarryoverRows(InternalRow args) {
+    if (args.isNullAt(REMOVE_CARRYOVERS_ORDINAL)) {
+      return true;
+    } else {
+      return args.getBoolean(REMOVE_CARRYOVERS_ORDINAL);
+    }
+  }
+
+  private Dataset<Row> removeCarryoverRows(Dataset<Row> df) {
+    Column[] repartitionColumns =
+        Arrays.stream(df.columns())
+            .filter(c -> !c.equals(MetadataColumns.CHANGE_TYPE.name()))
+            .map(df::col)
+            .toArray(Column[]::new);
+    return applyChangelogIterator(df, repartitionColumns);
+  }
+
+  private String[] identifierColumns(InternalRow args, Identifier tableIdent) {
+    if (!args.isNullAt(IDENTIFIER_COLUMNS_ORDINAL)) {
+      return Arrays.stream(args.getArray(IDENTIFIER_COLUMNS_ORDINAL).array())
+          .map(column -> column.toString())
+          .toArray(String[]::new);
+    } else {
+      Table table = loadSparkTable(tableIdent).table();
+      return table.schema().identifierFieldNames().toArray(new String[0]);
+    }
+  }
+
+  private Identifier changelogTableIdent(Identifier tableIdent) {
+    List<String> namespace = Lists.newArrayList();
+    namespace.addAll(Arrays.asList(tableIdent.namespace()));
+    namespace.add(tableIdent.name());
+    return Identifier.of(namespace.toArray(new String[0]), SparkChangelogTable.TABLE_NAME);
+  }
+
+  private Map<String, String> options(InternalRow args) {
+    Map<String, String> options = Maps.newHashMap();
+
+    if (!args.isNullAt(OPTIONS_ORDINAL)) {
+      args.getMap(OPTIONS_ORDINAL)
+          .foreach(
+              DataTypes.StringType,
+              DataTypes.StringType,
+              (k, v) -> {
+                options.put(k.toString(), v.toString());
+                return BoxedUnit.UNIT;
+              });
+    }
+
+    return options;
+  }
+
+  private static String viewName(InternalRow args, String tableName) {
+    if (args.isNullAt(CHANGELOG_VIEW_NAME_ORDINAL)) {
+      return String.format("`%s_changes`", tableName);
+    } else {
+      return args.getString(CHANGELOG_VIEW_NAME_ORDINAL);
+    }
+  }
+
+  private Dataset<Row> applyChangelogIterator(Dataset<Row> df, Column[] repartitionColumns) {
+    Column[] sortSpec = sortSpec(df, repartitionColumns);
+    StructType schema = df.schema();
+    String[] identifierFields =
+        Arrays.stream(repartitionColumns).map(Column::toString).toArray(String[]::new);
+
+    return df.repartition(repartitionColumns)
+        .sortWithinPartitions(sortSpec)
+        .mapPartitions(
+            (MapPartitionsFunction<Row, Row>)
+                rowIterator -> ChangelogIterator.create(rowIterator, schema, identifierFields),
+            RowEncoder.apply(schema));
+  }
+
+  private static Column[] sortSpec(Dataset<Row> df, Column[] repartitionSpec) {
+    Column[] sortSpec = new Column[repartitionSpec.length + 1];
+    System.arraycopy(repartitionSpec, 0, sortSpec, 0, repartitionSpec.length);
+    sortSpec[sortSpec.length - 1] = df.col(MetadataColumns.CHANGE_TYPE.name());
+    return sortSpec;
+  }
+
+  private InternalRow[] toOutputRows(String viewName) {
+    InternalRow row = newInternalRow(UTF8String.fromString(viewName));
+    return new InternalRow[] {row};
+  }
+
+  @Override
+  public String description() {
+    return "CreateChangelogViewProcedure";
+  }
+}

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -53,6 +53,7 @@ public class SparkProcedures {
     mapBuilder.put("ancestors_of", AncestorsOfProcedure::builder);
     mapBuilder.put("register_table", RegisterTableProcedure::builder);
     mapBuilder.put("publish_changes", PublishChangesProcedure::builder);
+    mapBuilder.put("create_changelog_view", CreateChangelogViewProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
### Background

Flink1.16 `TableSchema` is Deprecated

```
This class has been deprecated as part of FLIP-164.
It has been replaced by two more dedicated classes `Schema` and `ResolvedSchema`.
Use Schema for declaration in APIs. 
ResolvedSchema is offered by the framework after resolution and validation.
```

Some methods have been marked by `Flink` as methods to be deleted, We should implement our code according to the method recommended by `Flink`.

TypeConversions#fromDataTypeToLegacyInfo

```
 /**
   * @deprecated Please don't use this method anymore. It will be removed soon and we should not
   *     make the removal more painful. Sources and sinks should use the method available in
   *     context to convert, within the planner you should use either {@code InternalTypeInfo} or
   *     {@code ExternalTypeInfo} depending on the use case.
   */
@Deprecated
public static TypeInformation<?>[] fromDataTypeToLegacyInfo(DataType[] dataType) {
    return Stream.of(dataType)
           .map(TypeConversions::fromDataTypeToLegacyInfo)
           .toArray(TypeInformation[]::new);
}
```

In This PR,  I will use `ResolvedSchema` to replace `TableSchema`.
Modifications Include:
1. Contains the method of tableSchema.
2. Junit Test.
3. Comment.
4. Link references.
