### PR TITLE
Fixed typos and Hive release version about Flink.

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -31,29 +31,29 @@ Apache Iceberg supports both [Apache Flink](https://flink.apache.org/)'s DataStr
 
 | Feature support                                             | Flink | Notes                                                                                  |
 | ----------------------------------------------------------- |-------|----------------------------------------------------------------------------------------|
-| [SQL create catalog](#creating-catalogs-and-using-catalogs) | ✔️    |                                                                                        |
-| [SQL create database](#create-database)                     | ✔️    |                                                                                        |
-| [SQL create table](#create-table)                           | ✔️    |                                                                                        |
-| [SQL create table like](#create-table-like)                 | ✔️    |                                                                                        |
-| [SQL alter table](#alter-table)                             | ✔️    | Only support altering table properties, column and partition changes are not supported |
-| [SQL drop_table](#drop-table)                               | ✔️    |                                                                                        |
-| [SQL select](#querying-with-sql)                            | ✔️    | Support both streaming and batch mode                                                  |
+| [SQL create catalog](#creating-catalogs-and-using-catalogs) | ✔️   |                                                                                        |
+| [SQL create database](#create-database)                     | ✔️   |                                                                                        |
+| [SQL create table](#create-table)                           | ✔️   |                                                                                        |
+| [SQL create table like](#create-table-like)                 | ✔️   |                                                                                        |
+| [SQL alter table](#alter-table)                             | ✔️   | Only support altering table properties, column and partition changes are not supported |
+| [SQL drop_table](#drop-table)                               | ✔️   |                                                                                        |
+| [SQL select](#querying-with-sql)                            | ✔️   | Support both streaming and batch mode                                                  |
 | [SQL insert into](#insert-into)                             | ✔️ ️  | Support both streaming and batch mode                                                  |
 | [SQL insert overwrite](#insert-overwrite)                   | ✔️ ️  |                                                                                        |
 | [DataStream read](#reading-with-datastream)                 | ✔️ ️  |                                                                                        |
 | [DataStream append](#appending-data)                        | ✔️ ️  |                                                                                        |
 | [DataStream overwrite](#overwrite-data)                     | ✔️ ️  |                                                                                        |
-| [Metadata tables](#inspecting-tables)                       | ✔️    |                                                                                        |
+| [Metadata tables](#inspecting-tables)                       | ✔️   |                                                                                        |
 | [Rewrite files action](#rewrite-files-action)               | ✔️ ️  |                                                                                        |
 
 ## Preparation when using Flink SQL Client
 
-To create Iceberg table in Flink, it is recommended to use [Flink SQL Client](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/sqlClient.html) as it's easier for users to understand the concepts.
+To create Iceberg table in Flink, it is recommended to use [Flink SQL Client](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sqlclient/) as it's easier for users to understand the concepts.
 
-Download Flink from the [Apache download page](https://flink.apache.org/downloads.html). Iceberg uses Scala 2.12 when compiling the Apache `iceberg-flink-runtime` jar, so it's recommended to use Flink 1.16 bundled with Scala 2.12.
+Download Flink from the [Apache download page](https://flink.apache.org/downloads/). Iceberg uses Scala 2.12 when compiling the Apache `iceberg-flink-runtime` jar, so it's recommended to use Flink 1.17 bundled with Scala 2.12.
 
 ```bash
-FLINK_VERSION=1.16.1
+FLINK_VERSION=1.17
 SCALA_VERSION=2.12
 APACHE_FLINK_URL=https://archive.apache.org/dist/flink/
 wget ${APACHE_FLINK_URL}/flink-${FLINK_VERSION}/flink-${FLINK_VERSION}-bin-scala_${SCALA_VERSION}.tgz
@@ -65,7 +65,7 @@ Start a standalone Flink cluster within Hadoop environment:
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.
 APACHE_HADOOP_URL=https://archive.apache.org/dist/hadoop/
-HADOOP_VERSION=2.8.5
+HADOOP_VERSION=3.1.3
 wget ${APACHE_HADOOP_URL}/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
 tar xzvf hadoop-${HADOOP_VERSION}.tar.gz
 HADOOP_HOME=`pwd`/hadoop-${HADOOP_VERSION}
@@ -76,16 +76,16 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 ./bin/start-cluster.sh
 ```
 
-Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{% icebergVersion %}}/).
+Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.17/{{% icebergVersion %}}/).
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.
 export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`   
 
-./bin/sql-client.sh embedded -j <flink-runtime-directory>/iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar shell
+./bin/sql-client.sh embedded -j <flink-runtime-directory>/iceberg-flink-runtime-1.17-{{% icebergVersion %}}.jar shell
 ```
 
-By default, Iceberg ships with Hadoop jars for Hadoop catalog. To use Hive catalog, load the Hive jars when opening the Flink SQL client. Fortunately, Flink has provided a [bundled hive jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hive-2.3.9_2.12/1.16.1/flink-sql-connector-hive-2.3.9_2.12-1.16.1.jar) for the SQL client. An example on how to download the dependencies and get started:
+By default, Iceberg ships with Hadoop jars for Hadoop catalog. To use Hive catalog, load the Hive jars when opening the Flink SQL client. Fortunately, Flink has provided a [bundled hive jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hive-3.1.3_2.12/1.17.0/flink-sql-connector-hive-3.1.3_2.12-1.17.0.jar) for the SQL client. An example on how to download the dependencies and get started:
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.
@@ -97,9 +97,9 @@ ICEBERG_MAVEN_URL=${MAVEN_URL}/org/apache/iceberg
 ICEBERG_PACKAGE=iceberg-flink-runtime
 wget ${ICEBERG_MAVEN_URL}/${ICEBERG_PACKAGE}-${FLINK_VERSION_MAJOR}/${ICEBERG_VERSION}/${ICEBERG_PACKAGE}-${FLINK_VERSION_MAJOR}-${ICEBERG_VERSION}.jar -P lib/
 
-HIVE_VERSION=2.3.9
+HIVE_VERSION=3.1.3
 SCALA_VERSION=2.12
-FLINK_VERSION=1.16.1
+FLINK_VERSION=1.17.0
 FLINK_CONNECTOR_URL=${MAVEN_URL}/org/apache/flink
 FLINK_CONNECTOR_PACKAGE=flink-sql-connector-hive
 wget ${FLINK_CONNECTOR_URL}/${FLINK_CONNECTOR_PACKAGE}-${HIVE_VERSION}_${SCALA_VERSION}/${FLINK_VERSION}/${FLINK_CONNECTOR_PACKAGE}-${HIVE_VERSION}_${SCALA_VERSION}-${FLINK_VERSION}.jar
@@ -109,14 +109,10 @@ wget ${FLINK_CONNECTOR_URL}/${FLINK_CONNECTOR_PACKAGE}-${HIVE_VERSION}_${SCALA_V
 
 ## Flink's Python API
 
-{{< hint info >}}
-PyFlink 1.6.1 [does not work on OSX with a M1 cpu](https://issues.apache.org/jira/browse/FLINK-28786)
-{{< /hint >}}
-
 Install the Apache Flink dependency using `pip`:
 
 ```python
-pip install apache-flink==1.16.1
+pip install apache-flink==1.17.0
 ```
 
 Provide a `file://` path to the `iceberg-flink-runtime` jar, which can be obtained by building the project and looking at `<iceberg-root-dir>/flink-runtime/build/libs`, or downloading it from the [Apache official repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime/). Third-party jars can be added to `pyflink` via:
@@ -124,7 +120,7 @@ Provide a `file://` path to the `iceberg-flink-runtime` jar, which can be obtain
 - `env.add_jars("file:///my/jar/path/connector.jar")`
 - `table_env.get_config().get_configuration().set_string("pipeline.jars", "file:///my/jar/path/connector.jar")`
 
-This is also mentioned in the official [docs](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/python/dependency_management/). The example below uses `env.add_jars(..)`:
+This is also mentioned in the official [docs](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/python/dependency_management/). The example below uses `env.add_jars(..)`:
 
 ```python
 import os
@@ -132,7 +128,7 @@ import os
 from pyflink.datastream import StreamExecutionEnvironment
 
 env = StreamExecutionEnvironment.get_execution_environment()
-iceberg_flink_runtime_jar = os.path.join(os.getcwd(), "iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar")
+iceberg_flink_runtime_jar = os.path.join(os.getcwd(), "iceberg-flink-runtime-1.17.0-{{% icebergVersion %}}.jar")
 
 env.add_jars("file://{}".format(iceberg_flink_runtime_jar))
 ```
@@ -173,7 +169,7 @@ Run a query:
 5 rows in set
 ```
 
-For more details, please refer to the [Python Table API](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/dev/python/table/intro_to_table_api/).
+For more details, please refer to the [Python Table API](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/python/table/intro_to_table_api/).
 
 ## Adding catalogs.
 
@@ -388,4 +384,3 @@ There are some features that are do not yet supported in the current Flink Icebe
 * Don't support creating iceberg table with computed column.
 * Don't support creating iceberg table with watermark.
 * Don't support adding columns, removing columns, renaming columns, changing columns. [FLINK-19062](https://issues.apache.org/jira/browse/FLINK-19062) is tracking this.
-* 


### PR DESCRIPTION
Fixed typos for Flink and Hive release version.
I want to fix the Flink version to 1.17.0 and Hive version to 3.1.3 but I don't know if iceberg supports it.