### PR TITLE
Hive: Fix using date type as partition field

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.InternalRecordWrapper ;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.FileIO;
@@ -50,6 +51,7 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
   // The current key is reused at every write to avoid unnecessary object creation
   private final PartitionKey currentKey;
   private final FileIO io;
+  private final InternalRecordWrapper wrapper;
 
   // <TaskAttemptId, <TABLE_NAME, HiveIcebergRecordWriter>> map to store the active writers
   // Stored in concurrent map, since some executor engines can share containers
@@ -79,11 +81,12 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
     this.currentKey = new PartitionKey(spec, schema);
     writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());
     writers.get(taskAttemptID).put(tableName, this);
+    wrapper = new InternalRecordWrapper(schema.asStruct());
   }
 
   @Override
   protected PartitionKey partition(Record row) {
-    currentKey.partition(row);
+    currentKey.partition(wrapper.wrap(row));
     return currentKey;
   }
 


### PR DESCRIPTION
When using date/timestamp/time as a partition field, it will throw IllegalStateException: Not not instance of...

for example:
`create table iceberg_test(id int, name string) partitioned by (dt date) stored by 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler';`

then insert into :
`insert into iceberg_test values(1, 'xxx', '2023-01-01');`

The exception is as follows:
`java.lang.IllegalStateException: Not an instance of java.lang.Integer: 2023-01-01 at org.apache.iceberg.data.GenericRecord.get(GenericRecord.java:123) at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:71) at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:58) at org.apache.iceberg.PartitionKey.partition(PartitionKey.java:104)
`

We will need to wrapping the record into an InternalRecordWrapper
