### PR TITLE
Core, AWS: Auto optimize table using post commit notifications

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -487,6 +487,9 @@ acceptedBreaks:
         \ @ org.apache.iceberg.SnapshotScan<ThisT, T extends org.apache.iceberg.ScanTask,\
         \ G extends org.apache.iceberg.ScanTaskGroup<T extends org.apache.iceberg.ScanTask>>"
       justification: "Removing deprecations for 1.3.0"
+    - code: "java.method.addedToInterface"
+      new: "method org.apache.iceberg.TableOperations org.apache.iceberg.metrics.CommitReport::tableOperations()"
+      justification: "Add TableOperations to fetch catalog properties"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.DeleteFileIndex org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedDeleteFiles(org.apache.iceberg.TableMetadata,\
         \ java.lang.Long, org.apache.iceberg.expressions.Expression, org.apache.iceberg.util.PartitionSet)\

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -24,7 +24,10 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -69,6 +72,30 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(awsProperties::applyHttpClientConfigurations)
         .applyMutation(awsProperties::applyDynamoDbEndpointConfigurations)
+        .build();
+  }
+
+  @Override
+  public EmrClient emr() {
+    return EmrClient.builder()
+        .applyMutation(this::applyAssumeRoleConfigurations)
+        .applyMutation(awsProperties::applyHttpClientConfigurations)
+        .build();
+  }
+
+  @Override
+  public EmrContainersClient emrContainers() {
+    return EmrContainersClient.builder()
+        .applyMutation(this::applyAssumeRoleConfigurations)
+        .applyMutation(awsProperties::applyHttpClientConfigurations)
+        .build();
+  }
+
+  @Override
+  public AthenaClient athena() {
+    return AthenaClient.builder()
+        .applyMutation(this::applyAssumeRoleConfigurations)
+        .applyMutation(awsProperties::applyHttpClientConfigurations)
         .build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -33,8 +33,11 @@ import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -133,6 +136,27 @@ public class AwsClientFactories {
           .applyMutation(awsProperties::applyHttpClientConfigurations)
           .applyMutation(awsProperties::applyClientCredentialConfigurations)
           .applyMutation(awsProperties::applyDynamoDbEndpointConfigurations)
+          .build();
+    }
+
+    @Override
+    public EmrClient emr() {
+      return EmrClient.builder()
+          .applyMutation(awsProperties::applyHttpClientConfigurations)
+          .build();
+    }
+
+    @Override
+    public EmrContainersClient emrContainers() {
+      return EmrContainersClient.builder()
+          .applyMutation(awsProperties::applyHttpClientConfigurations)
+          .build();
+    }
+
+    @Override
+    public AthenaClient athena() {
+      return AthenaClient.builder()
+          .applyMutation(awsProperties::applyHttpClientConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
@@ -20,7 +20,10 @@ package org.apache.iceberg.aws;
 
 import java.io.Serializable;
 import java.util.Map;
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -58,6 +61,27 @@ public interface AwsClientFactory extends Serializable {
    * @return dynamoDB client
    */
   DynamoDbClient dynamo();
+
+  /**
+   * Create a Amazon EMR client
+   *
+   * @return EMR client
+   */
+  EmrClient emr();
+
+  /**
+   * Create a Amazon Containers client
+   *
+   * @return EMR Containers client
+   */
+  EmrContainersClient emrContainers();
+
+  /**
+   * Create a Amazon Athena client
+   *
+   * @return Athena client
+   */
+  AthenaClient athena();
 
   /**
    * Initialize AWS client factory from catalog properties.

--- a/aws/src/main/java/org/apache/iceberg/aws/OptimizeTableUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/OptimizeTableUtil.java
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY_DEFAULT;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.aws.dynamodb.DynamoDbTableOperations;
+import org.apache.iceberg.aws.glue.GlueTableOperations;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.hadoop.HadoopTableOperations;
+import org.apache.iceberg.hive.HiveTableOperations;
+import org.apache.iceberg.metrics.Rewrite;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class to hold utilities to optimize table */
+public class OptimizeTableUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizeTableUtil.class);
+
+  public static final String COMMAND_RUNNER_JAR = "command-runner.jar";
+
+  public static final String EMR_STEP_CONTINUE = "CONTINUE";
+
+  public static final int EMR_STEP_INDEX = 0;
+
+  public static final int SLEEP_WAIT_DURATION_MS = 2000;
+
+  public static final String BLANK = " ";
+
+  public static final String DOT = ".";
+
+  public static final String OPEN_BRACKET = "(";
+
+  public static final String CLOSE_BRACKET = ")";
+
+  public static final String COMMA = ",";
+
+  public static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
+
+  public static final String PERSISTENT_APP_UI_ENABLED = "ENABLED";
+
+  public static final String EMR_CONTAINERS_LOG_GROUP_NAME = "/aws/emr-containers";
+
+  public static final String EMR_CONTAINERS_LOG_PREFIX = "iceberg";
+
+  /**
+   * Amazon Athena supports bin packing with optimize rewrite data command.
+   *
+   * <p>For more details, refer:
+   * https://docs.aws.amazon.com/athena/latest/ug/optimize-statement.html
+   */
+  public static final String ATHENA_QUERY_FORMAT = "OPTIMIZE %s REWRITE DATA USING BIN_PACK;";
+
+  private OptimizeTableUtil() {}
+
+  /**
+   * Load a custom {@link Rewrite} implementation.
+   *
+   * <p>The implementation must have a no-arg constructor.
+   *
+   * @param impl full class name of a custom {@link Rewrite} implementation
+   * @return An initialized {@link Rewrite}.
+   * @throws IllegalArgumentException if class path not found or right constructor not found or the
+   *     loaded class cannot be cast to the given interface type
+   */
+  public static Rewrite loadRewrite(String impl) {
+    LOG.info("Loading custom Rewrite implementation: {}", impl);
+    DynConstructors.Ctor<Rewrite> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(Rewrite.class)
+              .loader(OptimizeTableUtil.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot initialize Rewrite, missing no-arg constructor: %s", impl), e);
+    }
+
+    Rewrite rewrite;
+    try {
+      rewrite = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot initialize Rewrite, %s does not implement MetricsReporter.", impl),
+          e);
+    }
+
+    return rewrite;
+  }
+
+  /**
+   * Get catalog properties from {@link TableOperations} instance
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @return Catalog properties
+   */
+  public static Map<String, String> catalogProperties(TableOperations tableOperations) {
+    switch (tableOperations.getClass().getSimpleName()) {
+      case "GlueTableOperations":
+        return ((GlueTableOperations) tableOperations).tableCatalogProperties();
+      case "DynamoDbTableOperations":
+        return ((DynamoDbTableOperations) tableOperations).tableCatalogProperties();
+      case "HiveTableOperations":
+        return ((HiveTableOperations) tableOperations).tableCatalogProperties();
+      case "HadoopTableOperations":
+        return ((HadoopTableOperations) tableOperations).tableCatalogProperties();
+      default:
+        return Maps.newHashMap();
+    }
+  }
+
+  /**
+   * Get property as boolean from table properties or catalog properties. Table property is given
+   * more preference in case both table property and catalog property is provided by the user.
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @param property property to be fetched
+   * @param defaultValue default value of the property
+   * @return Property as boolean
+   */
+  public static boolean propertyAsBoolean(
+      TableOperations tableOperations, String property, boolean defaultValue) {
+    boolean tableProperty = tableOperations.current().propertyAsBoolean(property, defaultValue);
+    if (tableProperty == defaultValue) {
+      return PropertyUtil.propertyAsBoolean(
+          catalogProperties(tableOperations), property, defaultValue);
+    } else {
+      return tableProperty;
+    }
+  }
+
+  /**
+   * Get property as string from table properties or catalog properties. Table property is given
+   * more preference in case both table property and catalog property is provided by the user.
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @param property property to be fetched
+   * @param defaultValue default value of the property
+   * @return Property as string
+   */
+  public static String propertyAsString(
+      TableOperations tableOperations, String property, String defaultValue) {
+    String tableProperty = tableOperations.current().property(property, defaultValue);
+    if (Objects.equals(tableProperty, defaultValue)) {
+      return PropertyUtil.propertyAsString(
+          catalogProperties(tableOperations), property, defaultValue);
+    } else {
+      return tableProperty;
+    }
+  }
+
+  /**
+   * Get property as int from table properties or catalog properties. Table property is given more
+   * preference in case both table property and catalog property is provided by the user.
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @param property property to be fetched
+   * @param defaultValue default value of the property
+   * @return Property as int
+   */
+  public static int propertyAsInt(
+      TableOperations tableOperations, String property, int defaultValue) {
+    int tableProperty = tableOperations.current().propertyAsInt(property, defaultValue);
+    if (Objects.equals(tableProperty, defaultValue)) {
+      return PropertyUtil.propertyAsInt(catalogProperties(tableOperations), property, defaultValue);
+    } else {
+      return tableProperty;
+    }
+  }
+
+  /**
+   * Build Spark SQL launch command
+   *
+   * @return Spark SQL launch command
+   */
+  public static List<String> buildSparkSqlCommand() {
+    return ImmutableList.of("spark-sql");
+  }
+
+  /**
+   * Build Spark SQL extensions configuration
+   *
+   * @return Spark SQL extensions configuration
+   */
+  public static List<String> buildSparkSqlExtensions() {
+    return ImmutableList.of(
+        "--conf",
+        "spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions");
+  }
+
+  /**
+   * Build Spark SQL catalog configuration
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @return Spark SQL Catalog configuration
+   */
+  public static List<String> buildSparkSqlCatalog(TableOperations tableOperations) {
+    return ImmutableList.of(
+        "--conf",
+        "spark.sql.catalog.catalog_name=org.apache.iceberg.spark.SparkCatalog",
+        "--conf",
+        "spark.sql.catalog.catalog_name.io-impl=" + tableOperations.io().getClass().getName(),
+        "--conf",
+        "spark.sql.catalog.catalog_name.warehouse="
+            + propertyAsString(
+                tableOperations,
+                CatalogProperties.WAREHOUSE_LOCATION,
+                tableOperations.current().location()));
+  }
+
+  /**
+   * Build Spark SQL catalog implementation configuration
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @return Spark SQL Catalog implementation configuration
+   */
+  public static List<String> buildSparkSqlCatalogImplementation(TableOperations tableOperations) {
+    switch (tableOperations.getClass().getSimpleName()) {
+      case "GlueTableOperations":
+        return ImmutableList.of(
+            "--conf",
+            "spark.sql.catalog.catalog_name.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog");
+      case "DynamoDbTableOperations":
+        return ImmutableList.of(
+            "--conf",
+            "spark.sql.catalog.catalog_name.catalog-impl=org.apache.iceberg.aws.dynamodb.DynamoDbCatalog");
+      case "HiveTableOperations":
+        return ImmutableList.of(
+            "--conf",
+            "spark.sql.catalog.catalog_name.catalog-impl=org.apache.iceberg.hive.HiveCatalog",
+            "--conf",
+            "spark.sql.catalog.catalog_name.uri="
+                + ((HiveTableOperations) tableOperations).configuration().get(HIVE_METASTORE_URIS));
+      case "HadoopTableOperations":
+        return ImmutableList.of(
+            "--conf",
+            "spark.sql.catalog.catalog_name.catalog-impl=org.apache.iceberg.hadoop.HadoopCatalog");
+      default:
+        return ImmutableList.of();
+    }
+  }
+
+  /**
+   * Build Default Spark SQL job configurations. Users can override the Spark SQL job configurations
+   * using {@link org.apache.iceberg.TableProperties#AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS}
+   * property.
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @return Default Spark SQL job configurations
+   */
+  public static List<String> buildDefaultSparkConfigurations(TableOperations tableOperations) {
+    return Arrays.asList(
+        OptimizeTableUtil.propertyAsString(
+                tableOperations,
+                AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS,
+                AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS_DEFAULT)
+            .split(OptimizeTableUtil.BLANK));
+  }
+
+  /**
+   * Removes the catalog name, i.e. my_catalog.db.table gets converted to db.table
+   *
+   * @param tableNameWithCatalog Table with catalog name
+   * @return Table with database name
+   */
+  public static String tableName(String tableNameWithCatalog) {
+    return tableNameWithCatalog.substring(tableNameWithCatalog.indexOf(DOT) + 1);
+  }
+
+  /**
+   * Build Spark SQL Execute flag
+   *
+   * @return Spark SQL Execute flag
+   */
+  public static List<String> buildSparkSqlExecuteFlag() {
+    return ImmutableList.of("-e");
+  }
+
+  /**
+   * Build Spark SQL rewrite data files command. Users can configure the command using {@link
+   * org.apache.iceberg.TableProperties#AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS}, {@link
+   * org.apache.iceberg.TableProperties#AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY}, {@link
+   * org.apache.iceberg.TableProperties#AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER} properties. For
+   * example, the resulting Spark SQL rewrite data files command will be like CALL
+   * catalog_name.system.rewrite_data_files(table => 'db_name.table_name', options =>
+   * map('partial-progress.enabled','true'), strategy => 'binpack')
+   *
+   * @param tableNameWithCatalog Fully qualified name table with catalog. For example:
+   *     catalog_name.db_name.table_name
+   * @param tableOperations {@link TableOperations} instance
+   * @return Spark SQL rewrite data files command
+   */
+  public static List<String> buildSparkSqlRewriteDataFilesCommand(
+      String tableNameWithCatalog, TableOperations tableOperations) {
+    String tableNameWithDatabase = tableName(tableNameWithCatalog);
+    String optionsMap =
+        propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS_DEFAULT);
+    String strategy =
+        propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY_DEFAULT);
+    String sortOrder =
+        propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER_DEFAULT);
+
+    StringBuilder rewriteDataFilesCommand = new StringBuilder();
+    rewriteDataFilesCommand.append("CALL catalog_name.system.rewrite_data_files");
+    rewriteDataFilesCommand.append(OPEN_BRACKET);
+    rewriteDataFilesCommand.append(String.format("table => '%s'", tableNameWithDatabase));
+    if (optionsMap != null && !optionsMap.isEmpty()) {
+      rewriteDataFilesCommand.append(COMMA);
+      rewriteDataFilesCommand.append(BLANK);
+      rewriteDataFilesCommand.append(String.format("options => %s", optionsMap));
+    }
+    if (strategy != null && !strategy.isEmpty()) {
+      rewriteDataFilesCommand.append(COMMA);
+      rewriteDataFilesCommand.append(BLANK);
+      rewriteDataFilesCommand.append(String.format("strategy => '%s'", strategy));
+    }
+    if (sortOrder != null && !sortOrder.isEmpty()) {
+      rewriteDataFilesCommand.append(COMMA);
+      rewriteDataFilesCommand.append(BLANK);
+      rewriteDataFilesCommand.append(String.format("sort_order => '%s'", sortOrder));
+    }
+    rewriteDataFilesCommand.append(CLOSE_BRACKET);
+
+    return ImmutableList.of(rewriteDataFilesCommand.toString());
+  }
+
+  /**
+   * Build Spark Kubernetes file upload path configuration
+   *
+   * @param path Path where the files are to be uploaded
+   * @return Spark Kubernetes file upload path configuration
+   */
+  public static List<String> buildSparkKubernetesFileUploadPath(String path) {
+    return ImmutableList.of("--conf", String.format("spark.kubernetes.file.upload.path=%s", path));
+  }
+
+  /**
+   * Build Iceberg jar path
+   *
+   * @return Iceberg jar path
+   */
+  public static List<String> buildIcebergJarPath() {
+    return ImmutableList.of("--jars", "/usr/share/aws/iceberg/lib/iceberg-spark3-runtime.jar");
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/athena/RewriteUsingAthena.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/athena/RewriteUsingAthena.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.athena;
+
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT;
+
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.OptimizeTableUtil;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.Rewrite;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.AthenaException;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse;
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext;
+import software.amazon.awssdk.services.athena.model.QueryExecutionState;
+import software.amazon.awssdk.services.athena.model.ResultConfiguration;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse;
+
+/** An implementation of {@link Rewrite} to rewrite tables by launching OPTIMIZE jobs in Athena */
+public class RewriteUsingAthena implements Rewrite {
+  private static final Logger LOG = LoggerFactory.getLogger(RewriteUsingAthena.class);
+
+  private String tableName;
+
+  private AthenaClient athenaClient;
+
+  private boolean isSynchronousRewriteEnabled;
+
+  private String athenaOutputBucket;
+
+  private String athenaDatabase;
+
+  @Override
+  public void initialize(MetricsReport report) {
+    Preconditions.checkArgument(null != report, "Invalid metrics report: null");
+    TableOperations tableOperations = ((CommitReport) report).tableOperations();
+    this.tableName = OptimizeTableUtil.tableName(((CommitReport) report).tableName());
+    this.athenaClient = AwsClientFactories.defaultFactory().athena();
+    this.isSynchronousRewriteEnabled =
+        OptimizeTableUtil.propertyAsBoolean(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT);
+    this.athenaOutputBucket =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET_DEFAULT);
+    Preconditions.checkArgument(null != athenaOutputBucket, "Invalid output bucket: null");
+    this.athenaDatabase =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE_DEFAULT);
+  }
+
+  @Override
+  public void rewrite() {
+    String queryExecutionId = submitAthenaQuery();
+    // Wait for job to complete in case of synchronous rewrite
+    if (isSynchronousRewriteEnabled) {
+      waitForQueryToComplete(queryExecutionId);
+    }
+    athenaClient.close();
+  }
+
+  /**
+   * Submits a sample query to Amazon Athena and returns the execution ID of the query.
+   *
+   * @return Query execution id
+   */
+  private String submitAthenaQuery() {
+    try {
+      // The QueryExecutionContext allows us to set the database.
+      QueryExecutionContext queryExecutionContext =
+          QueryExecutionContext.builder().database(athenaDatabase).build();
+
+      // The result configuration specifies where the results of the query should go.
+      ResultConfiguration resultConfiguration =
+          ResultConfiguration.builder().outputLocation(athenaOutputBucket).build();
+
+      StartQueryExecutionRequest startQueryExecutionRequest =
+          StartQueryExecutionRequest.builder()
+              .queryString(String.format(OptimizeTableUtil.ATHENA_QUERY_FORMAT, tableName))
+              .queryExecutionContext(queryExecutionContext)
+              .resultConfiguration(resultConfiguration)
+              .build();
+
+      StartQueryExecutionResponse startQueryExecutionResponse =
+          athenaClient.startQueryExecution(startQueryExecutionRequest);
+      LOG.info(
+          "Rewrite job submitted for table {}.{} on Athena (query execution id: {})",
+          athenaDatabase,
+          tableName,
+          startQueryExecutionResponse.queryExecutionId());
+      return startQueryExecutionResponse.queryExecutionId();
+
+    } catch (AthenaException e) {
+      LOG.error("Exception occurred while submitting query: ", e);
+    }
+    return OptimizeTableUtil.BLANK;
+  }
+
+  /**
+   * Wait for an Amazon Athena query to complete, fail or to be cancelled.
+   *
+   * @param queryExecutionId Query execution id
+   */
+  private void waitForQueryToComplete(String queryExecutionId) {
+    GetQueryExecutionRequest getQueryExecutionRequest =
+        GetQueryExecutionRequest.builder().queryExecutionId(queryExecutionId).build();
+
+    GetQueryExecutionResponse getQueryExecutionResponse;
+    boolean isQueryStillRunning = true;
+    while (isQueryStillRunning) {
+      getQueryExecutionResponse = athenaClient.getQueryExecution(getQueryExecutionRequest);
+      String queryState = getQueryExecutionResponse.queryExecution().status().state().toString();
+      if (queryState.equals(QueryExecutionState.FAILED.toString())) {
+        throw new RuntimeException(
+            "The Amazon Athena query failed to run with error message: "
+                + getQueryExecutionResponse.queryExecution().status().stateChangeReason());
+      } else if (queryState.equals(QueryExecutionState.CANCELLED.toString())) {
+        throw new RuntimeException("The Amazon Athena query was cancelled.");
+      } else if (queryState.equals(QueryExecutionState.SUCCEEDED.toString())) {
+        isQueryStillRunning = false;
+      } else {
+        // Sleep an amount of time before retrying again.
+        try {
+          Thread.sleep(OptimizeTableUtil.SLEEP_WAIT_DURATION_MS);
+        } catch (InterruptedException e) {
+          LOG.error("Exception occurred while waiting for query to complete: ", e);
+        }
+      }
+      LOG.info("Status of rewrite job: {}", queryState);
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -155,7 +155,8 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
   @Override
   protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
     validateTableIdentifier(tableIdentifier);
-    return new DynamoDbTableOperations(dynamo, awsProperties, catalogName, fileIO, tableIdentifier);
+    return new DynamoDbTableOperations(
+        dynamo, awsProperties, catalogName, fileIO, tableIdentifier, catalogProperties);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -43,7 +43,7 @@ import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 
-class DynamoDbTableOperations extends BaseMetastoreTableOperations {
+public class DynamoDbTableOperations extends BaseMetastoreTableOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(DynamoDbTableOperations.class);
 
@@ -52,6 +52,8 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
   private final TableIdentifier tableIdentifier;
   private final String fullTableName;
   private final FileIO fileIO;
+
+  private Map<String, String> tableCatalogProperties = null;
 
   DynamoDbTableOperations(
       DynamoDbClient dynamo,
@@ -64,6 +66,17 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
     this.fullTableName = String.format("%s.%s", catalogName, tableIdentifier);
     this.tableIdentifier = tableIdentifier;
     this.fileIO = fileIO;
+  }
+
+  DynamoDbTableOperations(
+      DynamoDbClient dynamo,
+      AwsProperties awsProperties,
+      String catalogName,
+      FileIO fileIO,
+      TableIdentifier tableIdentifier,
+      Map<String, String> tableCatalogProperties) {
+    this(dynamo, awsProperties, catalogName, fileIO, tableIdentifier);
+    this.tableCatalogProperties = tableCatalogProperties;
   }
 
   @Override
@@ -231,5 +244,14 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
               .conditionExpression("attribute_not_exists(" + DynamoDbCatalog.COL_VERSION + ")")
               .build());
     }
+  }
+
+  /**
+   * Return the table catalog properties intialized in {@link DynamoDbCatalog}
+   *
+   * @return table catalog properties intialized in {@link DynamoDbCatalog}
+   */
+  public Map<String, String> tableCatalogProperties() {
+    return tableCatalogProperties;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/emr/RewriteUsingEMROnEC2.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/emr/RewriteUsingEMROnEC2.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.emr;
+
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT;
+
+import java.util.List;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.OptimizeTableUtil;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.Rewrite;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emr.model.AddJobFlowStepsRequest;
+import software.amazon.awssdk.services.emr.model.AddJobFlowStepsResponse;
+import software.amazon.awssdk.services.emr.model.DescribeStepRequest;
+import software.amazon.awssdk.services.emr.model.DescribeStepResponse;
+import software.amazon.awssdk.services.emr.model.HadoopJarStepConfig;
+import software.amazon.awssdk.services.emr.model.StepConfig;
+import software.amazon.awssdk.services.emr.model.StepState;
+
+/**
+ * An implementation of {@link Rewrite} to rewrite tables by launching Spark SQL jobs in EMR-on-EC2
+ */
+public class RewriteUsingEMROnEC2 implements Rewrite {
+  private static final Logger LOG = LoggerFactory.getLogger(RewriteUsingEMROnEC2.class);
+
+  private TableOperations tableOperations;
+  private String tableName;
+  private EmrClient emrClient;
+
+  private String emrClusterId;
+
+  private boolean isSynchronousRewriteEnabled;
+
+  @Override
+  public void initialize(MetricsReport report) {
+    Preconditions.checkArgument(null != report, "Invalid metrics report: null");
+    this.tableOperations = ((CommitReport) report).tableOperations();
+    this.tableName = ((CommitReport) report).tableName();
+    this.emrClient = AwsClientFactories.defaultFactory().emr();
+    this.emrClusterId =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID_DEFAULT);
+    Preconditions.checkArgument(
+        null != emrClusterId,
+        "%s should be be set",
+        AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID);
+    this.isSynchronousRewriteEnabled =
+        OptimizeTableUtil.propertyAsBoolean(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT);
+  }
+
+  @Override
+  public void rewrite() {
+    String stepId = submitEmrStep();
+    // Wait for job to complete in case of synchronous rewrite
+    if (isSynchronousRewriteEnabled) {
+      waitForStepToComplete(stepId);
+    }
+    emrClient.close();
+  }
+
+  /**
+   * Submit an EMR step to an EMR cluster
+   *
+   * @return EMR step id
+   */
+  private String submitEmrStep() {
+    AddJobFlowStepsResponse response =
+        emrClient.addJobFlowSteps(
+            AddJobFlowStepsRequest.builder()
+                .jobFlowId(emrClusterId)
+                .steps(
+                    StepConfig.builder()
+                        .name(String.format("Rewrite job for %s", tableName))
+                        .actionOnFailure(OptimizeTableUtil.EMR_STEP_CONTINUE)
+                        .hadoopJarStep(
+                            HadoopJarStepConfig.builder()
+                                .jar(OptimizeTableUtil.COMMAND_RUNNER_JAR)
+                                .args(buildArguments().toArray(new String[0]))
+                                .build())
+                        .build())
+                .build());
+    if (response != null && response.hasStepIds()) {
+      String stepId = response.stepIds().get(OptimizeTableUtil.EMR_STEP_INDEX);
+      LOG.info(
+          "Rewrite job submitted for table {} on EMR-EC2 cluster {} (step {})",
+          tableName,
+          emrClusterId,
+          stepId);
+      return stepId;
+    }
+    return OptimizeTableUtil.BLANK;
+  }
+
+  /**
+   * Build the {@link HadoopJarStepConfig} arguments
+   *
+   * @return {@link HadoopJarStepConfig} arguments
+   */
+  private List<String> buildArguments() {
+    List<String> arguments = Lists.newArrayList(OptimizeTableUtil.buildSparkSqlCommand());
+    arguments.addAll(OptimizeTableUtil.buildSparkSqlExtensions());
+    arguments.addAll(OptimizeTableUtil.buildSparkSqlCatalog(tableOperations));
+    arguments.addAll(OptimizeTableUtil.buildSparkSqlCatalogImplementation(tableOperations));
+    arguments.addAll(OptimizeTableUtil.buildDefaultSparkConfigurations(tableOperations));
+    arguments.addAll(OptimizeTableUtil.buildSparkSqlExecuteFlag());
+    arguments.addAll(
+        OptimizeTableUtil.buildSparkSqlRewriteDataFilesCommand(tableName, tableOperations));
+    return arguments;
+  }
+
+  /**
+   * Checks job status regularly for a specific EMR step id after {@link
+   * OptimizeTableUtil#SLEEP_WAIT_DURATION_MS} duration
+   *
+   * @param stepId EMR step id
+   */
+  private void waitForStepToComplete(String stepId) {
+    StepState stepState = stepState(emrClusterId, stepId);
+    while (stepState == StepState.PENDING || stepState == StepState.RUNNING) {
+      stepState = stepState(emrClusterId, stepId);
+      LOG.info("Status of rewrite job: {}", stepState);
+      try {
+        Thread.sleep(OptimizeTableUtil.SLEEP_WAIT_DURATION_MS);
+      } catch (InterruptedException e) {
+        throw new IllegalStateException(
+            String.format("Failed to request status of the rewrite job for table %s", tableName),
+            e);
+      }
+    }
+  }
+
+  /**
+   * Get EMR {@link StepState} for a given cluster id and step id
+   *
+   * @param clusterId EMR cluster id
+   * @param stepId EMR step id
+   * @return EMR {@link StepState}
+   */
+  private StepState stepState(String clusterId, String stepId) {
+    DescribeStepResponse describeStepResponse =
+        emrClient.describeStep(
+            DescribeStepRequest.builder().clusterId(clusterId).stepId(stepId).build());
+    return describeStepResponse.step().status().state();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/emr/RewriteUsingEMROnEKS.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/emr/RewriteUsingEMROnEKS.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.emr;
+
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.OptimizeTableUtil;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.Rewrite;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
+import software.amazon.awssdk.services.emrcontainers.model.CloudWatchMonitoringConfiguration;
+import software.amazon.awssdk.services.emrcontainers.model.ConfigurationOverrides;
+import software.amazon.awssdk.services.emrcontainers.model.DescribeJobRunRequest;
+import software.amazon.awssdk.services.emrcontainers.model.DescribeJobRunResponse;
+import software.amazon.awssdk.services.emrcontainers.model.JobDriver;
+import software.amazon.awssdk.services.emrcontainers.model.JobRunState;
+import software.amazon.awssdk.services.emrcontainers.model.MonitoringConfiguration;
+import software.amazon.awssdk.services.emrcontainers.model.S3MonitoringConfiguration;
+import software.amazon.awssdk.services.emrcontainers.model.SparkSqlJobDriver;
+import software.amazon.awssdk.services.emrcontainers.model.StartJobRunRequest;
+import software.amazon.awssdk.services.emrcontainers.model.StartJobRunResponse;
+
+/**
+ * An implementation of {@link Rewrite} to rewrite tables by launching Spark SQL jobs in EMR-on-EKS
+ */
+public class RewriteUsingEMROnEKS implements Rewrite {
+  private static final Logger LOG = LoggerFactory.getLogger(RewriteUsingEMROnEKS.class);
+
+  private TableOperations tableOperations;
+  private String tableName;
+  private EmrContainersClient emrContainersClient;
+  private String emrClusterId;
+  private String emrReleaseLabel;
+  private String emrUploadBucket;
+  private String executionRole;
+  private String queryFilePath;
+  private boolean isSynchronousRewriteEnabled;
+
+  @Override
+  public void initialize(MetricsReport report) {
+    Preconditions.checkArgument(null != report, "Invalid metrics report: null");
+    this.tableOperations = ((CommitReport) report).tableOperations();
+    this.tableName = ((CommitReport) report).tableName();
+    this.emrContainersClient = AwsClientFactories.defaultFactory().emrContainers();
+    this.emrClusterId =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID_DEFAULT);
+    Preconditions.checkArgument(
+        null != emrClusterId,
+        "%s should be be set",
+        AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID);
+    this.executionRole =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE_DEFAULT);
+    Preconditions.checkArgument(
+        null != executionRole,
+        "%s should be be set",
+        AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE);
+    this.emrReleaseLabel =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL_DEFAULT);
+    Preconditions.checkArgument(
+        null != emrReleaseLabel,
+        "%s should be be set",
+        AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL);
+    this.emrUploadBucket =
+        OptimizeTableUtil.propertyAsString(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET_DEFAULT);
+    Preconditions.checkArgument(
+        null != emrUploadBucket,
+        "%s should be be set",
+        AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET);
+    this.isSynchronousRewriteEnabled =
+        OptimizeTableUtil.propertyAsBoolean(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT);
+    this.queryFilePath =
+        String.format("%s/query/query-%s.sql", emrUploadBucket, java.util.UUID.randomUUID());
+  }
+
+  @Override
+  public void rewrite() {
+    createQueryFile();
+    String jobId = submitJob();
+    // Wait for job to complete in case of synchronous rewrite
+    if (isSynchronousRewriteEnabled) {
+      waitForJobToComplete(jobId);
+    }
+    emrContainersClient.close();
+  }
+
+  /**
+   * Submit a job to an EMR-on-EKS cluster
+   *
+   * @return job id
+   */
+  private String submitJob() {
+    StartJobRunResponse response =
+        emrContainersClient.startJobRun(
+            StartJobRunRequest.builder()
+                .name(String.format("RewriteJob-%s", tableName))
+                .virtualClusterId(emrClusterId)
+                .executionRoleArn(executionRole)
+                .releaseLabel(emrReleaseLabel)
+                .jobDriver(
+                    JobDriver.builder()
+                        .sparkSqlJobDriver(
+                            SparkSqlJobDriver.builder()
+                                .entryPoint(queryFilePath)
+                                .sparkSqlParameters(buildSparkSqlParameters())
+                                .build())
+                        .build())
+                .configurationOverrides(
+                    ConfigurationOverrides.builder()
+                        .monitoringConfiguration(
+                            MonitoringConfiguration.builder()
+                                .persistentAppUI(OptimizeTableUtil.PERSISTENT_APP_UI_ENABLED)
+                                .cloudWatchMonitoringConfiguration(
+                                    CloudWatchMonitoringConfiguration.builder()
+                                        .logGroupName(
+                                            OptimizeTableUtil.EMR_CONTAINERS_LOG_GROUP_NAME)
+                                        .logStreamNamePrefix(
+                                            OptimizeTableUtil.EMR_CONTAINERS_LOG_PREFIX)
+                                        .build())
+                                .s3MonitoringConfiguration(
+                                    S3MonitoringConfiguration.builder()
+                                        .logUri(String.format("%s/logs/", emrUploadBucket))
+                                        .build())
+                                .build())
+                        .build())
+                .build());
+    if (response != null) {
+      String jobId = response.id();
+      LOG.info(
+          "Rewrite job submitted for table {} on EMR-on-EKS cluster {} (job id {})",
+          tableName,
+          emrClusterId,
+          jobId);
+      return jobId;
+    }
+    return OptimizeTableUtil.BLANK;
+  }
+
+  /** Create query file containing the Spark SQL in queryFilePath */
+  private void createQueryFile() {
+    OutputFile out = tableOperations.io().newOutputFile(queryFilePath);
+    try (OutputStream os = out.createOrOverwrite()) {
+      StringBuilder stringBuilder = new StringBuilder();
+      for (String parameter :
+          OptimizeTableUtil.buildSparkSqlRewriteDataFilesCommand(tableName, tableOperations)) {
+        stringBuilder.append(parameter);
+        stringBuilder.append(OptimizeTableUtil.BLANK);
+      }
+      IOUtils.write(stringBuilder.toString(), os);
+    } catch (IOException e) {
+      LOG.error("Exception occurred while writing the {}: ", queryFilePath, e);
+    }
+  }
+
+  /**
+   * Build the Spark SQL Parameters
+   *
+   * @return Spark SQL Parameters
+   */
+  private String buildSparkSqlParameters() {
+    StringBuilder stringBuilder = new StringBuilder();
+    List<String> parameters = Lists.newArrayList(OptimizeTableUtil.buildSparkSqlExtensions());
+    parameters.addAll(OptimizeTableUtil.buildSparkSqlCatalog(tableOperations));
+    parameters.addAll(OptimizeTableUtil.buildSparkSqlCatalogImplementation(tableOperations));
+    parameters.addAll(OptimizeTableUtil.buildDefaultSparkConfigurations(tableOperations));
+    parameters.addAll(
+        OptimizeTableUtil.buildSparkKubernetesFileUploadPath(
+            String.format("%s/upload/", emrUploadBucket)));
+    parameters.addAll(OptimizeTableUtil.buildIcebergJarPath());
+
+    for (String parameter : parameters) {
+      stringBuilder.append(parameter);
+      stringBuilder.append(OptimizeTableUtil.BLANK);
+    }
+
+    return stringBuilder.toString();
+  }
+
+  /**
+   * Checks job status regularly for a specific EMR job id after {@link
+   * OptimizeTableUtil#SLEEP_WAIT_DURATION_MS} duration
+   */
+  private void waitForJobToComplete(String jobId) {
+    JobRunState jobRunState = jobState(emrClusterId, jobId);
+    while (jobRunState == JobRunState.SUBMITTED
+        || jobRunState == JobRunState.PENDING
+        || jobRunState == JobRunState.RUNNING) {
+      jobRunState = jobState(emrClusterId, jobId);
+      LOG.info("Status of rewrite job: {}", jobRunState);
+      try {
+        Thread.sleep(OptimizeTableUtil.SLEEP_WAIT_DURATION_MS);
+      } catch (InterruptedException e) {
+        throw new IllegalStateException(
+            String.format("Failed to request status of the rewrite job for table %s", tableName),
+            e);
+      }
+    }
+  }
+
+  /**
+   * Get EMR {@link JobRunState} for a given cluster id and job id
+   *
+   * @param clusterId EMR cluster id
+   * @param jobId EMR job id
+   * @return EMR {@link JobRunState}
+   */
+  private JobRunState jobState(String clusterId, String jobId) {
+    DescribeJobRunResponse describeJobRunResponse =
+        emrContainersClient.describeJobRun(
+            DescribeJobRunRequest.builder().virtualClusterId(clusterId).id(jobId).build());
+    return describeJobRunResponse.jobRun().state();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -57,7 +57,7 @@ import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
 import software.amazon.awssdk.utils.ImmutableMap;
 
-class GlueTableOperations extends BaseMetastoreTableOperations {
+public class GlueTableOperations extends BaseMetastoreTableOperations {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlueTableOperations.class);
 
@@ -358,8 +358,12 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     }
   }
 
-  @VisibleForTesting
-  Map<String, String> tableCatalogProperties() {
+  /**
+   * Return the table catalog properties intialized in {@link GlueCatalog}
+   *
+   * @return table catalog properties intialized in {@link GlueCatalog}
+   */
+  public Map<String, String> tableCatalogProperties() {
     return tableCatalogProperties;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/reporter/OptimizeTableReporter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/reporter/OptimizeTableReporter.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.reporter;
+
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL_DEFAULT;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_MS_THRESHOLD;
+import static org.apache.iceberg.TableProperties.AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_THRESHOLD_MS_DEFAULT;
+
+import java.util.List;
+import java.util.ListIterator;
+import org.apache.iceberg.DataOperations;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.aws.OptimizeTableUtil;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.Rewrite;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link MetricsReporter} to decide and launch rewrite jobs. The
+ * implementation lets users to collect table activities during writes to make better decisions on
+ * how to optimize each table differently.
+ */
+public class OptimizeTableReporter implements MetricsReporter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OptimizeTableReporter.class);
+
+  @Override
+  public void report(MetricsReport report) {
+    Preconditions.checkArgument(null != report, "Invalid metrics report: null");
+    // CommitReport restricts RewriteDataFilesReporter only to the write path
+    if (report instanceof CommitReport) {
+      LOG.info("Received metrics report: {}", report);
+      TableOperations tableOperations = ((CommitReport) report).tableOperations();
+      // If the table should be rewritten to eliminate small files
+      if (shouldRewrite(tableOperations)) {
+        String rewriteImpl =
+            OptimizeTableUtil.propertyAsString(
+                tableOperations,
+                AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL,
+                AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL_DEFAULT);
+        Preconditions.checkArgument(
+            null != rewriteImpl,
+            "Auto optimize rewrite data files implementation %s should be set",
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL);
+        Rewrite rewrite = OptimizeTableUtil.loadRewrite(rewriteImpl);
+        rewrite.initialize(report);
+        rewrite.rewrite();
+      }
+    }
+  }
+
+  /**
+   * Determine if the table should be optimized based upon the defined thresholds (commit based,
+   * time based)
+   *
+   * @param tableOperations {@link TableOperations} instance
+   * @return true/false based upon which thresholds are met
+   */
+  private boolean shouldRewrite(TableOperations tableOperations) {
+    List<Snapshot> snapshotList = tableOperations.current().snapshots();
+    ListIterator<Snapshot> listIterator = snapshotList.listIterator(snapshotList.size());
+    int numSnapshotsSinceLastRewrite = 0;
+    int commitThreshold =
+        OptimizeTableUtil.propertyAsInt(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD_DEFAULT);
+    int timeThreshold =
+        OptimizeTableUtil.propertyAsInt(
+            tableOperations,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_MS_THRESHOLD,
+            AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_THRESHOLD_MS_DEFAULT);
+    // Traverse back from the latest snapshot
+    while (listIterator.hasPrevious()) {
+      Snapshot snapshot = listIterator.previous();
+      // Reached the latest rewrite snapshot without meeting any thresholds, so return false
+      if (snapshot.operation().equals(DataOperations.REPLACE)) {
+        return false;
+      }
+
+      // Met the time threshold, so return true
+      if (System.currentTimeMillis() - snapshot.timestampMillis() >= timeThreshold) {
+        LOG.info("Time threshold has been met");
+        return true;
+      }
+
+      // Met the commit threshold, so return true
+      numSnapshotsSinceLastRewrite++;
+      if (numSnapshotsSinceLastRewrite >= commitThreshold) {
+        LOG.info("Commit threshold has been met");
+        return true;
+      }
+    }
+
+    // Traversed the entire snapshot list without meeting any thresholds, so return false
+    return false;
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -34,7 +34,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.GetTablesRequest;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -303,6 +306,21 @@ public class TestAwsClientFactories {
 
     @Override
     public DynamoDbClient dynamo() {
+      return null;
+    }
+
+    @Override
+    public EmrClient emr() {
+      return null;
+    }
+
+    @Override
+    public EmrContainersClient emrContainers() {
+      return null;
+    }
+
+    @Override
+    public AthenaClient athena() {
       return null;
     }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/StaticClientFactory.java
@@ -20,7 +20,10 @@ package org.apache.iceberg.aws.s3;
 
 import java.util.Map;
 import org.apache.iceberg.aws.AwsClientFactory;
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.emr.EmrClient;
+import software.amazon.awssdk.services.emrcontainers.EmrContainersClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -45,6 +48,21 @@ class StaticClientFactory implements AwsClientFactory {
 
   @Override
   public DynamoDbClient dynamo() {
+    return null;
+  }
+
+  @Override
+  public EmrClient emr() {
+    return null;
+  }
+
+  @Override
+  public EmrContainersClient emrContainers() {
+    return null;
+  }
+
+  @Override
+  public AthenaClient athena() {
     return null;
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -449,6 +449,9 @@ project(':iceberg-aws') {
     compileOnly 'software.amazon.awssdk:sts'
     compileOnly 'software.amazon.awssdk:dynamodb'
     compileOnly 'software.amazon.awssdk:lakeformation'
+    compileOnly 'software.amazon.awssdk:emr'
+    compileOnly 'software.amazon.awssdk:emrcontainers'
+    compileOnly 'software.amazon.awssdk:athena'
 
     compileOnly("org.apache.hadoop:hadoop-common") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -457,6 +460,7 @@ project(':iceberg-aws') {
       exclude group: 'com.google.code.gson', module: 'gson'
     }
 
+    compileOnly project(':iceberg-hive-metastore')
     compileOnly 'org.apache.httpcomponents.client5:httpclient5'
 
     testImplementation 'software.amazon.awssdk:iam'

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -440,6 +440,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
           reporter.report(
               ImmutableCommitReport.builder()
+                  .tableOperations(ops)
                   .tableName(createSnapshotEvent.tableName())
                   .snapshotId(createSnapshotEvent.snapshotId())
                   .operation(createSnapshotEvent.operation())

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.util.Set;
+import org.apache.iceberg.metrics.Rewrite;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 
 public class TableProperties {
@@ -359,4 +360,83 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  /**
+   * Auto optimize related table properties. The below table properties with
+   * "auto.optimize.rewrite-data-files" prefix can be used as catalog properties as well in {@link
+   * Rewrite}.
+   */
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED =
+      "auto.optimize.rewrite-data-files.synchronous.enabled";
+
+  public static final boolean AUTO_OPTIMIZE_REWRITE_DATA_FILES_SYNCHRONOUS_ENABLED_DEFAULT = false;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL =
+      "auto.optimize.rewrite-data-files.impl";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_IMPL_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID =
+      "auto.optimize.rewrite-data-files.emr.cluster-id";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_CLUSTER_ID_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD =
+      "auto.optimize.rewrite-data-files.commit.threshold";
+
+  public static final int AUTO_OPTIMIZE_REWRITE_DATA_FILES_COMMIT_THRESHOLD_DEFAULT = 10;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_MS_THRESHOLD =
+      "auto.optimize.rewrite-data-files.time-ms.threshold";
+
+  public static final int AUTO_OPTIMIZE_REWRITE_DATA_FILES_TIME_THRESHOLD_MS_DEFAULT =
+      180 * 60 * 1000;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS =
+      "auto.optimize.rewrite-data-files.spark.confs";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_SPARK_CONFS_DEFAULT =
+      "--conf spark.driver.cores=4 --conf spark.driver.memory=32g --conf spark.executor.cores=4 "
+          + "--conf spark.executor.memory=16g --conf spark.executor.instances=10 --conf spark.dynamicAllocation.enabled=false";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS =
+      "auto.optimize.rewrite-data-files.options";
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_OPTIONS_DEFAULT =
+      "map('partial-progress.enabled','true')";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY =
+      "auto.optimize.rewrite-data-files.strategy";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_STRATEGY_DEFAULT = "binpack";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER =
+      "auto.optimize.rewrite-data-files.sort-order";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_SORT_ORDER_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET =
+      "auto.optimize.rewrite-data-files.athena.output-bucket";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_OUTPUT_BUCKET_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE =
+      "auto.optimize.rewrite-data-files.athena.data-source";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_ATHENA_DATABASE_DEFAULT =
+      "AwsDataCatalog";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE =
+      "auto.optimize.rewrite-data-files.execution-role";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EXECUTION_ROLE_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL =
+      "auto.optimize.rewrite-data-files.emr.release-label";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_RELEASE_LABEL_DEFAULT = null;
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET =
+      "auto.optimize.rewrite-data-files.emr.upload-bucket";
+
+  public static final String AUTO_OPTIMIZE_REWRITE_DATA_FILES_EMR_UPLOAD_BUCKET_DEFAULT = null;
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -226,7 +226,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog
   @Override
   protected TableOperations newTableOps(TableIdentifier identifier) {
     return new HadoopTableOperations(
-        new Path(defaultWarehouseLocation(identifier)), fileIO, conf, lockManager);
+        new Path(defaultWarehouseLocation(identifier)),
+        fileIO,
+        conf,
+        lockManager,
+        catalogProperties);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -70,12 +71,24 @@ public class HadoopTableOperations implements TableOperations {
   private volatile Integer version = null;
   private volatile boolean shouldRefresh = true;
 
+  private Map<String, String> tableCatalogProperties = null;
+
   protected HadoopTableOperations(
       Path location, FileIO fileIO, Configuration conf, LockManager lockManager) {
     this.conf = conf;
     this.location = location;
     this.fileIO = fileIO;
     this.lockManager = lockManager;
+  }
+
+  protected HadoopTableOperations(
+      Path location,
+      FileIO fileIO,
+      Configuration conf,
+      LockManager lockManager,
+      Map<String, String> tableCatalogProperties) {
+    this(location, fileIO, conf, lockManager);
+    this.tableCatalogProperties = tableCatalogProperties;
   }
 
   @Override
@@ -449,5 +462,14 @@ public class HadoopTableOperations implements TableOperations {
           newUUID);
     }
     return newMetadata;
+  }
+
+  /**
+   * Return the table catalog properties intialized in {@link HadoopCatalog}
+   *
+   * @return table catalog properties intialized in {@link HadoopCatalog}
+   */
+  public Map<String, String> tableCatalogProperties() {
+    return tableCatalogProperties;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/metrics/Rewrite.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/Rewrite.java
@@ -18,25 +18,16 @@
  */
 package org.apache.iceberg.metrics;
 
-import java.util.Map;
-import org.apache.iceberg.TableOperations;
-import org.immutables.value.Value;
+/** Interface to rewrite tables in a specific engine selected by the user */
+public interface Rewrite {
 
-/** A commit report that contains all relevant information from a Snapshot. */
-@Value.Immutable
-public interface CommitReport extends MetricsReport {
+  /**
+   * Initialize the {@link Rewrite} implementation
+   *
+   * @param metricsReport {@link MetricsReport} instance
+   */
+  void initialize(MetricsReport metricsReport);
 
-  TableOperations tableOperations();
-
-  String tableName();
-
-  long snapshotId();
-
-  long sequenceNumber();
-
-  String operation();
-
-  CommitMetricsResult commitMetrics();
-
-  Map<String, String> metadata();
+  /** Trigger rewrite jobs for the {@link Rewrite} implementation */
+  void rewrite();
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -478,7 +478,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    return new HiveTableOperations(conf, clients, fileIO, name, dbName, tableName);
+    return new HiveTableOperations(
+        conf, clients, fileIO, name, dbName, tableName, catalogProperties);
   }
 
   @Override

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -117,6 +117,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final FileIO fileIO;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
 
+  private Map<String, String> tableCatalogProperties = null;
+
   protected HiveTableOperations(
       Configuration conf,
       ClientPool metaClients,
@@ -137,6 +139,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             HIVE_ICEBERG_METADATA_REFRESH_MAX_RETRIES_DEFAULT);
     this.maxHiveTablePropertySize =
         conf.getLong(HIVE_TABLE_PROPERTY_MAX_SIZE, HIVE_TABLE_PROPERTY_MAX_SIZE_DEFAULT);
+  }
+
+  protected HiveTableOperations(
+      Configuration conf,
+      ClientPool metaClients,
+      FileIO fileIO,
+      String catalogName,
+      String database,
+      String table,
+      Map<String, String> tableCatalogProperties) {
+    this(conf, metaClients, fileIO, catalogName, database, table);
+    this.tableCatalogProperties = tableCatalogProperties;
   }
 
   @Override
@@ -575,5 +589,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   @VisibleForTesting
   HiveLock lockObject() {
     return new MetastoreLock(conf, metaClients, catalogName, database, tableName);
+  }
+
+  /**
+   * Return the table catalog properties intialized in {@link HiveCatalog}
+   *
+   * @return table catalog properties intialized in {@link HiveCatalog}
+   */
+  public Map<String, String> tableCatalogProperties() {
+    return tableCatalogProperties;
+  }
+
+  public Configuration configuration() {
+    return conf;
   }
 }


### PR DESCRIPTION
This PR uses `MetricsReporter` post commit notifications to auto optimize tables. The solution lets users to collect table activities during writes and make better decisions on how to optimize each table differently. This is an opt-in feature and would be helpful in scenarios where the users would not like to maintain different optimisations as scheduled pipelines.

The overall approach is to form the rewrite data files SQL command and submit it to EMR-on-EC2, EMR-on-EKS, or Athena after write operations. Users can use either of these implementations (via table or catalog properties): `RewriteUsingEMREC2`, `RewriteUsingEMROnEKS` or `RewriteUsingAthena` to rewrite the tables when some defined thresholds are met (commit based or time based).

Looking forward to the community feedback.

---

Command to launch session:
```
spark-sql --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
    --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://bucket/warehouse/test-table \
    --conf spark.sql.catalog.my_catalog.metrics-reporter-impl=org.apache.iceberg.aws.reporter.OptimizeTableReporter \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.synchronous.enabled=true \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.impl=org.apache.iceberg.aws.emr.RewriteUsingEMROnEC2 \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.emr.cluster-id=j-3QLCP3UJJ7IOZ \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.commit.threshold=1
```

```
spark-sql --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
    --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://bucket/warehouse/test-table \
    --conf spark.sql.catalog.my_catalog.metrics-reporter-impl=org.apache.iceberg.aws.reporter.OptimizeTableReporter \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.synchronous.enabled=true \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.impl=org.apache.iceberg.aws.athena.RewriteUsingAthena \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.emr.cluster-id=j-3QLCP3UJJ7IOZ \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.commit.threshold=1 \
    --conf spark.sql.catalog.my_catalog.auto.optimize.rewrite-data-files.athena.output-bucket=s3://bucket
```

---
cc: @jackye1995 @singhpk234 @amogh-jahagirdar 