### PR TITLE
Use 6 bytes for path encoding buffer to avoid filler characters

### DIFF
--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -109,7 +109,7 @@ public class LocationProviders {
 
     private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
     private static final BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
-    private final ThreadLocal<byte[]> temp = ThreadLocal.withInitial(() -> new byte[4]);
+    private final ThreadLocal<byte[]> temp = ThreadLocal.withInitial(() -> new byte[6]);
     private final String storageLocation;
     private final String context;
 


### PR DESCRIPTION
This avoids using `=` characters as filler in path locations so that they are not used as part of the hash prefix.

Before
```
jshell> enc.encodeToString(new byte[4])
$8 ==> "AAAAAA=="
```

After
```
jshell> enc.encodeToString(new byte[6])
$9 ==> "AAAAAAAA"
```