### PR TITLE
REST: fix previous locations for refs-only load

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -327,6 +327,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
       tableMetadata =
           TableMetadata.buildFrom(response.tableMetadata())
               .withMetadataLocation(response.metadataLocation())
+              .setPreviousFileLocation(null)
               .setSnapshotsSupplier(
                   () ->
                       loadInternal(context, identifier, SnapshotMode.ALL)


### PR DESCRIPTION
This PR fixes an issue in the REST catalog when loading metadata with refs only, where the current metadata location is being added as a previous location. The change in this PR prevents that, so the previous location list is retained as-is.