### PR TITLE
AWS: Simplify enabling S3 remote signing

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
 import org.apache.iceberg.aws.s3.S3FileIO;
-import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -47,7 +47,6 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
-import software.amazon.awssdk.core.signer.Signer;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
@@ -269,7 +268,9 @@ public class AwsProperties implements Serializable {
 
   public static final boolean S3_CHECKSUM_ENABLED_DEFAULT = false;
 
-  public static final String S3_SIGNER_IMPL = "s3.signer-impl";
+  public static final String S3_REMOTE_SIGNING_ENABLED = "s3.remote-signing-enabled";
+
+  public static final boolean S3_REMOTE_SIGNING_ENABLED_DEFAULT = false;
 
   /** Configure the batch size used when deleting multiple files from a given S3 bucket */
   public static final String S3FILEIO_DELETE_BATCH_SIZE = "s3.delete.batch-size";
@@ -712,7 +713,7 @@ public class AwsProperties implements Serializable {
   private String dynamoDbTableName;
   private String dynamoDbEndpoint;
 
-  private final String s3SignerImpl;
+  private final boolean s3RemoteSigningEnabled;
   private final Map<String, String> allProperties;
 
   private String restSigningRegion;
@@ -768,7 +769,7 @@ public class AwsProperties implements Serializable {
     this.dynamoDbEndpoint = null;
     this.dynamoDbTableName = DYNAMODB_TABLE_NAME_DEFAULT;
 
-    this.s3SignerImpl = null;
+    this.s3RemoteSigningEnabled = S3_REMOTE_SIGNING_ENABLED_DEFAULT;
     this.allProperties = Maps.newHashMap();
 
     this.restSigningName = REST_SIGNING_NAME_DEFAULT;
@@ -898,7 +899,9 @@ public class AwsProperties implements Serializable {
     this.dynamoDbTableName =
         PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME, DYNAMODB_TABLE_NAME_DEFAULT);
 
-    this.s3SignerImpl = properties.get(S3_SIGNER_IMPL);
+    this.s3RemoteSigningEnabled =
+        PropertyUtil.propertyAsBoolean(
+            properties, S3_REMOTE_SIGNING_ENABLED, S3_REMOTE_SIGNING_ENABLED_DEFAULT);
     this.allProperties = SerializableMap.copyOf(properties);
 
     this.restSigningRegion = properties.get(REST_SIGNER_REGION);
@@ -1157,54 +1160,12 @@ public class AwsProperties implements Serializable {
    * </pre>
    */
   public <T extends S3ClientBuilder> void applyS3SignerConfiguration(T builder) {
-    if (null != s3SignerImpl) {
+    if (s3RemoteSigningEnabled) {
       builder.overrideConfiguration(
-          c -> c.putAdvancedOption(SdkAdvancedClientOption.SIGNER, loadS3SignerDynamically()));
+          c ->
+              c.putAdvancedOption(
+                  SdkAdvancedClientOption.SIGNER, S3V4RestSignerClient.create(allProperties)));
     }
-  }
-
-  private Signer loadS3SignerDynamically() {
-    // load the signer implementation dynamically
-    Object signer = null;
-    try {
-      signer =
-          DynMethods.builder("create")
-              .impl(s3SignerImpl, Map.class)
-              .buildStaticChecked()
-              .invoke(allProperties);
-    } catch (NoSuchMethodException e) {
-      LOG.warn(
-          "Cannot find static method create(Map<String, String> properties) for signer {}",
-          s3SignerImpl,
-          e);
-    }
-
-    if (null == signer) {
-      try {
-        signer = DynMethods.builder("create").impl(s3SignerImpl).buildChecked().invoke(null);
-      } catch (NoSuchMethodException e) {
-        LOG.warn("Cannot find static method create() for signer {}", s3SignerImpl, e);
-      }
-    }
-
-    if (null == signer) {
-      // try via default no-arg constructor
-      try {
-        signer = DynConstructors.builder().impl(s3SignerImpl).buildChecked().newInstance();
-      } catch (NoSuchMethodException e) {
-        LOG.warn("Cannot find no-arg constructor for signer {}", s3SignerImpl, e);
-      }
-    }
-
-    Preconditions.checkArgument(
-        null != signer, "Cannot instantiate custom signer: %s", s3SignerImpl);
-
-    Preconditions.checkArgument(
-        signer instanceof Signer,
-        "Custom signer %s must be an instance of %s",
-        s3SignerImpl,
-        Signer.class.getName());
-    return (Signer) signer;
   }
 
   /**


### PR DESCRIPTION
After talking to @danielcweeks / @rdblue we concluded that it's probably better to have a `s3.remote-signing-enabled` flag rather than dynamic signer loading via `s3.signer-impl`.
This PR simplifies this and removes dynamic S3 signer loading.