### PR TITLE
 Improve vectorized read decimal type performance

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -301,15 +301,17 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
             this.typeWidth = primitive.getTypeLength();
             break;
           case INT64:
-            arrowField = new Field(
-                icebergField.name(), new FieldType(icebergField.isOptional(),
-                new ArrowType.Int(Long.SIZE, true /* signed */), null, null),
-                Lists.newArrayList());
-            this.vec = arrowField.createVector(rootAlloc);
+            Field arrowLongField =
+                new Field(
+                    icebergField.name(),
+                    new FieldType(
+                        icebergField.isOptional(),
+                        new ArrowType.Int(Long.SIZE, true /* signed */),
+                        null,
+                        null),
+                    Lists.newArrayList());
+            this.vec = arrowLongField.createVector(rootAlloc);
             ((BigIntVector) vec).allocateNew(batchSize);
-
-            this.vec = arrowField.createVector(rootAlloc);
-            ((DecimalVector) vec).allocateNew(batchSize);
             this.readType = ReadType.LONG_BACKED_DECIMAL;
             this.typeWidth = (int) BigIntVector.TYPE_WIDTH;
             break;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.nio.ByteBuffer;
 import org.apache.arrow.vector.BaseVariableWidthVector;
-import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.nio.ByteBuffer;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
@@ -173,7 +174,11 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     @Override
     protected void nextVal(
         FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
-      ((DecimalVector) vector).set(idx, dict.decodeToLong(currentVal));
+      if (vector instanceof BigIntVector) {
+        vector.getDataBuffer().setLong((long) idx * Long.BYTES, dict.decodeToLong(currentVal));
+      } else {
+        ((DecimalVector) vector).set(idx, dict.decodeToLong(currentVal));
+      }
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -174,11 +174,7 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     @Override
     protected void nextVal(
         FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
-      if (vector instanceof BigIntVector) {
-        vector.getDataBuffer().setLong((long) idx * Long.BYTES, dict.decodeToLong(currentVal));
-      } else {
-        ((DecimalVector) vector).set(idx, dict.decodeToLong(currentVal));
-      }
+      vector.getDataBuffer().setLong((long) idx * Long.BYTES, dict.decodeToLong(currentVal));
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.DecimalVector;
@@ -637,7 +638,11 @@ public final class VectorizedParquetDefinitionLevelReader
         ValuesAsBytesReader valuesReader,
         int typeWidth,
         byte[] byteArray) {
-      ((DecimalVector) vector).set(idx, valuesReader.getBuffer(Long.BYTES).getLong());
+      if (vector instanceof BigIntVector) {
+        vector.getDataBuffer().setLong(idx * Long.BYTES, valuesReader.readLong());
+      } else {
+        ((DecimalVector) vector).set(idx, valuesReader.getBuffer(Long.BYTES).getLong());
+      }
     }
 
     @Override

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -660,7 +660,15 @@ public final class VectorizedParquetDefinitionLevelReader
             .longBackedDecimalDictEncodedReader()
             .nextBatch(vector, idx, numValuesToRead, dict, nullabilityHolder, typeWidth);
       } else if (Mode.PACKED.equals(mode)) {
-        ((DecimalVector) vector).set(idx, dict.decodeToLong(reader.readInteger()));
+        if (vector instanceof BigIntVector) {
+          vector
+              .getDataBuffer()
+              .setLong(
+                  (long) idx * typeWidth,
+                  dict.decodeToLong(reader.readInteger()));
+        } else {
+          ((DecimalVector) vector).set(idx, dict.decodeToLong(reader.readInteger()));
+        }
       }
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 import java.nio.ByteBuffer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BaseVariableWidthVector;
-import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.DecimalVector;
@@ -658,9 +657,7 @@ public final class VectorizedParquetDefinitionLevelReader
       } else if (Mode.PACKED.equals(mode)) {
         vector
             .getDataBuffer()
-            .setLong(
-                (long) idx * typeWidth,
-                dict.decodeToLong(reader.readInteger()));
+            .setLong((long) idx * typeWidth, dict.decodeToLong(reader.readInteger()));
       }
     }
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -638,11 +638,7 @@ public final class VectorizedParquetDefinitionLevelReader
         ValuesAsBytesReader valuesReader,
         int typeWidth,
         byte[] byteArray) {
-      if (vector instanceof BigIntVector) {
-        vector.getDataBuffer().setLong(idx * Long.BYTES, valuesReader.readLong());
-      } else {
-        ((DecimalVector) vector).set(idx, valuesReader.getBuffer(Long.BYTES).getLong());
-      }
+      vector.getDataBuffer().setLong(idx * Long.BYTES, valuesReader.readLong());
     }
 
     @Override
@@ -660,15 +656,11 @@ public final class VectorizedParquetDefinitionLevelReader
             .longBackedDecimalDictEncodedReader()
             .nextBatch(vector, idx, numValuesToRead, dict, nullabilityHolder, typeWidth);
       } else if (Mode.PACKED.equals(mode)) {
-        if (vector instanceof BigIntVector) {
-          vector
-              .getDataBuffer()
-              .setLong(
-                  (long) idx * typeWidth,
-                  dict.decodeToLong(reader.readInteger()));
-        } else {
-          ((DecimalVector) vector).set(idx, dict.decodeToLong(reader.readInteger()));
-        }
+        vector
+            .getDataBuffer()
+            .setLong(
+                (long) idx * typeWidth,
+                dict.decodeToLong(reader.readInteger()));
       }
     }
   }


### PR DESCRIPTION
This PR Improve the performance of decimal with long precision.
Before this PR, Iceberg read decimal twice slower than spark (Iceberg 7s/op vs spark 3s/op):
![image](https://user-images.githubusercontent.com/31469905/224586064-5108ffa7-7a3f-4b11-be4b-ef70ed2f7c62.png)

After this PR, reading speed of iceberg and spark is similar:
![image](https://user-images.githubusercontent.com/31469905/224586086-f97e5eb7-d7d5-4513-b22a-739713c5fc6c.png)

The main problem is how to build java `BigDecimal`. The cost of constructing java `BigDecimal` in the original way is too high. I have a  iceberg benchmark flame graph . Actually we can build decimal from `Long`. Spark does the same ( this is why spark is faster than Iceberg):
![image](https://user-images.githubusercontent.com/31469905/224855414-411304bb-f160-445a-9cd9-6e2882a5bf72.png)


