### PR TITLE
Docs: update documentation site link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Example:
 ## Style
 
 For Java styling, check out the section
-[Setting up IDE and Code Style](https://iceberg.apache.org/community/#setting-up-ide-and-code-style) from the
+[Setting up IDE and Code Style](https://iceberg.apache.org/contribute/#setting-up-ide-and-code-style) from the
 documentation site.
 
 ### Java style guidelines


### PR DESCRIPTION
In the code style section of the contribute documentation, the link seems not right.
- before：https://iceberg.apache.org/community/#setting-up-ide-and-code-style
- after：https://iceberg.apache.org/contribute/#setting-up-ide-and-code-style