### PR TITLE
Core: Fix flakiness in HadoopFileIOTest

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -52,7 +52,7 @@ public class HadoopFileIOTest {
   private FileSystem fs;
   private HadoopFileIO hadoopFileIO;
 
-  @TempDir File tempDir;
+  @TempDir private File tempDir;
 
   @BeforeEach
   public void before() throws Exception {

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -180,7 +180,6 @@ public class HadoopFileIOTest {
                 throw new UncheckedIOException(e);
               }
             });
-
     return paths;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopFileIOTest.java
@@ -27,8 +27,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.Vector;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -39,8 +38,6 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
-import org.assertj.core.api.Assertions;
-import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -169,9 +166,7 @@ public class HadoopFileIOTest {
   }
 
   private List<Path> createRandomFiles(Path parent, int count) {
-    List<Path> paths = Lists.newArrayList();
-    LongAdder createdFiles = new LongAdder();
-
+    Vector<Path> paths = new Vector<>();
     random
         .ints(count)
         .parallel()
@@ -181,15 +176,10 @@ public class HadoopFileIOTest {
                 Path path = new Path(parent, "file-" + i);
                 paths.add(path);
                 fs.createNewFile(path);
-                createdFiles.increment();
               } catch (IOException e) {
                 throw new UncheckedIOException(e);
               }
             });
-
-    Awaitility.await()
-        .atMost(30, TimeUnit.SECONDS)
-        .untilAsserted(() -> Assertions.assertThat(createdFiles.intValue()).isEqualTo(count));
 
     return paths;
   }


### PR DESCRIPTION
I've been able to reproduce this locally:

```
HadoopFileIOTest > testDeleteFiles() FAILED
    java.lang.NullPointerException
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
        at org.apache.iceberg.hadoop.HadoopFileIOTest.testDeleteFiles(HadoopFileIOTest.java:130)

> Task :iceberg-aws:test

> Task :iceberg-core:test

HadoopFileIOTest > testListPrefix() FAILED
    org.opentest4j.AssertionFailedError: expected: <3501> but was: <3511>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:166)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:161)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:629)
        at org.apache.iceberg.hadoop.HadoopFileIOTest.testListPrefix(HadoopFileIOTest.java:80)
```

* The flakiness in ` testListPrefix()` occurred because the temp directory was reused across tests and so `testListPrefix()` would find more files being created than the test itself actually created. 

* The flakiness with the NPE in `testDeleteFiles()` happens because `createRandomFiles()` uses a parallel stream and occasially returns a collection with a `null` path, meaning that `createRandomFiles()` sometimes returns faster than the files could have been created and added to the result.