### PR TITLE
Core: Require namespace when creating table using InMemoryCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -313,6 +313,12 @@ public class InMemoryCatalog extends BaseMetastoreCatalog implements SupportsNam
       String newLocation = writeNewMetadata(metadata, currentVersion() + 1);
       String oldLocation = base == null ? null : base.metadataFileLocation();
 
+      if (null == base && !namespaceExists(tableIdentifier.namespace())) {
+        throw new NoSuchNamespaceException(
+            "Cannot create table %s. Namespace %s does not exist",
+            tableIdentifier, tableIdentifier.namespace());
+      }
+
       tables.compute(
           tableIdentifier,
           (k, existingLocation) -> {

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -19,8 +19,13 @@
 package org.apache.iceberg.inmemory;
 
 import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   private InMemoryCatalog catalog;
@@ -39,5 +44,17 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   @Override
   protected boolean requiresNamespaceCreate() {
     return true;
+  }
+
+  @Test
+  public void tableCreationWithoutNamespace() {
+    Assumptions.assumeTrue(requiresNamespaceCreate());
+
+    // this should be moved to CatalogTests at some point, but TestNessieCatalog currently fails
+    // with a different exception than we would expect
+    Assertions.assertThatThrownBy(
+            () -> catalog().buildTable(TableIdentifier.of("ns", "table"), SCHEMA).create())
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Cannot create table ns.table. Namespace ns does not exist");
   }
 }


### PR DESCRIPTION
In https://github.com/apache/iceberg/blob/0c2f5240146035029081a5a12ac4d71e64258602/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java#L41 we were specifying that this catalog requires a namespace to exist before creating a table. However, this was actually never checked in the code.