### PR TITLE
Spark: Parameterize backup suffix in migrate procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -50,6 +50,16 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
     throw new UnsupportedOperationException("Dropping a backup is not supported");
   }
 
+  /**
+   * Sets a backup suffix to use in the backup table post-migration. Default suffix is __BACKUP__.
+   *
+   * @param backupSuffix a backup suffix string
+   * @return this for method chaining
+   */
+  default MigrateTable withBackupSuffix(String backupSuffix) {
+    throw new UnsupportedOperationException("Setting a backup suffix is not supported");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the number of migrated data files. */

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -38,7 +38,8 @@ class MigrateTableProcedure extends BaseProcedure {
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
-        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType)
+        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType),
+        ProcedureParameter.optional("backup_suffix", DataTypes.StringType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -90,9 +91,13 @@ class MigrateTableProcedure extends BaseProcedure {
     }
 
     boolean dropBackup = args.isNullAt(2) ? false : args.getBoolean(2);
+    String backupSuffix = args.isNullAt(3) ? null : args.getString(3);
 
     MigrateTable migrateTable =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+    if (backupSuffix != null) {
+      migrateTable = migrateTable.withBackupSuffix(backupSuffix);
+    }
 
     MigrateTable.Result result;
     if (dropBackup) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -95,16 +95,16 @@ class MigrateTableProcedure extends BaseProcedure {
 
     MigrateTable migrateTable =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+
     if (backupSuffix != null) {
       migrateTable = migrateTable.withBackupSuffix(backupSuffix);
     }
 
-    MigrateTable.Result result;
     if (dropBackup) {
-      result = migrateTable.dropBackup().execute();
-    } else {
-      result = migrateTable.execute();
+      migrateTable = migrateTable.dropBackup();
     }
+
+    MigrateTable.Result result = migrateTable.execute();
 
     return new InternalRow[] {newInternalRow(result.migratedDataFilesCount())};
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkSessionCatalog;
@@ -52,21 +53,29 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
     implements MigrateTable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrateTableSparkAction.class);
-  private static final String BACKUP_SUFFIX = "_BACKUP_";
+  private static final String DEFAULT_BACKUP_SUFFIX = "_BACKUP_";
 
   private final StagingTableCatalog destCatalog;
   private final Identifier destTableIdent;
-  private final Identifier backupIdent;
 
+  private Identifier backupIdent;
   private boolean dropBackup = false;
 
   MigrateTableSparkAction(
       SparkSession spark, CatalogPlugin sourceCatalog, Identifier sourceTableIdent) {
+    this(spark, sourceCatalog, sourceTableIdent, DEFAULT_BACKUP_SUFFIX);
+  }
+
+  MigrateTableSparkAction(
+      SparkSession spark,
+      CatalogPlugin sourceCatalog,
+      Identifier sourceTableIdent,
+      String backupSuffix) {
     super(spark, sourceCatalog, sourceTableIdent);
     this.destCatalog = checkDestinationCatalog(sourceCatalog);
     this.destTableIdent = sourceTableIdent;
-    String backupName = sourceTableIdent.name() + BACKUP_SUFFIX;
-    this.backupIdent = Identifier.of(sourceTableIdent.namespace(), backupName);
+    String backupName = destTableIdent.name() + DEFAULT_BACKUP_SUFFIX;
+    this.backupIdent = Identifier.of(destTableIdent.namespace(), backupName);
   }
 
   @Override
@@ -99,6 +108,15 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
   @Override
   public MigrateTableSparkAction dropBackup() {
     this.dropBackup = true;
+    return this;
+  }
+
+  @Override
+  public MigrateTableSparkAction withBackupSuffix(String backupSuffix) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(backupSuffix), "Backup suffix cannot be null or empty string");
+    String backupName = destTableIdent.name() + backupSuffix;
+    this.backupIdent = Identifier.of(destTableIdent.namespace(), backupName);
     return this;
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -39,7 +39,8 @@ class MigrateTableProcedure extends BaseProcedure {
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
-        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType)
+        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType),
+        ProcedureParameter.optional("backup_suffix", DataTypes.StringType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -91,9 +92,13 @@ class MigrateTableProcedure extends BaseProcedure {
     }
 
     boolean dropBackup = args.isNullAt(2) ? false : args.getBoolean(2);
+    String backupSuffix = args.isNullAt(3) ? null : args.getString(3);
 
     MigrateTableSparkAction migrateTableSparkAction =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+    if (backupSuffix != null) {
+      migrateTableSparkAction = migrateTableSparkAction.withBackupSuffix(backupSuffix);
+    }
 
     final MigrateTable.Result result;
     if (dropBackup) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -96,16 +96,16 @@ class MigrateTableProcedure extends BaseProcedure {
 
     MigrateTableSparkAction migrateTableSparkAction =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+
     if (backupSuffix != null) {
       migrateTableSparkAction = migrateTableSparkAction.withBackupSuffix(backupSuffix);
     }
 
-    final MigrateTable.Result result;
     if (dropBackup) {
-      result = migrateTableSparkAction.dropBackup().execute();
-    } else {
-      result = migrateTableSparkAction.execute();
+      migrateTableSparkAction = migrateTableSparkAction.dropBackup();
     }
+
+    MigrateTable.Result result = migrateTableSparkAction.execute();
 
     return new InternalRow[] {newInternalRow(result.migratedDataFilesCount())};
   }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark.extensions;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -106,20 +108,41 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     sql("DROP TABLE IF EXISTS  %s", tableName + "_BACKUP_");
   }
 
-  @Test
-  public void testMigrateWithDropBackup() throws IOException {
+  private void testMigrateWithDropBackup(@Nullable String backupSuffix) throws IOException {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
+    Optional<String> backupSuffixArg = Optional.ofNullable(backupSuffix);
     sql(
         "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
         tableName, location);
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
 
-    Object result =
-        scalarSql(
-            "CALL %s.system.migrate(table => '%s', drop_backup => true)", catalogName, tableName);
+    final Object result;
+    final String suffixUsed;
+    if (backupSuffixArg.isPresent()) {
+      suffixUsed = backupSuffixArg.get();
+      result =
+          scalarSql(
+              "CALL %s.system.migrate(table => '%s', drop_backup => true, backup_suffix => '%s')",
+              catalogName, tableName, suffixUsed);
+    } else {
+      suffixUsed = "__BACKUP__";
+      result =
+          scalarSql(
+              "CALL %s.system.migrate(table => '%s', drop_backup => true)", catalogName, tableName);
+    }
     Assert.assertEquals("Should have added one file", 1L, result);
-    Assert.assertFalse(spark.catalog().tableExists(tableName + "_BACKUP_"));
+    Assert.assertFalse(spark.catalog().tableExists(tableName + suffixUsed));
+  }
+
+  @Test
+  public void testMigrateWithDropBackupDefaultSuffix() throws IOException {
+    testMigrateWithDropBackup(null);
+  }
+
+  @Test
+  public void testMigrateWithDropBackupAndSuffix() throws IOException {
+    testMigrateWithDropBackup("_tmp");
   }
 
   @Test
@@ -144,12 +167,17 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     String tableLocation = createdTable.location().replace("file:", "");
     Assert.assertEquals("Table should have original location", location, tableLocation);
 
-    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
 
     assertEquals(
         "Should have expected rows",
-        ImmutableList.of(row(1L, "a"), row(1L, "a")),
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
         sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1L, "a")),
+        sql("SELECT * FROM %s ORDER BY id", tableName + backupSuffix));
 
     sql("DROP TABLE %s", tableName + backupSuffix);
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/MigrateTableSparkAction.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.spark.SparkSessionCatalog;
@@ -52,12 +53,12 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
     implements MigrateTable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrateTableSparkAction.class);
-  private static final String BACKUP_SUFFIX = "_BACKUP_";
+  private static final String DEFAULT_BACKUP_SUFFIX = "_BACKUP_";
 
   private final StagingTableCatalog destCatalog;
   private final Identifier destTableIdent;
-  private final Identifier backupIdent;
 
+  private Identifier backupIdent;
   private boolean dropBackup = false;
 
   MigrateTableSparkAction(
@@ -65,8 +66,8 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
     super(spark, sourceCatalog, sourceTableIdent);
     this.destCatalog = checkDestinationCatalog(sourceCatalog);
     this.destTableIdent = sourceTableIdent;
-    String backupName = sourceTableIdent.name() + BACKUP_SUFFIX;
-    this.backupIdent = Identifier.of(sourceTableIdent.namespace(), backupName);
+    String backupName = destTableIdent.name() + DEFAULT_BACKUP_SUFFIX;
+    this.backupIdent = Identifier.of(destTableIdent.namespace(), backupName);
   }
 
   @Override
@@ -99,6 +100,15 @@ public class MigrateTableSparkAction extends BaseTableCreationSparkAction<Migrat
   @Override
   public MigrateTableSparkAction dropBackup() {
     this.dropBackup = true;
+    return this;
+  }
+
+  @Override
+  public MigrateTableSparkAction withBackupSuffix(String backupSuffix) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(backupSuffix), "Backup suffix cannot be null or empty string");
+    String backupName = destTableIdent.name() + backupSuffix;
+    this.backupIdent = Identifier.of(destTableIdent.namespace(), backupName);
     return this;
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -96,16 +96,16 @@ class MigrateTableProcedure extends BaseProcedure {
 
     MigrateTableSparkAction migrateTableSparkAction =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+
     if (backupSuffix != null) {
       migrateTableSparkAction = migrateTableSparkAction.withBackupSuffix(backupSuffix);
     }
 
-    MigrateTable.Result result;
     if (dropBackup) {
-      result = migrateTableSparkAction.dropBackup().execute();
-    } else {
-      result = migrateTableSparkAction.execute();
+      migrateTableSparkAction = migrateTableSparkAction.dropBackup();
     }
+
+    MigrateTable.Result result = migrateTableSparkAction.execute();
 
     return new InternalRow[] {newInternalRow(result.migratedDataFilesCount())};
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/MigrateTableProcedure.java
@@ -39,7 +39,8 @@ class MigrateTableProcedure extends BaseProcedure {
       new ProcedureParameter[] {
         ProcedureParameter.required("table", DataTypes.StringType),
         ProcedureParameter.optional("properties", STRING_MAP),
-        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType)
+        ProcedureParameter.optional("drop_backup", DataTypes.BooleanType),
+        ProcedureParameter.optional("backup_suffix", DataTypes.StringType)
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -91,9 +92,13 @@ class MigrateTableProcedure extends BaseProcedure {
     }
 
     boolean dropBackup = args.isNullAt(2) ? false : args.getBoolean(2);
+    String backupSuffix = args.isNullAt(3) ? null : args.getString(3);
 
     MigrateTableSparkAction migrateTableSparkAction =
         SparkActions.get().migrateTable(tableName).tableProperties(properties);
+    if (backupSuffix != null) {
+      migrateTableSparkAction = migrateTableSparkAction.withBackupSuffix(backupSuffix);
+    }
 
     MigrateTable.Result result;
     if (dropBackup) {


### PR DESCRIPTION
This PR adds the ability to use a custom backup suffix during the `migrate` process. By default, the suffix `__BACKUP__` is used, which sometimes gets represented as `__backup__` in engines that lower case table names leading to confusion.

This change enables uses to optionally set a suffix for those backup tables. A follow up PR in docs would update the parameter list once merged.

PTAL Thanks.