### PR TITLE
REST: Set metadata location for lazy load snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -324,6 +324,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
     if (snapshotMode == SnapshotMode.REFS) {
       tableMetadata =
           TableMetadata.buildFrom(response.tableMetadata())
+              .withMetadataLocation(response.metadataLocation())
               .setSnapshotsSupplier(
                   () ->
                       loadInternal(context, identifier, SnapshotMode.ALL)


### PR DESCRIPTION
When lazy snapshot loading is being used, the metadata from the response is modified to set a snapshot supplier. However, the metadata location is not set, and this has a secondary effect of not building a new metadata object. Thus the supplier is never set, and the full snapshot list is never retrieved.

This PR sets the metadata location, so a new metadata object is built with the snapshot supplier and the location set.