### PR TITLE
[Rest Catalog Spec] Return 204 on no content response

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -726,7 +726,7 @@ paths:
         Check if a table exists within a given namespace. This request does not return a response body.
       responses:
         204:
-          description: OK - Table Exists
+          description: Success, no content
         400:
           description: Bad Request
         401:
@@ -764,7 +764,7 @@ paths:
         required: true
       responses:
         204:
-          description: OK
+          description: Success, no content
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -725,7 +725,7 @@ paths:
       description:
         Check if a table exists within a given namespace. This request does not return a response body.
       responses:
-        200:
+        204:
           description: OK - Table Exists
         400:
           description: Bad Request
@@ -763,7 +763,7 @@ paths:
                 $ref: '#/components/examples/RenameTableSameNamespace'
         required: true
       responses:
-        200:
+        204:
           description: OK
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'


### PR DESCRIPTION
Change list:
1. Change success code of `tableExists` and `renameTable` from HTTP 200 to HTTP 204

Incentive:
According to [RFC spec](https://www.rfc-editor.org/rfc/rfc7231#section-6.3.1), if HTTP 200 is returned, then the response always have payload content. However, the 2 APIs above does not seem to have any return payload, for which cases, the correct success code should be 204.