### PR TITLE
Refactor PartitionsTable planning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.util.PropertyUtil;
 abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     implements Scan<ThisT, T, G> {
 
-  private static final List<String> SCAN_COLUMNS =
+  protected static final List<String> SCAN_COLUMNS =
       ImmutableList.of(
           "snapshot_id",
           "file_path",

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -107,9 +107,9 @@ public class PartitionsTable extends BaseMetadataTable {
       PartitionData original = (PartitionData) dataFile.partition();
 
       int[] normalizedPositions =
-              normalizedPositionsBySpec.computeIfAbsent(
-                      dataFile.specId(),
-                      specId -> normalizedPositions(table, specId, normalizedPartitionType));
+          normalizedPositionsBySpec.computeIfAbsent(
+              dataFile.specId(),
+              specId -> normalizedPositions(table, specId, normalizedPartitionType));
 
       PartitionData normalized =
           normalizePartition(original, normalizedPartitionType, normalizedPositions);
@@ -153,9 +153,9 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   /**
-   * Builds an integer array to map the partition field from original to normalized
-   * where index of the array represent the index of given field in the original partition type
-   * the value of the array represent the index of same field in normalized partition type
+   * Builds an integer array to map the partition field from original to normalized where index of
+   * the array represent the index of given field in the original partition type the value of the
+   * array represent the index of same field in normalized partition type
    *
    * @param table iceberg table
    * @param specId spec id where original partition type is written

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -102,10 +102,8 @@ public class PartitionsTable extends BaseMetadataTable {
         Maps.newHashMapWithExpectedSize(table.specs().size());
 
     CloseableIterable<DataFile> datafiles = planDataFiles(scan);
-
     for (DataFile dataFile : datafiles) {
       PartitionData original = (PartitionData) dataFile.partition();
-
       int[] normalizedPositions =
           normalizedPositionsBySpec.computeIfAbsent(
               dataFile.specId(),
@@ -153,9 +151,12 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   /**
-   * Builds an integer array to map the partition field from original to normalized where index of
-   * the array represent the index of given field in the original partition type the value of the
-   * array represent the index of same field in normalized partition type
+   * Builds an integer array for a specific partition type to map its partitions to the final
+   * normalized type.
+   *
+   * <p>The array represents fields in the original partition type, with the index being the field's
+   * index in the original partition type, and the value being the field's index in the normalized
+   * partition type.
    *
    * @param table iceberg table
    * @param specId spec id where original partition type is written

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -86,8 +86,8 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
         "File scan tasks do not include correct file",
         StreamSupport.stream(dataFiles.spliterator(), false)
             .anyMatch(
-                part -> {
-                  StructLike partition = part.partition();
+                dataFile -> {
+                  StructLike partition = dataFile.partition();
                   if (position >= partition.size()) {
                     return false;
                   }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -81,13 +81,13 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
   }
 
   protected void validatePartition(
-      Iterable<PartitionsTable.Partition> parts, int position, int partitionValue) {
+      CloseableIterable<DataFile> dataFiles, int position, int partitionValue) {
     Assert.assertTrue(
         "File scan tasks do not include correct file",
-        StreamSupport.stream(parts.spliterator(), false)
+        StreamSupport.stream(dataFiles.spliterator(), false)
             .anyMatch(
                 part -> {
-                  StructLike partition = part.key();
+                  StructLike partition = part.partition();
                   if (position >= partition.size()) {
                     return false;
                   }

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -79,24 +80,19 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
     }
   }
 
-  protected void validateIncludesPartitionScan(
-      CloseableIterable<FileScanTask> tasks, int partValue) {
-    validateIncludesPartitionScan(tasks, 0, partValue);
-  }
-
-  protected void validateIncludesPartitionScan(
-      CloseableIterable<FileScanTask> tasks, int position, int partValue) {
+  protected void validatePartition(
+      Iterable<PartitionsTable.Partition> parts, int position, int partitionValue) {
     Assert.assertTrue(
         "File scan tasks do not include correct file",
-        StreamSupport.stream(tasks.spliterator(), false)
+        StreamSupport.stream(parts.spliterator(), false)
             .anyMatch(
-                task -> {
-                  StructLike partition = task.file().partition();
+                part -> {
+                  StructLike partition = part.key();
                   if (position >= partition.size()) {
                     return false;
                   }
 
-                  return partition.get(position, Object.class).equals(partValue);
+                  return Objects.equals(partitionValue, partition.get(position, Object.class));
                 }));
   }
 

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -80,6 +80,12 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
     }
   }
 
+  /** Used for asserting on data files where partition size = 1 */
+  protected void validateSingletonPartition(
+      CloseableIterable<DataFile> dataFiles, int partitionValue) {
+    validatePartition(dataFiles, 0, partitionValue);
+  }
+
   protected void validatePartition(
       CloseableIterable<DataFile> dataFiles, int position, int partitionValue) {
     Assert.assertTrue(

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -80,8 +80,7 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
     }
   }
 
-  /** Used for asserting on data files where partition size = 1 */
-  protected void validateSingletonPartition(
+  protected void validateSingleFieldPartition(
       CloseableIterable<DataFile> dataFiles, int partitionValue) {
     validatePartition(dataFiles, 0, partitionValue);
   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -317,13 +317,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
 
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -337,13 +337,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanWithProjection);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanWithProjection);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -373,10 +373,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
+    Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
   }
 
   @Test
@@ -390,11 +390,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.lessThan("partition.data_bucket", 2),
             Expressions.greaterThan("record_count", 0));
     TableScan scanLtAnd = partitionsTable.newScan().filter(ltAnd);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanLtAnd);
-    Assert.assertEquals(2, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanLtAnd);
+    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
   }
 
   @Test
@@ -409,13 +409,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanOr = partitionsTable.newScan().filter(or);
 
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanOr);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scanOr);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -425,11 +424,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanNot);
-    Assert.assertEquals(2, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanNot);
+    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -440,11 +439,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanSet);
-    Assert.assertEquals(2, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanSet);
+    Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -455,13 +454,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanUnary);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanUnary);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
   }
 
   @Test
@@ -664,19 +663,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scan);
+    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
     // Four data files of old spec, one new data file of new spec
-    Assert.assertEquals(5, Iterables.size(partitions));
+    Assert.assertEquals(5, Iterables.size(dataFiles));
     filter =
         Expressions.and(
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    partitions = PartitionsTable.partitions(table, (StaticTableScan) scan);
+    dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
 
     // 1 original data file written by old spec, plus 1 new data file written by new spec
-    Assert.assertEquals(2, Iterables.size(partitions));
+    Assert.assertEquals(2, Iterables.size(dataFiles));
   }
 
   @Test
@@ -717,11 +715,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scan);
+    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
 
     // Four original files of original spec, one data file written by new spec
-    Assert.assertEquals(5, Iterables.size(partitions));
+    Assert.assertEquals(5, Iterables.size(dataFiles));
 
     // Filter for a dropped partition spec field.  Correct behavior is that only old partitions are
     // returned.
@@ -730,11 +727,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    partitions = PartitionsTable.partitions(table, (StaticTableScan) scan);
+    dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
 
     if (formatVersion == 1) {
       // 1 original data file written by old spec
-      Assert.assertEquals(1, Iterables.size(partitions));
+      Assert.assertEquals(1, Iterables.size(dataFiles));
     } else {
       // 1 original data/delete files written by old spec, plus both of new data file/delete file
       // written by new spec
@@ -745,11 +742,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
       //
       // However, these partition rows are filtered out later in Spark data filtering, as the newer
       // partitions
-      // will have 'data=null' field added as part of normalization to the Partitions table final
+      // will have 'data=null' field added as part of normalization to the Partition table final
       // schema.
-      // The Partitions table final schema is a union of fields of all specs, including dropped
+      // The Partition table final schema is a union of fields of all specs, including dropped
       // fields.
-      Assert.assertEquals(3, Iterables.size(partitions));
+      Assert.assertEquals(3, Iterables.size(dataFiles));
     }
   }
 
@@ -800,10 +797,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.partition", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
+    Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
   }
 
   @Test
@@ -871,9 +868,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scan);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
+    CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scan);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
     Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -320,10 +320,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 0);
+    validateSingletonPartition(dataFiles, 1);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -340,10 +340,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanWithProjection);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 0);
+    validateSingletonPartition(dataFiles, 1);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -376,7 +376,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
     Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
+    validateSingletonPartition(dataFiles, 0);
   }
 
   @Test
@@ -393,8 +393,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanLtAnd);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
+    validateSingletonPartition(dataFiles, 0);
+    validateSingletonPartition(dataFiles, 1);
   }
 
   @Test
@@ -411,10 +411,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scanOr);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 0);
+    validateSingletonPartition(dataFiles, 1);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -427,8 +427,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanNot);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -442,8 +442,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanSet);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -457,10 +457,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanUnary);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
-    validatePartition(dataFiles, 0, 1);
-    validatePartition(dataFiles, 0, 2);
-    validatePartition(dataFiles, 0, 3);
+    validateSingletonPartition(dataFiles, 0);
+    validateSingletonPartition(dataFiles, 1);
+    validateSingletonPartition(dataFiles, 2);
+    validateSingletonPartition(dataFiles, 3);
   }
 
   @Test
@@ -800,7 +800,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
     Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validatePartition(dataFiles, 0, 0);
+    validateSingletonPartition(dataFiles, 0);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -320,10 +320,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
-    validateSingletonPartition(dataFiles, 1);
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 1);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -340,10 +340,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanWithProjection);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
-    validateSingletonPartition(dataFiles, 1);
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 1);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -376,7 +376,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
     Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 0);
   }
 
   @Test
@@ -393,8 +393,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanLtAnd);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
-    validateSingletonPartition(dataFiles, 1);
+    validateSingleFieldPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 1);
   }
 
   @Test
@@ -411,10 +411,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     CloseableIterable<DataFile> dataFiles = PartitionsTable.planDataFiles((StaticTableScan) scanOr);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
-    validateSingletonPartition(dataFiles, 1);
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 1);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -427,8 +427,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanNot);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -442,8 +442,8 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanSet);
     Assert.assertEquals(2, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -457,10 +457,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanUnary);
     Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
-    validateSingletonPartition(dataFiles, 1);
-    validateSingletonPartition(dataFiles, 2);
-    validateSingletonPartition(dataFiles, 3);
+    validateSingleFieldPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 1);
+    validateSingleFieldPartition(dataFiles, 2);
+    validateSingleFieldPartition(dataFiles, 3);
   }
 
   @Test
@@ -800,7 +800,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     CloseableIterable<DataFile> dataFiles =
         PartitionsTable.planDataFiles((StaticTableScan) scanAndEq);
     Assert.assertEquals(1, Iterators.size(dataFiles.iterator()));
-    validateSingletonPartition(dataFiles, 0);
+    validateSingleFieldPartition(dataFiles, 0);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -152,15 +152,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
-    Iterable<PartitionsTable.Partition> partitions =
-        PartitionsTable.partitions(table, (StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
-    validatePartition(partitions, 0, 0);
-    validatePartition(partitions, 0, 1);
-    validatePartition(partitions, 0, 2);
-    validatePartition(partitions, 0, 3);
-    validatePartition(partitions, 1, 2);
-    validatePartition(partitions, 1, 3);
+    CloseableIterable<DataFile> dataFiles =
+        PartitionsTable.planDataFiles((StaticTableScan) scanNoFilter);
+    Assert.assertEquals(4, Iterators.size(dataFiles.iterator()));
+    validatePartition(dataFiles, 0, 0);
+    validatePartition(dataFiles, 0, 1);
+    validatePartition(dataFiles, 0, 2);
+    validatePartition(dataFiles, 0, 3);
+    validatePartition(dataFiles, 1, 2);
+    validatePartition(dataFiles, 1, 3);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -29,6 +29,7 @@ import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
@@ -151,16 +152,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
-    try (CloseableIterable<FileScanTask> tasksNoFilter =
-        PartitionsTable.planFiles((StaticTableScan) scanNoFilter)) {
-      Assertions.assertThat(tasksNoFilter).hasSize(4);
-      validateIncludesPartitionScan(tasksNoFilter, 0);
-      validateIncludesPartitionScan(tasksNoFilter, 1);
-      validateIncludesPartitionScan(tasksNoFilter, 2);
-      validateIncludesPartitionScan(tasksNoFilter, 3);
-      validateIncludesPartitionScan(tasksNoFilter, 1, 2);
-      validateIncludesPartitionScan(tasksNoFilter, 1, 3);
-    }
+    Iterable<PartitionsTable.Partition> partitions =
+        PartitionsTable.partitions(table, (StaticTableScan) scanNoFilter);
+    Assert.assertEquals(4, Iterators.size(partitions.iterator()));
+    validatePartition(partitions, 0, 0);
+    validatePartition(partitions, 0, 1);
+    validatePartition(partitions, 0, 2);
+    validatePartition(partitions, 0, 3);
+    validatePartition(partitions, 1, 2);
+    validatePartition(partitions, 1, 3);
   }
 
   @Test


### PR DESCRIPTION
close #7189 

- Maintain original functionality of parallelizable manifest read
- hardcoded to avoid reading stats columns of data files in partition table

CC @szehon-ho 