### PR TITLE
Support timestamp type in partition string when importing files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -27,6 +27,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -68,6 +69,8 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        return (long) Timestamp.valueOf(asString).getNanos() / 1000;
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/core/src/test/java/org/apache/iceberg/TestTimestampPartitions.java
+++ b/core/src/test/java/org/apache/iceberg/TestTimestampPartitions.java
@@ -45,17 +45,23 @@ public class TestTimestampPartitions extends TableTestBase {
     Schema dateSchema =
         new Schema(
             required(1, "id", Types.LongType.get()),
-            optional(2, "timestamp", Types.TimestampType.withoutZone()));
+            optional(2, "timestamp", Types.TimestampType.withoutZone()),
+            optional(3, "timestamptz", Types.TimestampType.withZone()));
 
     PartitionSpec partitionSpec =
-        PartitionSpec.builderFor(dateSchema).day("timestamp", "date").build();
+        PartitionSpec.builderFor(dateSchema)
+            .day("timestamp", "date")
+            .identity("timestamp")
+            .identity("timestamptz")
+            .build();
 
     DataFile dataFile =
         DataFiles.builder(partitionSpec)
             .withPath("/path/to/data-1.parquet")
             .withFileSizeInBytes(0)
             .withRecordCount(0)
-            .withPartitionPath("date=2018-06-08")
+            .withPartitionPath(
+                "date=2018-06-08/timestamp=2023-02-11 18:30:00/timestamptz=2023-02-11 18:30:00")
             .build();
 
     File tableDir = temp.newFolder();


### PR DESCRIPTION
When building snapshot for a Hive table whose partition column is of timestamptz type, it fails with 

```java.lang.UnsupportedOperationException: Unsupported type for fromPartitionString: timestamptz```

This PR tries to fix it.