### PR TITLE
Spark: broadcast table instead of file IO in rewrite manifests

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -45,7 +45,6 @@ import org.apache.iceberg.actions.ImmutableRewriteManifests;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -373,11 +372,13 @@ public class RewriteManifestsSparkAction
       StructType sparkType)
       throws IOException {
 
-    FileIO io = tableBroadcast.value().io();
-
     String manifestName = "optimized-m-" + UUID.randomUUID();
     Path manifestPath = new Path(location, manifestName);
-    OutputFile outputFile = io.newOutputFile(FileFormat.AVRO.addExtension(manifestPath.toString()));
+    OutputFile outputFile =
+        tableBroadcast
+            .value()
+            .io()
+            .newOutputFile(FileFormat.AVRO.addExtension(manifestPath.toString()));
 
     Types.StructType combinedFileType = DataFile.getType(combinedPartitionType);
     Types.StructType manifestFileType = DataFile.getType(spec.partitionType());


### PR DESCRIPTION
This PR changes the Spark rewrite manifest action to broadcast a `Table` instead of a `FileIO`. This issue with `FileIO` is that it implements `Closeable`, so when Spark is removing the broadcast, it automatically calls `close()` on it. This happens in Spark's MemoryStore class [here](https://github.com/apache/spark/blob/309c65a353489b70bf5135a01d1f159328eaa3f3/core/src/main/scala/org/apache/spark/storage/memory/MemoryStore.scala#L397).

With `S3FileIO` and using the Apache HTTP client, that has the consequence of closing the connection pool, and can cause subsequent request failures if there is an attempt to use the FileIO object again. This currently only impacts the rewrite manifests procedure, as it is the only action that broadcasts a FileIO rather than a Table.

The `SparkUtil.serializableFileIO()`is not longer used by anything, but was left in place as it is public.