### PR TITLE
Flink: Apply row level filtering

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
+++ b/data/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
@@ -91,6 +91,13 @@ public class GenericAppenderHelper {
     appendToTable(writeFile(partition, records));
   }
 
+  public DataFile writeFile(List<Record> records) throws IOException {
+    Preconditions.checkNotNull(table, "table not set");
+    File file = tmp.newFile();
+    Assert.assertTrue(file.delete());
+    return appendToLocalFile(table, file, fileFormat, null, records, conf);
+  }
+
   public DataFile writeFile(StructLike partition, List<Record> records) throws IOException {
     Preconditions.checkNotNull(table, "table not set");
     File file = tmp.newFile();

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkSourceFilter.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkSourceFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.types.Types;
+
+public class FlinkSourceFilter implements FilterFunction<RowData> {
+
+  private final RowType rowType;
+  private final Evaluator evaluator;
+  private final Types.StructType struct;
+  private volatile RowDataWrapper wrapper;
+
+  public FlinkSourceFilter(Schema schema, Expression expr, boolean caseSensitive) {
+    this.rowType = FlinkSchemaUtil.convert(schema);
+    this.struct = schema.asStruct();
+    this.evaluator = new Evaluator(struct, expr, caseSensitive);
+  }
+
+  @Override
+  public boolean filter(RowData value) {
+    if (wrapper == null) {
+      this.wrapper = new RowDataWrapper(rowType, struct);
+    }
+    return evaluator.eval(wrapper.wrap(value));
+  }
+}

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -69,7 +69,11 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
     } else {
       this.rowDataReader =
           new RowDataFileScanTaskReader(
-              tableSchema, context.project(), context.nameMapping(), context.caseSensitive());
+              tableSchema,
+              context.project(),
+              context.nameMapping(),
+              context.caseSensitive(),
+              context.filters());
     }
   }
 

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -449,7 +449,8 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
                   context.nameMapping(),
                   context.caseSensitive(),
                   table.io(),
-                  table.encryption());
+                  table.encryption(),
+                  context.filters());
           this.readerFunction = (ReaderFunction<T>) rowDataReaderFunction;
         }
       }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source;
 import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.flink.api.common.functions.RichMapFunction;
@@ -125,7 +126,8 @@ public class RowDataRewriter {
       this.encryptionManager = encryptionManager;
       this.taskWriterFactory = taskWriterFactory;
       this.rowDataReader =
-          new RowDataFileScanTaskReader(schema, schema, nameMapping, caseSensitive);
+          new RowDataFileScanTaskReader(
+              schema, schema, nameMapping, caseSensitive, Collections.emptyList());
     }
 
     @Override

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/reader/AvroGenericRecordReaderFunction.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.List;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.AvroGenericRecordFileScanTaskReader;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
@@ -54,7 +56,8 @@ public class AvroGenericRecordReaderFunction extends DataIteratorReaderFunction<
         null,
         false,
         table.io(),
-        table.encryption());
+        table.encryption(),
+        null);
   }
 
   public AvroGenericRecordReaderFunction(
@@ -65,14 +68,15 @@ public class AvroGenericRecordReaderFunction extends DataIteratorReaderFunction<
       String nameMapping,
       boolean caseSensitive,
       FileIO io,
-      EncryptionManager encryption) {
+      EncryptionManager encryption,
+      List<Expression> filters) {
     super(new ListDataIteratorBatcher<>(config));
     this.tableName = tableName;
     this.readSchema = readSchema(tableSchema, projectedSchema);
     this.io = io;
     this.encryption = encryption;
     this.rowDataReader =
-        new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive);
+        new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive, filters);
   }
 
   @Override

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.List;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
@@ -36,6 +38,7 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
   private final boolean caseSensitive;
   private final FileIO io;
   private final EncryptionManager encryption;
+  private final List<Expression> filters;
 
   public RowDataReaderFunction(
       ReadableConfig config,
@@ -44,7 +47,8 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
       String nameMapping,
       boolean caseSensitive,
       FileIO io,
-      EncryptionManager encryption) {
+      EncryptionManager encryption,
+      List<Expression> filters) {
     super(
         new ArrayPoolDataIteratorBatcher<>(
             config,
@@ -56,12 +60,13 @@ public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
     this.caseSensitive = caseSensitive;
     this.io = io;
     this.encryption = encryption;
+    this.filters = filters;
   }
 
   @Override
   public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
     return new DataIterator<>(
-        new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive),
+        new RowDataFileScanTaskReader(tableSchema, readSchema, nameMapping, caseSensitive, filters),
         split.task(),
         io,
         encryption);

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.logical.RowType;
@@ -34,8 +36,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
@@ -138,6 +142,43 @@ public class TestFlinkInputFormat extends TestFlinkSource {
     }
 
     TestHelpers.assertRows(result, expected);
+  }
+
+  public static Record createRecord(Schema writeSchema, long val) {
+    Record record = GenericRecord.create(writeSchema);
+    record.set(0, val);
+    return record;
+  }
+
+  @Test
+  public void testBasicFormatFiltering() throws IOException {
+    Schema writeSchema = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
+
+    List<Record> writeRecords =
+        LongStream.rangeClosed(-1, 1)
+            .mapToObj(i -> createRecord(writeSchema, i))
+            .collect(Collectors.toList());
+
+    Table sourceTable =
+        catalogResource.catalog().createTable(TableIdentifier.of("default", "t"), writeSchema);
+
+    new GenericAppenderHelper(sourceTable, fileFormat, TEMPORARY_FOLDER)
+        .appendToTable(writeRecords);
+
+    List<Row> result =
+        runFormat(
+            FlinkSource.forRowData()
+                .tableLoader(tableLoader())
+                .filters(Collections.singletonList(Expressions.greaterThanOrEqual("id", 0)))
+                .buildFormat());
+
+    List<Row> expectedRows =
+        writeRecords.stream()
+            .filter(r -> r.get(0, Long.class) >= 0)
+            .map(r -> Row.of(r.get(0, Long.class)))
+            .collect(Collectors.toList());
+
+    TestHelpers.assertRows(result, expectedRows);
   }
 
   @Test

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -439,16 +439,16 @@ public abstract class TestFlinkScan {
         catalogResource.catalog().createTable(TestFixtures.TABLE_IDENTIFIER, TestFixtures.SCHEMA);
 
     List<Record> expectedRecords = RandomGenericData.generate(TestFixtures.SCHEMA, 3, 0L);
-    expectedRecords.get(0).set(2, "a");
-    expectedRecords.get(1).set(2, "b");
-    expectedRecords.get(2).set(2, "c");
+    expectedRecords.get(0).set(0, "a");
+    expectedRecords.get(1).set(0, "b");
+    expectedRecords.get(2).set(0, "c");
 
     GenericAppenderHelper helper = new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER);
     DataFile dataFile = helper.writeFile(expectedRecords);
     helper.appendToTable(dataFile);
     List<Row> actual =
         runWithFilter(Expressions.greaterThanOrEqual("data", "b"), "where data>='b'");
-    TestHelpers.assertRecords(actual, expectedRecords, TestFixtures.SCHEMA);
+    TestHelpers.assertRecords(actual, expectedRecords.subList(1, 3), TestFixtures.SCHEMA);
   }
 
   @Test

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
@@ -51,15 +51,20 @@ public abstract class TestFlinkSource extends TestFlinkScan {
   }
 
   @Override
-  protected List<Row> runWithFilter(Expression filter, String sqlFilter) throws Exception {
+  protected List<Row> runWithFilter(Expression filter, String sqlFilter, boolean caseSensitive)
+      throws Exception {
     FlinkSource.Builder builder =
         FlinkSource.forRowData().filters(Collections.singletonList(filter));
-    return run(builder, Maps.newHashMap(), sqlFilter, "*");
+    Map<String, String> options = Maps.newHashMap();
+    options.put("case-sensitive", Boolean.toString(caseSensitive));
+    return run(builder, options, sqlFilter, "*");
   }
 
   @Override
   protected List<Row> runWithOptions(Map<String, String> options) throws Exception {
     FlinkSource.Builder builder = FlinkSource.forRowData();
+    Optional.ofNullable(options.get("case-sensitive"))
+        .ifPresent(value -> builder.caseSensitive(Boolean.getBoolean(value)));
     Optional.ofNullable(options.get("snapshot-id"))
         .ifPresent(value -> builder.snapshotId(Long.parseLong(value)));
     Optional.ofNullable(options.get("tag")).ifPresent(value -> builder.tag(value));

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.flink.source;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -68,8 +68,11 @@ public class TestIcebergSourceBounded extends TestFlinkScan {
   }
 
   @Override
-  protected List<Row> runWithFilter(Expression filter, String sqlFilter) throws Exception {
-    return run(null, Arrays.asList(filter), Maps.newHashMap(), sqlFilter, "*");
+  protected List<Row> runWithFilter(Expression filter, String sqlFilter, boolean caseSensitive)
+      throws Exception {
+    Map<String, String> options = Maps.newHashMap();
+    options.put("case-sensitive", Boolean.toString(caseSensitive));
+    return run(null, Collections.singletonList(filter), options, sqlFilter, "*");
   }
 
   @Override

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBoundedGenericRecord.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBoundedGenericRecord.java
@@ -163,7 +163,8 @@ public class TestIcebergSourceBoundedGenericRecord {
             null,
             false,
             table.io(),
-            table.encryption());
+            table.encryption(),
+            filters);
 
     IcebergSource.Builder<GenericRecord> sourceBuilder =
         IcebergSource.<GenericRecord>builder()

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.source.reader;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.BaseCombinedScanTask;
@@ -83,7 +84,8 @@ public class ReaderUtil {
 
   public static DataIterator<RowData> createDataIterator(CombinedScanTask combinedTask) {
     return new DataIterator<>(
-        new RowDataFileScanTaskReader(TestFixtures.SCHEMA, TestFixtures.SCHEMA, null, true),
+        new RowDataFileScanTaskReader(
+            TestFixtures.SCHEMA, TestFixtures.SCHEMA, null, true, Collections.emptyList()),
         combinedTask,
         new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
         new PlaintextEncryptionManager());

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.source.reader;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
@@ -106,7 +107,8 @@ public class TestIcebergSourceReader {
             null,
             true,
             new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
-            new PlaintextEncryptionManager());
+            new PlaintextEncryptionManager(),
+            Collections.emptyList());
     return new IcebergSourceReader<>(readerMetrics, readerFunction, readerContext);
   }
 }

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.source.reader;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.flink.configuration.Configuration;
@@ -55,7 +56,8 @@ public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
         null,
         true,
         new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
-        new PlaintextEncryptionManager());
+        new PlaintextEncryptionManager(),
+        Collections.emptyList());
   }
 
   @Override


### PR DESCRIPTION
For Flink, we apply partition pruning, filtering based on metrics, and row-group skipping, but no row-level filtering.

See the issue for more details

Resolves #7022

@stevenzwu would you have time to take a peek at this one?