### PR TITLE
Spark: Revert "Spark: Add "Iceberg" prefix to SparkTable name string for SparkUI (#5629)

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -163,7 +163,7 @@ public class SparkTable
 
   @Override
   public String name() {
-    return String.format("Iceberg %s", icebergTable.name());
+    return icebergTable.toString();
   }
 
   public Long snapshotId() {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTable.java
@@ -57,14 +57,4 @@ public class TestSparkTable extends SparkCatalogTestBase {
     Assert.assertNotSame("References must be different", table1, table2);
     Assert.assertEquals("Tables must be equivalent", table1, table2);
   }
-
-  @Test
-  public void testTableName() throws NoSuchTableException {
-    CatalogManager catalogManager = spark.sessionState().catalogManager();
-    TableCatalog catalog = (TableCatalog) catalogManager.catalog(catalogName);
-    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
-    String actualTableName = catalog.loadTable(identifier).name();
-    String expectedTableName = String.format("Iceberg %s.%s", catalogName, tableIdent);
-    Assert.assertEquals("Table name mismatched", expectedTableName, actualTableName);
-  }
 }


### PR DESCRIPTION
Fixes #7239

This reverts commit fc501f33761ae35a48f257d6d973d835fccd6da7.

Based on https://github.com/apache/iceberg/issues/7239 Spark `SHOW CREATE TABLE` has a regression in 1.2 because we prefix `Iceberg` to the SparkTable name. Since `name()` is a public API, opting to revert the change to maintain the existing behavior. To get the Spark UI we desire, my recommendation is we look at leveraging another API.

@aokolnychyi @RussellSpitzer @sumeetgajjar @szehon-ho @jackye1995 @singhpk234 