### PR TITLE
Make `TableMetadataParser.fromJson` taking `JsonNode` public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -299,7 +299,7 @@ public class TableMetadataParser {
     return JsonUtil.parse(json, node -> TableMetadataParser.fromJson(metadataLocation, node));
   }
 
-  static TableMetadata fromJson(InputFile file, JsonNode node) {
+  public static TableMetadata fromJson(InputFile file, JsonNode node) {
     return fromJson(file.location(), node);
   }
 
@@ -308,7 +308,7 @@ public class TableMetadataParser {
   }
 
   @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
-  static TableMetadata fromJson(String metadataLocation, JsonNode node) {
+  public static TableMetadata fromJson(String metadataLocation, JsonNode node) {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse metadata from a non-object: %s", node);
 


### PR DESCRIPTION
In the WIP for the Nessie Iceberg REST catalog server, there are a few places that currently require us to first serialize a `TableMetadata` to a `String` just to parse it right back into a `TableMetadata`, but this time with the right metadata-location.

First occurence is when we write the table metadata, where we have to first store the table metadata, get the metadata location, and then return the table metadata with the metadata location (and updates cleared). Second occurence is when we return a table metadata with "transient properties", which are used to pass the "expected Nessie commit" around.

This change makes the two `TableMetadataParser.fromJson()` taking a `JsonNode` public