### PR TITLE
Flink: Fixes flink sink failed due to updating partition spec

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -104,7 +105,8 @@ class FlinkManifestUtil {
     return new DeltaManifests(dataManifest, deleteManifest, result.referencedDataFiles());
   }
 
-  static WriteResult readCompletedFiles(DeltaManifests deltaManifests, FileIO io)
+  static WriteResult readCompletedFiles(
+      DeltaManifests deltaManifests, FileIO io, Map<Integer, PartitionSpec> specsById)
       throws IOException {
     WriteResult.Builder builder = WriteResult.builder();
 
@@ -116,7 +118,7 @@ class FlinkManifestUtil {
     // Read the completed delete files from persisted delete manifests file.
     if (deltaManifests.deleteManifest() != null) {
       try (CloseableIterable<DeleteFile> deleteFiles =
-          ManifestFiles.readDeleteManifest(deltaManifests.deleteManifest(), io, null)) {
+          ManifestFiles.readDeleteManifest(deltaManifests.deleteManifest(), io, specsById)) {
         builder.addDeleteFiles(deleteFiles);
       }
     }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -107,14 +107,10 @@ class FlinkManifestUtil {
 
     // Write the completed delete files into a newly created delete manifest file.
     if (result.deleteFiles() != null && result.deleteFiles().length > 0) {
-      int specId = result.deleteFiles()[0].specId();
       if (spec == null) {
-        spec = specsById.get(specId);
-      } else {
-        Preconditions.checkState(
-            specId == spec.specId(),
-            "The PartitionSpec of data files and delete files should match");
+        spec = specsById.get(result.deleteFiles()[0].specId());
       }
+      int specId = spec.specId();
       Preconditions.checkState(
           Arrays.stream(result.deleteFiles()).allMatch(file -> file.specId() == specId),
           "All delete files should have same partition spec");

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -428,7 +428,8 @@ public class FlinkSink {
               flinkWriteConf.overwriteMode(),
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
-              flinkWriteConf.branch());
+              flinkWriteConf.branch(),
+              table.spec());
       SingleOutputStreamOperator<Void> committerStream =
           writerStream
               .transform(operatorName(ICEBERG_FILES_COMMITTER_NAME), Types.VOID, filesCommitter)

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -428,7 +428,8 @@ public class FlinkSink {
               flinkWriteConf.overwriteMode(),
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
-              flinkWriteConf.branch());
+              flinkWriteConf.branch(),
+              table.spec().specId());
       SingleOutputStreamOperator<Void> committerStream =
           writerStream
               .transform(operatorName(ICEBERG_FILES_COMMITTER_NAME), Types.VOID, filesCommitter)

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -428,8 +428,7 @@ public class FlinkSink {
               flinkWriteConf.overwriteMode(),
               snapshotProperties,
               flinkWriteConf.workerPoolSize(),
-              flinkWriteConf.branch(),
-              table.spec().specId());
+              flinkWriteConf.branch());
       SingleOutputStreamOperator<Void> committerStream =
           writerStream
               .transform(operatorName(ICEBERG_FILES_COMMITTER_NAME), Types.VOID, filesCommitter)

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.data.GenericRecord;
@@ -134,6 +135,19 @@ public class SimpleDataUtil {
       String filename,
       List<RowData> rows)
       throws IOException {
+    return writeFile(table, schema, spec, conf, location, filename, rows, null);
+  }
+
+  public static DataFile writeFile(
+      Table table,
+      Schema schema,
+      PartitionSpec spec,
+      Configuration conf,
+      String location,
+      String filename,
+      List<RowData> rows,
+      StructLike partition)
+      throws IOException {
     Path path = new Path(location, filename);
     FileFormat fileFormat = FileFormat.fromFileName(filename);
     Preconditions.checkNotNull(fileFormat, "Cannot determine format for file: %s", filename);
@@ -148,10 +162,16 @@ public class SimpleDataUtil {
       closeableAppender.addAll(rows);
     }
 
-    return DataFiles.builder(spec)
-        .withInputFile(HadoopInputFile.fromPath(path, conf))
-        .withMetrics(appender.metrics())
-        .build();
+    DataFiles.Builder builder =
+        DataFiles.builder(spec)
+            .withInputFile(HadoopInputFile.fromPath(path, conf))
+            .withMetrics(appender.metrics());
+
+    if (partition != null) {
+      builder = builder.withPartition(partition);
+    }
+
+    return builder.build();
   }
 
   public static DeleteFile writeEqDeleteFile(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -138,6 +138,7 @@ public class SimpleDataUtil {
     return writeFile(table, schema, spec, conf, location, filename, rows, null);
   }
 
+  /** Write the list of {@link RowData} to the given path and with the given partition data */
   public static DataFile writeFile(
       Table table,
       Schema schema,

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -41,6 +43,7 @@ import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.BoundedTestSource;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -389,5 +392,46 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
           env.execute("Test Iceberg DataStream.");
           return null;
         });
+  }
+
+  @Test
+  public void testPartitionEvolution() throws Exception {
+    List<List<Row>> rows =
+        IntStream.range(0, 10)
+            .mapToObj(i -> createRows(String.valueOf(i)))
+            .collect(Collectors.toList());
+
+    DataStream<Row> dataStream = env.addSource(new BoundedTestSource<>(rows), ROW_TYPE_INFO);
+
+    FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+        .table(table)
+        .tableLoader(tableLoader)
+        .writeParallelism(parallelism)
+        .append();
+
+    Thread thread = null;
+    if (partitioned) {
+      thread =
+          new Thread(
+              () -> {
+                try {
+                  Thread.sleep(120);
+                  table.updateSpec().removeField("data").addField("id").commit();
+                } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+      thread.start();
+    }
+
+    // Execute the program.
+    env.execute("Test Iceberg DataStream.");
+    if (thread != null) {
+      thread.join();
+    }
+
+    List<RowData> expected = Lists.newArrayList();
+    rows.forEach(piece -> expected.addAll(convertToRowData(piece)));
+    SimpleDataUtil.assertTableRows(table, expected);
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -409,26 +409,21 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
         .writeParallelism(parallelism)
         .append();
 
-    Thread thread = null;
-    if (partitioned) {
-      thread =
-          new Thread(
-              () -> {
-                try {
-                  Thread.sleep(120);
-                  table.updateSpec().removeField("data").addField("id").commit();
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
-                }
-              });
-      thread.start();
-    }
+    Thread thread =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(120);
+                table.updateSpec().addField("id").commit();
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            });
+    thread.start();
 
     // Execute the program.
     env.execute("Test Iceberg DataStream.");
-    if (thread != null) {
-      thread.join();
-    }
+    thread.join();
 
     List<RowData> expected = Lists.newArrayList();
     rows.forEach(piece -> expected.addAll(convertToRowData(piece)));

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -110,7 +110,8 @@ public class TestFlinkManifest {
               () -> factory.create(curCkpId),
               table.spec());
 
-      WriteResult result = FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io());
+      WriteResult result =
+          FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
       Assert.assertEquals("Size of data file list are not equal.", 10, result.deleteFiles().length);
       for (int i = 0; i < dataFiles.size(); i++) {
         TestHelpers.assertEquals(dataFiles.get(i), result.dataFiles()[i]);
@@ -157,7 +158,8 @@ public class TestFlinkManifest {
         userProvidedFolder.toPath(),
         Paths.get(deltaManifests.dataManifest().path()).getParent());
 
-    WriteResult result = FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io());
+    WriteResult result =
+        FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
 
     Assert.assertEquals(0, result.deleteFiles().length);
     Assert.assertEquals(5, result.dataFiles().length);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -108,7 +108,7 @@ public class TestFlinkManifest {
                   .addDeleteFiles(posDeleteFiles)
                   .build(),
               () -> factory.create(curCkpId),
-              table.specs());
+              table.spec());
 
       WriteResult result =
           FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
@@ -149,7 +149,7 @@ public class TestFlinkManifest {
         FlinkManifestUtil.writeCompletedFiles(
             WriteResult.builder().addDataFiles(dataFiles).build(),
             () -> factory.create(checkpointId),
-            table.specs());
+            table.spec());
 
     Assert.assertNotNull("Data manifest shouldn't be null", deltaManifests.dataManifest());
     Assert.assertNull("Delete manifest should be null", deltaManifests.deleteManifest());
@@ -190,7 +190,7 @@ public class TestFlinkManifest {
                 .addDeleteFiles(posDeleteFiles)
                 .build(),
             () -> factory.create(checkpointId),
-            table.specs());
+            table.spec());
 
     byte[] versionedSerializeData =
         SimpleVersionedSerialization.writeVersionAndSerialize(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -108,7 +108,7 @@ public class TestFlinkManifest {
                   .addDeleteFiles(posDeleteFiles)
                   .build(),
               () -> factory.create(curCkpId),
-              table.spec());
+              table.specs());
 
       WriteResult result =
           FlinkManifestUtil.readCompletedFiles(deltaManifests, table.io(), table.specs());
@@ -149,7 +149,7 @@ public class TestFlinkManifest {
         FlinkManifestUtil.writeCompletedFiles(
             WriteResult.builder().addDataFiles(dataFiles).build(),
             () -> factory.create(checkpointId),
-            table.spec());
+            table.specs());
 
     Assert.assertNotNull("Data manifest shouldn't be null", deltaManifests.dataManifest());
     Assert.assertNull("Delete manifest should be null", deltaManifests.deleteManifest());
@@ -190,7 +190,7 @@ public class TestFlinkManifest {
                 .addDeleteFiles(posDeleteFiles)
                 .build(),
             () -> factory.create(checkpointId),
-            table.spec());
+            table.specs());
 
     byte[] versionedSerializeData =
         SimpleVersionedSerialization.writeVersionAndSerialize(
@@ -230,7 +230,8 @@ public class TestFlinkManifest {
         "Serialization v1 should not have null data manifest.", delta.dataManifest());
     TestHelpers.assertEquals(manifest, delta.dataManifest());
 
-    List<DataFile> actualFiles = FlinkManifestUtil.readDataFiles(delta.dataManifest(), table.io());
+    List<DataFile> actualFiles =
+        FlinkManifestUtil.readDataFiles(delta.dataManifest(), table.io(), table.specs());
     Assert.assertEquals(10, actualFiles.size());
     for (int i = 0; i < 10; i++) {
       TestHelpers.assertEquals(dataFiles.get(i), actualFiles.get(i));

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -964,7 +964,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private OneInputStreamOperatorTestHarness<WriteResult, Void> createStreamSink(JobID jobID)
       throws Exception {
-    TestOperatorFactory factory = TestOperatorFactory.of(table.location(), branch);
+    TestOperatorFactory factory =
+        TestOperatorFactory.of(table.location(), branch, table.spec().specId());
     return new OneInputStreamOperatorTestHarness<>(factory, createEnvironment(jobID));
   }
 
@@ -985,14 +986,16 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       implements OneInputStreamOperatorFactory<WriteResult, Void> {
     private final String tablePath;
     private final String branch;
+    private final int specId;
 
-    private TestOperatorFactory(String tablePath, String branch) {
+    private TestOperatorFactory(String tablePath, String branch, int specId) {
       this.tablePath = tablePath;
       this.branch = branch;
+      this.specId = specId;
     }
 
-    private static TestOperatorFactory of(String tablePath, String branch) {
-      return new TestOperatorFactory(tablePath, branch);
+    private static TestOperatorFactory of(String tablePath, String branch, int specId) {
+      return new TestOperatorFactory(tablePath, branch, specId);
     }
 
     @Override
@@ -1005,7 +1008,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
               false,
               Collections.singletonMap("flink.test", TestIcebergFilesCommitter.class.getName()),
               ThreadPools.WORKER_THREAD_POOL_SIZE,
-              branch);
+              branch,
+              specId);
       committer.setup(param.getContainingTask(), param.getStreamConfig(), param.getOutput());
       return (T) committer;
     }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -28,9 +28,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.NavigableMap;
+import java.util.SortedMap;
 import java.util.stream.Collectors;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -50,7 +55,9 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.GenericManifestFile;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.SimpleDataUtil;
@@ -60,6 +67,7 @@ import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.ThreadPools;
 import org.junit.Assert;
@@ -744,7 +752,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
       // 2. Read the data files from manifests and assert.
       List<DataFile> dataFiles =
-          FlinkManifestUtil.readDataFiles(createTestingManifestFile(manifestPath), table.io());
+          FlinkManifestUtil.readDataFiles(
+              createTestingManifestFile(manifestPath), table.io(), table.specs());
       Assert.assertEquals(1, dataFiles.size());
       TestHelpers.assertEquals(dataFile1, dataFiles.get(0));
 
@@ -790,7 +799,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
       // 2. Read the data files from manifests and assert.
       List<DataFile> dataFiles =
-          FlinkManifestUtil.readDataFiles(createTestingManifestFile(manifestPath), table.io());
+          FlinkManifestUtil.readDataFiles(
+              createTestingManifestFile(manifestPath), table.io(), table.specs());
       Assert.assertEquals(1, dataFiles.size());
       TestHelpers.assertEquals(dataFile1, dataFiles.get(0));
 
@@ -880,59 +890,125 @@ public class TestIcebergFilesCommitter extends TableTestBase {
   @Test
   public void testSpecEvolution() throws Exception {
     long timestamp = 0;
+    int checkpointId = 0;
+    List<RowData> rows = Lists.newArrayList();
+    JobID jobId = new JobID();
 
-    JobID jobID = new JobID();
     OperatorID operatorId;
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobID)) {
+    OperatorSubtaskState snapshot;
+    DataFile dataFile;
+    int specId;
+
+    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
       operatorId = harness.getOperator().getOperatorID();
 
       assertSnapshotSize(0);
 
-      List<RowData> rows = Lists.newArrayListWithExpectedSize(3);
-
-      int checkpointId = 1;
+      checkpointId++;
       RowData rowData = SimpleDataUtil.createRowData(checkpointId, "hello" + checkpointId);
-      DataFile dataFile = writeDataFile("data-" + checkpointId, ImmutableList.of(rowData));
+      // table unpartitioned
+      dataFile = writeDataFile("data-" + checkpointId, ImmutableList.of(rowData));
       harness.processElement(of(dataFile), ++timestamp);
       rows.add(rowData);
       harness.snapshot(checkpointId, ++timestamp);
+
+      specId =
+          getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
+      Assert.assertEquals(
+          String.format(
+              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
+              table.spec().specId(), specId),
+          table.spec().specId(),
+          specId);
+
       harness.notifyOfCompletedCheckpoint(checkpointId);
 
       // Change partition spec
       table.refresh();
+      PartitionSpec oldSpec = table.spec();
       table.updateSpec().addField("id").commit();
 
-      checkpointId = 2;
+      checkpointId++;
       rowData = SimpleDataUtil.createRowData(checkpointId, "hello" + checkpointId);
-      dataFile = writeDataFile("data-" + checkpointId, ImmutableList.of(rowData));
+      // write data with old partition spec
+      dataFile = writeDataFile("data-" + checkpointId, ImmutableList.of(rowData), oldSpec, null);
       harness.processElement(of(dataFile), ++timestamp);
       rows.add(rowData);
-      harness.snapshot(checkpointId, ++timestamp);
-      harness.notifyOfCompletedCheckpoint(checkpointId);
+      snapshot = harness.snapshot(checkpointId, ++timestamp);
 
-      // Change partition spec again
-      table.refresh();
-      table.updateSpec().addField("data").commit();
+      specId =
+          getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
+      Assert.assertEquals(
+          String.format(
+              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
+              oldSpec.specId(), specId),
+          oldSpec.specId(),
+          specId);
 
-      checkpointId = 3;
-      rowData = SimpleDataUtil.createRowData(checkpointId, "hello" + checkpointId);
-      dataFile = writeDataFile("data-" + checkpointId, ImmutableList.of(rowData));
-      harness.processElement(of(dataFile), ++timestamp);
-      rows.add(rowData);
-      harness.snapshot(checkpointId, ++timestamp);
       harness.notifyOfCompletedCheckpoint(checkpointId);
 
       assertFlinkManifests(0);
 
       SimpleDataUtil.assertTableRows(table, ImmutableList.copyOf(rows), branch);
       assertSnapshotSize(checkpointId);
-      assertMaxCommittedCheckpointId(jobID, operatorId, checkpointId);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpointId);
       Assert.assertEquals(
           TestIcebergFilesCommitter.class.getName(),
           SimpleDataUtil.latestSnapshot(table, branch).summary().get("flink.test"));
     }
+
+    // Restore from the given snapshot
+    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+      harness.getStreamConfig().setOperatorID(operatorId);
+      harness.setup();
+      harness.initializeState(snapshot);
+      harness.open();
+
+      SimpleDataUtil.assertTableRows(table, rows, branch);
+      assertSnapshotSize(checkpointId);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpointId);
+
+      checkpointId++;
+      RowData row = SimpleDataUtil.createRowData(checkpointId, "world" + checkpointId);
+      StructLike partition = new PartitionData(table.spec().partitionType());
+      partition.set(0, checkpointId);
+      dataFile =
+          writeDataFile("data-" + checkpointId, ImmutableList.of(row), table.spec(), partition);
+      harness.processElement(of(dataFile), ++timestamp);
+      rows.add(row);
+      harness.snapshot(checkpointId, ++timestamp);
+      assertFlinkManifests(1);
+
+      specId =
+          getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
+      Assert.assertEquals(
+          String.format(
+              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
+              table.spec().specId(), specId),
+          table.spec().specId(),
+          specId);
+
+      harness.notifyOfCompletedCheckpoint(checkpointId);
+      assertFlinkManifests(0);
+
+      SimpleDataUtil.assertTableRows(table, rows, branch);
+      assertSnapshotSize(checkpointId);
+      assertMaxCommittedCheckpointId(jobId, operatorId, checkpointId);
+    }
+  }
+
+  private int getStagingManifestSpecId(OperatorStateStore operatorStateStore, long checkPointId)
+      throws Exception {
+    ListState<SortedMap<Long, byte[]>> checkpointsState =
+        operatorStateStore.getListState(IcebergFilesCommitter.buildStateDescriptor());
+    NavigableMap<Long, byte[]> statedDataFiles =
+        Maps.newTreeMap(checkpointsState.get().iterator().next());
+    DeltaManifests deltaManifests =
+        SimpleVersionedSerialization.readVersionAndDeSerialize(
+            DeltaManifestsSerializer.INSTANCE, statedDataFiles.get(checkPointId));
+    return deltaManifests.dataManifest().partitionSpecId();
   }
 
   private DeleteFile writeEqDeleteFile(
@@ -1007,6 +1083,20 @@ public class TestIcebergFilesCommitter extends TableTestBase {
         rows);
   }
 
+  private DataFile writeDataFile(
+      String filename, List<RowData> rows, PartitionSpec spec, StructLike partition)
+      throws IOException {
+    return SimpleDataUtil.writeFile(
+        table,
+        table.schema(),
+        spec,
+        CONF,
+        table.location(),
+        format.addExtension(filename),
+        rows,
+        partition);
+  }
+
   private void assertMaxCommittedCheckpointId(JobID jobID, OperatorID operatorID, long expectedId) {
     table.refresh();
     long actualId =
@@ -1022,8 +1112,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private OneInputStreamOperatorTestHarness<WriteResult, Void> createStreamSink(JobID jobID)
       throws Exception {
-    TestOperatorFactory factory =
-        TestOperatorFactory.of(table.location(), branch, table.spec().specId());
+    TestOperatorFactory factory = TestOperatorFactory.of(table.location(), branch);
     return new OneInputStreamOperatorTestHarness<>(factory, createEnvironment(jobID));
   }
 
@@ -1044,16 +1133,14 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       implements OneInputStreamOperatorFactory<WriteResult, Void> {
     private final String tablePath;
     private final String branch;
-    private final int specId;
 
-    private TestOperatorFactory(String tablePath, String branch, int specId) {
+    private TestOperatorFactory(String tablePath, String branch) {
       this.tablePath = tablePath;
       this.branch = branch;
-      this.specId = specId;
     }
 
-    private static TestOperatorFactory of(String tablePath, String branch, int specId) {
-      return new TestOperatorFactory(tablePath, branch, specId);
+    private static TestOperatorFactory of(String tablePath, String branch) {
+      return new TestOperatorFactory(tablePath, branch);
     }
 
     @Override
@@ -1066,8 +1153,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
               false,
               Collections.singletonMap("flink.test", TestIcebergFilesCommitter.class.getName()),
               ThreadPools.WORKER_THREAD_POOL_SIZE,
-              branch,
-              specId);
+              branch);
       committer.setup(param.getContainingTask(), param.getStreamConfig(), param.getOutput());
       return (T) committer;
     }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.flink.sink.IcebergFilesCommitter.MAX_CONTINUOUS_EMPTY_COMMITS;
 import static org.apache.iceberg.flink.sink.ManifestOutputFileFactory.FLINK_MANIFEST_LOCATION;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -916,12 +917,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
       specId =
           getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
-      Assert.assertEquals(
-          String.format(
-              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
-              table.spec().specId(), specId),
-          table.spec().specId(),
-          specId);
+      assertThat(specId).isEqualTo(table.spec().specId());
 
       harness.notifyOfCompletedCheckpoint(checkpointId);
 
@@ -940,12 +936,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
       specId =
           getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
-      Assert.assertEquals(
-          String.format(
-              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
-              oldSpec.specId(), specId),
-          oldSpec.specId(),
-          specId);
+      assertThat(specId).isEqualTo(oldSpec.specId());
 
       harness.notifyOfCompletedCheckpoint(checkpointId);
 
@@ -954,9 +945,6 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       SimpleDataUtil.assertTableRows(table, ImmutableList.copyOf(rows), branch);
       assertSnapshotSize(checkpointId);
       assertMaxCommittedCheckpointId(jobId, operatorId, checkpointId);
-      Assert.assertEquals(
-          TestIcebergFilesCommitter.class.getName(),
-          SimpleDataUtil.latestSnapshot(table, branch).summary().get("flink.test"));
     }
 
     // Restore from the given snapshot
@@ -983,12 +971,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
       specId =
           getStagingManifestSpecId(harness.getOperator().getOperatorStateBackend(), checkpointId);
-      Assert.assertEquals(
-          String.format(
-              "Expected the partition spec ID of staging manifest is %s, but the ID is: %s",
-              table.spec().specId(), specId),
-          table.spec().specId(),
-          specId);
+      assertThat(specId).isEqualTo(table.spec().specId());
 
       harness.notifyOfCompletedCheckpoint(checkpointId);
       assertFlinkManifests(0);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -1112,7 +1112,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private OneInputStreamOperatorTestHarness<WriteResult, Void> createStreamSink(JobID jobID)
       throws Exception {
-    TestOperatorFactory factory = TestOperatorFactory.of(table.location(), branch);
+    TestOperatorFactory factory = TestOperatorFactory.of(table.location(), branch, table.spec());
     return new OneInputStreamOperatorTestHarness<>(factory, createEnvironment(jobID));
   }
 
@@ -1133,14 +1133,16 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       implements OneInputStreamOperatorFactory<WriteResult, Void> {
     private final String tablePath;
     private final String branch;
+    private final PartitionSpec spec;
 
-    private TestOperatorFactory(String tablePath, String branch) {
+    private TestOperatorFactory(String tablePath, String branch, PartitionSpec spec) {
       this.tablePath = tablePath;
       this.branch = branch;
+      this.spec = spec;
     }
 
-    private static TestOperatorFactory of(String tablePath, String branch) {
-      return new TestOperatorFactory(tablePath, branch);
+    private static TestOperatorFactory of(String tablePath, String branch, PartitionSpec spec) {
+      return new TestOperatorFactory(tablePath, branch, spec);
     }
 
     @Override
@@ -1153,7 +1155,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
               false,
               Collections.singletonMap("flink.test", TestIcebergFilesCommitter.class.getName()),
               ThreadPools.WORKER_THREAD_POOL_SIZE,
-              branch);
+              branch,
+              spec);
       committer.setup(param.getContainingTask(), param.getStreamConfig(), param.getOutput());
       return (T) committer;
     }


### PR DESCRIPTION
We use a `SerializableTable` instance to create `IcebergStreamWriter`. The PartitionSpec of `SerializableTable` is fixed and will not change after the job started. While the PartitionSpec for `IcebergFilesCommitter` is refreshed with the table snapshot changing. This could fail the fink sink job when updating the partition spec in another job. Because we use the wrong partition spec to write those DataFiles/DeleteFiles to ManifestFile.

For example, we got the following error when updating the partition spec:

<img width="850" alt="image" src="https://user-images.githubusercontent.com/12733256/226897732-a556cfdc-3841-4a3c-a966-da3f9cc33d30.png">


In this patch, we use the correct partition spec to write the staging manifest file.
