### PR TITLE
Core: Allow customizing FileIO in REST catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -122,9 +122,9 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     }
   }
 
-  public void setFileIOBuilder(Function<Map<String, String>, FileIO> ioBuilder) {
+  public void setFileIOBuilder(Function<Map<String, String>, FileIO> newIOBuilder) {
     Preconditions.checkState(null == io, "Cannot set IO builder after calling initialize");
-    this.ioBuilder = ioBuilder;
+    this.ioBuilder = newIOBuilder;
   }
 
   private void initializeCatalogTables() throws InterruptedException, SQLException {

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -75,7 +75,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
   private Object conf;
   private JdbcClientPool connections;
   private Map<String, String> catalogProperties;
-  private Function<Map<String, String>, FileIO> ioBuilder;
+  private Function<Map<String, String>, FileIO> ioBuilder = null;
 
   public JdbcCatalog() {}
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -203,9 +203,9 @@ public class RESTSessionCatalog extends BaseSessionCatalog
     super.initialize(name, mergedProps);
   }
 
-  public void setFileIOBuilder(Function<Map<String, String>, FileIO> ioBuilder) {
+  public void setFileIOBuilder(Function<Map<String, String>, FileIO> newIOBuilder) {
     Preconditions.checkState(null == io, "Cannot set IO builder after calling initialize");
-    this.ioBuilder = ioBuilder;
+    this.ioBuilder = newIOBuilder;
   }
 
   private AuthSession session(SessionContext context) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -769,9 +769,9 @@ public class RESTSessionCatalog extends BaseSessionCatalog
     if (null != ioBuilder) {
       return ioBuilder.apply(properties);
     } else {
-      String ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-      return CatalogUtil.loadFileIO(
-          ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), properties, conf);
+      String ioImpl =
+          properties.getOrDefault(CatalogProperties.FILE_IO_IMPL, ResolvingFileIO.class.getName());
+      return CatalogUtil.loadFileIO(ioImpl, properties, conf);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -98,7 +98,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
           OAuth2Properties.SAML1_TOKEN_TYPE);
 
   private final Function<Map<String, String>, RESTClient> clientBuilder;
-  private Function<Map<String, String>, FileIO> ioBuilder;
+  private Function<Map<String, String>, FileIO> ioBuilder = null;
   private Cache<String, AuthSession> sessions = null;
   private AuthSession catalogAuth = null;
   private boolean keepTokenRefreshed = true;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -770,9 +770,8 @@ public class RESTSessionCatalog extends BaseSessionCatalog
       return ioBuilder.apply(properties);
     } else {
       String ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-      return
-          CatalogUtil.loadFileIO(
-              ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), properties, conf);
+      return CatalogUtil.loadFileIO(
+          ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), properties, conf);
     }
   }
 


### PR DESCRIPTION
This adds `setFileIOBuilder(Function<Map<String, String>, FileIO)` to the `RESTSessionCatalog`. This allows another way to customize the `FileIO` instances used by the REST catalog. For example, Trino has custom `FileIO` implementations that manage resources differently than `S3FileIO`.

The function accepts a string map of config properties, which allows passing context from the catalog and table level for the IO, including `token` for remote S3 signing as well as the `s3.*` properties for access to S3.