### PR TITLE
Bug Fix GCSInputStream Single Byte Read

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -113,11 +113,12 @@ class GCSInputStream extends SeekableInputStream {
     singleByteBuffer.position(0);
 
     pos += 1;
-    channel.read(singleByteBuffer);
+    if (channel.read(singleByteBuffer) == -1)
+      return -1;
     readBytes.increment();
     readOperations.increment();
 
-    return singleByteBuffer.array()[0];
+    return singleByteBuffer.array()[0] & 0xFF;
   }
 
   @Override


### PR DESCRIPTION
The current implementation ignores EOF and will return EOF or invalid result when the byte is negative.

This is causing an issue where unexpected EOF is returned for the hadoop parquet file reader when reading parquet metadata: https://github.com/apache/parquet-mr/blob/master/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java#L542
