### PR TITLE
Core: Allow injecting resources in REST and JDBC catalogs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -126,7 +126,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
     this(config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build());
   }
 
-  RESTSessionCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {
+  public RESTSessionCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {
     this.clientBuilder = clientBuilder;
   }
 


### PR DESCRIPTION
Allow catalogs to be stateless by injecting the long-lived resources.