### PR TITLE
Core: Add initialize method for MetricsReporter

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
@@ -18,9 +18,20 @@
  */
 package org.apache.iceberg.metrics;
 
+import java.util.Map;
+
 /** This interface defines the basic API for reporting metrics for operations to a Table. */
 @FunctionalInterface
 public interface MetricsReporter {
+
+  /**
+   * A custom MetricsReporter implementation must have a no-arg constructor, which will be called
+   * first. {@link MetricsReporter#initialize(Map properties)} is called to complete the
+   * initialization.
+   *
+   * @param properties properties
+   */
+  default void initialize(Map<String, String> properties) {}
 
   /**
    * Indicates that an operation is done by reporting a {@link MetricsReport}. A {@link

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -308,11 +307,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
   private MetricsReporter metricsReporter() {
     if (metricsReporter == null) {
-      metricsReporter =
-          properties().containsKey(CatalogProperties.METRICS_REPORTER_IMPL)
-              ? CatalogUtil.loadMetricsReporter(
-                  properties().get(CatalogProperties.METRICS_REPORTER_IMPL))
-              : LoggingMetricsReporter.instance();
+      metricsReporter = CatalogUtil.loadMetricsReporter(properties());
     }
 
     return metricsReporter;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -57,7 +57,6 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.ResolvingFileIO;
-import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -198,11 +197,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
                     mergedProps, REST_SNAPSHOT_LOADING_MODE, SnapshotMode.ALL.name())
                 .toUpperCase(Locale.US));
 
-    String metricsReporterImpl = mergedProps.get(CatalogProperties.METRICS_REPORTER_IMPL);
-    this.reporter =
-        null != metricsReporterImpl
-            ? CatalogUtil.loadMetricsReporter(metricsReporterImpl)
-            : LoggingMetricsReporter.instance();
+    this.reporter = CatalogUtil.loadMetricsReporter(mergedProps);
 
     this.reportingViaRestEnabled =
         PropertyUtil.propertyAsBoolean(mergedProps, REST_METRICS_REPORTING_ENABLED, true);

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -193,16 +194,21 @@ public class TestCatalogUtil {
   public void loadCustomMetricsReporter_noArg() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put("key", "val");
+    properties.put(
+        CatalogProperties.METRICS_REPORTER_IMPL, TestMetricsReporterDefault.class.getName());
 
-    MetricsReporter metricsReporter =
-        CatalogUtil.loadMetricsReporter(TestMetricsReporterDefault.class.getName());
+    MetricsReporter metricsReporter = CatalogUtil.loadMetricsReporter(properties);
     Assertions.assertThat(metricsReporter).isInstanceOf(TestMetricsReporterDefault.class);
   }
 
   @Test
   public void loadCustomMetricsReporter_badArg() {
     Assertions.assertThatThrownBy(
-            () -> CatalogUtil.loadMetricsReporter(TestMetricsReporterBadArg.class.getName()))
+            () ->
+                CatalogUtil.loadMetricsReporter(
+                    ImmutableMap.of(
+                        CatalogProperties.METRICS_REPORTER_IMPL,
+                        TestMetricsReporterBadArg.class.getName())))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("missing no-arg constructor");
   }
@@ -210,7 +216,11 @@ public class TestCatalogUtil {
   @Test
   public void loadCustomMetricsReporter_badClass() {
     Assertions.assertThatThrownBy(
-            () -> CatalogUtil.loadMetricsReporter(TestFileIONotImpl.class.getName()))
+            () ->
+                CatalogUtil.loadMetricsReporter(
+                    ImmutableMap.of(
+                        CatalogProperties.METRICS_REPORTER_IMPL,
+                        TestFileIONotImpl.class.getName())))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("does not implement MetricsReporter");
   }


### PR DESCRIPTION
A custom MetricsReporter implementation must have a no-arg constructor, but in some case , custom metrics reporter may need args , initialize method will be called after no-arg constructor,  then the reporter can get args through catalog properties