### PR TITLE
[Core][Spark] Improve DeleteOrphanFiles action to return additional details of deleted orphan files

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -66,6 +66,19 @@ acceptedBreaks:
       old: "method void org.apache.iceberg.io.DataWriter<T>::add(T)"
       justification: "Removing deprecated method"
   "1.1.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.method.addedToInterface"
+      new: "method java.lang.Iterable<org.apache.iceberg.actions.DeleteOrphanFiles.OrphanFileStatus>\
+        \ org.apache.iceberg.actions.DeleteOrphanFiles.Result::statuses()"
+      justification: "Introduced improved API to represent results of DeleteOrphanFiles\
+        \ action. The new API will allow users to gracefully deal with failure encountered\
+        \ during file deletion"
+    - code: "java.method.numberOfParametersChanged"
+      old: "method void org.apache.iceberg.io.BulkDeletionFailureException::<init>(int)"
+      new: "method void org.apache.iceberg.io.BulkDeletionFailureException::<init>(java.util.Set<java.lang.String>,\
+        \ int)"
+      justification: "Intoduced improved API to collect the file paths that failed\
+        \ to delete"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.noLongerImplementsInterface"
       old: "class org.apache.iceberg.jdbc.JdbcCatalog"

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -22,6 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.immutables.value.Value;
@@ -144,7 +146,25 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
   @Value.Immutable
   interface Result {
     /** Returns locations of orphan files. */
-    Iterable<String> orphanFileLocations();
+    default Iterable<String> orphanFileLocations() {
+      return StreamSupport.stream(statuses().spliterator(), false)
+          .map(DeleteOrphanFiles.OrphanFileStatus::location)
+          .collect(Collectors.toList());
+    }
+
+    Iterable<OrphanFileStatus> statuses();
+  }
+
+  interface OrphanFileStatus {
+
+    /** Returns the location of the orphan file. */
+    String location();
+
+    /** Returns whether the orphan file was successfully deleted or not. */
+    boolean deleted();
+
+    /** Returns the exception that occurred while deleting the file, else returns null. */
+    Exception failureCause();
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
@@ -25,14 +25,15 @@ package org.apache.iceberg.actions;
 @Deprecated
 public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
 
-  private final Iterable<String> orphanFileLocations;
+  private final Iterable<DeleteOrphanFiles.OrphanFileStatus> statuses;
 
-  public BaseDeleteOrphanFilesActionResult(Iterable<String> orphanFileLocations) {
-    this.orphanFileLocations = orphanFileLocations;
+  public BaseDeleteOrphanFilesActionResult(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileLocations) {
+    this.statuses = orphanFileLocations;
   }
 
   @Override
-  public Iterable<String> orphanFileLocations() {
-    return orphanFileLocations;
+  public Iterable<DeleteOrphanFiles.OrphanFileStatus> statuses() {
+    return statuses;
   }
 }

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+
+public class BaseOrphanFileStatus implements DeleteOrphanFiles.OrphanFileStatus {
+
+  private final String location;
+  private final boolean deleted;
+  private final Exception failureCause;
+
+  public BaseOrphanFileStatus(String location) {
+    this(location, true, null);
+  }
+
+  public BaseOrphanFileStatus(String location, boolean deleted, Exception failureCause) {
+    this.location = location;
+    this.deleted = deleted;
+    this.failureCause = failureCause;
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public boolean deleted() {
+    return deleted;
+  }
+
+  @Override
+  public Exception failureCause() {
+    return failureCause;
+  }
+}

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -286,11 +286,11 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -139,16 +140,14 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     invalidFiles.removeAll(validFiles);
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result1 =
         actions.deleteOrphanFiles(table).deleteWith(s -> {}).execute();
     Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+        "Default olderThan interval should be safe", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -158,12 +157,14 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result2.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result2.statuses());
 
     DeleteOrphanFiles.Result result3 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
     Assert.assertEquals("Action should delete 1 file", invalidFiles, result3.orphanFileLocations());
     Assert.assertFalse(
         "Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result3.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -212,15 +213,15 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Path dataPath = new Path(tableLocation + "/data");
     FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
@@ -264,8 +265,7 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     Set<String> deletedFiles = Sets.newHashSet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
@@ -285,7 +285,7 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
         SparkActions.get()
             .deleteOrphanFiles(table)
             .executeDeleteWith(executorService)
-            .olderThan(System.currentTimeMillis())
+            .olderThan(System.currentTimeMillis() + 5000) // Ensure all orphan files are selected
             .deleteWith(
                 file -> {
                   deleteThreads.add(Thread.currentThread().getName());
@@ -301,6 +301,69 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
             "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));
 
     Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
+    assertDeletedStatusAndFailureCause(result.statuses());
+  }
+
+  @Test
+  public void testOrphanFileDeleteThrowsException() {
+    Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df1 = spark.createDataFrame(records1, ThreeColumnRecord.class).coalesce(1);
+
+    // original append
+    df1.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df2 = spark.createDataFrame(records2, ThreeColumnRecord.class).coalesce(1);
+
+    // dynamic partition overwrite
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("overwrite").save(tableLocation);
+
+    // second append
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
+
+    waitUntilAfter(System.currentTimeMillis());
+
+    String locationSubstringForException = "invalid";
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(
+                file -> {
+                  if (file.contains(locationSubstringForException)) {
+                    throw new RuntimeException("simulating failure during file deletion");
+                  }
+                  table.io().deleteFile(file);
+                })
+            .execute();
+
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+
+    DeleteOrphanFiles.OrphanFileStatus fileStatus =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> status.location().contains(locationSubstringForException))
+            .findFirst()
+            .get();
+    Assert.assertFalse("Deleted status should be false", fileStatus.deleted());
+    Assert.assertEquals(
+        "Failure cause should be present",
+        "simulating failure during file deletion",
+        fileStatus.failureCause().getMessage());
+
+    List<DeleteOrphanFiles.OrphanFileStatus> deletedFileStatuses =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> !status.location().contains(locationSubstringForException))
+            .collect(Collectors.toList());
+    assertDeletedStatusAndFailureCause(deletedFileStatuses);
   }
 
   @Test
@@ -326,16 +389,14 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     Assert.assertEquals("Should not return data from the staged snapshot", records, actualRecords);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
   }
 
   @Test
@@ -353,15 +414,15 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(tableLocation + "/c2_trunc=AA/c3=AAAA");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -382,11 +443,11 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     long timestamp = System.currentTimeMillis();
 
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis() + 1000L);
 
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
@@ -395,8 +456,8 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(timestamp).execute();
 
-    Assert.assertEquals(
-        "Should delete only 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 2 files", 2, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -414,19 +475,19 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -451,16 +512,14 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -481,16 +540,14 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -552,8 +609,7 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     invalidFiles.removeIf(file -> file.contains(validFile));
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
     DeleteOrphanFiles.Result result =
@@ -564,6 +620,7 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -586,16 +643,15 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(table.location() + "/data");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     table.refresh();
 
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals(
-        "Should delete only 1 files", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 1 files", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
@@ -634,8 +690,11 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -733,5 +792,25 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
         .as("Deleted file")
         .isEqualTo(statsLocation.toURI().toString());
     Assertions.assertThat(statsLocation.exists()).as("stats file should be deleted").isFalse();
+    assertDeletedStatusAndFailureCause(result.statuses());
+  }
+
+  protected List<Exception> toNonNullFailureCauses(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    return StreamSupport.stream(fileStatuses.spliterator(), false)
+        .map(DeleteOrphanFiles.OrphanFileStatus::failureCause)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  protected void assertDeletedStatusAndFailureCause(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    Assert.assertTrue(
+        "Deleted status of orphan file should be true",
+        StreamSupport.stream(fileStatuses.spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    Assert.assertTrue(
+        "Failure cause of deleted orphan file should be null",
+        toNonNullFailureCauses(fileStatuses).isEmpty());
   }
 }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1613,12 +1613,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .execute();
     Assert.assertTrue(
-        "Should not delete any metadata files", Iterables.isEmpty(result1.orphanFileLocations()));
+        "Should not delete any metadata files", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
-    Assert.assertEquals(
-        "Should delete 1 data file", 1, Iterables.size(result2.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords =

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -31,6 +31,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Files;
@@ -129,6 +130,10 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
                 + "older_than => TIMESTAMP '%s')",
             catalogName, tableIdent, currentTimestamp);
     Assert.assertEquals("Should be orphan files in the data folder", 1, output2.size());
+    Assert.assertTrue(
+        "Deleted status of orphan file should be true", toDeletedStatus(output2.get(0)));
+    Assert.assertNull(
+        "Error message of orphan file should be null", toErrorMessage(output2.get(0)));
 
     // the previous call should have deleted all orphan files
     List<Object[]> output3 =
@@ -180,6 +185,12 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
                 + "dry_run => true)",
             catalogName, tableIdent, currentTimestamp);
     Assert.assertEquals("Should be one orphan files", 1, output1.size());
+    Assert.assertFalse(
+        "Deleted status of orphan file should be false during dry run",
+        toDeletedStatus(output1.get(0)));
+    Assert.assertNull(
+        "Error message of orphan file should be null during dry run",
+        toErrorMessage(output1.get(0)));
 
     // actually delete orphans
     List<Object[]> output2 =
@@ -189,6 +200,10 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
                 + "older_than => TIMESTAMP '%s')",
             catalogName, tableIdent, currentTimestamp);
     Assert.assertEquals("Should be one orphan files", 1, output2.size());
+    Assert.assertTrue(
+        "Deleted status of orphan file should be true", toDeletedStatus(output2.get(0)));
+    Assert.assertNull(
+        "Error message of orphan file should be null", toErrorMessage(output2.get(0)));
 
     // the previous call should have deleted all orphan files
     List<Object[]> output3 =
@@ -311,6 +326,12 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
                 + "older_than => TIMESTAMP '%s')",
             catalogName, tableIdent, 4, currentTimestamp);
     Assert.assertEquals("Should be orphan files in the data folder", 4, output.size());
+    Assert.assertTrue(
+        "Deleted status of orphan files should be true",
+        output.stream().allMatch(this::toDeletedStatus));
+    Assert.assertTrue(
+        "Error message of orphan files should be null",
+        output.stream().map(this::toErrorMessage).allMatch(Objects::isNull));
 
     // the previous call should have deleted all orphan files
     List<Object[]> output3 =
@@ -440,7 +461,7 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
     Assertions.assertThat(output).as("Should be orphan files").hasSize(1);
     Assertions.assertThat(Iterables.getOnlyElement(output))
         .as("Deleted files")
-        .containsExactly(statsLocation.toURI().toString());
+        .containsExactly(statsLocation.toURI().toString(), true, null);
     Assertions.assertThat(statsLocation.exists()).as("stats file should be deleted").isFalse();
   }
 
@@ -461,5 +482,13 @@ public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
     Preconditions.checkState(
         file.isDirectory(), "Table location '%s' does not point to a directory", location);
     return file;
+  }
+
+  private boolean toDeletedStatus(Object[] row) {
+    return (boolean) row[1];
+  }
+
+  private String toErrorMessage(Object[] row) {
+    return (String) row[2];
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+
+public class BaseOrphanFileStatus implements DeleteOrphanFiles.OrphanFileStatus {
+
+  private final String location;
+  private final boolean deleted;
+  private final Exception failureCause;
+
+  public BaseOrphanFileStatus(String location) {
+    this(location, true, null);
+  }
+
+  public BaseOrphanFileStatus(String location, boolean deleted, Exception failureCause) {
+    this.location = location;
+    this.deleted = deleted;
+    this.failureCause = failureCause;
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public boolean deleted() {
+    return deleted;
+  }
+
+  @Override
+  public Exception failureCause() {
+    return failureCause;
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -60,7 +60,9 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   private static final StructType OUTPUT_TYPE =
       new StructType(
           new StructField[] {
-            new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty())
+            new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty()),
+            new StructField("deleted", DataTypes.BooleanType, false, Metadata.empty()),
+            new StructField("error_message", DataTypes.StringType, true, Metadata.empty())
           });
 
   public static ProcedureBuilder builder() {
@@ -126,19 +128,30 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
           DeleteOrphanFiles.Result result = action.execute();
 
-          return toOutputRows(result);
+          return toOutputRows(dryRun, result);
         });
   }
 
-  private InternalRow[] toOutputRows(DeleteOrphanFiles.Result result) {
-    Iterable<String> orphanFileLocations = result.orphanFileLocations();
+  private InternalRow[] toOutputRows(boolean dryRun, DeleteOrphanFiles.Result result) {
+    Iterable<DeleteOrphanFiles.OrphanFileStatus> orphanFileStatuses = result.statuses();
 
-    int orphanFileLocationsCount = Iterables.size(orphanFileLocations);
+    int orphanFileLocationsCount = Iterables.size(orphanFileStatuses);
     InternalRow[] rows = new InternalRow[orphanFileLocationsCount];
 
     int index = 0;
-    for (String fileLocation : orphanFileLocations) {
-      rows[index] = newInternalRow(UTF8String.fromString(fileLocation));
+    for (DeleteOrphanFiles.OrphanFileStatus fileStatus : orphanFileStatuses) {
+      String errorMessage =
+          fileStatus.failureCause() != null ? fileStatus.failureCause().getMessage() : null;
+      // During dry run DeleteOrphanFiles.OrphanFileStatus#deleted() will be ignored and deleted
+      // will always be false.
+      // For an actual run, deleted will use the value of
+      // DeleteOrphanFiles.OrphanFileStatus#deleted().
+      boolean deleted = dryRun ? false : fileStatus.deleted();
+      rows[index] =
+          newInternalRow(
+              UTF8String.fromString(fileStatus.location()),
+              deleted,
+              UTF8String.fromString(errorMessage));
       index++;
     }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -286,11 +286,11 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -139,16 +140,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     invalidFiles.removeAll(validFiles);
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result1 =
         actions.deleteOrphanFiles(table).deleteWith(s -> {}).execute();
     Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+        "Default olderThan interval should be safe", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -158,12 +157,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result2.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result2.statuses());
 
     DeleteOrphanFiles.Result result3 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
     Assert.assertEquals("Action should delete 1 file", invalidFiles, result3.orphanFileLocations());
     Assert.assertFalse(
         "Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result3.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -212,15 +213,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Path dataPath = new Path(tableLocation + "/data");
     FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
@@ -264,8 +265,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     Set<String> deletedFiles = Sets.newHashSet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
@@ -285,7 +285,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         SparkActions.get()
             .deleteOrphanFiles(table)
             .executeDeleteWith(executorService)
-            .olderThan(System.currentTimeMillis())
+            .olderThan(System.currentTimeMillis() + 5000) // Ensure all orphan files are selected
             .deleteWith(
                 file -> {
                   deleteThreads.add(Thread.currentThread().getName());
@@ -301,6 +301,69 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));
 
     Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
+    assertDeletedStatusAndFailureCause(result.statuses());
+  }
+
+  @Test
+  public void testOrphanFileDeleteThrowsException() {
+    Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df1 = spark.createDataFrame(records1, ThreeColumnRecord.class).coalesce(1);
+
+    // original append
+    df1.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df2 = spark.createDataFrame(records2, ThreeColumnRecord.class).coalesce(1);
+
+    // dynamic partition overwrite
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("overwrite").save(tableLocation);
+
+    // second append
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
+
+    waitUntilAfter(System.currentTimeMillis());
+
+    String locationSubstringForException = "invalid";
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(
+                file -> {
+                  if (file.contains(locationSubstringForException)) {
+                    throw new RuntimeException("simulating failure during file deletion");
+                  }
+                  table.io().deleteFile(file);
+                })
+            .execute();
+
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+
+    DeleteOrphanFiles.OrphanFileStatus fileStatus =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> status.location().contains(locationSubstringForException))
+            .findFirst()
+            .get();
+    Assert.assertFalse("Deleted status should be false", fileStatus.deleted());
+    Assert.assertEquals(
+        "Failure cause should be present",
+        "simulating failure during file deletion",
+        fileStatus.failureCause().getMessage());
+
+    List<DeleteOrphanFiles.OrphanFileStatus> deletedFileStatuses =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> !status.location().contains(locationSubstringForException))
+            .collect(Collectors.toList());
+    assertDeletedStatusAndFailureCause(deletedFileStatuses);
   }
 
   @Test
@@ -326,16 +389,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     Assert.assertEquals("Should not return data from the staged snapshot", records, actualRecords);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
   }
 
   @Test
@@ -353,15 +414,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(tableLocation + "/c2_trunc=AA/c3=AAAA");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -382,11 +443,11 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     long timestamp = System.currentTimeMillis();
 
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis() + 1000L);
 
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
@@ -395,8 +456,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(timestamp).execute();
 
-    Assert.assertEquals(
-        "Should delete only 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 2 files", 2, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -414,19 +475,19 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -451,16 +512,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -481,16 +540,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
 
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -552,8 +609,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     invalidFiles.removeIf(file -> file.contains(validFile));
     Assert.assertEquals("Should be 1 invalid file", 1, invalidFiles.size());
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     SparkActions actions = SparkActions.get();
     DeleteOrphanFiles.Result result =
@@ -564,6 +620,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -586,16 +643,15 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(table.location() + "/data");
 
-    // sleep for 1 second to unsure files will be old enough
-    Thread.sleep(1000);
+    waitUntilAfter(System.currentTimeMillis());
 
     table.refresh();
 
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals(
-        "Should delete only 1 files", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 1 files", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
@@ -634,8 +690,11 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -733,5 +792,25 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .as("Deleted file")
         .isEqualTo(statsLocation.toURI().toString());
     Assertions.assertThat(statsLocation.exists()).as("stats file should be deleted").isFalse();
+    assertDeletedStatusAndFailureCause(result.statuses());
+  }
+
+  protected List<Exception> toNonNullFailureCauses(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    return StreamSupport.stream(fileStatuses.spliterator(), false)
+        .map(DeleteOrphanFiles.OrphanFileStatus::failureCause)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  protected void assertDeletedStatusAndFailureCause(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    Assert.assertTrue(
+        "Deleted status of orphan file should be true",
+        StreamSupport.stream(fileStatuses.spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    Assert.assertTrue(
+        "Failure cause of deleted orphan file should be null",
+        toNonNullFailureCauses(fileStatuses).isEmpty());
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -60,8 +60,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -90,8 +93,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -120,8 +126,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -153,8 +162,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -186,8 +198,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @After

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1304,7 +1304,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis())
             .execute()
-            .orphanFileLocations());
+            .statuses());
   }
 
   protected void shouldHaveACleanCache(Table table) {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1611,12 +1611,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .execute();
     Assert.assertTrue(
-        "Should not delete any metadata files", Iterables.isEmpty(result1.orphanFileLocations()));
+        "Should not delete any metadata files", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
-    Assert.assertEquals(
-        "Should delete 1 data file", 1, Iterables.size(result2.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+
+public class BaseOrphanFileStatus implements DeleteOrphanFiles.OrphanFileStatus {
+
+  private final String location;
+  private final boolean deleted;
+  private final Exception failureCause;
+
+  public BaseOrphanFileStatus(String location) {
+    this(location, true, null);
+  }
+
+  public BaseOrphanFileStatus(String location, boolean deleted, Exception failureCause) {
+    this.location = location;
+    this.deleted = deleted;
+    this.failureCause = failureCause;
+  }
+
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public boolean deleted() {
+    return deleted;
+  }
+
+  @Override
+  public Exception failureCause() {
+    return failureCause;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -27,6 +27,7 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.sql.Timestamp;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -233,13 +234,29 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     return String.format("Deleting orphan files (%s) from %s", optionsAsString, table.name());
   }
 
-  private void deleteFiles(SupportsBulkOperations io, List<String> paths) {
+  private void deleteFiles(
+      SupportsBulkOperations io,
+      List<String> paths,
+      List<DeleteOrphanFiles.OrphanFileStatus> orphanFileStatuses) {
+    Set<String> deleteFailedFiles = new HashSet<String>();
     try {
       io.deleteFiles(paths);
       LOG.info("Deleted {} files using bulk deletes", paths.size());
     } catch (BulkDeletionFailureException e) {
+      deleteFailedFiles.addAll(e.deleteFailedFiles());
       int deletedFilesCount = paths.size() - e.numberFailedObjects();
       LOG.warn("Deleted only {} of {} files using bulk deletes", deletedFilesCount, paths.size());
+    } finally {
+      paths.forEach(
+          (path) -> {
+            boolean deleted = true;
+            Exception exc = null;
+            if (deleteFailedFiles.contains(path)) {
+              deleted = false;
+              exc = new Exception("Failed to delete file during bulk delete");
+            }
+            orphanFileStatuses.add(new BaseOrphanFileStatus(path, deleted, exc));
+          });
     }
   }
 
@@ -250,8 +267,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     List<String> orphanFiles =
         findOrphanFiles(spark(), actualFileIdentDS, validFileIdentDS, prefixMismatchMode);
 
+    List<DeleteOrphanFiles.OrphanFileStatus> orphanFileStatuses =
+        Lists.newArrayListWithCapacity(orphanFiles.size());
+
     if (deleteFunc == null && table.io() instanceof SupportsBulkOperations) {
-      deleteFiles((SupportsBulkOperations) table.io(), orphanFiles);
+      deleteFiles((SupportsBulkOperations) table.io(), orphanFiles, orphanFileStatuses);
     } else {
 
       Tasks.Builder<String> deleteTasks =
@@ -259,20 +279,32 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
               .noRetry()
               .executeWith(deleteExecutorService)
               .suppressFailureWhenFinished()
-              .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc));
+              .onFailure(
+                  (file, exc) -> {
+                    LOG.warn("Failed to delete file: {}", file, exc);
+                    orphanFileStatuses.add(new BaseOrphanFileStatus(file, false, exc));
+                  });
 
       if (deleteFunc == null) {
         LOG.info(
             "Table IO {} does not support bulk operations. Using non-bulk deletes.",
             table.io().getClass().getName());
-        deleteTasks.run(table.io()::deleteFile);
+        deleteTasks.run(
+            (file) -> {
+              table.io().deleteFile(file);
+              orphanFileStatuses.add(new BaseOrphanFileStatus(file));
+            });
       } else {
         LOG.info("Custom delete function provided. Using non-bulk deletes");
-        deleteTasks.run(deleteFunc::accept);
+        deleteTasks.run(
+            (file) -> {
+              deleteFunc.accept(file);
+              orphanFileStatuses.add(new BaseOrphanFileStatus(file));
+            });
       }
     }
 
-    return new BaseDeleteOrphanFilesActionResult(orphanFiles);
+    return new BaseDeleteOrphanFilesActionResult(orphanFileStatuses);
   }
 
   private Dataset<FileURI> validFileIdentDS() {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -349,11 +349,11 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -60,8 +60,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -90,8 +93,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -120,8 +126,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -153,8 +162,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -186,8 +198,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @After

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1424,7 +1424,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis())
             .execute()
-            .orphanFileLocations());
+            .statuses());
   }
 
   protected void shouldHaveACleanCache(Table table) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1630,12 +1630,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .execute();
     Assert.assertTrue(
-        "Should not delete any metadata files", Iterables.isEmpty(result1.orphanFileLocations()));
+        "Should not delete any metadata files", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
-    Assert.assertEquals(
-        "Should delete 1 data file", 1, Iterables.size(result2.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords =

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseOrphanFileStatus.java
@@ -16,25 +16,38 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.io;
+package org.apache.iceberg.spark.actions;
 
-import java.util.Set;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
 
-public class BulkDeletionFailureException extends RuntimeException {
-  private final int numberFailedObjects;
-  private final Set<String> deleteFailedFiles;
+public class BaseOrphanFileStatus implements DeleteOrphanFiles.OrphanFileStatus {
 
-  public BulkDeletionFailureException(Set<String> deleteFailedFiles, int numberFailedObjects) {
-    super(String.format("Failed to delete %d files", numberFailedObjects));
-    this.deleteFailedFiles = deleteFailedFiles;
-    this.numberFailedObjects = numberFailedObjects;
+  private final String location;
+  private final boolean deleted;
+  private final Exception failureCause;
+
+  public BaseOrphanFileStatus(String location) {
+    this(location, true, null);
   }
 
-  public int numberFailedObjects() {
-    return numberFailedObjects;
+  public BaseOrphanFileStatus(String location, boolean deleted, Exception failureCause) {
+    this.location = location;
+    this.deleted = deleted;
+    this.failureCause = failureCause;
   }
 
-  public Set<String> deleteFailedFiles() {
-    return deleteFailedFiles;
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public boolean deleted() {
+    return deleted;
+  }
+
+  @Override
+  public Exception failureCause() {
+    return failureCause;
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -304,9 +304,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       }
     }
 
-    return ImmutableDeleteOrphanFiles.Result.builder()
-        .orphanFileLocations(orphanFileStatuses)
-        .build();
+    return ImmutableDeleteOrphanFiles.Result.builder().statuses(orphanFileStatuses).build();
   }
 
   private Dataset<FileURI> validFileIdentDS() {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -304,7 +304,9 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
       }
     }
 
-    return ImmutableDeleteOrphanFiles.Result.builder().orphanFileLocations(orphanFileStatuses).build();
+    return ImmutableDeleteOrphanFiles.Result.builder()
+        .orphanFileLocations(orphanFileStatuses)
+        .build();
   }
 
   private Dataset<FileURI> validFileIdentDS() {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -349,11 +349,11 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         sparkActions().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
 
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(table.io());

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -29,6 +29,7 @@ import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -153,8 +154,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result1 =
         actions.deleteOrphanFiles(table).deleteWith(s -> {}).execute();
     Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+        "Default olderThan interval should be safe", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -164,12 +164,14 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result2.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result2.statuses());
 
     DeleteOrphanFiles.Result result3 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
     Assert.assertEquals("Action should delete 1 file", invalidFiles, result3.orphanFileLocations());
     Assert.assertFalse(
         "Invalid file should not be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result3.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -225,7 +227,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Path dataPath = new Path(tableLocation + "/data");
     FileSystem fs = dataPath.getFileSystem(spark.sessionState().newHadoopConf());
@@ -305,6 +308,69 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             "remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));
 
     Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
+    assertDeletedStatusAndFailureCause(result.statuses());
+  }
+
+  @Test
+  public void testOrphanFileDeleteThrowsException() {
+    Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+
+    List<ThreeColumnRecord> records1 =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df1 = spark.createDataFrame(records1, ThreeColumnRecord.class).coalesce(1);
+
+    // original append
+    df1.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    List<ThreeColumnRecord> records2 =
+        Lists.newArrayList(new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> df2 = spark.createDataFrame(records2, ThreeColumnRecord.class).coalesce(1);
+
+    // dynamic partition overwrite
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("overwrite").save(tableLocation);
+
+    // second append
+    df2.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
+
+    waitUntilAfter(System.currentTimeMillis());
+
+    String locationSubstringForException = "invalid";
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(
+                file -> {
+                  if (file.contains(locationSubstringForException)) {
+                    throw new RuntimeException("simulating failure during file deletion");
+                  }
+                  table.io().deleteFile(file);
+                })
+            .execute();
+
+    Assert.assertEquals("Should delete 4 files", 4, Iterables.size(result.statuses()));
+
+    DeleteOrphanFiles.OrphanFileStatus fileStatus =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> status.location().contains(locationSubstringForException))
+            .findFirst()
+            .get();
+    Assert.assertFalse("Deleted status should be false", fileStatus.deleted());
+    Assert.assertEquals(
+        "Failure cause should be present",
+        "simulating failure during file deletion",
+        fileStatus.failureCause().getMessage());
+
+    List<DeleteOrphanFiles.OrphanFileStatus> deletedFileStatuses =
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .filter(status -> !status.location().contains(locationSubstringForException))
+            .collect(Collectors.toList());
+    assertDeletedStatusAndFailureCause(deletedFileStatuses);
   }
 
   @Test
@@ -337,8 +403,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
   }
 
   @Test
@@ -363,7 +428,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -397,8 +463,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(timestamp).execute();
 
-    Assert.assertEquals(
-        "Should delete only 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 2 files", 2, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -423,11 +489,12 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 file", 1, Iterables.size(result.statuses()));
     Assert.assertTrue(
         "Should remove v1 file",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("v1.metadata.json")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(fileStatus -> fileStatus.location().contains("v1.metadata.json")));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -459,8 +526,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -488,8 +554,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertTrue(
-        "Should not delete any files", Iterables.isEmpty(result.orphanFileLocations()));
+    Assert.assertTrue("Should not delete any files", Iterables.isEmpty(result.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
     List<ThreeColumnRecord> actualRecords =
@@ -527,7 +592,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -563,7 +629,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 2 files", 2, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -599,7 +666,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals("Should delete 0 files", 0, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete 0 files", 0, Iterables.size(result.statuses()));
     Assert.assertTrue(fs.exists(pathToFileInHiddenFolder));
   }
 
@@ -668,6 +735,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertEquals("Action should find 1 file", invalidFiles, result.orphanFileLocations());
     Assert.assertTrue("Invalid file should be present", fs.exists(new Path(invalidFiles.get(0))));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -697,8 +765,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     DeleteOrphanFiles.Result result =
         SparkActions.get().deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
 
-    Assert.assertEquals(
-        "Should delete only 1 files", 1, Iterables.size(result.orphanFileLocations()));
+    Assert.assertEquals("Should delete only 1 files", 1, Iterables.size(result.statuses()));
+    assertDeletedStatusAndFailureCause(result.statuses());
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(table.location());
     List<ThreeColumnRecord> actualRecords =
@@ -737,8 +805,11 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(result.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(result.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -828,8 +899,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .deleteWith(s -> {})
             .execute();
     Assert.assertTrue(
-        "Default olderThan interval should be safe",
-        Iterables.isEmpty(result1.orphanFileLocations()));
+        "Default olderThan interval should be safe", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions
@@ -842,6 +912,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         "Action should find 1 file", invalidFilePaths, result2.orphanFileLocations());
     Assert.assertTrue(
         "Invalid file should be present", fs.exists(new Path(invalidFilePaths.get(0))));
+    assertDeletedStatusAndFailureCause(result2.statuses());
 
     DeleteOrphanFiles.Result result3 =
         actions
@@ -853,6 +924,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         "Action should delete 1 file", invalidFilePaths, result3.orphanFileLocations());
     Assert.assertFalse(
         "Invalid file should not be present", fs.exists(new Path(invalidFilePaths.get(0))));
+    assertDeletedStatusAndFailureCause(result3.statuses());
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records);
@@ -878,8 +950,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
             .compareToFileList(compareToFileListWithOutsideLocation)
             .deleteWith(s -> {})
             .execute();
-    Assert.assertEquals(
-        "Action should find nothing", Lists.newArrayList(), result4.orphanFileLocations());
+    Assert.assertEquals("Action should find nothing", Lists.newArrayList(), result4.statuses());
   }
 
   protected long waitUntilAfter(long timestampMillis) {
@@ -964,6 +1035,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         .as("Deleted file")
         .isEqualTo(statsLocation.toURI().toString());
     Assertions.assertThat(statsLocation.exists()).as("stats file should be deleted").isFalse();
+    assertDeletedStatusAndFailureCause(result.statuses());
   }
 
   @Test
@@ -1087,5 +1159,24 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
         DeleteOrphanFilesSparkAction.findOrphanFiles(
             spark, toFileUri.apply(actualFileDS), toFileUri.apply(validFileDS), mode);
     Assert.assertEquals(expectedOrphanFiles, orphanFiles);
+  }
+
+  protected List<Exception> toNonNullFailureCauses(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    return StreamSupport.stream(fileStatuses.spliterator(), false)
+        .map(DeleteOrphanFiles.OrphanFileStatus::failureCause)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  protected void assertDeletedStatusAndFailureCause(
+      Iterable<DeleteOrphanFiles.OrphanFileStatus> fileStatuses) {
+    Assert.assertTrue(
+        "Deleted status of orphan file should be true",
+        StreamSupport.stream(fileStatuses.spliterator(), false)
+            .allMatch(DeleteOrphanFiles.OrphanFileStatus::deleted));
+    Assert.assertTrue(
+        "Failure cause of deleted orphan file should be null",
+        toNonNullFailureCauses(fileStatuses).isEmpty());
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -60,8 +60,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -90,8 +93,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -120,8 +126,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -153,8 +162,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @Test
@@ -186,8 +198,11 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
             .execute();
     Assert.assertTrue(
         "trash file should be removed",
-        StreamSupport.stream(results.orphanFileLocations().spliterator(), false)
-            .anyMatch(file -> file.contains("file:" + location + "/data/trashfile")));
+        StreamSupport.stream(results.statuses().spliterator(), false)
+            .anyMatch(
+                fileStatus ->
+                    fileStatus.location().contains("file:" + location + "/data/trashfile")));
+    assertDeletedStatusAndFailureCause(results.statuses());
   }
 
   @After

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1424,7 +1424,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
             .deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis())
             .execute()
-            .orphanFileLocations());
+            .statuses());
   }
 
   protected void shouldHaveACleanCache(Table table) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1632,12 +1632,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .olderThan(System.currentTimeMillis())
             .execute();
     Assert.assertTrue(
-        "Should not delete any metadata files", Iterables.isEmpty(result1.orphanFileLocations()));
+        "Should not delete any metadata files", Iterables.isEmpty(result1.statuses()));
 
     DeleteOrphanFiles.Result result2 =
         actions.deleteOrphanFiles(table).olderThan(System.currentTimeMillis()).execute();
-    Assert.assertEquals(
-        "Should delete 1 data file", 1, Iterables.size(result2.orphanFileLocations()));
+    Assert.assertEquals("Should delete 1 data file", 1, Iterables.size(result2.statuses()));
 
     Dataset<Row> resultDF = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
     List<SimpleRecord> actualRecords =


### PR DESCRIPTION
### What changes are proposed in this PR?
---
  
This PR adds a new Interface OrphanFileStatus that indicates if an orphan file was deleted or not. In cases of failure during file deletion, It provides a reference to the encountered exception.

With this additional information, a user can choose to record this failure and retry the deletion process in a controlled fashion in the future.

### Why are the changes are needed?
During the execution of the DeleteOrphanFiles spark action or remove_orphan_files SQL procedure, a failure encountered during deletion of the orphan file is not bubbled up to the user nor is there any indication of the failure in the returned result.

The return value of the Spark action is Iterable and the SQL procedure simply displays a list of orphan files in a table. With this limited information, the only way for the user to know if the orphan file was deleted or not is to
- grep the logs for the warning
- for each of the locations returned in the iterable, query the cloud storage for its existence


One can re-run the expensive delete action to delete the files that failed during the previous delete action run, however, that is not very desirable since re-listing the dir contents to identify the orphan files would result in duplicate work plus wastage of precious API calls. One of the common causes of delete failure in the public cloud is hitting the API quotas and unnecessary re-runs of the delete action can lead to a temporary denial of access to other workloads accessing the same storage resource. 

Providing information about the failed delete files gives users the ability to take appropriate action based on their use case. 

## Output
### Before this change
#### DryRun => true/false
```
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => true)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+
|orphan_file_location                                                                                                      |
+--------------------------------------------------------------------------------------------------------------------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|
+--------------------------------------------------------------------------------------------------------------------------+
```
### After this change
#### DryRun => true

```
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => true)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|orphan_file_location                                                                                                      |deleted|error_message|
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|false   |null         |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|false   |null         |
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
```
#### DryRun => false
```
scala> sql("CALL spark_catalog.system.remove_orphan_files(table => 't1', older_than => TIMESTAMP '2022-05-21 00:00:00.000', dry_run => false)").show(false)
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|orphan_file_location                                                                                                      |deleted|error_message|
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|true   |null         |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-8251ec5f-dd9b-4754-8e68-2cdd01e66e56-c000.snappy.parquet|true   |null         |
+--------------------------------------------------------------------------------------------------------------------------+-------+-------------+
```
#### DryRun => false, simulating failure during delete
```
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
|orphan_file_location                                                                                                      |deleted|error_message                          |
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00000-615125af-bfbb-4279-b22b-559dee4f0b13-c000.snappy.parquet|true   |null                                   |
|file:/tmp/iceberg_warehouse/default/t1/non_table_files/part-00001-705370fd-ea3e-4ae7-8b40-c0362b0ba7df-c000.snappy.parquet|false  |simulating failure during file deletion|
+--------------------------------------------------------------------------------------------------------------------------+-------+---------------------------------------+
```
## Code Credit
This PR is a reimplementation of #4817 published by @sumeetgajjar  for spark3.2. As @sumeetgajjar mentioned in #4817 he moved on to other projects and I am taking this up. I tried cherry-picking Sumeet's changes but I had a hard time resolving the conflicts, It was easier to reimplement the change on the master branch directly. I am not sure how to give credit to Sumeet's work. @sumeetgajjar maybe you can push a dummy commit on top of this branch so that if and when this PR gets merged, it will show your name as well in the commit message.

In the original PR(#4817) @RussellSpitzer and @aokolnychyi said that they can take a look at it after [#4652](https://github.com/apache/iceberg/pull/4652) is merged. @RussellSpitzer @aokolnychyi @szehon-ho Could you please take a look at this PR as [#4652](https://github.com/apache/iceberg/pull/4652) is now merged. Apart from the changes @sumeetgajjar did in #4817 I implemented this feature for bulk deletes as well. I also implemented it for spark-3.3, spark3.1, spark-2.4 along with spark-3.2. 

cc: @wypoon 