### PR TITLE
Spark 3.3: Use ProcedureInput in AddFilesProcedure

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -33,10 +33,9 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
@@ -51,18 +50,21 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import scala.runtime.BoxedUnit;
 
 class AddFilesProcedure extends BaseProcedure {
 
-  private static final Joiner.MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
+  private static final ProcedureParameter TABLE_PARAM =
+      ProcedureParameter.required("table", DataTypes.StringType);
+  private static final ProcedureParameter SOURCE_TABLE_PARAM =
+      ProcedureParameter.required("source_table", DataTypes.StringType);
+  private static final ProcedureParameter PARTITION_FILTER_PARAM =
+      ProcedureParameter.optional("partition_filter", STRING_MAP);
+  private static final ProcedureParameter CHECK_DUPLICATE_FILES_PARAM =
+      ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
-        ProcedureParameter.required("table", DataTypes.StringType),
-        ProcedureParameter.required("source_table", DataTypes.StringType),
-        ProcedureParameter.optional("partition_filter", STRING_MAP),
-        ProcedureParameter.optional("check_duplicate_files", DataTypes.BooleanType)
+        TABLE_PARAM, SOURCE_TABLE_PARAM, PARTITION_FILTER_PARAM, CHECK_DUPLICATE_FILES_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -97,30 +99,17 @@ class AddFilesProcedure extends BaseProcedure {
 
   @Override
   public InternalRow[] call(InternalRow args) {
-    Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
+    ProcedureInput input = new ProcedureInput(spark(), tableCatalog(), PARAMETERS, args);
+
+    Identifier tableIdent = input.ident(TABLE_PARAM);
 
     CatalogPlugin sessionCat = spark().sessionState().catalogManager().v2SessionCatalog();
-    Identifier sourceIdent =
-        toCatalogAndIdentifier(args.getString(1), PARAMETERS[1].name(), sessionCat).identifier();
+    Identifier sourceIdent = input.ident(SOURCE_TABLE_PARAM, sessionCat);
 
-    Map<String, String> partitionFilter = Maps.newHashMap();
-    if (!args.isNullAt(2)) {
-      args.getMap(2)
-          .foreach(
-              DataTypes.StringType,
-              DataTypes.StringType,
-              (k, v) -> {
-                partitionFilter.put(k.toString(), v.toString());
-                return BoxedUnit.UNIT;
-              });
-    }
+    Map<String, String> partitionFilter =
+        input.stringMap(PARTITION_FILTER_PARAM, ImmutableMap.of());
 
-    boolean checkDuplicateFiles;
-    if (args.isNullAt(3)) {
-      checkDuplicateFiles = true;
-    } else {
-      checkDuplicateFiles = args.getBoolean(3);
-    }
+    boolean checkDuplicateFiles = input.bool(CHECK_DUPLICATE_FILES_PARAM, true);
 
     return importToIceberg(tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles);
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
@@ -154,33 +154,34 @@ class ProcedureInput {
   }
 
   public Identifier ident(ProcedureParameter param) {
-    String identAsString = string(param);
-    CatalogAndIdentifier catalogAndIdent = toCatalogAndIdent(identAsString, param.name(), catalog);
+    CatalogAndIdentifier catalogAndIdent = catalogAndIdent(param, catalog);
 
     Preconditions.checkArgument(
         catalogAndIdent.catalog().equals(catalog),
         "Cannot run procedure in catalog '%s': '%s' is a table in catalog '%s'",
         catalog.name(),
-        identAsString,
+        catalogAndIdent.identifier(),
         catalogAndIdent.catalog().name());
 
     return catalogAndIdent.identifier();
   }
 
   public Identifier ident(ProcedureParameter param, CatalogPlugin defaultCatalog) {
-    String identAsString = string(param);
-    return toCatalogAndIdent(identAsString, param.name(), defaultCatalog).identifier();
+    CatalogAndIdentifier catalogAndIdent = catalogAndIdent(param, defaultCatalog);
+    return catalogAndIdent.identifier();
   }
 
-  private CatalogAndIdentifier toCatalogAndIdent(
-      String identAsString, String paramName, CatalogPlugin defaultCatalog) {
+  private CatalogAndIdentifier catalogAndIdent(
+      ProcedureParameter param, CatalogPlugin defaultCatalog) {
+
+    String identAsString = string(param);
 
     Preconditions.checkArgument(
         StringUtils.isNotBlank(identAsString),
         "Cannot handle an empty identifier for parameter '%s'",
-        paramName);
+        param.name());
 
-    String desc = String.format("identifier for parameter '%s'", paramName);
+    String desc = String.format("identifier for parameter '%s'", param.name());
     return Spark3Util.catalogAndIdentifier(desc, spark, identAsString, defaultCatalog);
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/ProcedureInput.java
@@ -167,6 +167,11 @@ class ProcedureInput {
     return catalogAndIdent.identifier();
   }
 
+  public Identifier ident(ProcedureParameter param, CatalogPlugin defaultCatalog) {
+    String identAsString = string(param);
+    return toCatalogAndIdent(identAsString, param.name(), defaultCatalog).identifier();
+  }
+
   private CatalogAndIdentifier toCatalogAndIdent(
       String identAsString, String paramName, CatalogPlugin defaultCatalog) {
 


### PR DESCRIPTION
This PR migrates `AddFilesProcedure` to use `ProcedureInput`.