### PR TITLE
[ORC][Spark] - Support selected vector with ORC reader on the row and batch reader

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -171,8 +171,10 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
         nextRow = 0;
         this.reader.setBatchContext(nextBatch.second());
       }
-
-      return this.reader.read(current, nextRow++);
+      // If selected is in use then the row ids should be determined from the selected vector
+      int rowId = current.isSelectedInUse() ? current.selected[nextRow] : nextRow;
+      nextRow++;
+      return this.reader.read(current, rowId);
     }
 
     @Override

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.orc.GenericOrcReader;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcConf;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestOrcDataReader {
+  @ClassRule public static TemporaryFolder temp = new TemporaryFolder();
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional(3, "binary", Types.BinaryType.get()));
+  private static DataFile dataFile;
+  private static OutputFile outputFile;
+
+  @BeforeClass
+  public static void createDataFile() throws IOException {
+    GenericRecord bufferRecord = GenericRecord.create(SCHEMA);
+
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    builder.add(bufferRecord.copy(ImmutableMap.of("id", 1L, "data", "a")));
+    builder.add(bufferRecord.copy(ImmutableMap.of("id", 2L, "data", "b")));
+    builder.add(bufferRecord.copy(ImmutableMap.of("id", 3L, "data", "c")));
+    builder.add(bufferRecord.copy(ImmutableMap.of("id", 4L, "data", "d")));
+    builder.add(bufferRecord.copy(ImmutableMap.of("id", 5L, "data", "e")));
+
+    outputFile = Files.localOutput(File.createTempFile("test", ".orc", temp.getRoot()));
+
+    DataWriter<Record> dataWriter =
+        ORC.writeData(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+
+    try {
+      for (Record record : builder.build()) {
+        dataWriter.write(record);
+      }
+    } finally {
+      dataWriter.close();
+    }
+
+    dataFile = dataWriter.toDataFile();
+  }
+
+  @Test
+  public void testWrite() {
+    Assert.assertEquals("Format should be ORC", FileFormat.ORC, dataFile.format());
+    Assert.assertEquals("Should be data file", FileContent.DATA, dataFile.content());
+    Assert.assertEquals("Record count should match", 5, dataFile.recordCount());
+    Assert.assertEquals("Partition should be empty", 0, dataFile.partition().size());
+    Assert.assertNull("Key metadata should be null", dataFile.keyMetadata());
+  }
+
+  private void validateAllRecords(List<Record> records) {
+    Assert.assertEquals(5, records.size());
+    long id = 1;
+    char data = 'a';
+    for (Record record : records) {
+      Assert.assertEquals(id, record.getField("id"));
+      id++;
+      Assert.assertEquals(data, ((String) record.getField("data")).charAt(0));
+      data++;
+    }
+  }
+
+  @Test
+  public void testRowReader() throws IOException {
+    try (CloseableIterable<Record> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(SCHEMA, fileSchema))
+            .filter(Expressions.and(Expressions.notNull("data"), Expressions.equal("id", 3L)))
+            .build()) {
+      validateAllRecords(Lists.newArrayList(reader));
+    }
+  }
+
+  @Test
+  public void testRowReaderWithFilter() throws IOException {
+    try (CloseableIterable<Record> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(SCHEMA, fileSchema))
+            .filter(Expressions.and(Expressions.notNull("data"), Expressions.equal("id", 3L)))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.name(), String.valueOf(true))
+            .build()) {
+      validateAllRecords(Lists.newArrayList(reader));
+    }
+  }
+
+  @Test
+  public void testRowReaderWithFilterWithSelected() throws IOException {
+    List<Record> writtenRecords;
+    try (CloseableIterable<Record> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(SCHEMA, fileSchema))
+            .filter(Expressions.and(Expressions.notNull("data"), Expressions.equal("id", 3L)))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .config(OrcConf.READER_USE_SELECTED.getAttribute(), String.valueOf(true))
+            .build()) {
+      writtenRecords = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals(1, writtenRecords.size());
+    Assert.assertEquals(3L, writtenRecords.get(0).get(0));
+    Assert.assertEquals("c", writtenRecords.get(0).get(1));
+  }
+}

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -104,6 +104,10 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation "org.xerial:sqlite-jdbc"
   }
 
+  test {
+    useJUnitPlatform()
+  }
+
   tasks.withType(Test) {
     // Vectorized reads need more memory
     maxHeapSize '2560m'

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestVectorizedOrcDataReader.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestVectorizedOrcDataReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcConf;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestVectorizedOrcDataReader {
+  @TempDir public static Path temp;
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()),
+          Types.NestedField.optional(3, "binary", Types.BinaryType.get()),
+          Types.NestedField.required(
+              4, "array", Types.ListType.ofOptional(5, Types.IntegerType.get())));
+  private static OutputFile outputFile;
+
+  @BeforeAll
+  public static void createDataFile() throws IOException {
+    GenericRecord bufferRecord = GenericRecord.create(SCHEMA);
+
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    builder.add(
+        bufferRecord.copy(
+            ImmutableMap.of("id", 1L, "data", "a", "array", Collections.singletonList(1))));
+    builder.add(
+        bufferRecord.copy(ImmutableMap.of("id", 2L, "data", "b", "array", Arrays.asList(2, 3))));
+    builder.add(
+        bufferRecord.copy(ImmutableMap.of("id", 3L, "data", "c", "array", Arrays.asList(3, 4, 5))));
+    builder.add(
+        bufferRecord.copy(
+            ImmutableMap.of("id", 4L, "data", "d", "array", Arrays.asList(4, 5, 6, 7))));
+    builder.add(
+        bufferRecord.copy(
+            ImmutableMap.of("id", 5L, "data", "e", "array", Arrays.asList(5, 6, 7, 8, 9))));
+
+    outputFile = Files.localOutput(File.createTempFile("test", ".orc", temp.toFile()));
+
+    try (DataWriter<Record> dataWriter =
+        ORC.writeData(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build()) {
+      for (Record record : builder.build()) {
+        dataWriter.write(record);
+      }
+    }
+  }
+
+  private Iterator<InternalRow> batchesToRows(Iterator<ColumnarBatch> batches) {
+    return Iterators.concat(Iterators.transform(batches, ColumnarBatch::rowIterator));
+  }
+
+  private void validateAllRows(Iterator<InternalRow> rows) {
+    long rowCount = 0;
+    long expId = 1;
+    char expChar = 'a';
+    while (rows.hasNext()) {
+      InternalRow row = rows.next();
+      Assertions.assertEquals(expId, row.getLong(0));
+      Assertions.assertEquals(expChar, row.getString(1).charAt(0));
+      Assertions.assertTrue(row.isNullAt(2));
+      expId += 1;
+      expChar += 1;
+      rowCount += 1;
+    }
+    Assertions.assertEquals(5, rowCount);
+  }
+
+  @Test
+  public void testVectorizedReader() throws IOException {
+    try (CloseableIterable<ColumnarBatch> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createBatchedReaderFunc(
+                readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(SCHEMA, readOrcSchema, ImmutableMap.of()))
+            .build()) {
+      validateAllRows(batchesToRows(reader.iterator()));
+    }
+  }
+
+  @Test
+  public void testRowReaderWithFilter() throws IOException {
+    try (CloseableIterable<ColumnarBatch> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createBatchedReaderFunc(
+                readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(SCHEMA, readOrcSchema, ImmutableMap.of()))
+            .filter(Expressions.equal("id", 3L))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .build()) {
+      validateAllRows(batchesToRows(reader.iterator()));
+    }
+  }
+
+  @Test
+  public void testRowReaderWithFilterWithSelected() throws IOException {
+    try (CloseableIterable<ColumnarBatch> reader =
+        ORC.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createBatchedReaderFunc(
+                readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(SCHEMA, readOrcSchema, ImmutableMap.of()))
+            .filter(Expressions.equal("id", 3L))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .config(OrcConf.READER_USE_SELECTED.getAttribute(), String.valueOf(true))
+            .build()) {
+      Iterator<InternalRow> rows = batchesToRows(reader.iterator());
+      Assertions.assertTrue(rows.hasNext());
+      InternalRow row = rows.next();
+      Assertions.assertEquals(3L, row.getLong(0));
+      Assertions.assertEquals("c", row.getString(1));
+      Assertions.assertArrayEquals(new int[] {3, 4, 5}, row.getArray(3).toIntArray());
+      Assertions.assertFalse(rows.hasNext());
+    }
+  }
+}


### PR DESCRIPTION
## What?
Currently Iceberg does not support the use of the selected vector when reading ORC Files. This requires reads on ORC to be run in compatibility mode by not setting `orc.filter.use.selected` in the presence of filter processing that is triggered via `orc.sarg.to.filter`.

Filter processing was introduced as part of [ORC-744](https://issues.apache.org/jira/browse/ORC-744) where ORC has the ability to filter out records and indicate this status in partially filtered batches using the selected vector in VectorizedRowBatch.

This PR uses the selected vector to determine valid rows when applicable.

## Why?
ORC can only operate in compatibility mode by not setting `orc.filter.use.selected`. Enabling this will further hasten the processing of rows by ignoring rows that are already filtered out in the batch.

## Tested?
New Unit tests have been added to verify the behavior.