### PR TITLE
Update Nessie tests to work with enforced namespaces

### DIFF
--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.nessie;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.avro.generic.GenericRecordBuilder;
@@ -455,6 +456,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
     Namespace namespace = Namespace.of("a", "b");
     Assertions.assertThat(nessieCatalog.listNamespaces(namespace)).isEmpty();
 
+    createMissingNamespaces(nessieCatalog, Namespace.of(Arrays.copyOf(namespace.levels(), namespace.length() - 1)));
     nessieCatalog.createNamespace(namespace);
     Assertions.assertThat(nessieCatalog.listNamespaces(namespace)).isNotEmpty();
     Assertions.assertThat(nessieCatalog.listTables(namespace)).isEmpty();
@@ -503,10 +505,13 @@ public class TestBranchVisibility extends BaseTestIceberg {
     TableIdentifier identifier = TableIdentifier.of("db", "table1");
 
     NessieCatalog nessieCatalog = initCatalog(branch1);
+
+    createMissingNamespaces(nessieCatalog, identifier);
     Table table1 = nessieCatalog.createTable(identifier, schema1);
     Assertions.assertThat(table1.schema().asStruct()).isEqualTo(schema1.asStruct());
 
     nessieCatalog = initCatalog(branch2);
+    createMissingNamespaces(nessieCatalog, identifier);
     Table table2 = nessieCatalog.createTable(identifier, schema2);
     Assertions.assertThat(table2.schema().asStruct()).isEqualTo(schema2.asStruct());
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java
@@ -135,6 +135,16 @@ public class TestNessieCatalog extends CatalogTests<NessieCatalog> {
   }
 
   @Override
+  protected boolean requiresNamespaceCreate() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsNestedNamespaces() {
+    return true;
+  }
+
+  @Override
   protected boolean supportsNamespaceProperties() {
     return true;
   }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -94,7 +94,7 @@ public class TestNessieTable extends BaseTestIceberg {
       throws IOException {
     super.beforeEach(clientFactory, nessieUri);
     this.tableLocation =
-        catalog.createTable(TABLE_IDENTIFIER, schema).location().replaceFirst("file:", "");
+        createTable(TABLE_IDENTIFIER, schema).location().replaceFirst("file:", "");
   }
 
   @Override
@@ -326,6 +326,7 @@ public class TestNessieTable extends BaseTestIceberg {
     Assertions.assertThat(log)
         .isNotNull()
         .isNotEmpty()
+        .filteredOn(e -> !e.getCommitMeta().getMessage().startsWith("create namespace "))
         .allSatisfy(
             logEntry -> {
               CommitMeta commit = logEntry.getCommitMeta();
@@ -418,6 +419,7 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   private void validateRegister(TableIdentifier identifier, String metadataVersionFiles) {
+    createMissingNamespaces(identifier);
     Assertions.assertThat(catalog.registerTable(identifier, "file:" + metadataVersionFiles))
         .isNotNull();
     Table newTable = catalog.loadTable(identifier);


### PR DESCRIPTION
Nessie will enforce the existence of (parent) namespaces. This PR updates the Nessie related tests to ensure that behavior..
