### PR TITLE
Spark - Accept an `output-spec-id` that allows writing to a desired partition spec

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -20,10 +20,12 @@ package org.apache.iceberg.spark;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
@@ -51,11 +53,15 @@ public class SparkWriteConf {
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
+  private final int currentSpecId;
+  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
+    this.currentSpecId = table.spec().specId();
+    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -115,8 +121,18 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
-  public Integer outputSpecId() {
-    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  public int outputSpecId() {
+    final int outputSpecId =
+        confParser
+            .intConf()
+            .option(SparkWriteOptions.OUTPUT_SPEC_ID)
+            .defaultValue(currentSpecId)
+            .parse();
+    Preconditions.checkArgument(
+        partitionSpecIds.contains(outputSpecId),
+        "Output spec id %s is not a valid spec id for table",
+        outputSpecId);
+    return outputSpecId;
   }
 
   public FileFormat dataFileFormat() {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -115,6 +115,10 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
+  public Integer outputSpecId() {
+    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  }
+
   public FileFormat dataFileFormat() {
     String valueAsString =
         confParser

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -122,7 +122,7 @@ public class SparkWriteConf {
   }
 
   public int outputSpecId() {
-    final int outputSpecId =
+    int outputSpecId =
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -51,7 +51,6 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
-  // Output partition spec ID where writes should go.
   public static final String OUTPUT_SPEC_ID = "output-spec-id";
 
   public static final String OVERWRITE_MODE = "overwrite-mode";

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -51,5 +51,8 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
+  // Output partition spec ID where writes should go.
+  public static final String OUTPUT_SPEC_ID = "output-spec-id";
+
   public static final String OVERWRITE_MODE = "overwrite-mode";
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -597,8 +597,8 @@ class SparkWrite {
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       Table table = tableBroadcast.value();
-      FileIO io = table.io();
       PartitionSpec spec = table.specs().get(outputSpecId);
+      FileIO io = table.io();
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId).format(format).build();

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -130,14 +130,15 @@ class SparkWrite {
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
 
-    Preconditions.checkArgument(
-        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
-        "Cannot write to unknown spec: %s",
-        writeConf.outputSpecId());
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
+    if (writeConf.outputSpecId() == null) {
+      this.outputSpecId = table.spec().specId();
+    } else {
+      this.outputSpecId = writeConf.outputSpecId();
+      Preconditions.checkArgument(
+          table.specs().containsKey(outputSpecId),
+          "Cannot write to unknown spec: %s",
+          outputSpecId);
+    }
   }
 
   BatchWrite asBatchAppend() {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -123,15 +124,20 @@ class SparkWrite {
     this.applicationId = applicationId;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
     this.targetFileSize = writeConf.targetDataFileSize();
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
+
+    Preconditions.checkArgument(
+        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
+        "Cannot write to unknown spec: %s",
+        writeConf.outputSpecId());
+    this.outputSpecId =
+        writeConf.outputSpecId() != null
+            ? table.specs().get(writeConf.outputSpecId()).specId()
+            : table.spec().specId();
   }
 
   BatchWrite asBatchAppend() {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
@@ -162,6 +162,9 @@ public class TestPartitionedWrites extends SparkCatalogTestBase {
   @Test
   public void testWriteWithOutputSpec() throws NoSuchTableException {
     Table table = validationCatalog.loadTable(tableIdent);
+    // Drop all records in table to have a fresh start.
+    sql("DELETE FROM %s", tableName);
+    table.refresh();
 
     final int originalSpecId = table.spec().specId();
     table.updateSpec().addField("data").commit();
@@ -197,6 +200,26 @@ public class TestPartitionedWrites extends SparkCatalogTestBase {
         "Rows must match",
         expected,
         sql("SELECT id, data, _spec_id FROM %s WHERE id >= 10 ORDER BY id", tableName));
+
+    // Verify that the actual partitions are written with the correct spec ID.
+    // Two of the partitions should have the original spec ID and one should have the new one.
+    Dataset<Row> actualPartitionRows =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableName + ".partitions")
+            .select("spec_id", "partition.id_trunc", "partition.data")
+            .orderBy("spec_id", "partition.id_trunc");
+
+    expected =
+        ImmutableList.of(
+            row(originalSpecId, 9L, null),
+            row(originalSpecId, 12L, null),
+            row(table.spec().specId(), 9L, "a"));
+    assertEquals(
+        "There are 3 partitions, one with the original spec ID and two with the new one",
+        expected,
+        rowsToJava(actualPartitionRows.collectAsList()));
 
     // Even the default spec ID should be followed when present.
     data = ImmutableList.of(new SimpleRecord(13, "d"));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -130,7 +130,7 @@ public class SparkWriteConf {
   }
 
   public int outputSpecId() {
-    final int outputSpecId =
+    int outputSpecId =
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -123,6 +123,10 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
+  public Integer outputSpecId() {
+    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  }
+
   public boolean mergeSchema() {
     return confParser
         .booleanConf()

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -24,12 +24,14 @@ import static org.apache.iceberg.DistributionMode.RANGE;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
@@ -58,12 +60,16 @@ public class SparkWriteConf {
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
+  private final int currentSpecId;
+  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
     this.table = table;
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
+    this.currentSpecId = table.spec().specId();
+    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -123,8 +129,18 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
-  public Integer outputSpecId() {
-    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  public int outputSpecId() {
+    final int outputSpecId =
+        confParser
+            .intConf()
+            .option(SparkWriteOptions.OUTPUT_SPEC_ID)
+            .defaultValue(currentSpecId)
+            .parse();
+    Preconditions.checkArgument(
+        partitionSpecIds.contains(outputSpecId),
+        "Output spec id %s is not a valid spec id for table",
+        outputSpecId);
+    return outputSpecId;
   }
 
   public boolean mergeSchema() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -57,6 +57,9 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
+  // Output partition spec ID where writes should go.
+  public static final String OUTPUT_SPEC_ID = "output-spec-id";
+
   public static final String OVERWRITE_MODE = "overwrite-mode";
 
   // Overrides the default distribution mode for a write operation

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -57,7 +57,6 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
-  // Output partition spec ID where writes should go.
   public static final String OUTPUT_SPEC_ID = "output-spec-id";
 
   public static final String OVERWRITE_MODE = "overwrite-mode";

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -128,14 +128,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.requiredDistribution = requiredDistribution;
     this.requiredOrdering = requiredOrdering;
 
-    Preconditions.checkArgument(
-        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
-        "Cannot write to unknown spec: %s",
-        writeConf.outputSpecId());
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
+    if (writeConf.outputSpecId() == null) {
+      this.outputSpecId = table.spec().specId();
+    } else {
+      this.outputSpecId = writeConf.outputSpecId();
+      Preconditions.checkArgument(
+          table.specs().containsKey(outputSpecId),
+          "Cannot write to unknown spec: %s",
+          outputSpecId);
+    }
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CommitMetadata;
@@ -119,10 +120,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.applicationId = applicationId;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
     this.targetFileSize = writeConf.targetDataFileSize();
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
@@ -130,6 +127,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
     this.requiredDistribution = requiredDistribution;
     this.requiredOrdering = requiredOrdering;
+
+    Preconditions.checkArgument(
+        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
+        "Cannot write to unknown spec: %s",
+        writeConf.outputSpecId());
+    this.outputSpecId =
+        writeConf.outputSpecId() != null
+            ? table.specs().get(writeConf.outputSpecId()).specId()
+            : table.spec().specId();
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -621,8 +621,8 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       Table table = tableBroadcast.value();
-      FileIO io = table.io();
       PartitionSpec spec = table.specs().get(outputSpecId);
+      FileIO io = table.io();
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
@@ -162,6 +162,9 @@ public class TestPartitionedWrites extends SparkCatalogTestBase {
   @Test
   public void testWriteWithOutputSpec() throws NoSuchTableException {
     Table table = validationCatalog.loadTable(tableIdent);
+    // Drop all records in table to have a fresh start.
+    sql("DELETE FROM %s", tableName);
+    table.refresh();
 
     final int originalSpecId = table.spec().specId();
     table.updateSpec().addField("data").commit();
@@ -197,6 +200,26 @@ public class TestPartitionedWrites extends SparkCatalogTestBase {
         "Rows must match",
         expected,
         sql("SELECT id, data, _spec_id FROM %s WHERE id >= 10 ORDER BY id", tableName));
+
+    // Verify that the actual partitions are written with the correct spec ID.
+    // Two of the partitions should have the original spec ID and one should have the new one.
+    Dataset<Row> actualPartitionRows =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableName + ".partitions")
+            .select("spec_id", "partition.id_trunc", "partition.data")
+            .orderBy("spec_id", "partition.id_trunc");
+
+    expected =
+        ImmutableList.of(
+            row(originalSpecId, 9L, null),
+            row(originalSpecId, 12L, null),
+            row(table.spec().specId(), 9L, "a"));
+    assertEquals(
+        "There are 3 partitions, one with the original spec ID and two with the new one",
+        expected,
+        rowsToJava(actualPartitionRows.collectAsList()));
 
     // Even the default spec ID should be followed when present.
     data = ImmutableList.of(new SimpleRecord(13, "d"));

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -148,7 +148,7 @@ public class SparkWriteConf {
   }
 
   public int outputSpecId() {
-    final int outputSpecId =
+    int outputSpecId =
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -141,6 +141,10 @@ public class SparkWriteConf {
         .parse();
   }
 
+  public Integer outputSpecId() {
+    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  }
+
   public FileFormat dataFileFormat() {
     String valueAsString =
         confParser

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -24,6 +24,7 @@ import static org.apache.iceberg.DistributionMode.RANGE;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.IsolationLevel;
@@ -31,6 +32,7 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
@@ -61,6 +63,8 @@ public class SparkWriteConf {
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
+  private final int currentSpecId;
+  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
     this(spark, table, null, writeOptions);
@@ -73,6 +77,8 @@ public class SparkWriteConf {
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
+    this.currentSpecId = table.spec().specId();
+    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -141,8 +147,18 @@ public class SparkWriteConf {
         .parse();
   }
 
-  public Integer outputSpecId() {
-    return confParser.intConf().option(SparkWriteOptions.OUTPUT_SPEC_ID).parseOptional();
+  public int outputSpecId() {
+    final int outputSpecId =
+        confParser
+            .intConf()
+            .option(SparkWriteOptions.OUTPUT_SPEC_ID)
+            .defaultValue(currentSpecId)
+            .parse();
+    Preconditions.checkArgument(
+        partitionSpecIds.contains(outputSpecId),
+        "Output spec id %s is not a valid spec id for table",
+        outputSpecId);
+    return outputSpecId;
   }
 
   public FileFormat dataFileFormat() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -57,6 +57,9 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
+  // Output partition spec ID where writes should go.
+  public static final String OUTPUT_SPEC_ID = "output-spec-id";
+
   public static final String OVERWRITE_MODE = "overwrite-mode";
 
   // Overrides the default distribution mode for a write operation

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -57,7 +57,6 @@ public class SparkWriteOptions {
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =
       "handle-timestamp-without-timezone";
 
-  // Output partition spec ID where writes should go.
   public static final String OUTPUT_SPEC_ID = "output-spec-id";
 
   public static final String OVERWRITE_MODE = "overwrite-mode";

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -641,8 +641,8 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       Table table = tableBroadcast.value();
-      FileIO io = table.io();
       PartitionSpec spec = table.specs().get(outputSpecId);
+      FileIO io = table.io();
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId)

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -91,7 +91,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final String applicationId;
   private final boolean wapEnabled;
   private final String wapId;
-  private final PartitionSpec outputSpec;
+  private final int outputSpecId;
   private final String branch;
   private final long targetFileSize;
   private final Schema writeSchema;
@@ -121,10 +121,10 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.applicationId = applicationId;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
-    this.outputSpec =
+    this.outputSpecId =
         writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId())
-            : table.spec();
+            ? table.specs().get(writeConf.outputSpecId()).specId()
+            : table.spec().specId();
     this.branch = writeConf.branch();
     this.targetFileSize = writeConf.targetDataFileSize();
     this.writeSchema = writeSchema;
@@ -182,7 +182,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
         tableBroadcast,
         queryId,
         format,
-        outputSpec,
+        outputSpecId,
         targetFileSize,
         writeSchema,
         dsSchema,
@@ -610,7 +610,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private static class WriterFactory implements DataWriterFactory, StreamingDataWriterFactory {
     private final Broadcast<Table> tableBroadcast;
     private final FileFormat format;
-    private final PartitionSpec outputSpec;
+    private final int outputSpecId;
     private final long targetFileSize;
     private final Schema writeSchema;
     private final StructType dsSchema;
@@ -621,14 +621,14 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
         Broadcast<Table> tableBroadcast,
         String queryId,
         FileFormat format,
-        PartitionSpec outputSpec,
+        int outputSpecId,
         long targetFileSize,
         Schema writeSchema,
         StructType dsSchema,
         boolean partitionedFanoutEnabled) {
       this.tableBroadcast = tableBroadcast;
       this.format = format;
-      this.outputSpec = outputSpec;
+      this.outputSpecId = outputSpecId;
       this.targetFileSize = targetFileSize;
       this.writeSchema = writeSchema;
       this.dsSchema = dsSchema;
@@ -645,6 +645,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       Table table = tableBroadcast.value();
       FileIO io = table.io();
+      PartitionSpec outputSpec = table.specs().get(outputSpecId);
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId)

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -131,14 +131,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.requiredDistribution = requiredDistribution;
     this.requiredOrdering = requiredOrdering;
 
-    Preconditions.checkArgument(
-        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
-        "Cannot write to unknown spec: %s",
-        writeConf.outputSpecId());
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
+    if (writeConf.outputSpecId() == null) {
+      this.outputSpecId = table.spec().specId();
+    } else {
+      this.outputSpecId = writeConf.outputSpecId();
+      Preconditions.checkArgument(
+          table.specs().containsKey(outputSpecId),
+          "Cannot write to unknown spec: %s",
+          outputSpecId);
+    }
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -121,10 +122,6 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.applicationId = applicationId;
     this.wapEnabled = writeConf.wapEnabled();
     this.wapId = writeConf.wapId();
-    this.outputSpecId =
-        writeConf.outputSpecId() != null
-            ? table.specs().get(writeConf.outputSpecId()).specId()
-            : table.spec().specId();
     this.branch = writeConf.branch();
     this.targetFileSize = writeConf.targetDataFileSize();
     this.writeSchema = writeSchema;
@@ -133,6 +130,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
     this.requiredDistribution = requiredDistribution;
     this.requiredOrdering = requiredOrdering;
+
+    Preconditions.checkArgument(
+        writeConf.outputSpecId() == null || table.specs().containsKey(writeConf.outputSpecId()),
+        "Cannot write to unknown spec: %s",
+        writeConf.outputSpecId());
+    this.outputSpecId =
+        writeConf.outputSpecId() != null
+            ? table.specs().get(writeConf.outputSpecId()).specId()
+            : table.spec().specId();
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -51,7 +51,6 @@ import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.io.PartitioningWriter;
 import org.apache.iceberg.io.RollingDataWriter;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -130,16 +129,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
     this.requiredDistribution = requiredDistribution;
     this.requiredOrdering = requiredOrdering;
-
-    if (writeConf.outputSpecId() == null) {
-      this.outputSpecId = table.spec().specId();
-    } else {
-      this.outputSpecId = writeConf.outputSpecId();
-      Preconditions.checkArgument(
-          table.specs().containsKey(outputSpecId),
-          "Cannot write to unknown spec: %s",
-          outputSpecId);
-    }
+    this.outputSpecId = writeConf.outputSpecId();
   }
 
   @Override
@@ -652,7 +642,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       Table table = tableBroadcast.value();
       FileIO io = table.io();
-      PartitionSpec outputSpec = table.specs().get(outputSpecId);
+      PartitionSpec spec = table.specs().get(outputSpecId);
 
       OutputFileFactory fileFactory =
           OutputFileFactory.builderFor(table, partitionId, taskId)
@@ -666,16 +656,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
               .dataSparkType(dsSchema)
               .build();
 
-      if (outputSpec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(
-            writerFactory, fileFactory, io, outputSpec, targetFileSize);
+      if (spec.isUnpartitioned()) {
+        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
 
       } else {
         return new PartitionedDataWriter(
             writerFactory,
             fileFactory,
             io,
-            outputSpec,
+            spec,
             writeSchema,
             dsSchema,
             targetFileSize,

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/PartitionedWritesTestBase.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.sql;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -182,5 +183,65 @@ public abstract class PartitionedWritesTestBase extends SparkCatalogTestBase {
         "View should have expected rows",
         ImmutableList.of(row(1L, "a"), row(1L, "a")),
         sql("SELECT * FROM tmp"));
+  }
+
+  @Test
+  public void testWriteWithOutputSpec() throws NoSuchTableException {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    final int originalSpecId = table.spec().specId();
+    table.updateSpec().addField("data").commit();
+
+    table.refresh();
+    sql("REFRESH TABLE %s", tableName);
+
+    // By default, we write to the current spec.
+    sql("INSERT INTO TABLE %s VALUES (10, 'a')", tableName);
+
+    List<Object[]> expected = ImmutableList.of(row(10L, "a", table.spec().specId()));
+    assertEquals(
+        "Rows must match",
+        expected,
+        sql("SELECT id, data, _spec_id FROM %s WHERE id >= 10 ORDER BY id", tableName));
+
+    // Output spec ID should be respected when present.
+    List<SimpleRecord> data =
+        ImmutableList.of(new SimpleRecord(11, "b"), new SimpleRecord(12, "c"));
+    spark
+        .createDataFrame(data, SimpleRecord.class)
+        .toDF()
+        .writeTo(tableName)
+        .option("output-spec-id", Integer.toString(originalSpecId))
+        .append();
+
+    expected =
+        ImmutableList.of(
+            row(10L, "a", table.spec().specId()),
+            row(11L, "b", originalSpecId),
+            row(12L, "c", originalSpecId));
+    assertEquals(
+        "Rows must match",
+        expected,
+        sql("SELECT id, data, _spec_id FROM %s WHERE id >= 10 ORDER BY id", tableName));
+
+    // Even the default spec ID should be followed when present.
+    data = ImmutableList.of(new SimpleRecord(13, "d"));
+    spark
+        .createDataFrame(data, SimpleRecord.class)
+        .toDF()
+        .writeTo(tableName)
+        .option("output-spec-id", Integer.toString(table.spec().specId()))
+        .append();
+
+    expected =
+        ImmutableList.of(
+            row(10L, "a", table.spec().specId()),
+            row(11L, "b", originalSpecId),
+            row(12L, "c", originalSpecId),
+            row(13L, "d", table.spec().specId()));
+    assertEquals(
+        "Rows must match",
+        expected,
+        sql("SELECT id, data, _spec_id FROM %s WHERE id >= 10 ORDER BY id", tableName));
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesToWapBranch.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.sql;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.Table;
@@ -87,5 +88,12 @@ public class TestPartitionedWritesToWapBranch extends PartitionedWritesTestBase 
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot set both WAP ID and branch, but got ID [%s] and branch [%s]", wapId, BRANCH);
+  }
+
+  @Override
+  protected void assertPartitionMetadata(
+      String tableName, List<Object[]> expected, String... selectPartitionColumns) {
+    // Cannot read from the .partitions table newly written data into the WAP branch. See
+    // https://github.com/apache/iceberg/issues/7297 for more details.
   }
 }


### PR DESCRIPTION
## Summary

Allow passing `output-spec-id` to the Spark writer, so that we can customize which partition spec to write. This is useful for when a table has more than one active spec (e.g. daily and hourly partition spec).

Fixes https://github.com/apache/iceberg/issues/6932

## Testing

- [x] Unit tests for Spark 3.1, 3.2 & 3.3