### PR TITLE
AWS: Use Apache HTTP client as default AWS HTTP client

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -372,7 +372,7 @@ public class AwsProperties implements Serializable {
    */
   public static final String HTTP_CLIENT_TYPE_APACHE = "apache";
 
-  public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_URLCONNECTION;
+  public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_APACHE;
 
   /**
    * Used to configure the connection timeout in milliseconds for {@link

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -60,7 +60,6 @@ AWS_SDK_VERSION=2.20.18
 AWS_MAVEN_GROUP=software.amazon.awssdk
 AWS_PACKAGES=(
     "bundle"
-    "apache-client"
 )
 for pkg in "${AWS_PACKAGES[@]}"; do
     DEPENDENCIES+=",$AWS_MAVEN_GROUP:$pkg:$AWS_SDK_VERSION"
@@ -93,7 +92,6 @@ AWS_SDK_VERSION=2.20.18
 AWS_MAVEN_URL=$MAVEN_URL/software/amazon/awssdk
 AWS_PACKAGES=(
     "bundle"
-    "apache-client"
 )
 for pkg in "${AWS_PACKAGES[@]}"; do
     wget $AWS_MAVEN_URL/$pkg/$AWS_SDK_VERSION/$pkg-$AWS_SDK_VERSION.jar
@@ -103,7 +101,6 @@ done
 /path/to/bin/sql-client.sh embedded \
     -j iceberg-flink-runtime-$ICEBERG_VERSION.jar \
     -j bundle-$AWS_SDK_VERSION.jar \
-    -j apache-client-$AWS_SDK_VERSION.jar \
     shell
 ```
 
@@ -137,7 +134,6 @@ and then add them to the Hive classpath or add the jars at runtime in CLI:
 ```
 add jar /my/path/to/iceberg-hive-runtime.jar;
 add jar /my/path/to/aws/bundle.jar;
-add jar /my/path/to/aws/apache-client.jar;
 ```
 
 With those dependencies, you can register a Glue catalog and create external tables in Hive at runtime in CLI by:
@@ -656,7 +652,6 @@ LIB_PATH=/usr/share/aws/aws-java-sdk/
 
 AWS_PACKAGES=(
   "bundle"
-  "apache-client"
 )
 
 ICEBERG_PACKAGES=(

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -60,7 +60,7 @@ AWS_SDK_VERSION=2.20.18
 AWS_MAVEN_GROUP=software.amazon.awssdk
 AWS_PACKAGES=(
     "bundle"
-    "url-connection-client"
+    "apache-client"
 )
 for pkg in "${AWS_PACKAGES[@]}"; do
     DEPENDENCIES+=",$AWS_MAVEN_GROUP:$pkg:$AWS_SDK_VERSION"
@@ -93,7 +93,7 @@ AWS_SDK_VERSION=2.20.18
 AWS_MAVEN_URL=$MAVEN_URL/software/amazon/awssdk
 AWS_PACKAGES=(
     "bundle"
-    "url-connection-client"
+    "apache-client"
 )
 for pkg in "${AWS_PACKAGES[@]}"; do
     wget $AWS_MAVEN_URL/$pkg/$AWS_SDK_VERSION/$pkg-$AWS_SDK_VERSION.jar
@@ -103,7 +103,7 @@ done
 /path/to/bin/sql-client.sh embedded \
     -j iceberg-flink-runtime-$ICEBERG_VERSION.jar \
     -j bundle-$AWS_SDK_VERSION.jar \
-    -j url-connection-client-$AWS_SDK_VERSION.jar \
+    -j apache-client-$AWS_SDK_VERSION.jar \
     shell
 ```
 
@@ -137,7 +137,7 @@ and then add them to the Hive classpath or add the jars at runtime in CLI:
 ```
 add jar /my/path/to/iceberg-hive-runtime.jar;
 add jar /my/path/to/aws/bundle.jar;
-add jar /my/path/to/aws/url-connection-client.jar;
+add jar /my/path/to/aws/apache-client.jar;
 ```
 
 With those dependencies, you can register a Glue catalog and create external tables in Hive at runtime in CLI by:
@@ -656,7 +656,7 @@ LIB_PATH=/usr/share/aws/aws-java-sdk/
 
 AWS_PACKAGES=(
   "bundle"
-  "url-connection-client"
+  "apache-client"
 )
 
 ICEBERG_PACKAGES=(

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -586,9 +586,9 @@ For more details of configuration, see sections [URL Connection HTTP Client Conf
 
 Configure the following property to set the type of HTTP client:
 
-| Property         | Default       | Description                                                                                                |
-|------------------|---------------|------------------------------------------------------------------------------------------------------------|
-| http-client.type | urlconnection | Types of HTTP Client. <br/> `urlconnection`: URL Connection HTTP Client <br/> `apache`: Apache HTTP Client |
+| Property         | Default | Description                                                                                                |
+|------------------|---------|------------------------------------------------------------------------------------------------------------|
+| http-client.type | apache  | Types of HTTP Client. <br/> `urlconnection`: URL Connection HTTP Client <br/> `apache`: Apache HTTP Client |
 
 #### URL Connection HTTP Client Configurations
 

--- a/python/dev/Dockerfile
+++ b/python/dev/Dockerfile
@@ -47,12 +47,12 @@ RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runt
  && mv iceberg-spark-runtime-3.3_2.12-1.1.0.jar /opt/spark/jars
 
 # Download Java AWS SDK
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.20.8/bundle-2.20.8.jar -Lo bundle-2.20.8.jar \
- && mv bundle-2.20.8.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.165/bundle-2.17.165.jar -Lo bundle-2.17.165.jar \
+ && mv bundle-2.17.165.jar /opt/spark/jars
 
 # Download URL connection client required for S3FileIO
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.20.8/apache-client-2.20.8.jar -Lo apache-client-2.20.8.jar \
- && mv apache-client-2.20.8.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/2.17.165/url-connection-client-2.17.165.jar -Lo url-connection-client-2.17.165.jar \
+ && mv url-connection-client-2.17.165.jar /opt/spark/jars
 
 COPY spark-defaults.conf /opt/spark/conf
 ENV PATH="/opt/spark/sbin:/opt/spark/bin:${PATH}"

--- a/python/dev/Dockerfile
+++ b/python/dev/Dockerfile
@@ -47,12 +47,12 @@ RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runt
  && mv iceberg-spark-runtime-3.3_2.12-1.1.0.jar /opt/spark/jars
 
 # Download Java AWS SDK
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.165/bundle-2.17.165.jar -Lo bundle-2.17.165.jar \
- && mv bundle-2.17.165.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.20.8/bundle-2.20.8.jar -Lo bundle-2.20.8.jar \
+ && mv bundle-2.20.8.jar /opt/spark/jars
 
 # Download URL connection client required for S3FileIO
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/2.17.165/url-connection-client-2.17.165.jar -Lo url-connection-client-2.17.165.jar \
- && mv url-connection-client-2.17.165.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/apache-client/2.20.8/apache-client-2.20.8.jar -Lo apache-client-2.20.8.jar \
+ && mv apache-client-2.20.8.jar /opt/spark/jars
 
 COPY spark-defaults.conf /opt/spark/conf
 ENV PATH="/opt/spark/sbin:/opt/spark/bin:${PATH}"


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/7118