### PR TITLE
Spark: apply rewrite manifest action fix to 3.1,3.2

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -63,7 +63,13 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
-  /** @deprecated will be removed in 1.4.0 */
+  /**
+   * Using this to broadcast FileIO can lead to unexpected behavior, as broadcast variables that
+   * implement {@link AutoCloseable} will be closed by Spark during broadcast removal. As an
+   * alternative, use {@link org.apache.iceberg.SerializableTable}.
+   *
+   * @deprecated will be removed in 1.4.0
+   */
   @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -63,6 +63,8 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
+  /** @deprecated will be removed in 1.4.0 */
+  @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {
       // we need to use Spark's SerializableConfiguration to avoid issues with Kryo serialization

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -75,7 +75,13 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
-  /** @deprecated will be removed in 1.4.0 */
+  /**
+   * Using this to broadcast FileIO can lead to unexpected behavior, as broadcast variables that
+   * implement {@link AutoCloseable} will be closed by Spark during broadcast removal. As an
+   * alternative, use {@link org.apache.iceberg.SerializableTable}.
+   *
+   * @deprecated will be removed in 1.4.0
+   */
   @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -75,6 +75,8 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
+  /** @deprecated will be removed in 1.4.0 */
+  @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {
       // we need to use Spark's SerializableConfiguration to avoid issues with Kryo serialization

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -77,6 +77,8 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
+  /** @deprecated will be removed in 1.4.0 */
+  @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {
       // we need to use Spark's SerializableConfiguration to avoid issues with Kryo serialization

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -77,7 +77,13 @@ public class SparkUtil {
 
   private SparkUtil() {}
 
-  /** @deprecated will be removed in 1.4.0 */
+  /**
+   * Using this to broadcast FileIO can lead to unexpected behavior, as broadcast variables that
+   * implement {@link AutoCloseable} will be closed by Spark during broadcast removal. As an
+   * alternative, use {@link org.apache.iceberg.SerializableTable}.
+   *
+   * @deprecated will be removed in 1.4.0
+   */
   @Deprecated
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {


### PR DESCRIPTION
This PR applies the changes from https://github.com/apache/iceberg/pull/7263 to Spark v3.2 and v3.1 also. It marks the unused method `SparkUtil.serializableFileIO()` as deprecated, as using this to broadcast a FileIO can lead to unintended consequences, i.e. the underlying S3 client being closed during broadcast removal.