### PR TITLE
Python: fix config loading on windows

### DIFF
--- a/python/mkdocs/docs/api.md
+++ b/python/mkdocs/docs/api.md
@@ -28,7 +28,7 @@ catalog:
     credential: t-1234:secret
 ```
 
-This information must be placed inside a file called .pyiceberg.yaml located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively) or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
+This information must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively) or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
 
 For more details on possible configurations refer to the [specific page](https://py.iceberg.apache.org/configuration/).
 

--- a/python/mkdocs/docs/api.md
+++ b/python/mkdocs/docs/api.md
@@ -28,7 +28,7 @@ catalog:
     credential: t-1234:secret
 ```
 
-These info must be placed inside a file called `.pyiceberg.yaml` located either in the `$HOME` directory or in the `$PYICEBERG_HOME` directory (if var is set).
+This information must be placed inside a file called .pyiceberg.yaml located either in the `$HOME` or `%USERPROFILE%` directory (depending on whether the operating system is Unix-based or Windows-based, respectively) or in the `$PYICEBERG_HOME` directory (if the corresponding environment variable is set).
 
 For more details on possible configurations refer to the [specific page](https://py.iceberg.apache.org/configuration/).
 

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -86,7 +86,7 @@ class Config:
         if pyiceberg_home_config := _load_yaml(os.environ.get(PYICEBERG_HOME)):
             return pyiceberg_home_config
         # Look into the home directory
-        if pyiceberg_home_config := _load_yaml(os.path.expanduser('~')):
+        if pyiceberg_home_config := _load_yaml(os.path.expanduser("~")):
             return pyiceberg_home_config
         # Didn't find a config
         return None

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -26,10 +26,7 @@ PYICEBERG = "pyiceberg_"
 DEFAULT = "default"
 CATALOG = "catalog"
 DEFAULT_CATALOG = f"{DEFAULT}-{CATALOG}"
-if os.name == 'nt':
-    HOME = "USERPROFILE"
-else:
-    HOME = "HOME"
+HOME = os.path.expanduser('~')
 PYICEBERG_HOME = "PYICEBERG_HOME"
 PYICEBERG_YML = ".pyiceberg.yaml"
 

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -26,7 +26,6 @@ PYICEBERG = "pyiceberg_"
 DEFAULT = "default"
 CATALOG = "catalog"
 DEFAULT_CATALOG = f"{DEFAULT}-{CATALOG}"
-HOME = os.path.expanduser('~')
 PYICEBERG_HOME = "PYICEBERG_HOME"
 PYICEBERG_YML = ".pyiceberg.yaml"
 
@@ -75,7 +74,7 @@ class Config:
 
         def _load_yaml(directory: Optional[str]) -> Optional[RecursiveDict]:
             if directory:
-                path = f"{directory.rstrip('/')}/{PYICEBERG_YML}"
+                path = os.path.join(directory, PYICEBERG_YML)
                 if os.path.isfile(path):
                     with open(path, encoding="utf-8") as f:
                         file_config = yaml.safe_load(f)
@@ -87,7 +86,7 @@ class Config:
         if pyiceberg_home_config := _load_yaml(os.environ.get(PYICEBERG_HOME)):
             return pyiceberg_home_config
         # Look into the home directory
-        if pyiceberg_home_config := _load_yaml(os.environ.get(HOME)):
+        if pyiceberg_home_config := _load_yaml(os.path.expanduser('~')):
             return pyiceberg_home_config
         # Didn't find a config
         return None

--- a/python/pyiceberg/utils/config.py
+++ b/python/pyiceberg/utils/config.py
@@ -26,7 +26,10 @@ PYICEBERG = "pyiceberg_"
 DEFAULT = "default"
 CATALOG = "catalog"
 DEFAULT_CATALOG = f"{DEFAULT}-{CATALOG}"
-HOME = "HOME"
+if os.name == 'nt':
+    HOME = "USERPROFILE"
+else:
+    HOME = "HOME"
 PYICEBERG_HOME = "PYICEBERG_HOME"
 PYICEBERG_YML = ".pyiceberg.yaml"
 


### PR DESCRIPTION
The .pyiceberg.yaml file located in the %USERPROFILE% folder on Windows could not be loaded previously. This pull request addresses the issue and enables successful loading of the file.

And fixes the issue #7001.