### PR TITLE
Flink: Use starting sequence number by default when rewriting data files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -74,7 +74,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     this.spec = table.spec();
     this.filter = Expressions.alwaysTrue();
     this.caseSensitive = false;
-    this.useStartingSequenceNumber = true;
+    this.useStartingSequenceNumber = false;
 
     long splitSize =
         PropertyUtil.propertyAsLong(

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -200,6 +200,16 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     return this;
   }
 
+  /**
+   * If the compaction should use the sequence number of the snapshot at compaction start time for
+   * new data files, instead of using the sequence number of the newly produced snapshot.
+   *
+   * <p>This avoids commit conflicts with updates that add newer equality deletes at a higher
+   * sequence number.
+   *
+   * @param useStarting use starting sequence number if set to true
+   * @return this for method chaining
+   */
   public BaseRewriteDataFilesAction<ThisT> useStartingSequenceNumber(boolean useStarting) {
     this.useStartingSequenceNumber = useStarting;
     return this;

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -322,6 +322,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     } else {
       rewriteFiles.rewriteFiles(Sets.newHashSet(deletedDataFiles), Sets.newHashSet(addedDataFiles));
     }
+
     commit(rewriteFiles);
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -314,13 +314,11 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       Iterable<DataFile> deletedDataFiles,
       Iterable<DataFile> addedDataFiles,
       long startingSnapshotId) {
-    RewriteFiles rewriteFiles =
-        table
-            .newRewrite()
-            .validateFromSnapshot(startingSnapshotId);
+    RewriteFiles rewriteFiles = table.newRewrite().validateFromSnapshot(startingSnapshotId);
     if (useStartingSequenceNumber) {
       long sequenceNumber = table.snapshot(startingSnapshotId).sequenceNumber();
-      rewriteFiles.rewriteFiles(Sets.newHashSet(deletedDataFiles), Sets.newHashSet(addedDataFiles), sequenceNumber);
+      rewriteFiles.rewriteFiles(
+          Sets.newHashSet(deletedDataFiles), Sets.newHashSet(addedDataFiles), sequenceNumber);
     } else {
       rewriteFiles.rewriteFiles(Sets.newHashSet(deletedDataFiles), Sets.newHashSet(addedDataFiles));
     }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -461,6 +461,9 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     // Should not rewrite files from the new commit
     Assert.assertEquals("Action should rewrite 2 data files", 2, result.deletedDataFiles().size());
     Assert.assertEquals("Action should add 1 data file", 1, result.addedDataFiles().size());
+    // The 2 older files with file-sequence-number <= 2 should be rewritten into a new file.
+    // The new file is the one with file-sequence-number == 4.
+    // The new file should use rewrite's starting-sequence-number 2 as its data-sequence-number.
     shouldHaveDataAndFileSequenceNumbers(
         TABLE_NAME_WITH_PK, ImmutableList.of(Pair.of(3L, 3L), Pair.of(3L, 3L), Pair.of(2L, 4L)));
 
@@ -471,6 +474,14 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
             SimpleDataUtil.createRecord(1, "hi"), SimpleDataUtil.createRecord(2, "world")));
   }
 
+  /**
+   * Assert that data files and delete files in the table should have expected data sequence numbers
+   * and file sequence numbers
+   *
+   * @param tableName table name
+   * @param expectedSequenceNumbers list of {@link Pair}'s. Each {@link Pair} contains
+   *     (expectedDataSequenceNumber, expectedFileSequenceNumber) of a file.
+   */
   private void shouldHaveDataAndFileSequenceNumbers(
       String tableName, List<Pair<Long, Long>> expectedSequenceNumbers) {
     // "status < 2" for added or existing entries

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.flink.actions;
 
 import static org.apache.iceberg.flink.SimpleDataUtil.RECORD;
 
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -53,6 +52,7 @@ import org.apache.iceberg.flink.FlinkCatalogTestBase;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;


### PR DESCRIPTION
When rewriting data files using Spark, the original starting sequence number is assigned to the rewritten files to avoid possible conflicts with newer eq-delete files. However, when rewriting data files using Flink, rewritten files are currently assigned a new sequence number. Consequently, conflicts between rewritten files and new eq-delete files cannot be ignored while checking conflicts in MergingSnapshotProducer.validateNoNewDeletesForDataFiles(). This creates an issue when continuously committing new eq-delete files to a table as we won't be able to rewrite files without conflicts.

This PR proposes to solve this problem by enabling Flink to use the starting sequence number by default when rewriting data files.