### PR TITLE
Flink: Data statistics operator sends local data statistics to coordinator and receive aggregated data statistics from coordinator for smart shuffling

### DIFF
--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsEvent.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsEvent.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink.shuffle;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.iceberg.flink.sink.shuffle.statistics.DataStatistics;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 
 /**
  * DataStatisticsEvent is sent between data statistics coordinator and operator to transmit data
@@ -49,7 +50,9 @@ class DataStatisticsEvent<K> implements OperatorEvent {
 
   @Override
   public String toString() {
-    return String.format(
-        "DataStatisticEvent[checkpointId = %d, dataStatistics = %s)", checkpointId, dataStatistics);
+    return MoreObjects.toStringHelper(this)
+        .add("checkpointId", checkpointId)
+        .add("dataStatistics", dataStatistics)
+        .toString();
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsEvent.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsEvent.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.shuffle;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.iceberg.flink.sink.shuffle.statistics.DataStatistics;
+
+/**
+ * DataStatisticsEvent is sent between data statistics coordinator and operator to transmit data
+ * statistics
+ */
+@Internal
+class DataStatisticsEvent<K> implements OperatorEvent {
+
+  private static final long serialVersionUID = 1L;
+
+  private final long checkpointId;
+  private final DataStatistics<K> dataStatistics;
+
+  DataStatisticsEvent(long checkpointId, DataStatistics<K> dataStatistics) {
+    this.checkpointId = checkpointId;
+    this.dataStatistics = dataStatistics;
+  }
+
+  long checkpointId() {
+    return checkpointId;
+  }
+
+  DataStatistics<K> dataStatistics() {
+    return dataStatistics;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "DataStatisticEvent[checkpointId = %d, dataStatistics = %s)", checkpointId, dataStatistics);
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsOperator.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.iceberg.flink.sink.shuffle.statistics.DataStatistics;
 import org.apache.iceberg.flink.sink.shuffle.statistics.DataStatisticsFactory;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * DataStatisticsOperator collects traffic distribution statistics. A custom partitioner shall be
@@ -98,14 +99,12 @@ class DataStatisticsOperator<T, K> extends AbstractStreamOperator<DataStatistics
 
   @Override
   @SuppressWarnings("unchecked")
-  public void handleOperatorEvent(OperatorEvent evt) {
-    if (evt instanceof DataStatisticsEvent) {
-      globalStatistics = ((DataStatisticsEvent<K>) evt).dataStatistics();
-      output.collect(
-          new StreamRecord<>(DataStatisticsOrRecord.fromDataStatistics(globalStatistics)));
-    } else {
-      throw new IllegalStateException("Received unexpected operator event " + evt);
-    }
+  public void handleOperatorEvent(OperatorEvent event) {
+    Preconditions.checkArgument(
+        event instanceof DataStatisticsEvent,
+        "Received unexpected operator event " + event.getClass());
+    globalStatistics = ((DataStatisticsEvent<K>) event).dataStatistics();
+    output.collect(new StreamRecord<>(DataStatisticsOrRecord.fromDataStatistics(globalStatistics)));
   }
 
   @Override


### PR DESCRIPTION
This PR is created as part of issue https://github.com/apache/iceberg/issues/6303 and project https://github.com/apache/iceberg/projects/27

In this PR, we implement the logic in DataStatisticsOperator to send local data statistics to the coordinator and receive aggregated data statistics from the coordinator. 
