### PR TITLE
Core, Spark: Fix delete with filter on nested columns

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -66,7 +66,18 @@ public class TestStrictMetricsEvaluator {
           optional(11, "all_nulls_double", Types.DoubleType.get()),
           optional(12, "all_nans_v1_stats", Types.FloatType.get()),
           optional(13, "nan_and_null_only", Types.DoubleType.get()),
-          optional(14, "no_nan_stats", Types.DoubleType.get()));
+          optional(14, "no_nan_stats", Types.DoubleType.get()),
+          optional(
+              15,
+              "struct",
+              Types.StructType.of(Types.NestedField.required(16, "c1", Types.IntegerType.get()))),
+          optional(
+              17,
+              "list",
+              Types.ListType.ofRequired(
+                  18,
+                  Types.StructType.of(
+                      Types.NestedField.required(19, "c2", Types.IntegerType.get())))));
 
   private static final int INT_MIN_VALUE = 30;
   private static final int INT_MAX_VALUE = 79;
@@ -88,6 +99,7 @@ public class TestStrictMetricsEvaluator {
               .put(12, 50L)
               .put(13, 50L)
               .put(14, 50L)
+              .put(16, 50L)
               .buildOrThrow(),
           // null value counts
           ImmutableMap.<Integer, Long>builder()
@@ -97,6 +109,7 @@ public class TestStrictMetricsEvaluator {
               .put(11, 50L)
               .put(12, 0L)
               .put(13, 1L)
+              .put(16, 0L)
               .buildOrThrow(),
           // nan value counts
           ImmutableMap.of(
@@ -108,13 +121,15 @@ public class TestStrictMetricsEvaluator {
               1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
               7, toByteBuffer(IntegerType.get(), 5),
               12, toByteBuffer(Types.FloatType.get(), Float.NaN),
-              13, toByteBuffer(Types.DoubleType.get(), Double.NaN)),
+              13, toByteBuffer(Types.DoubleType.get(), Double.NaN),
+              16, toByteBuffer(Types.IntegerType.get(), INT_MIN_VALUE)),
           // upper bounds
           ImmutableMap.of(
               1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
               7, toByteBuffer(IntegerType.get(), 5),
               12, toByteBuffer(Types.FloatType.get(), Float.NaN),
-              13, toByteBuffer(Types.DoubleType.get(), Double.NaN)));
+              13, toByteBuffer(Types.DoubleType.get(), Double.NaN),
+              16, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
 
   private static final DataFile FILE_2 =
       new TestDataFile(
@@ -616,5 +631,33 @@ public class TestStrictMetricsEvaluator {
 
     shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("no_nulls", "abc", "def")).eval(FILE);
     Assert.assertFalse("Should not match: no_nulls field does not have bounds", shouldRead);
+  }
+
+  @Test
+  public void testEvaluateOnNestedColumns() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, greaterThan("struct.c1", INT_MAX_VALUE)).eval(FILE);
+    Assert.assertFalse("Should not match: always false", shouldRead);
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("struct.c1", INT_MAX_VALUE)).eval(FILE);
+    Assert.assertTrue("Should match: always true", shouldRead);
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, greaterThan("struct.c1", INT_MAX_VALUE)).eval(FILE_2);
+    Assert.assertFalse("Should never match when stats are missing", shouldRead);
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("struct.c1", INT_MAX_VALUE))
+            .eval(FILE_2);
+    Assert.assertFalse("Should never match when stats are missing", shouldRead);
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("list.element.c2", INT_MAX_VALUE))
+            .eval(FILE);
+    Assert.assertFalse("Should never match for repeated fields", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("list")).eval(FILE);
+    Assert.assertFalse("Should never match for complex fields", shouldRead);
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -511,6 +511,22 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @Test
+  public void testDeleteWithFilterOnNestedColumn() {
+    createAndInitNestedColumnsTable();
+
+    sql("INSERT INTO TABLE %s VALUES (1, named_struct(\"c1\", 3, \"c2\", \"v1\"))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, named_struct(\"c1\", 2, \"c2\", \"v2\"))", tableName);
+
+    sql("DELETE FROM %s WHERE complex.c1 = 3", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(row(2)), sql("SELECT id FROM %s", tableName));
+
+    sql("DELETE FROM %s t WHERE t.complex.c1 = 2", tableName);
+    assertEquals(
+        "Should have expected rows", ImmutableList.of(), sql("SELECT id FROM %s", tableName));
+  }
+
+  @Test
   public void testDeleteWithInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 


### PR DESCRIPTION
Fixes #7065.

This fixes Spark delete data when using a filter on nested columns. Now such operations will fail because Spark calls `canDeleteUsingMetadata` which uses `StrictMetricsEvaluator` to evaluate whether a file should be completely deleted, however `StrictMetricsEvaluator` doesn't support evaluate on nested columns now, and a NPE will be thrown out, see #7065.

This updates `StrictMetricsEvaluator` to support evaluation on nested columns(only for columns nested in a chain of Struct fileds, will return `ROWS_MIGHT_NOT_MATCH`  if columns are nested in Map or List fields), which solve this problem.