### PR TITLE
Core: reduce scale factor for HadoopFileIOTest prefix tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -62,7 +62,7 @@ public class HadoopFileIOTest {
   public void testListPrefix() {
     Path parent = new Path(tempDir.toURI());
 
-    List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
+    List<Integer> scaleSizes = Lists.newArrayList(1, 5, 500);
 
     scaleSizes
         .parallelStream()
@@ -98,7 +98,7 @@ public class HadoopFileIOTest {
   public void testDeletePrefix() {
     Path parent = new Path(tempDir.toURI());
 
-    List<Integer> scaleSizes = Lists.newArrayList(1, 1000, 2500);
+    List<Integer> scaleSizes = Lists.newArrayList(1, 5, 500);
 
     scaleSizes
         .parallelStream()


### PR DESCRIPTION
When running these tests, I notice it's taking a long time locally. I tried a few combinations

Current scale factors: 2 min 25 seconds
scale factors (1, 10, 1000): 46 seconds
scale factors (1, 5, 500): 24 seconds

Could we reduce the scale factor to (1, 5, 500)? It seems sufficient to me for the operation to run for half a minute for testing purpose. Is there anything that we need to test only in 2500 scale factor?

@edgarRd @danielcweeks 