### PR TITLE
Python: Update docker file

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_bug_report.yml
@@ -9,7 +9,8 @@ body:
       description: What Apache Iceberg version are you using?
       multiple: false
       options:
-        - "1.1.0 (latest release)"
+        - "1.2.0 (latest release)"
+        - "1.1.0"
         - "1.0.0"
         - "0.14.1"
         - "0.14.0"

--- a/python/dev/Dockerfile
+++ b/python/dev/Dockerfile
@@ -52,6 +52,10 @@ RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runt
 RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/${AWS_SDK_VERSION}/bundle-${AWS_SDK_VERSION}.jar -Lo bundle-${AWS_SDK_VERSION}.jar \
  && mv bundle-${AWS_SDK_VERSION}.jar /opt/spark/jars
 
+# Download URL connection client required for S3FileIO
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/${AWS_SDK_VERSION}/url-connection-client-${AWS_SDK_VERSION}.jar -Lo url-connection-client-${AWS_SDK_VERSION}.jar \
+ && mv url-connection-client-${AWS_SDK_VERSION}.jar /opt/spark/jars
+
 COPY spark-defaults.conf /opt/spark/conf
 ENV PATH="/opt/spark/sbin:/opt/spark/bin:${PATH}"
 

--- a/python/dev/Dockerfile
+++ b/python/dev/Dockerfile
@@ -37,22 +37,20 @@ RUN mkdir -p ${HADOOP_HOME} && mkdir -p ${SPARK_HOME} && mkdir -p /home/iceberg/
 WORKDIR ${SPARK_HOME}
 
 ENV SPARK_VERSION=3.3.2
+ENV ICEBERG_VERSION=1.2.0
+ENV AWS_SDK_VERSION=2.20.18
 
 RUN curl -s https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
  && tar xzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 
 # Download iceberg spark runtime
-RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.1.0/iceberg-spark-runtime-3.3_2.12-1.1.0.jar -Lo iceberg-spark-runtime-3.3_2.12-1.1.0.jar \
- && mv iceberg-spark-runtime-3.3_2.12-1.1.0.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/${ICEBERG_VERSION}/iceberg-spark-runtime-3.3_2.12-${ICEBERG_VERSION}.jar -Lo iceberg-spark-runtime-3.3_2.12-${ICEBERG_VERSION}.jar \
+ && mv iceberg-spark-runtime-3.3_2.12-${ICEBERG_VERSION}.jar /opt/spark/jars
 
 # Download Java AWS SDK
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/2.17.165/bundle-2.17.165.jar -Lo bundle-2.17.165.jar \
- && mv bundle-2.17.165.jar /opt/spark/jars
-
-# Download URL connection client required for S3FileIO
-RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/url-connection-client/2.17.165/url-connection-client-2.17.165.jar -Lo url-connection-client-2.17.165.jar \
- && mv url-connection-client-2.17.165.jar /opt/spark/jars
+RUN curl -s https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/${AWS_SDK_VERSION}/bundle-${AWS_SDK_VERSION}.jar -Lo bundle-${AWS_SDK_VERSION}.jar \
+ && mv bundle-${AWS_SDK_VERSION}.jar /opt/spark/jars
 
 COPY spark-defaults.conf /opt/spark/conf
 ENV PATH="/opt/spark/sbin:/opt/spark/bin:${PATH}"

--- a/python/dev/docker-compose-integration.yml
+++ b/python/dev/docker-compose-integration.yml
@@ -21,6 +21,8 @@ services:
     image: python-integration
     container_name: pyiceberg-spark
     build: .
+    networks:
+      iceberg_net:
     depends_on:
       - rest
       - minio
@@ -37,15 +39,17 @@ services:
       - rest:rest
       - minio:minio
   rest:
-    image: tabulario/iceberg-rest:0.2.0
+    image: tabulario/iceberg-rest
     container_name: pyiceberg-rest
+    networks:
+      iceberg_net:
     ports:
       - 8181:8181
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password
       - AWS_REGION=us-east-1
-      - CATALOG_WAREHOUSE=s3a://warehouse/wh/
+      - CATALOG_WAREHOUSE=s3://warehouse/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio:9000
   minio:
@@ -54,6 +58,11 @@ services:
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
+    networks:
+      iceberg_net:
+        aliases:
+          - warehouse.minio
     ports:
       - 9001:9001
       - 9000:9000
@@ -63,6 +72,8 @@ services:
       - minio
     image: minio/mc
     container_name: pyiceberg-mc
+    networks:
+      iceberg_net:
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password
@@ -74,3 +85,5 @@ services:
       /usr/bin/mc policy set public minio/warehouse;
       tail -f /dev/null
       "
+networks:
+  iceberg_net:

--- a/python/dev/docker-compose.yml
+++ b/python/dev/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     environment:
       - MINIO_ROOT_USER=admin
       - MINIO_ROOT_PASSWORD=password
+      - MINIO_DOMAIN=minio
     ports:
       - 9001:9001
       - 9000:9000

--- a/python/mkdocs/docs/verify-release.md
+++ b/python/mkdocs/docs/verify-release.md
@@ -101,6 +101,6 @@ This will include a Minio S3 container being spun up.
 
 Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`.
 
-> \[ \] +1 Release this as Apache Iceberg 1.1.0 \[ \] +0 \[ \] -1 Do not release this because…
+> \[ \] +1 Release this as Apache Iceberg 1.2.0 \[ \] +0 \[ \] -1 Do not release this because…
 
 In addition to your vote, it’s customary to specify if your vote is binding or non-binding. Only members of the Project Management Committee have formally binding votes. If you’re unsure, you can specify that your vote is non-binding. To read more about voting in the Apache framework, checkout the [Voting](https://www.apache.org/foundation/voting.html) information page on the Apache foundation’s website.

--- a/python/mkdocs/docs/verify-release.md
+++ b/python/mkdocs/docs/verify-release.md
@@ -99,8 +99,8 @@ This will include a Minio S3 container being spun up.
 
 # Cast the vote
 
-Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`.
+Votes are cast by replying to the release candidate announcement email on the dev mailing list with either `+1`, `0`, or `-1`. For example :
 
-> \[ \] +1 Release this as Apache Iceberg 1.2.0 \[ \] +0 \[ \] -1 Do not release this because…
+> \[ \] +1 Release this as PyIceberg 0.3.0 \[ \] +0 \[ \] -1 Do not release this because…
 
 In addition to your vote, it’s customary to specify if your vote is binding or non-binding. Only members of the Project Management Committee have formally binding votes. If you’re unsure, you can specify that your vote is non-binding. To read more about voting in the Apache framework, checkout the [Voting](https://www.apache.org/foundation/voting.html) information page on the Apache foundation’s website.


### PR DESCRIPTION
This change focuses mainly to make sure docker file uses the most recent set-up as per 1.2.0 release
[1] AWS SDK changed to 2.20.18
[2] ~~url-connection-client is no longer required~~ (It's present in master only at the moment)
[3] minor refactoring 

Also updates iceberg_bug_report yml with recent version. 


cc @jackye1995 @Fokko 