### PR TITLE
[Draft][HiveCatalog] Skip updating column schema when filed schema string is larger than maxHiveTablePropertySize

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -1237,4 +1237,9 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         .hasMessage("Table already exists: hivedb.t1");
     assertThat(catalog.dropTable(identifier, true)).isTrue();
   }
+
+  @Test
+  public void testSkipSettingColsPropertyWhenSchemaTooLarge() throws Exception {
+
+  }
 }


### PR DESCRIPTION
When using HiveCatalog, column schema type string should be within maxHiveTablePropertySize otherwise results in failures.

This diffs propose retain the original schema in the HMS DB.