### PR TITLE
AWS: Check commit status after failed commit if AWS client performed retries

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.LockManagers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -83,13 +82,7 @@ public class GlueTestBase {
     AwsProperties properties = new AwsProperties();
     properties.setS3FileIoDeleteBatchSize(10);
     glueCatalog.initialize(
-        catalogName,
-        testBucketPath,
-        properties,
-        glue,
-        LockManagers.defaultLockManager(),
-        fileIO,
-        ImmutableMap.of());
+        catalogName, testBucketPath, properties, glue, null, fileIO, ImmutableMap.of());
 
     glueCatalogWithSkipNameValidation = new GlueCatalog();
     AwsProperties propertiesSkipNameValidation = new AwsProperties();
@@ -99,7 +92,7 @@ public class GlueTestBase {
         testBucketPath,
         propertiesSkipNameValidation,
         glue,
-        LockManagers.defaultLockManager(),
+        null,
         fileIO,
         ImmutableMap.of());
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.s3.S3TestUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -253,7 +254,8 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
               realOps.persistGlueTable(
                   i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
                   mapProperties,
-                  i.getArgument(2, TableMetadata.class));
+                  i.getArgument(2, TableMetadata.class),
+                  i.getArgument(3, AwsClientFactories.InternalRetryDetector.class));
 
               // new metadata location is stored in map property, and used for locking
               String newMetadataLocation =
@@ -267,7 +269,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
               throw new RuntimeException("Datacenter on fire");
             })
         .when(spyOperations)
-        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any(), Mockito.any());
   }
 
   @Test
@@ -422,11 +424,12 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
               realOps.persistGlueTable(
                   i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
                   i.getArgument(1, Map.class),
-                  i.getArgument(2, TableMetadata.class));
+                  i.getArgument(2, TableMetadata.class),
+                  i.getArgument(3, AwsClientFactories.InternalRetryDetector.class));
               throw new RuntimeException("Datacenter on fire");
             })
         .when(spyOps)
-        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any(), Mockito.any());
   }
 
   private void failCommitAndThrowException(GlueTableOperations spyOps) {
@@ -436,7 +439,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   private void failCommitAndThrowException(GlueTableOperations spyOps, Exception exceptionToThrow) {
     Mockito.doThrow(exceptionToThrow)
         .when(spyOps)
-        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any());
+        .persistGlueTable(Mockito.any(), Mockito.anyMap(), Mockito.any(), Mockito.any());
   }
 
   private void breakFallbackCatalogCommitCheck(GlueTableOperations spyOperations) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -30,12 +30,9 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
-import software.amazon.awssdk.core.metrics.CoreMetric;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
-import software.amazon.awssdk.metrics.MetricCollection;
-import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -89,32 +86,6 @@ public class AwsClientFactories {
 
     factory.initialize(properties);
     return factory;
-  }
-
-  /**
-   * Metrics are the only reliable way provided by the AWS SDK to determine if an API call was
-   * retried. Not for public use.
-   */
-  public static class InternalRetryDetector implements MetricPublisher {
-    private boolean retried = false;
-
-    @Override
-    public void publish(MetricCollection metricCollection) {
-      if (!retried) {
-        if (metricCollection.metricValues(CoreMetric.RETRY_COUNT).stream().anyMatch(i -> i > 0)) {
-          retried = true;
-        } else {
-          metricCollection.children().forEach(this::publish);
-        }
-      }
-    }
-
-    @Override
-    public void close() {}
-
-    public boolean wasRetried() {
-      return retried;
-    }
   }
 
   static class DefaultAwsClientFactory implements AwsClientFactory {

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -129,15 +129,13 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       // If we got an exception we weren't expecting, or we got a ConditionalCheckFailedException
       // but retries were performed, attempt to reconcile the actual commit status.
       if (!conditionCheckFailed || retryDetector.retried()) {
-        LOG.error(
-            "Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
+        LOG.warn(
+            "Received unexpected failure when committing to {}, validating if commit ended up succeeding.",
             fullTableName,
             persistFailure);
         commitStatus = checkCommitStatus(newMetadataLocation, metadata);
       }
 
-      // If we got ConditionalCheckFailedException, but find we
-      // succeeded on a retry that threw an exception, skip this exception.
       if (commitStatus != CommitStatus.SUCCESS && conditionCheckFailed) {
         throw new CommitFailedException(
             persistFailure, "Cannot commit %s: concurrent update detected", tableName());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -142,6 +143,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     CommitStatus commitStatus = CommitStatus.FAILURE;
+    AwsClientFactories.InternalRetryDetector retryDetector =
+        new AwsClientFactories.InternalRetryDetector();
 
     String newMetadataLocation = null;
     boolean glueTempTableCreated = false;
@@ -154,45 +157,27 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       Table glueTable = getGlueTable();
       checkMetadataLocation(glueTable, base);
       Map<String, String> properties = prepareProperties(glueTable, newMetadataLocation);
-      persistGlueTable(glueTable, properties, metadata);
+      persistGlueTable(glueTable, properties, metadata, retryDetector);
       commitStatus = CommitStatus.SUCCESS;
     } catch (CommitFailedException e) {
       throw e;
-    } catch (ConcurrentModificationException e) {
-      throw new CommitFailedException(
-          e, "Cannot commit %s because Glue detected concurrent update", tableName());
-    } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
-      throw new AlreadyExistsException(
-          e,
-          "Cannot commit %s because its Glue table already exists when trying to create one",
-          tableName());
-    } catch (EntityNotFoundException e) {
-      throw new NotFoundException(
-          e, "Cannot commit %s because Glue cannot find the requested entity", tableName());
-    } catch (AccessDeniedException e) {
-      throw new ForbiddenException(
-          e, "Cannot commit %s because Glue cannot access the requested resources", tableName());
-    } catch (software.amazon.awssdk.services.glue.model.ValidationException e) {
-      throw new ValidationException(
-          e,
-          "Cannot commit %s because Glue encountered a validation exception "
-              + "while accessing requested resources",
-          tableName());
     } catch (RuntimeException persistFailure) {
-      LOG.error(
-          "Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
-          fullTableName,
-          persistFailure);
+      boolean isAwsServiceException = persistFailure instanceof AwsServiceException;
 
-      if (persistFailure instanceof AwsServiceException) {
-        int statusCode = ((AwsServiceException) persistFailure).statusCode();
-        if (statusCode >= 500 && statusCode < 600) {
-          commitStatus = CommitStatus.FAILURE;
-        } else {
-          throw persistFailure;
-        }
-      } else {
+      // If we got an exception we weren't expecting, or we got an AWS service exception
+      // but retries were performed, attempt to reconcile the actual commit status.
+      if (!isAwsServiceException || retryDetector.wasRetried()) {
+        LOG.error(
+            "Confirming if commit to {} indeed failed to persist, attempting to reconnect and check.",
+            fullTableName,
+            persistFailure);
         commitStatus = checkCommitStatus(newMetadataLocation, metadata);
+      }
+
+      // If we got an AWS exception we would usually handle, but find we
+      // succeeded on a retry that threw an exception, skip the exception.
+      if (commitStatus != CommitStatus.SUCCESS && isAwsServiceException) {
+        handleAWSExceptions((AwsServiceException) persistFailure);
       }
 
       switch (commitStatus) {
@@ -298,11 +283,16 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   }
 
   @VisibleForTesting
-  void persistGlueTable(Table glueTable, Map<String, String> parameters, TableMetadata metadata) {
+  void persistGlueTable(
+      Table glueTable,
+      Map<String, String> parameters,
+      TableMetadata metadata,
+      AwsClientFactories.InternalRetryDetector retryDetector) {
     if (glueTable != null) {
       LOG.debug("Committing existing Glue table: {}", tableName());
       UpdateTableRequest.Builder updateTableRequest =
           UpdateTableRequest.builder()
+              .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
               .catalogId(awsProperties.glueCatalogId())
               .databaseName(databaseName)
               .skipArchive(awsProperties.glueCatalogSkipArchive())
@@ -325,6 +315,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       LOG.debug("Committing new Glue table: {}", tableName());
       glue.createTable(
           CreateTableRequest.builder()
+              .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
               .catalogId(awsProperties.glueCatalogId())
               .databaseName(databaseName)
               .tableInput(
@@ -337,6 +328,39 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
                       .parameters(parameters)
                       .build())
               .build());
+    }
+  }
+
+  private void handleAWSExceptions(AwsServiceException persistFailure) {
+    int statusCode = persistFailure.statusCode();
+    if (persistFailure instanceof ConcurrentModificationException) {
+      throw new CommitFailedException(
+          persistFailure, "Cannot commit %s because Glue detected concurrent update", tableName());
+    } else if (persistFailure
+        instanceof software.amazon.awssdk.services.glue.model.AlreadyExistsException) {
+      throw new AlreadyExistsException(
+          persistFailure,
+          "Cannot commit %s because its Glue table already exists when trying to create one",
+          tableName());
+    } else if (persistFailure instanceof EntityNotFoundException) {
+      throw new NotFoundException(
+          persistFailure,
+          "Cannot commit %s because Glue cannot find the requested entity",
+          tableName());
+    } else if (persistFailure instanceof AccessDeniedException) {
+      throw new ForbiddenException(
+          persistFailure,
+          "Cannot commit %s because Glue cannot access the requested resources",
+          tableName());
+    } else if (persistFailure
+        instanceof software.amazon.awssdk.services.glue.model.ValidationException) {
+      throw new ValidationException(
+          persistFailure,
+          "Cannot commit %s because Glue encountered a validation exception "
+              + "while accessing requested resources",
+          tableName());
+    } else if (statusCode < 500 || statusCode >= 600) {
+      throw persistFailure;
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/util/RetryDetector.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/util/RetryDetector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+/**
+ * Metrics are the only reliable way provided by the AWS SDK to determine if an API call was
+ * retried. This class can be attached to an AWS API call and checked after to determine if retries
+ * occurred.
+ */
+public class RetryDetector implements MetricPublisher {
+  private final AtomicBoolean retried = new AtomicBoolean(false);
+
+  @Override
+  public void publish(MetricCollection metricCollection) {
+    if (!retried.get()) {
+      if (metricCollection.metricValues(CoreMetric.RETRY_COUNT).stream().anyMatch(i -> i > 0)) {
+        retried.set(true);
+      } else {
+        metricCollection.children().forEach(this::publish);
+      }
+    }
+  }
+
+  @Override
+  public void close() {}
+
+  public boolean retried() {
+    return retried.get();
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/util/TestRetryDetector.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/util/TestRetryDetector.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricCollector;
+
+public class TestRetryDetector {
+  private static final String METRICS_NAME = "name";
+
+  @Test
+  public void testNoMetrics() {
+    RetryDetector detector = new RetryDetector();
+    Assert.assertFalse("Should default to false", detector.retried());
+  }
+
+  @Test
+  public void testRetryCountMissing() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertFalse(
+        "Should not detect retries if RETRY_COUNT metric is not reported", detector.retried());
+  }
+
+  @Test
+  public void testRetryCountZero() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertFalse("Should not detect retries if RETRY_COUNT is zero", detector.retried());
+  }
+
+  @Test
+  public void testRetryCountNonZero() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertTrue("Should detect retries if RETRY_COUNT is non-zero", detector.retried());
+  }
+
+  @Test
+  public void testMultipleRetryCounts() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertTrue(
+        "Should detect retries if even one RETRY_COUNT is non-zero", detector.retried());
+  }
+
+  @Test
+  public void testNestedRetryCountZero() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollector childMetrics = metrics.createChild("child1").createChild("child2");
+    childMetrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertFalse(
+        "Should not detect retries if nested RETRY_COUNT is zero", detector.retried());
+  }
+
+  @Test
+  public void testNestedRetryCountNonZero() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollector childMetrics = metrics.createChild("child1").createChild("child2");
+    childMetrics.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertTrue(
+        "Should detect retries if nested RETRY_COUNT is non-zero", detector.retried());
+  }
+
+  @Test
+  public void testNestedRetryCountMultipleChildren() {
+    MetricCollector metrics = MetricCollector.create(METRICS_NAME);
+    metrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    for (int i = 0; i < 5; i++) {
+      MetricCollector childMetrics = metrics.createChild("child" + i);
+      childMetrics.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    }
+
+    MetricCollector childMetrics = metrics.createChild("child10");
+    childMetrics.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics.collect());
+    Assert.assertTrue(
+        "Should detect retries if even one nested RETRY_COUNT is non-zero", detector.retried());
+  }
+
+  @Test
+  public void testMultipleCollectionsReported() {
+    MetricCollector metrics1 = MetricCollector.create(METRICS_NAME);
+    metrics1.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollector metrics2 = MetricCollector.create(METRICS_NAME);
+    metrics2.reportMetric(CoreMetric.RETRY_COUNT, 1);
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics1.collect());
+    Assert.assertFalse("Should not detect retries if RETRY_COUNT is zero", detector.retried());
+    detector.publish(metrics2.collect());
+    Assert.assertTrue(
+        "Should continue detecting retries in additional metrics", detector.retried());
+  }
+
+  @Test
+  public void testNoOpAfterDetection() {
+    MetricCollector metrics1 = MetricCollector.create(METRICS_NAME);
+    metrics1.reportMetric(CoreMetric.RETRY_COUNT, 1);
+    MetricCollection metrics1Spy = Mockito.spy(metrics1.collect());
+    MetricCollector metrics2 = MetricCollector.create(METRICS_NAME);
+    metrics2.reportMetric(CoreMetric.RETRY_COUNT, 0);
+    MetricCollection metrics2Spy = Mockito.spy(metrics2.collect());
+
+    RetryDetector detector = new RetryDetector();
+    detector.publish(metrics1Spy);
+    Assert.assertTrue("Should detect retries if RETRY_COUNT is zero", detector.retried());
+    detector.publish(metrics2Spy);
+    Assert.assertTrue("Should remain true once a retry is detected", detector.retried());
+
+    Mockito.verify(metrics1Spy).metricValues(Mockito.eq(CoreMetric.RETRY_COUNT));
+    Mockito.verifyNoMoreInteractions(metrics1Spy, metrics2Spy);
+  }
+}


### PR DESCRIPTION
This PR fixes the issue described by #7151 where a commit can succeed but Glue or Dynamo backed tables see a failure and delete the now-committed metadata.