### PR TITLE
data: Remove AssertHelpers Usage

### DIFF
--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -35,7 +35,7 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
   private final Random random = ThreadLocalRandom.current();
 
   @Test
-  public void testARead() throws Exception {
+  public void testRead() throws Exception {
     OSSURI uri = new OSSURI(location("read.dat"));
     int dataSize = 1024 * 1024 * 10;
     byte[] data = randomData(dataSize);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -35,7 +35,7 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
   private final Random random = ThreadLocalRandom.current();
 
   @Test
-  public void testRead() throws Exception {
+  public void testARead() throws Exception {
     OSSURI uri = new OSSURI(location("read.dat"));
     int dataSize = 1024 * 1024 * 10;
     byte[] data = randomData(dataSize);

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
@@ -56,6 +56,6 @@ public class TestGenericRecord {
 
     Assertions.assertThatThrownBy(() -> record.get(0, CharSequence.class))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Not an instance of java.lang.CharSequence: 10");
+        .hasMessage("Not an instance of java.lang.CharSequence: 10");
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericRecord.java
@@ -20,9 +20,9 @@ package org.apache.iceberg.data;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,10 +54,8 @@ public class TestGenericRecord {
     GenericRecord record = GenericRecord.create(schema);
     record.set(0, 10L);
 
-    AssertHelpers.assertThrows(
-        "Should fail on incorrect class instance",
-        IllegalStateException.class,
-        "Not an instance of java.lang.CharSequence: 10",
-        () -> record.get(0, CharSequence.class));
+    Assertions.assertThatThrownBy(() -> record.get(0, CharSequence.class))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Not an instance of java.lang.CharSequence: 10");
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -499,20 +500,19 @@ public class TestLocalScan {
     Assertions.assertThatThrownBy(
             () -> scanBuilder.useSnapshot(/* unknown snapshot id */ minSnapshotId - 1))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot find snapshot with ID ");
+        .hasMessage("Cannot find snapshot with ID " + (minSnapshotId - 1));
   }
 
   @Test
   public void testAsOfTimeOlderThanFirstSnapshot() {
     IcebergGenerics.ScanBuilder scanBuilder = IcebergGenerics.read(sharedTable);
+    long timestamp = sharedTable.history().get(0).timestampMillis() - 1;
 
     Assertions.assertThatThrownBy(
-            () ->
-                scanBuilder.asOfTime(
-                    /* older than first snapshot */ sharedTable.history().get(0).timestampMillis()
-                        - 1))
+            () -> scanBuilder.asOfTime(/* older than first snapshot */ timestamp))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot find a snapshot older than ");
+        .hasMessage(
+            "Cannot find a snapshot older than " + DateTimeUtil.formatTimestampMillis(timestamp));
   }
 
   private DataFile writeFile(String location, String filename, List<Record> records)

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -59,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -496,25 +496,23 @@ public class TestLocalScan {
 
     IcebergGenerics.ScanBuilder scanBuilder = IcebergGenerics.read(sharedTable);
 
-    AssertHelpers.assertThrows(
-        "Should fail on unknown snapshot id",
-        IllegalArgumentException.class,
-        "Cannot find snapshot with ID ",
-        () -> scanBuilder.useSnapshot(/* unknown snapshot id */ minSnapshotId - 1));
+    Assertions.assertThatThrownBy(
+            () -> scanBuilder.useSnapshot(/* unknown snapshot id */ minSnapshotId - 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find snapshot with ID ");
   }
 
   @Test
   public void testAsOfTimeOlderThanFirstSnapshot() {
     IcebergGenerics.ScanBuilder scanBuilder = IcebergGenerics.read(sharedTable);
 
-    AssertHelpers.assertThrows(
-        "Should fail on timestamp sooner than first write",
-        IllegalArgumentException.class,
-        "Cannot find a snapshot older than ",
-        () ->
-            scanBuilder.asOfTime(
-                /* older than first snapshot */ sharedTable.history().get(0).timestampMillis()
-                    - 1));
+    Assertions.assertThatThrownBy(
+            () ->
+                scanBuilder.asOfTime(
+                    /* older than first snapshot */ sharedTable.history().get(0).timestampMillis()
+                        - 1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find a snapshot older than ");
   }
 
   private DataFile writeFile(String location, String filename, List<Record> records)

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -140,7 +140,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     Assertions.assertThatThrownBy(
             () -> writer.write(toRow(6, "aaa"), spec, partitionKey(spec, "aaa")))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Encountered records that belong to already closed files");
+        .hasMessageContaining("Encountered records that belong to already closed files")
+        .hasMessageEndingWith("partition 'data=aaa' in spec " + spec);
 
     writer.close();
   }
@@ -265,11 +266,13 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     Assertions.assertThatThrownBy(
             () -> writer.write(toRow(7, "ccc"), identitySpec, partitionKey(identitySpec, "ccc")))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Encountered records that belong to already closed files");
+        .hasMessageContaining("Encountered records that belong to already closed files")
+        .hasMessageEndingWith("partition 'data=ccc' in spec " + identitySpec);
 
     Assertions.assertThatThrownBy(() -> writer.write(toRow(7, "aaa"), unpartitionedSpec, null))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Encountered records that belong to already closed files");
+        .hasMessageContaining("Encountered records that belong to already closed files")
+        .hasMessageEndingWith("spec []");
 
     writer.close();
   }
@@ -401,7 +404,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
               writer.write(positionDelete, identitySpec, partitionKey(identitySpec, "ccc"));
             })
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Encountered records that belong to already closed files");
+        .hasMessageContaining("Encountered records that belong to already closed files")
+        .hasMessageEndingWith("partition 'data=ccc' in spec " + identitySpec);
 
     Assertions.assertThatThrownBy(
             () -> {
@@ -409,7 +413,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
               writer.write(positionDelete, unpartitionedSpec, null);
             })
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("Encountered records that belong to already closed files");
+        .hasMessageContaining("Encountered records that belong to already closed files")
+        .hasMessageEndingWith("spec []");
 
     writer.close();
   }


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in `iceberg-data` module