### PR TITLE
AWS: Prevent token refresh scheduling on every sign request

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
@@ -112,6 +112,7 @@ public class S3SignerServlet extends HttpServlet {
                 .withToken("client-credentials-token:sub=" + requestMap.get("client_id"))
                 .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
                 .withTokenType("Bearer")
+                .setExpirationInSeconds(100)
                 .build());
 
       case "urn:ietf:params:oauth:grant-type:token-exchange":
@@ -126,6 +127,7 @@ public class S3SignerServlet extends HttpServlet {
                 .withToken(token)
                 .withIssuedTokenType("urn:ietf:params:oauth:token-type:access_token")
                 .withTokenType("Bearer")
+                .setExpirationInSeconds(100)
                 .build());
 
       default:

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -18,14 +18,16 @@
  */
 package org.apache.iceberg.aws.s3.signer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.s3.MinioContainer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -33,6 +35,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.jetbrains.annotations.NotNull;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -68,6 +71,7 @@ public class TestS3RestSigner {
           AwsBasicCredentials.create("accessKeyId", "secretAccessKey"));
 
   private static Server httpServer;
+  private static ValidatingSigner validatingSigner;
   private S3Client s3;
 
   @Rule public TemporaryFolder temp = new TemporaryFolder();
@@ -76,20 +80,13 @@ public class TestS3RestSigner {
   public MinioContainer minioContainer =
       new MinioContainer(CREDENTIALS_PROVIDER.resolveCredentials());
 
-  @AfterClass
-  public static void afterClass() throws Exception {
-    if (null != httpServer) {
-      httpServer.stop();
-    }
-  }
-
-  @Before
-  public void before() throws Exception {
+  @BeforeClass
+  public static void beforeClass() throws Exception {
     if (null == httpServer) {
       httpServer = initHttpServer();
     }
 
-    ValidatingSigner validatingSigner =
+    validatingSigner =
         new ValidatingSigner(
             ImmutableS3V4RestSignerClient.builder()
                 .properties(
@@ -100,7 +97,34 @@ public class TestS3RestSigner {
                         "catalog:12345"))
                 .build(),
             new CustomAwsS3V4Signer());
+  }
 
+  @AfterClass
+  public static void afterClass() throws Exception {
+    assertThat(validatingSigner.icebergSigner.tokenRefreshExecutor())
+        .isInstanceOf(ScheduledThreadPoolExecutor.class);
+
+    ScheduledThreadPoolExecutor executor =
+        ((ScheduledThreadPoolExecutor) validatingSigner.icebergSigner.tokenRefreshExecutor());
+    // token expiration is set to 100s so there should be exactly one token scheduled for refresh
+    assertThat(executor.getPoolSize()).isEqualTo(1);
+    assertThat(executor.getQueue())
+        .as("should only have a single token scheduled for refresh")
+        .hasSize(1);
+    assertThat(executor.getActiveCount())
+        .as("should not have any token being refreshed")
+        .isEqualTo(0);
+    assertThat(executor.getCompletedTaskCount())
+        .as("should not have any expired token that required a refresh")
+        .isEqualTo(0);
+
+    if (null != httpServer) {
+      httpServer.stop();
+    }
+  }
+
+  @Before
+  public void before() throws Exception {
     s3 =
         S3Client.builder()
             .region(REGION)
@@ -126,7 +150,7 @@ public class TestS3RestSigner {
         CreateMultipartUploadRequest.builder().bucket(BUCKET).key("random/multipart-key").build());
   }
 
-  private Server initHttpServer() throws Exception {
+  private static Server initHttpServer() throws Exception {
     S3SignerServlet servlet = new S3SignerServlet(S3ObjectMapper.mapper());
     ServletContextHandler servletContext =
         new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
@@ -258,10 +282,10 @@ public class TestS3RestSigner {
 
       SdkHttpFullRequest awsResult = signWithAwsSigner(request, signerParams);
 
-      Assertions.assertThat(awsResult.headers().get("Authorization"))
+      assertThat(awsResult.headers().get("Authorization"))
           .isEqualTo(icebergResult.headers().get("Authorization"));
 
-      Assertions.assertThat(awsResult.headers()).isEqualTo(icebergResult.headers());
+      assertThat(awsResult.headers()).isEqualTo(icebergResult.headers());
       return awsResult;
     }
 


### PR DESCRIPTION
One of the main issues here was that we were previously scheduling a token for refresh on every single sign request. 
This PR caches the `AuthSession` based on the given token/credential to prevent this issue.
The existing `TestS3RestSigner` was slightly restructured and additional checks were added that immediately showed the original problem.