### PR TITLE
Docs: clarify Hive on Tez configuration

### DIFF
--- a/docs/hive.md
+++ b/docs/hive.md
@@ -130,8 +130,7 @@ To use the Tez engine on Hive `3.1.2` or later, Tez needs to be upgraded to >= `
 To use the Tez engine on Hive `2.3.x`, you will need to manually build Tez from the `branch-0.9` branch due to a
 backwards incompatibility issue with Tez `0.10.1`.
 
-In both cases, you will also need to set the following property in the `tez-site.xml` configuration
-file: `tez.mrreader.config.update.properties=hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids`.
+In both cases, you will also need to set the following property in the `tez-site.xml` configuration file: `tez.mrreader.config.update.properties=hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids`.
 
 ## Catalog Management
 

--- a/docs/hive.md
+++ b/docs/hive.md
@@ -127,12 +127,11 @@ The table level configuration overrides the global Hadoop configuration.
 
 To use the Tez engine on Hive `3.1.2` or later, Tez needs to be upgraded to >= `0.10.1` which contains a necessary fix [TEZ-4248](https://issues.apache.org/jira/browse/TEZ-4248).
 
-
 To use the Tez engine on Hive `2.3.x`, you will need to manually build Tez from the `branch-0.9` branch due to a
 backwards incompatibility issue with Tez `0.10.1`.
 
-You will also need to set the following property in the Hive
-configuration: `tez.mrreader.config.update.properties=hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids`.
+In both cases, you will also need to set the following property in the `tez-site.xml` configuration
+file: `tez.mrreader.config.update.properties=hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids`.
 
 ## Catalog Management
 


### PR DESCRIPTION
I had the impression that the original sentence (`You will also need to set the following property in the Hive configuration: tez.mrreader.config.update.properties=hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids.`) meant that this configuration was needed for the Tez engine on Hive 2.3.x only.

Besides, I thought that `Hive configuration` meant `hive-site.xml` rather than `tez-site.xml`.

Hence, I propose this change in wording to make it clearer.