### PR TITLE
Build: Show API Deprecation rules on RevAPI failure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,26 @@ subprojects {
       oldName = project.name
       oldVersion = "1.1.0"
     }
+
+    tasks.register('showDeprecationRulesOnRevApiFailure') {
+      doLast {
+        throw new RuntimeException("==================================================================================" +
+                "\nAPI/ABI breaks detected.\n" +
+                "Adding RevAPI breaks should only be done after going through a deprecation cycle." +
+                "\nPlease make sure to follow the deprecation rules defined in\n" +
+                "https://github.com/apache/iceberg/blob/master/CONTRIBUTING.md#semantic-versioning.\n" +
+                "==================================================================================")
+      }
+      onlyIf {
+        tasks.revapi.state.failure != null
+      }
+    }
+
+    tasks.configureEach { rootTask ->
+      if (rootTask.name == 'revapi') {
+        rootTask.finalizedBy showDeprecationRulesOnRevApiFailure
+      }
+    }
   }
 
   configurations {


### PR DESCRIPTION
The main reasoning behind this change is to make people more aware of the API guarantees that the Iceberg project defined as part of https://github.com/apache/iceberg/blob/master/CONTRIBUTING.md#semantic-versioning.

Once RevAPI fails, we also point people to the API Deprecation rules via the `showDeprecationRulesOnRevApiFailure` task. 

Below is an example of the output that users would see (I've introduced an artificial API break so that RevAPI complains about it):
 
```
./gradlew revapi                                                                                                                                                                                                                                             1 ↵ ──(Fri,Mar03)─┘
> Task :iceberg-api:revapi FAILED
> Task :iceberg-api:showDeprecationRulesOnRevApiFailure FAILED

FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':iceberg-api:revapi'.
> There were Java public API/ABI breaks reported by revapi:
  
  java.method.addedToInterface: Method was added to an interface.
  
  old: <none>
  new: method void org.apache.iceberg.catalog.SessionCatalog::createTransaction()
  
  SOURCE: BREAKING, BINARY: NON_BREAKING, SEMANTIC: POTENTIALLY_BREAKING
  
  From old archive: <none>
  From new archive: iceberg-api-1.2.0-SNAPSHOT.jar
  
  If this is an acceptable break that will not harm your users, you can ignore it in future runs like so for:
  
    * Just this break:
        ./gradlew :iceberg-api:revapiAcceptBreak --justification "{why this break is ok}" \
          --code "java.method.addedToInterface" \
          --new "method void org.apache.iceberg.catalog.SessionCatalog::createTransaction()"
    * All breaks in this project:
        ./gradlew :iceberg-api:revapiAcceptAllBreaks --justification "{why this break is ok}"
    * All breaks in all projects:
        ./gradlew revapiAcceptAllBreaks --justification "{why this break is ok}"
  ----------------------------------------------------------------------------------------------------


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================

2: Task failed with an exception.
-----------
* Where:
Build file '/home/nastra/Development/workspace/iceberg/build.gradle' line: 131

* What went wrong:
Execution failed for task ':iceberg-api:showDeprecationRulesOnRevApiFailure'.
> ==================================================================================
  API/ABI breaks detected.
  Adding RevAPI breaks should only be done after going through a deprecation cycle.
  Please make sure to follow the deprecation rules defined in
  https://github.com/apache/iceberg/blob/master/CONTRIBUTING.md#semantic-versioning.
  ==================================================================================
```