### PR TITLE
Flink: Resolve writers object of PartitionedDeltaWriter will cause OOM when partition number is big

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
@@ -40,14 +40,15 @@ class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
 
   private final int capacity = 10;
 
-  private final Map<PartitionKey, RowDataDeltaWriter> writers = new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
+  private final Map<PartitionKey, RowDataDeltaWriter> writers =
+      new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
           (int) Math.ceil(capacity / 0.75f) + 1, 0.75f, true) {
 
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
-      return size() > capacity;
-    }
-  };
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
+          return size() > capacity;
+        }
+      };
 
   PartitionedDeltaWriter(
       PartitionSpec spec,

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
@@ -40,14 +40,15 @@ class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
 
   private final int capacity = 10;
 
-  private final Map<PartitionKey, RowDataDeltaWriter> writers = new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
+  private final Map<PartitionKey, RowDataDeltaWriter> writers =
+      new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
           (int) Math.ceil(capacity / 0.75f) + 1, 0.75f, true) {
 
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
-      return size() > capacity;
-    }
-  };
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
+          return size() > capacity;
+        }
+      };
 
   PartitionedDeltaWriter(
       PartitionSpec spec,

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
@@ -40,14 +40,15 @@ class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
 
   private final int capacity = 10;
 
-  private final Map<PartitionKey, RowDataDeltaWriter> writers = new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
+  private final Map<PartitionKey, RowDataDeltaWriter> writers =
+      new LinkedHashMap<PartitionKey, RowDataDeltaWriter>(
           (int) Math.ceil(capacity / 0.75f) + 1, 0.75f, true) {
 
-    @Override
-    protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
-      return size() > capacity;
-    }
-  };
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<PartitionKey, RowDataDeltaWriter> eldest) {
+          return size() > capacity;
+        }
+      };
 
   PartitionedDeltaWriter(
       PartitionSpec spec,


### PR DESCRIPTION
I use LRU map to replace hashmap to resolve OOM problem for `PartitionedDeltaWriter` class.
link issue:https://github.com/apache/iceberg/issues/7216