### PR TITLE
Avoid conflicts between rewrite datafiles and flink CDC writes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -490,10 +490,9 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         return Boolean.parseBoolean(
             snapshot
                 .summary()
-                .getOrDefault(SnapshotSummary.POSITION_DELETES_WITHIN_COMMIT_ONLY, "false"));
+                .getOrDefault(SnapshotSummary.NO_POS_DELETE_APPLY_TO_PREVIOUS_DATA, "false"));
       default:
-        throw new RuntimeException(
-            String.format("Unknown data operation: %s", snapshot.operation()));
+        return false;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -58,8 +58,8 @@ public class SnapshotSummary {
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
   public static final String EXTRA_METADATA_PREFIX = "snapshot-property.";
-  public static final String POSITION_DELETES_WITHIN_COMMIT_ONLY =
-      "position-deletes-within-commit-only";
+  public static final String NO_POS_DELETE_APPLY_TO_PREVIOUS_DATA =
+      "no-pos-delete-apply-to-previous-data";
 
   public static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -58,6 +58,8 @@ public class SnapshotSummary {
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
   public static final String EXTRA_METADATA_PREFIX = "snapshot-property.";
+  public static final String POSITION_DELETES_WITHIN_COMMIT_ONLY =
+      "position-deletes-within-commit-only";
 
   public static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -374,7 +374,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
         // files to be concurrently removed, so there is no need to validate the files referenced by
         // the position delete files that are being committed.
         RowDelta rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
-        rowDelta.set(SnapshotSummary.POSITION_DELETES_WITHIN_COMMIT_ONLY, "true");
+        rowDelta.set(SnapshotSummary.NO_POS_DELETE_APPLY_TO_PREVIOUS_DATA, "true");
 
         Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
         Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
@@ -373,6 +374,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
         // files to be concurrently removed, so there is no need to validate the files referenced by
         // the position delete files that are being committed.
         RowDelta rowDelta = table.newRowDelta().scanManifestsWith(workerPool);
+        rowDelta.set(SnapshotSummary.POSITION_DELETES_WITHIN_COMMIT_ONLY, "true");
 
         Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
         Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);


### PR DESCRIPTION
When performing a RewriteDataFiles operation, if Iceberg finds new position-delete files that were produced after the starting snapshot of the rewrite, it checks whether these files could potentially contain deletes for the rewritten data files. If they do, then the rewrite operation fails.

Currently, the check is based on the upper and lower bounds of the DELETE_FILE_PATH field of the pos-delete records. However, this approach can produce false positives, causing rewrites to fail even when there are no actual conflicts. As a result, it becomes impossible to rewrite a table when it is being written to using streaming CDC (Change Data Capture).

To address this issue, this PR proposes adding a new snapshot property, "position-deletes-within-commit-only", which will be set to "true" when CDC-writing using Flink. This property will indicate that the new pos-deletes only refer to data files within the same commit, not commits before it. When checking for conflicts during rewrites, we can then skip the commits generated by Flink CDC-writes.

By implementing this change, we can resolve the following issues:

https://github.com/apache/iceberg/issues/4996
https://github.com/apache/iceberg/issues/5397
https://github.com/apache/iceberg/issues/6330