### PR TITLE
Spark 3.2: Support metadata column in the changelog table

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestChangelogTable.java
@@ -260,6 +260,25 @@ public class TestChangelogTable extends SparkExtensionsTestBase {
         sql("SELECT id, _change_type FROM %s.changes ORDER BY id", tableName));
   }
 
+  @Test
+  public void testMetadataColumns() {
+    createTableWithDefaultRows();
+    List<Object[]> rows =
+        sql(
+            "SELECT id, _file, _pos, _deleted, _spec_id, _partition FROM %s.changes ORDER BY id",
+            tableName);
+
+    String file1 = rows.get(0)[1].toString();
+    Assert.assertTrue(file1.startsWith("file:/"));
+    String file2 = rows.get(1)[1].toString();
+
+    assertEquals(
+        "Rows should match",
+        ImmutableList.of(
+            row(1, file1, 0L, false, 0, row("a")), row(2, file2, 0L, false, 0, row("b"))),
+        rows);
+  }
+
   private void createTableWithDefaultRows() {
     createTable();
     insertDefaultRows();


### PR DESCRIPTION
A Spark3.2 version of #7152  cc @aokolnychyi 