### PR TITLE
Throw NoSuchIcebergTableException instead of ValidationException in G…

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -196,9 +196,9 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   }
 
   /**
-   * Validate the Glue table is Iceberg table by checking its parameters. We throw a {@link
-   * NoSuchIcebergTableException} here so that the catalog can decide whether to fail or potentially
-   * use the Spark built-in catalog instead.
+   * Validate the Glue table is Iceberg table by checking its parameters. If the table properties
+   * check does not pass, for Iceberg it is equivalent to not having a table in the catalog. We
+   * throw a {@link NoSuchIcebergTableException} in that case.
    *
    * @param table glue table
    * @param fullName full table name for logging

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -196,10 +196,13 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   }
 
   /**
-   * Validate the Glue table is Iceberg table by checking its parameters
+   * Validate the Glue table is Iceberg table by checking its parameters. We throw a {@link
+   * NoSuchIcebergTableException} here so that the catalog can decide whether to fail or potentially
+   * use the Spark built-in catalog instead.
    *
    * @param table glue table
    * @param fullName full table name for logging
+   * @throws NoSuchIcebergTableException if the table is not an Iceberg table
    */
   static void checkIfTableIsIceberg(Table table, String fullName) {
     String tableType = table.parameters().get(TABLE_TYPE_PROP);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueToIcebergConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueToIcebergConverter.java
@@ -18,10 +18,8 @@
  */
 package org.apache.iceberg.aws.glue;
 
-import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.ValidationException;
 import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.Table;
 
@@ -35,21 +33,5 @@ class GlueToIcebergConverter {
 
   static TableIdentifier toTableId(Table table) {
     return TableIdentifier.of(table.databaseName(), table.name());
-  }
-
-  /**
-   * Validate the Glue table is Iceberg table by checking its parameters
-   *
-   * @param table glue table
-   * @param fullName full table name for logging
-   */
-  static void validateTable(Table table, String fullName) {
-    String tableType = table.parameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP);
-    ValidationException.check(
-        tableType != null
-            && tableType.equalsIgnoreCase(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE),
-        "Input Glue table is not an iceberg table: %s (type=%s)",
-        fullName,
-        tableType);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
@@ -47,21 +47,11 @@ public class TestGlueToIcebergConverter {
   }
 
   @Test
-  public void testValidateTable() {
-    Map<String, String> properties =
-        ImmutableMap.of(
-            BaseMetastoreTableOperations.TABLE_TYPE_PROP,
-            BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
-    Table table = Table.builder().parameters(properties).build();
-    GlueToIcebergConverter.validateTable(table, "name");
-  }
-
-  @Test
   public void testValidateTableIcebergPropertyNotFound() {
     Table table = Table.builder().parameters(ImmutableMap.of()).build();
 
-    Assertions.assertThatThrownBy(() -> GlueToIcebergConverter.validateTable(table, "name"))
-        .isInstanceOf(ValidationException.class)
+    Assertions.assertThatThrownBy(() -> GlueTableOperations.checkIfTableIsIceberg(table, "name"))
+        .isInstanceOf(NoSuchIcebergTableException.class)
         .hasMessage("Input Glue table is not an iceberg table: name (type=null)");
   }
 
@@ -71,8 +61,8 @@ public class TestGlueToIcebergConverter {
         ImmutableMap.of(BaseMetastoreTableOperations.TABLE_TYPE_PROP, "other");
     Table table = Table.builder().parameters(properties).build();
 
-    Assertions.assertThatThrownBy(() -> GlueToIcebergConverter.validateTable(table, "name"))
-        .isInstanceOf(ValidationException.class)
+    Assertions.assertThatThrownBy(() -> GlueTableOperations.checkIfTableIsIceberg(table, "name"))
+        .isInstanceOf(NoSuchIcebergTableException.class)
         .hasMessage("Input Glue table is not an iceberg table: name (type=other)");
   }
 }


### PR DESCRIPTION
Currently, the Hive catalog is throwing a `NoSuchIcebergTableException` upon discovering that the table in question is not Iceberg.

This is most apparent in Spark, where currently `SparkSessionCatalog` in conjunction with `GlueCatalog` cannot read non-Iceberg tables despite that being the purpose of the `SparkSessionCatalog` (falling back to the built-in catalog)