### PR TITLE
AWS: Remove deprecated AssertHelpers

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aws;
 
 import java.io.IOException;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -68,19 +67,17 @@ public class TestAwsClientFactories {
   public void testS3FileIoCredentialsVerification() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(AwsProperties.S3FILEIO_ACCESS_KEY_ID, "key");
-    AssertHelpers.assertThrows(
-        "Should fail if only access key ID is set",
-        ValidationException.class,
-        "S3 client access key ID and secret access key must be set at the same time",
-        () -> AwsClientFactories.from(properties));
+
+    Assertions.assertThatThrownBy(() -> AwsClientFactories.from(properties))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("S3 client access key ID and secret access key must be set at the same time");
 
     properties.remove(AwsProperties.S3FILEIO_ACCESS_KEY_ID);
     properties.put(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY, "secret");
-    AssertHelpers.assertThrows(
-        "Should fail if only secret access key is set",
-        ValidationException.class,
-        "S3 client access key ID and secret access key must be set at the same time",
-        () -> AwsClientFactories.from(properties));
+
+    Assertions.assertThatThrownBy(() -> AwsClientFactories.from(properties))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("S3 client access key ID and secret access key must be set at the same time");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
@@ -51,11 +50,10 @@ public class TestAwsProperties {
   public void testS3FileIoSseCustom_mustHaveCustomKey() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_SSE_TYPE, AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM);
-    AssertHelpers.assertThrows(
-        "must have key for SSE-C",
-        NullPointerException.class,
-        "Cannot initialize SSE-C S3FileIO with null encryption key",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Cannot initialize SSE-C S3FileIO with null encryption key");
   }
 
   @Test
@@ -63,11 +61,10 @@ public class TestAwsProperties {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_SSE_TYPE, AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM);
     map.put(AwsProperties.S3FILEIO_SSE_KEY, "something");
-    AssertHelpers.assertThrows(
-        "must have md5 for SSE-C",
-        NullPointerException.class,
-        "Cannot initialize SSE-C S3FileIO with null encryption key MD5",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Cannot initialize SSE-C S3FileIO with null encryption key MD5");
   }
 
   @Test
@@ -82,66 +79,60 @@ public class TestAwsProperties {
   public void testS3FileIoAcl_unknownType() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_ACL, "bad-input");
-    AssertHelpers.assertThrows(
-        "should not accept bad input",
-        IllegalArgumentException.class,
-        "Cannot support S3 CannedACL bad-input",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot support S3 CannedACL bad-input");
   }
 
   @Test
   public void testS3MultipartSizeTooSmall() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_MULTIPART_SIZE, "1");
-    AssertHelpers.assertThrows(
-        "should not accept small part size",
-        IllegalArgumentException.class,
-        "Minimum multipart upload object size must be larger than 5 MB",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Minimum multipart upload object size must be larger than 5 MB.");
   }
 
   @Test
   public void testS3MultipartSizeTooLarge() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_MULTIPART_SIZE, "5368709120"); // 5GB
-    AssertHelpers.assertThrows(
-        "should not accept too big part size",
-        IllegalArgumentException.class,
-        "Input malformed or exceeded maximum multipart upload size 5GB",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Input malformed or exceeded maximum multipart upload size 5GB: 5368709120");
   }
 
   @Test
   public void testS3MultipartThresholdFactorLessThanOne() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_MULTIPART_THRESHOLD_FACTOR, "0.9");
-    AssertHelpers.assertThrows(
-        "should not accept factor less than 1",
-        IllegalArgumentException.class,
-        "Multipart threshold factor must be >= to 1.0",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Multipart threshold factor must be >= to 1.0");
   }
 
   @Test
   public void testS3FileIoDeleteBatchSizeTooLarge() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_DELETE_BATCH_SIZE, "2000");
-    AssertHelpers.assertThrows(
-        "should not accept batch size greater than 1000",
-        IllegalArgumentException.class,
-        "Deletion batch size must be between 1 and 1000",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Deletion batch size must be between 1 and 1000");
   }
 
   @Test
   public void testS3FileIoDeleteBatchSizeTooSmall() {
     Map<String, String> map = Maps.newHashMap();
     map.put(AwsProperties.S3FILEIO_DELETE_BATCH_SIZE, "0");
-    AssertHelpers.assertThrows(
-        "should not accept batch size less than 1",
-        IllegalArgumentException.class,
-        "Deletion batch size must be between 1 and 1000",
-        () -> new AwsProperties(map));
+
+    Assertions.assertThatThrownBy(() -> new AwsProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Deletion batch size must be between 1 and 1000");
   }
 
   @Test
@@ -261,11 +252,10 @@ public class TestAwsProperties {
     AwsProperties awsProperties = new AwsProperties(properties);
     S3ClientBuilder s3ClientBuilder = S3Client.builder();
 
-    AssertHelpers.assertThrows(
-        "should not support http client types other than urlconnection and apache",
-        IllegalArgumentException.class,
-        "Unrecognized HTTP client type",
-        () -> awsProperties.applyHttpClientConfigurations(s3ClientBuilder));
+    Assertions.assertThatThrownBy(
+            () -> awsProperties.applyHttpClientConfigurations(s3ClientBuilder))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unrecognized HTTP client type test");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
@@ -19,12 +19,12 @@
 package org.apache.iceberg.aws.glue;
 
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.services.glue.model.Database;
@@ -59,11 +59,10 @@ public class TestGlueToIcebergConverter {
   @Test
   public void testValidateTableIcebergPropertyNotFound() {
     Table table = Table.builder().parameters(ImmutableMap.of()).build();
-    AssertHelpers.assertThrows(
-        "Iceberg property not found",
-        ValidationException.class,
-        "Input Glue table is not an iceberg table",
-        () -> GlueToIcebergConverter.validateTable(table, "name"));
+
+    Assertions.assertThatThrownBy(() -> GlueToIcebergConverter.validateTable(table, "name"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Input Glue table is not an iceberg table: name (type=null)");
   }
 
   @Test
@@ -71,10 +70,9 @@ public class TestGlueToIcebergConverter {
     Map<String, String> properties =
         ImmutableMap.of(BaseMetastoreTableOperations.TABLE_TYPE_PROP, "other");
     Table table = Table.builder().parameters(properties).build();
-    AssertHelpers.assertThrows(
-        "Iceberg property value wrong",
-        ValidationException.class,
-        "Input Glue table is not an iceberg table",
-        () -> GlueToIcebergConverter.validateTable(table, "name"));
+
+    Assertions.assertThatThrownBy(() -> GlueToIcebergConverter.validateTable(table, "name"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Input Glue table is not an iceberg table: name (type=other)");
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.aws.glue;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -33,6 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import software.amazon.awssdk.services.glue.model.Column;
@@ -63,11 +63,13 @@ public class TestIcebergToGlueConverter {
             Namespace.of(""),
             Namespace.of(new String(new char[600]).replace("\0", "a")));
     for (Namespace name : badNames) {
-      AssertHelpers.assertThrows(
-          "bad namespace name",
-          ValidationException.class,
-          "Cannot convert namespace",
-          () -> IcebergToGlueConverter.toDatabaseName(name, false));
+
+      Assertions.assertThatThrownBy(() -> IcebergToGlueConverter.toDatabaseName(name, false))
+          .isInstanceOf(ValidationException.class)
+          .hasMessageStartingWith("Cannot convert namespace")
+          .hasMessageEndingWith(
+              "to Glue database name, "
+                  + "because it must be 1-252 chars of lowercase letters, numbers, underscore");
     }
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
@@ -21,10 +21,10 @@ package org.apache.iceberg.aws.s3;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestS3URI {
@@ -51,11 +51,10 @@ public class TestS3URI {
 
   @Test
   public void testMissingScheme() {
-    AssertHelpers.assertThrows(
-        "Should not allow missing scheme",
-        ValidationException.class,
-        "Invalid S3 URI, cannot determine scheme",
-        () -> new S3URI("/path/to/file"));
+
+    Assertions.assertThatThrownBy(() -> new S3URI("/path/to/file"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Invalid S3 URI, cannot determine scheme: /path/to/file");
   }
 
   @Test


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in `iceberg-aws` module