### PR TITLE
Core: Refactor actions results

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.immutables.value.Value;
 
 /**
  * An action that deletes orphan metadata, data and delete files in a table.
@@ -31,6 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * <p>A file is considered orphan if it is not reachable by any valid snapshot. The set of actual
  * files is built by listing the underlying storage which makes this operation expensive.
  */
+@Value.Enclosing
 public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrphanFiles.Result> {
   /**
    * Passes a location which should be scanned for orphan files.
@@ -139,6 +141,7 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
   }
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
     /** Returns locations of orphan files. */
     Iterable<String> orphanFileLocations();

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteReachableFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteReachableFiles.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
+import org.immutables.value.Value;
 
 /**
  * An action that deletes all files referenced by a table metadata file.
@@ -32,6 +33,7 @@ import org.apache.iceberg.io.SupportsBulkOperations;
  *
  * <p>Implementations may use a query engine to distribute parts of work.
  */
+@Value.Enclosing
 public interface DeleteReachableFiles
     extends Action<DeleteReachableFiles, DeleteReachableFiles.Result> {
 
@@ -65,6 +67,7 @@ public interface DeleteReachableFiles
   DeleteReachableFiles io(FileIO io);
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
 
     /** Returns the number of deleted data files. */

--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg.actions;
 
 import java.util.Map;
+import org.immutables.value.Value;
 
 /** An action that migrates an existing table to Iceberg. */
+@Value.Enclosing
 public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> {
   /**
    * Sets table properties in the newly created Iceberg table. Any properties with the same key name
@@ -51,6 +53,7 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
   }
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
     /** Returns the number of migrated data files. */
     long migratedDataFilesCount();

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -23,11 +23,13 @@ import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.Expression;
+import org.immutables.value.Value;
 
 /**
  * An action for rewriting data files according to a rewrite strategy. Generally used for optimizing
  * the sizing and layout of data files within a table.
  */
+@Value.Enclosing
 public interface RewriteDataFiles
     extends SnapshotUpdate<RewriteDataFiles, RewriteDataFiles.Result> {
 
@@ -175,19 +177,23 @@ public interface RewriteDataFiles
    * null then that particular file group failed. We should only have failed groups if partial
    * progress is enabled otherwise we will report a total failure for the job.
    */
+  @Value.Immutable
   interface Result {
     List<FileGroupRewriteResult> rewriteResults();
 
+    @Value.Default
     default int addedDataFilesCount() {
       return rewriteResults().stream().mapToInt(FileGroupRewriteResult::addedDataFilesCount).sum();
     }
 
+    @Value.Default
     default int rewrittenDataFilesCount() {
       return rewriteResults().stream()
           .mapToInt(FileGroupRewriteResult::rewrittenDataFilesCount)
           .sum();
     }
 
+    @Value.Default
     default long rewrittenBytesCount() {
       return rewriteResults().stream().mapToLong(FileGroupRewriteResult::rewrittenBytesCount).sum();
     }
@@ -197,6 +203,7 @@ public interface RewriteDataFiles
    * For a particular file group, the number of files which are newly created and the number of
    * files which were formerly part of the table but have been rewritten.
    */
+  @Value.Immutable
   interface FileGroupRewriteResult {
     FileGroupInfo info();
 
@@ -204,6 +211,7 @@ public interface RewriteDataFiles
 
     int rewrittenDataFilesCount();
 
+    @Value.Default
     default long rewrittenBytesCount() {
       return 0L;
     }
@@ -213,6 +221,7 @@ public interface RewriteDataFiles
    * A description of a file group, when it was processed, and within which partition. For use
    * tracking rewrite operations and for returning results.
    */
+  @Value.Immutable
   interface FileGroupInfo {
 
     /** returns which file group this is out of the total set of file groups for this rewrite */

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteManifests.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.actions;
 
 import java.util.function.Predicate;
 import org.apache.iceberg.ManifestFile;
+import org.immutables.value.Value;
 
 /** An action that rewrites manifests. */
+@Value.Enclosing
 public interface RewriteManifests
     extends SnapshotUpdate<RewriteManifests, RewriteManifests.Result> {
   /**
@@ -55,6 +57,7 @@ public interface RewriteManifests
   RewriteManifests stagingLocation(String stagingLocation);
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
     /** Returns rewritten manifests. */
     Iterable<ManifestFile> rewrittenManifests();

--- a/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg.actions;
 
 import java.util.Map;
+import org.immutables.value.Value;
 
 /** An action that creates an independent snapshot of an existing table. */
+@Value.Enclosing
 public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Result> {
   /**
    * Sets the table identifier for the newly created Iceberg table.
@@ -58,6 +60,7 @@ public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Resul
   SnapshotTable tableProperty(String key, String value);
 
   /** The action result that contains a summary of the execution. */
+  @Value.Immutable
   interface Result {
     /** Returns the number of imported data files. */
     long importedDataFilesCount();

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.actions;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableDeleteOrphanFiles.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.actions;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
 
   private final Iterable<String> orphanFileLocations;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.actions;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableDeleteReachableFiles.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseDeleteReachableFilesActionResult implements DeleteReachableFiles.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.actions;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseDeleteReachableFilesActionResult implements DeleteReachableFiles.Result {
 
   private final long deletedDataFilesCount;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.actions;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableExpireSnapshots.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseFileGroupRewriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseFileGroupRewriteResult.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupInfo;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupRewriteResult;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link
+ *     ImmutableRewriteDataFiles.FileGroupRewriteResult#builder()} instead.
+ */
 @Deprecated
 public class BaseFileGroupRewriteResult implements FileGroupRewriteResult {
   private final int addedDataFilesCount;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseFileGroupRewriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseFileGroupRewriteResult.java
@@ -21,18 +21,14 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupInfo;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupRewriteResult;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseFileGroupRewriteResult implements FileGroupRewriteResult {
   private final int addedDataFilesCount;
   private final int rewrittenDataFilesCount;
   private final long rewrittenBytesCount;
   private final FileGroupInfo info;
 
-  /**
-   * @deprecated Will be removed in 1.3.0; use {@link
-   *     BaseFileGroupRewriteResult#BaseFileGroupRewriteResult(FileGroupInfo, int, int, long)}
-   *     instead.
-   */
-  @Deprecated
   public BaseFileGroupRewriteResult(
       FileGroupInfo info, int addedFilesCount, int rewrittenFilesCount) {
     this(info, addedFilesCount, rewrittenFilesCount, 0L);

--- a/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTableActionResult.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.actions;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseMigrateTableActionResult implements MigrateTable.Result {
 
   private final long migratedDataFilesCount;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTableActionResult.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg.actions;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableMigrateTable.Result#builder()} instead.
+ */
 @Deprecated
 public class BaseMigrateTableActionResult implements MigrateTable.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesFileGroupInfo.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesFileGroupInfo.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link
+ *     ImmutableRewriteDataFiles.FileGroupInfo#builder()} instead.
+ */
 @Deprecated
 public class BaseRewriteDataFilesFileGroupInfo implements RewriteDataFiles.FileGroupInfo {
   private final int globalIndex;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesFileGroupInfo.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesFileGroupInfo.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseRewriteDataFilesFileGroupInfo implements RewriteDataFiles.FileGroupInfo {
   private final int globalIndex;
   private final int partitionIndex;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesResult.java
@@ -22,6 +22,8 @@ import java.util.List;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupRewriteResult;
 import org.apache.iceberg.actions.RewriteDataFiles.Result;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseRewriteDataFilesResult implements Result {
   private final List<FileGroupRewriteResult> rewriteResults;
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesResult.java
@@ -22,7 +22,10 @@ import java.util.List;
 import org.apache.iceberg.actions.RewriteDataFiles.FileGroupRewriteResult;
 import org.apache.iceberg.actions.RewriteDataFiles.Result;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableRewriteDataFiles.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseRewriteDataFilesResult implements Result {
   private final List<FileGroupRewriteResult> rewriteResults;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifestsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifestsActionResult.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableRewriteManifests.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseRewriteManifestsActionResult implements RewriteManifests.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifestsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifestsActionResult.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseRewriteManifestsActionResult implements RewriteManifests.Result {
 
   private final Iterable<ManifestFile> rewrittenManifests;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTableActionResult.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.actions;
 
+/** @deprecated will be removed in 1.3.0. */
+@Deprecated
 public class BaseSnapshotTableActionResult implements SnapshotTable.Result {
 
   private final long importedDataFilesCount;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTableActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTableActionResult.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.actions;
 
-/** @deprecated will be removed in 1.3.0. */
+/**
+ * @deprecated will be removed in 1.4.0; use {@link ImmutableSnapshotTable.Result#builder()}
+ *     instead.
+ */
 @Deprecated
 public class BaseSnapshotTableActionResult implements SnapshotTable.Result {
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -65,8 +65,12 @@ public class RewriteFileGroup {
 
   public RewriteDataFiles.FileGroupRewriteResult asResult() {
     Preconditions.checkState(addedFiles != null, "Cannot get result, Group was never rewritten");
-    return new BaseFileGroupRewriteResult(
-        info, addedFiles.size(), fileScanTasks.size(), sizeInBytes());
+    return ImmutableRewriteDataFiles.FileGroupRewriteResult.builder()
+        .info(info)
+        .addedDataFilesCount(addedFiles.size())
+        .rewrittenDataFilesCount(fileScanTasks.size())
+        .rewrittenBytesCount(sizeInBytes())
+        .build();
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -44,8 +44,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.BaseDeleteOrphanFilesActionResult;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.ImmutableDeleteOrphanFiles;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HiddenPathFilter;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -272,7 +272,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       }
     }
 
-    return new BaseDeleteOrphanFilesActionResult(orphanFiles);
+    return ImmutableDeleteOrphanFiles.Result.builder().orphanFileLocations(orphanFiles).build();
   }
 
   private Dataset<FileURI> validFileIdentDS() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteReachableFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteReachableFilesSparkAction.java
@@ -27,8 +27,8 @@ import java.util.function.Consumer;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.actions.BaseDeleteReachableFilesActionResult;
 import org.apache.iceberg.actions.DeleteReachableFiles;
+import org.apache.iceberg.actions.ImmutableDeleteReachableFiles;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
@@ -144,12 +144,13 @@ public class DeleteReachableFilesSparkAction
 
     LOG.info("Deleted {} total files", summary.totalFilesCount());
 
-    return new BaseDeleteReachableFilesActionResult(
-        summary.dataFilesCount(),
-        summary.positionDeleteFilesCount(),
-        summary.equalityDeleteFilesCount(),
-        summary.manifestsCount(),
-        summary.manifestListsCount(),
-        summary.otherFilesCount());
+    return ImmutableDeleteReachableFiles.Result.builder()
+        .deletedDataFilesCount(summary.dataFilesCount())
+        .deletedPositionDeleteFilesCount(summary.positionDeleteFilesCount())
+        .deletedEqualityDeleteFilesCount(summary.equalityDeleteFilesCount())
+        .deletedManifestsCount(summary.manifestsCount())
+        .deletedManifestListsCount(summary.manifestListsCount())
+        .deletedOtherFilesCount(summary.otherFilesCount())
+        .build();
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.BaseMigrateTableActionResult;
+import org.apache.iceberg.actions.ImmutableMigrateTable;
 import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -162,7 +162,9 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
         "Successfully loaded Iceberg metadata for {} files to {}",
         migratedDataFilesCount,
         destTableIdent());
-    return new BaseMigrateTableActionResult(migratedDataFilesCount);
+    return ImmutableMigrateTable.Result.builder()
+        .migratedDataFilesCount(migratedDataFilesCount)
+        .build();
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.spark.actions;
 
 import java.io.IOException;
 import java.math.RoundingMode;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -38,9 +37,8 @@ import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.BaseRewriteDataFilesFileGroupInfo;
-import org.apache.iceberg.actions.BaseRewriteDataFilesResult;
 import org.apache.iceberg.actions.BinPackStrategy;
+import org.apache.iceberg.actions.ImmutableRewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
@@ -157,7 +155,7 @@ public class RewriteDataFilesSparkAction
   @Override
   public RewriteDataFiles.Result execute() {
     if (table.currentSnapshot() == null) {
-      return new BaseRewriteDataFilesResult(ImmutableList.of());
+      return ImmutableRewriteDataFiles.Result.builder().rewriteResults(ImmutableList.of()).build();
     }
 
     long startingSnapshotId = table.currentSnapshot().snapshotId();
@@ -175,7 +173,7 @@ public class RewriteDataFilesSparkAction
 
     if (ctx.totalGroupCount() == 0) {
       LOG.info("Nothing found to rewrite in {}", table.name());
-      return new BaseRewriteDataFilesResult(Collections.emptyList());
+      return ImmutableRewriteDataFiles.Result.builder().rewriteResults(ImmutableList.of()).build();
     }
 
     Stream<RewriteFileGroup> groupStream = toGroupStream(ctx, fileGroupsByPartition);
@@ -334,7 +332,7 @@ public class RewriteDataFilesSparkAction
 
     List<FileGroupRewriteResult> rewriteResults =
         rewrittenGroups.stream().map(RewriteFileGroup::asResult).collect(Collectors.toList());
-    return new BaseRewriteDataFilesResult(rewriteResults);
+    return ImmutableRewriteDataFiles.Result.builder().rewriteResults(rewriteResults).build();
   }
 
   private Result doExecuteWithPartialProgress(
@@ -374,7 +372,7 @@ public class RewriteDataFilesSparkAction
 
     List<FileGroupRewriteResult> rewriteResults =
         commitResults.stream().map(RewriteFileGroup::asResult).collect(Collectors.toList());
-    return new BaseRewriteDataFilesResult(rewriteResults);
+    return ImmutableRewriteDataFiles.Result.builder().rewriteResults(rewriteResults).build();
   }
 
   Stream<RewriteFileGroup> toGroupStream(
@@ -392,8 +390,11 @@ public class RewriteDataFilesSparkAction
                             int globalIndex = ctx.currentGlobalIndex();
                             int partitionIndex = ctx.currentPartitionIndex(partition);
                             FileGroupInfo info =
-                                new BaseRewriteDataFilesFileGroupInfo(
-                                    globalIndex, partitionIndex, partition);
+                                ImmutableRewriteDataFiles.FileGroupInfo.builder()
+                                    .globalIndex(globalIndex)
+                                    .partitionIndex(partitionIndex)
+                                    .partition(partition)
+                                    .build();
                             return new RewriteFileGroup(info, tasks);
                           });
                 });

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -40,7 +40,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.actions.BaseRewriteManifestsActionResult;
+import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -154,7 +154,10 @@ public class RewriteManifestsSparkAction
   private RewriteManifests.Result doExecute() {
     List<ManifestFile> matchingManifests = findMatchingManifests();
     if (matchingManifests.isEmpty()) {
-      return BaseRewriteManifestsActionResult.empty();
+      return ImmutableRewriteManifests.Result.builder()
+          .addedManifests(ImmutableList.of())
+          .rewrittenManifests(ImmutableList.of())
+          .build();
     }
 
     long totalSizeBytes = 0L;
@@ -173,7 +176,10 @@ public class RewriteManifestsSparkAction
     int targetNumManifestEntries = targetNumManifestEntries(numEntries, targetNumManifests);
 
     if (targetNumManifests == 1 && matchingManifests.size() == 1) {
-      return BaseRewriteManifestsActionResult.empty();
+      return ImmutableRewriteManifests.Result.builder()
+          .addedManifests(ImmutableList.of())
+          .rewrittenManifests(ImmutableList.of())
+          .build();
     }
 
     Dataset<Row> manifestEntryDF = buildManifestEntryDF(matchingManifests);
@@ -189,7 +195,10 @@ public class RewriteManifestsSparkAction
 
     replaceManifests(matchingManifests, newManifests);
 
-    return new BaseRewriteManifestsActionResult(matchingManifests, newManifests);
+    return ImmutableRewriteManifests.Result.builder()
+        .rewrittenManifests(matchingManifests)
+        .addedManifests(newManifests)
+        .build();
   }
 
   private Dataset<Row> buildManifestEntryDF(List<ManifestFile> manifests) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.actions.BaseSnapshotTableActionResult;
+import org.apache.iceberg.actions.ImmutableSnapshotTable;
 import org.apache.iceberg.actions.SnapshotTable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -150,7 +150,9 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
         "Successfully loaded Iceberg metadata for {} files to {}",
         importedDataFilesCount,
         destTableIdent());
-    return new BaseSnapshotTableActionResult(importedDataFilesCount);
+    return ImmutableSnapshotTable.Result.builder()
+        .importedDataFilesCount(importedDataFilesCount)
+        .build();
   }
 
   @Override


### PR DESCRIPTION
Each action has a separate boilerplate code with the public constructor. Which is hard to maintain. Also, the addition of new fields requires deprecating older constructors and adding a new one. 

Recently two of the PRs (#6801, and #6091) also had to go through new constructors.   

Changes:
- deprecated the old action results. 
- Replaced the usage with immutables for the same.

This is a follow-up on https://github.com/apache/iceberg/pull/6091#discussion_r1129758863

Note: only spark-3.3 is using the new builders. Other versions are still using the newly deprecated builders.
Will be replaced in a single follow-up PR after the review. 