### PR TITLE
AWS: abort S3 input stream on close if not EOS

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.http.Abortable;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
@@ -196,7 +197,17 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
 
   private void closeStream() throws IOException {
     if (stream != null) {
-      stream.close();
+      // if we aren't at the end of the stream, and the stream is abortable, then
+      // call abort() instead of close() to skip reading the remaining data
+      try {
+        if (stream instanceof Abortable && stream.read() != -1) {
+          ((Abortable) stream).abort();
+        } else {
+          stream.close();
+        }
+      } finally {
+        stream = null;
+      }
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -195,19 +195,27 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     }
   }
 
-  private void closeStream() throws IOException {
+  private void closeStream() {
     if (stream != null) {
       // if we aren't at the end of the stream, and the stream is abortable, then
-      // call abort() instead of close() to skip reading the remaining data
+      // call abort() so we don't read the remaining data
+      abortStream();
       try {
-        if (stream instanceof Abortable && stream.read() != -1) {
-          ((Abortable) stream).abort();
-        } else {
-          stream.close();
-        }
-      } finally {
-        stream = null;
+        stream.close();
+      } catch (Exception e) {
+        // close quietly
       }
+      stream = null;
+    }
+  }
+
+  private void abortStream() {
+    try {
+      if (stream instanceof Abortable && stream.read() != -1) {
+        ((Abortable) stream).abort();
+      }
+    } catch (Exception e) {
+      LOG.debug("An error occurred while aborting the stream", e);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -203,8 +203,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
       try {
         stream.close();
       } catch (Exception e) {
-        // log at trace level as closing an aborted stream will throw a checksum exception
-        // with the Apache HTTP client
+        // log at trace level as closing an aborted stream will throw a content length
+        // check exception with the Apache HTTP client
         LOG.trace("Error closing stream", e);
       }
       stream = null;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -198,12 +198,14 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
   private void closeStream() {
     if (stream != null) {
       // if we aren't at the end of the stream, and the stream is abortable, then
-      // call abort() so we don't read the remaining data
+      // call abort() so we don't read the remaining data with the Apache HTTP client
       abortStream();
       try {
         stream.close();
       } catch (Exception e) {
-        // close quietly
+        // log at trace level as closing an aborted stream will throw a checksum exception
+        // with the Apache HTTP client
+        LOG.trace("Error closing stream", e);
       }
       stream = null;
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -203,9 +203,8 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
       try {
         stream.close();
       } catch (Exception e) {
-        // log at trace level as closing an aborted stream will throw a content length
-        // check exception with the Apache HTTP client
-        LOG.trace("Error closing stream", e);
+        // close quietly, closing an aborted stream will throw a content length
+        // check exception with the Apache HTTP client, which is expected
       }
       stream = null;
     }
@@ -217,7 +216,7 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
         ((Abortable) stream).abort();
       }
     } catch (Exception e) {
-      LOG.debug("An error occurred while aborting the stream", e);
+      LOG.warn("An error occurred while aborting the stream", e);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -195,16 +195,19 @@ class S3InputStream extends SeekableInputStream implements RangeReadable {
     }
   }
 
-  private void closeStream() {
+  private void closeStream() throws IOException {
     if (stream != null) {
       // if we aren't at the end of the stream, and the stream is abortable, then
       // call abort() so we don't read the remaining data with the Apache HTTP client
       abortStream();
       try {
         stream.close();
-      } catch (Exception e) {
-        // close quietly, closing an aborted stream will throw a content length
-        // check exception with the Apache HTTP client, which is expected
+      } catch (IOException e) {
+        // the Apache HTTP client will throw a ConnectionClosedException
+        // when closing an aborted stream, which is expected
+        if (!e.getClass().getSimpleName().equals("ConnectionClosedException")) {
+          throw e;
+        }
       }
       stream = null;
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -212,9 +212,7 @@ class S3OutputStream extends PositionOutputStream {
   }
 
   private void newStream() throws IOException {
-    if (stream != null) {
-      stream.close();
-    }
+    closeStream();
 
     createStagingDirectoryIfNotExists();
     currentStagingFile = File.createTempFile("s3fileio-", ".tmp", stagingDirectory);
@@ -265,10 +263,20 @@ class S3OutputStream extends PositionOutputStream {
     closed = true;
 
     try {
-      stream.close();
+      closeStream();
       completeUploads();
     } finally {
       cleanUpStagingFiles();
+    }
+  }
+
+  private void closeStream() throws IOException {
+    if (stream != null) {
+      try {
+        stream.close();
+      } finally {
+        stream = null;
+      }
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -212,7 +212,9 @@ class S3OutputStream extends PositionOutputStream {
   }
 
   private void newStream() throws IOException {
-    closeStream();
+    if (stream != null) {
+      stream.close();
+    }
 
     createStagingDirectoryIfNotExists();
     currentStagingFile = File.createTempFile("s3fileio-", ".tmp", stagingDirectory);
@@ -263,20 +265,10 @@ class S3OutputStream extends PositionOutputStream {
     closed = true;
 
     try {
-      closeStream();
+      stream.close();
       completeUploads();
     } finally {
       cleanUpStagingFiles();
-    }
-  }
-
-  private void closeStream() throws IOException {
-    if (stream != null) {
-      try {
-        stream.close();
-      } finally {
-        stream = null;
-      }
     }
   }
 


### PR DESCRIPTION
This PR adds a check when closing an S3 input stream if the stream is at end-of-stream. If not, it calls `abort()` on the stream instead of `close()`. This avoids reading to the end of the stream when closing.

The Apache HTTP connection will always read the [entire stream](https://github.com/apache/httpcomponents-core/blob/2135596b1319910d56efb148566ecbbec0884638/httpcore/src/main/java/org/apache/http/impl/io/ContentLengthInputStream.java#L108) on close, which results in much more data being read than needed. The URL connection client does not behave this way.

Now that the Apache HTTP client is the default instead of URL connection client for AWS, this change should prevent a performance regression.