### PR TITLE
Python: Add conversion from iceberg table scan to ray dataset

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -17,7 +17,7 @@
 
 install:
 	pip install poetry
-	poetry install -E pyarrow -E hive -E s3fs -E glue -E adlfs -E duckdb
+	poetry install -E pyarrow -E hive -E s3fs -E glue -E adlfs -E duckdb -E ray
 
 check-license:
 	./dev/check-license

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -66,6 +66,7 @@ from pyiceberg.typedef import (
 if TYPE_CHECKING:
     import pandas as pd
     import pyarrow as pa
+    import ray
     from duckdb import DuckDBPyConnection
 
 
@@ -415,3 +416,8 @@ class DataScan(TableScan):
         con.register(table_name, self.to_arrow())
 
         return con
+
+    def to_ray_dataset(self) -> ray.data.dataset.Dataset:
+        import ray
+
+        return ray.data.from_arrow(self.to_arrow())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -68,6 +68,8 @@ pandas = { version = ">=1.4.4,<=1.5.3", optional = true }
 
 duckdb = { version = ">=0.6.0,<=0.7.1", optional = true }
 
+ray = { version = ">=2.0.0,<=2.3.0", optional = true }
+
 python-snappy = { version = "0.6.1", optional = true }
 
 thrift = { version = "0.16.0", optional = true }
@@ -100,6 +102,7 @@ build-backend = "poetry.core.masonry.api"
 pyarrow = ["pyarrow"]
 pandas = ["pandas", "pyarrow"]
 duckdb = ["duckdb", "pyarrow"]
+ray = ["ray", "pyarrow", "pandas"]
 snappy = ["python-snappy"]
 hive = ["thrift"]
 s3fs = ["s3fs"]
@@ -235,6 +238,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "duckdb.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "ray.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -86,3 +86,4 @@ def test_duckdb_nan(table_test_null_nan_rewritten: Table) -> None:
 def test_ray_dataset_nan(table_test_null_nan_rewritten: Table) -> None:
     ray_dataset = table_test_null_nan_rewritten.scan().to_ray_dataset()
     assert ray_dataset.count() == 3
+    assert math.isnan(ray_dataset.take()[0]["col_numeric"])

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -80,3 +80,9 @@ def test_duckdb_nan(table_test_null_nan_rewritten: Table) -> None:
     result = con.query("SELECT idx, col_numeric FROM table_test_null_nan WHERE isnan(col_numeric)").fetchone()
     assert result[0] == 1
     assert math.isnan(result[1])
+
+
+@pytest.mark.integration
+def test_ray_dataset_nan(table_test_null_nan_rewritten: Table) -> None:
+    ray_dataset = table_test_null_nan_rewritten.scan().to_ray_dataset()
+    assert ray_dataset.count() == 3


### PR DESCRIPTION
## Added Feature
Add `to_ray_dataset()` method to allow conversion from iceberg table scan to [ray dataset](https://docs.ray.io/en/latest/data/api/doc/ray.data.Dataset.html)

## Example:
```python
ray_dataset = table_test_null_nan_rewritten.scan().to_ray_dataset()
print(ray_dataset)
```
Output
```bash
Dataset(num_blocks=1, num_rows=3, schema={idx: int32, col_numeric: float})
```