### PR TITLE
API: Fix retainAll and removeAll in CharSequenceSet

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -139,16 +139,25 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   @Override
   public boolean retainAll(Collection<?> objects) {
     if (objects != null) {
-      return Iterables.retainAll(wrapperSet, objects);
+      Set<CharSequenceWrapper> toRetain =
+          objects.stream()
+              .filter(CharSequence.class::isInstance)
+              .map(CharSequence.class::cast)
+              .map(CharSequenceWrapper::wrap)
+              .collect(Collectors.toSet());
+
+      return Iterables.retainAll(wrapperSet, toRetain);
     }
+
     return false;
   }
 
   @Override
   public boolean removeAll(Collection<?> objects) {
     if (objects != null) {
-      return Iterables.removeAll(wrapperSet, objects);
+      return objects.stream().filter(this::remove).count() != 0;
     }
+
     return false;
   }
 

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -139,7 +139,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   @Override
   public boolean retainAll(Collection<?> objects) {
     if (objects != null) {
-      return Iterables.removeAll(wrapperSet, objects);
+      return Iterables.retainAll(wrapperSet, objects);
     }
     return false;
   }

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -153,6 +153,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   }
 
   @Override
+  @SuppressWarnings("CollectionUndefinedEquality")
   public boolean removeAll(Collection<?> objects) {
     if (objects != null) {
       return objects.stream().filter(this::remove).count() != 0;

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.util;
 
 import java.util.Arrays;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TestCharSequenceSet {
@@ -34,5 +36,34 @@ public class TestCharSequenceSet {
 
     // this would fail with a normal Set<CharSequence>
     Assertions.assertThat(set.contains("def")).isTrue();
+  }
+
+  @Test
+  public void testRetainAll() {
+    CharSequenceSet set = CharSequenceSet.of(ImmutableList.of("123", "456"));
+
+    Assert.assertTrue("Set should be changed", set.retainAll(ImmutableList.of("456", "789", 123)));
+    Assert.assertTrue("Should not retain element \"123\"", set.size() == 1);
+    Assert.assertTrue("Should retain element \"456\"", set.contains("456"));
+
+    set = CharSequenceSet.of(ImmutableList.of("123", "456"));
+    Assert.assertFalse("Set should not be changed", set.retainAll(ImmutableList.of("123", "456")));
+
+    Assert.assertTrue("Set should be changed", set.retainAll(ImmutableList.of(123, 456)));
+    Assert.assertTrue("Should retain no elements", set.isEmpty());
+  }
+
+  @Test
+  public void testRemoveAll() {
+    CharSequenceSet set = CharSequenceSet.of(ImmutableList.of("123", "456"));
+    Assert.assertTrue("Set should be changed", set.removeAll(ImmutableList.of("456", "789", 123)));
+    Assert.assertTrue("Should remove \"456\"", set.size() == 1);
+    Assert.assertTrue("Should not remove \"123\"", set.contains("123"));
+
+    set = CharSequenceSet.of(ImmutableList.of("123", "456"));
+    Assert.assertFalse("Set should not be changed", set.removeAll(ImmutableList.of(123, 456)));
+
+    Assert.assertTrue("Set should be changed", set.removeAll(ImmutableList.of("123", "456")));
+    Assert.assertTrue("Should remove all elements", set.isEmpty());
   }
 }

--- a/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestCharSequenceSet.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestCharSequenceSet {
@@ -42,28 +41,42 @@ public class TestCharSequenceSet {
   public void testRetainAll() {
     CharSequenceSet set = CharSequenceSet.of(ImmutableList.of("123", "456"));
 
-    Assert.assertTrue("Set should be changed", set.retainAll(ImmutableList.of("456", "789", 123)));
-    Assert.assertTrue("Should not retain element \"123\"", set.size() == 1);
-    Assert.assertTrue("Should retain element \"456\"", set.contains("456"));
+    Assertions.assertThat(set.retainAll(ImmutableList.of("456", "789", 123)))
+        .overridingErrorMessage("Set should be changed")
+        .isTrue();
+
+    Assertions.assertThat(set).hasSize(1).contains("456");
 
     set = CharSequenceSet.of(ImmutableList.of("123", "456"));
-    Assert.assertFalse("Set should not be changed", set.retainAll(ImmutableList.of("123", "456")));
+    Assertions.assertThat(set.retainAll(ImmutableList.of("123", "456")))
+        .overridingErrorMessage("Set should not be changed")
+        .isFalse();
 
-    Assert.assertTrue("Set should be changed", set.retainAll(ImmutableList.of(123, 456)));
-    Assert.assertTrue("Should retain no elements", set.isEmpty());
+    Assertions.assertThat(set.retainAll(ImmutableList.of(123, 456)))
+        .overridingErrorMessage("Set should be changed")
+        .isTrue();
+
+    Assertions.assertThat(set).isEmpty();
   }
 
   @Test
   public void testRemoveAll() {
     CharSequenceSet set = CharSequenceSet.of(ImmutableList.of("123", "456"));
-    Assert.assertTrue("Set should be changed", set.removeAll(ImmutableList.of("456", "789", 123)));
-    Assert.assertTrue("Should remove \"456\"", set.size() == 1);
-    Assert.assertTrue("Should not remove \"123\"", set.contains("123"));
+    Assertions.assertThat(set.removeAll(ImmutableList.of("456", "789", 123)))
+        .overridingErrorMessage("Set should be changed")
+        .isTrue();
+
+    Assertions.assertThat(set).hasSize(1).contains("123");
 
     set = CharSequenceSet.of(ImmutableList.of("123", "456"));
-    Assert.assertFalse("Set should not be changed", set.removeAll(ImmutableList.of(123, 456)));
+    Assertions.assertThat(set.removeAll(ImmutableList.of(123, 456)))
+        .overridingErrorMessage("Set should not be changed")
+        .isFalse();
 
-    Assert.assertTrue("Set should be changed", set.removeAll(ImmutableList.of("123", "456")));
-    Assert.assertTrue("Should remove all elements", set.isEmpty());
+    Assertions.assertThat(set.removeAll(ImmutableList.of("123", "456")))
+        .overridingErrorMessage("Set should be changed")
+        .isTrue();
+
+    Assertions.assertThat(set).isEmpty();
   }
 }


### PR DESCRIPTION
Found this while browsing the code, and checked that this method does not seem to be used in the project at present, luckily.