### PR TITLE
Build: Remove services files introduced by third-party jars

### DIFF
--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -207,6 +207,14 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -209,6 +209,14 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -209,6 +209,14 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/hive-runtime/build.gradle
+++ b/hive-runtime/build.gradle
@@ -53,6 +53,8 @@ project(':iceberg-hive-runtime') {
   }
 
   shadowJar {
+    exclude "META-INF/services/**"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -145,6 +145,16 @@ project(':iceberg-spark:iceberg-spark-runtime-2.4') {
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/com.fasterxml.jackson.databind.Module"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/services/reactor.blockhound.integration.BlockHoundIntegration"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -231,6 +231,16 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/com.fasterxml.jackson.databind.Module"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/services/reactor.blockhound.integration.BlockHoundIntegration"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -236,6 +236,16 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/com.fasterxml.jackson.databind.Module"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/services/reactor.blockhound.integration.BlockHoundIntegration"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -235,6 +235,16 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   }
 
   shadowJar {
+    exclude "META-INF/services/com.fasterxml.jackson.core.JsonFactory"
+    exclude "META-INF/services/com.fasterxml.jackson.core.ObjectCodec"
+    exclude "META-INF/services/com.fasterxml.jackson.databind.Module"
+    exclude "META-INF/services/org.apache.orc.DataMask\$Provider"
+    exclude "META-INF/services/org.apache.orc.impl.KeyProvider\$Factory"
+    exclude "META-INF/services/org.projectnessie.client.auth.NessieAuthenticationProvider"
+    exclude "META-INF/services/org.projectnessie.model.types.ContentTypeBundle"
+    exclude "META-INF/services/java.time.chrono.Chronology"
+    exclude "META-INF/services/reactor.blockhound.integration.BlockHoundIntegration"
+    exclude "META-INF/maven/**"
     configurations = [project.configurations.runtimeClasspath]
 
     zip64 true


### PR DESCRIPTION
All the runtime project has relocated the third-party jars, but the service files has not relocated. If user's application use a service loader to load any service in the shadowed jar,  it will find a service file but with the origin class name , that will cause `ClassNotFoundException`

The class name in the service file will be relocated too if add `mergeServiceFiles` in the `shadowJar` script. But I think the reason why we use `relocate` is  avoid conflict with user's application, therefor I just remove all service files of third-party jars

In the spark and flink project, we has provided some service file for register data source, I can't find an easy way to exculde all service file of third-pary but keep the one we provided, I just exclude one by one. Maybe there is an easy way to do this,  thanks for any suggestion.