### PR TITLE
API: Add ParquetUtils.getSplitOffsets that takes an InputFile

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -229,12 +229,7 @@ public class ParquetUtil {
   public static List<Long> getSplitOffsets(InputFile file) {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
       ParquetMetadata md = reader.getFooter();
-      List<Long> splitOffsets = Lists.newArrayListWithExpectedSize(md.getBlocks().size());
-      for (BlockMetaData blockMetaData : md.getBlocks()) {
-        splitOffsets.add(blockMetaData.getStartingPos());
-      }
-      Collections.sort(splitOffsets);
-      return splitOffsets;
+      return getSplitOffsets(md);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -226,6 +226,24 @@ public class ParquetUtil {
    * Returns a list of offsets in ascending order determined by the starting position of the row
    * groups.
    */
+  public static List<Long> getSplitOffsets(InputFile file) {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
+      ParquetMetadata md = reader.getFooter();
+      List<Long> splitOffsets = Lists.newArrayListWithExpectedSize(md.getBlocks().size());
+      for (BlockMetaData blockMetaData : md.getBlocks()) {
+        splitOffsets.add(blockMetaData.getStartingPos());
+      }
+      Collections.sort(splitOffsets);
+      return splitOffsets;
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
+    }
+  }
+
+  /**
+   * Returns a list of offsets in ascending order determined by the starting position of the row
+   * groups.
+   */
   public static List<Long> getSplitOffsets(ParquetMetadata md) {
     List<Long> splitOffsets = Lists.newArrayListWithExpectedSize(md.getBlocks().size());
     for (BlockMetaData blockMetaData : md.getBlocks()) {


### PR DESCRIPTION
Add an implementation for ParquetUtils.getSplitOffsets that takes an InputFile, without this function it required users to often add the Hadoop JARs to read the parquet file's metadata since ParquetIO isn't available to external callers of this module.