### PR TITLE
Spark 3.2: Remove deprecated methods in ExpireSnapshotsSparkAction

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -42,10 +42,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
-import org.apache.spark.sql.execution.QueryExecution;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,23 +127,6 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   public ExpireSnapshotsSparkAction deleteWith(Consumer<String> newDeleteFunc) {
     this.deleteFunc = newDeleteFunc;
     return this;
-  }
-
-  /**
-   * Expires snapshots and commits the changes to the table, returning a Dataset of files to delete.
-   *
-   * <p>This does not delete data files. To delete data files, run {@link #execute()}.
-   *
-   * <p>This may be called before or after {@link #execute()} to return the expired files.
-   *
-   * @return a Dataset of files that are no longer referenced by the table
-   * @deprecated since 1.0.0, will be removed in 1.1.0; use {@link #expireFiles()} instead.
-   */
-  @Deprecated
-  public Dataset<Row> expire() {
-    // rely on the same query execution to reuse shuffles
-    QueryExecution queryExecution = expireFiles().queryExecution();
-    return new Dataset<>(queryExecution, RowEncoder.apply(queryExecution.analyzed().schema()));
   }
 
   /**

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -57,7 +57,6 @@ import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1159,9 +1158,9 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
             .expireSnapshots(table)
             .expireOlderThan(tAfterCommits)
             .deleteWith(deletedFiles::add);
-    Dataset<Row> pendingDeletes = action.expire();
+    Dataset<FileInfo> pendingDeletes = action.expireFiles();
 
-    List<Row> pending = pendingDeletes.collectAsList();
+    List<FileInfo> pending = pendingDeletes.collectAsList();
 
     Assert.assertEquals(
         "Should not change current snapshot", snapshotId, table.currentSnapshot().snapshotId());
@@ -1172,16 +1171,16 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertEquals(
         "Pending delete should be the expired manifest list location",
         firstSnapshot.manifestListLocation(),
-        pending.get(0).getString(0));
+        pending.get(0).getPath());
     Assert.assertEquals(
-        "Pending delete should be a manifest list", "Manifest List", pending.get(0).getString(1));
+        "Pending delete should be a manifest list", "Manifest List", pending.get(0).getType());
 
     Assert.assertEquals("Should not delete any files", 0, deletedFiles.size());
 
     Assert.assertEquals(
         "Multiple calls to expire should return the same count of deleted files",
         pendingDeletes.count(),
-        action.expire().count());
+        action.expireFiles().count());
   }
 
   @Test
@@ -1249,7 +1248,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     List<FileInfo> typedExpiredFiles = action.expireFiles().collectAsList();
     Assert.assertEquals("Expired results must match", 1, typedExpiredFiles.size());
 
-    List<Row> untypedExpiredFiles = action.expire().collectAsList();
+    List<FileInfo> untypedExpiredFiles = action.expireFiles().collectAsList();
     Assert.assertEquals("Expired results must match", 1, untypedExpiredFiles.size());
   }
 


### PR DESCRIPTION
This PR backports PR #7069 to Spark 3.2.