### PR TITLE
Support case insensitive id assignment for applyNameMapping when reading parquet

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -130,7 +130,13 @@ public class ParquetSchemaUtil {
   }
 
   public static MessageType applyNameMapping(MessageType fileSchema, NameMapping nameMapping) {
-    return (MessageType) ParquetTypeVisitor.visit(fileSchema, new ApplyNameMapping(nameMapping));
+    return ParquetSchemaUtil.applyNameMapping(fileSchema, nameMapping, true);
+  }
+
+  public static MessageType applyNameMapping(
+      MessageType fileSchema, NameMapping nameMapping, boolean caseSensitive) {
+    return (MessageType)
+        ParquetTypeVisitor.visit(fileSchema, new ApplyNameMapping(nameMapping, caseSensitive));
   }
 
   public static class HasIds extends ParquetTypeVisitor<Boolean> {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -85,7 +85,7 @@ class ReadConf<T> {
       typeWithIds = fileSchema;
       this.projection = ParquetSchemaUtil.pruneColumns(fileSchema, expectedSchema);
     } else if (nameMapping != null) {
-      typeWithIds = ParquetSchemaUtil.applyNameMapping(fileSchema, nameMapping);
+      typeWithIds = ParquetSchemaUtil.applyNameMapping(fileSchema, nameMapping, caseSensitive);
       this.projection = ParquetSchemaUtil.pruneColumns(typeWithIds, expectedSchema);
     } else {
       typeWithIds = ParquetSchemaUtil.addFallbackIds(fileSchema);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -128,6 +128,33 @@ public class TestParquetSchemaUtil {
   }
 
   @Test
+  public void testAssignIdsByNameMappingCaseInsensitive() {
+    Types.StructType structTypeLowerCase =
+        Types.StructType.of(required(0, "id", Types.LongType.get()));
+    Schema schemaLowerCase =
+        new Schema(
+            TypeUtil.assignFreshIds(structTypeLowerCase, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
+    MessageType messageTypeWithIds = ParquetSchemaUtil.convert(schemaLowerCase, "parquet_type");
+
+    Types.StructType structTypeUpperCase =
+        Types.StructType.of(required(0, "ID", Types.LongType.get()));
+    Schema schemaUpperCase =
+        new Schema(
+            TypeUtil.assignFreshIds(structTypeUpperCase, new AtomicInteger(0)::incrementAndGet)
+                .asStructType()
+                .fields());
+    NameMapping nameMappingUpperCase = MappingUtil.create(schemaUpperCase);
+
+    MessageType messageTypeWithIdsFromNameMapping =
+        ParquetSchemaUtil.applyNameMapping(
+            RemoveIds.removeIds(messageTypeWithIds), nameMappingUpperCase, false);
+
+    Assert.assertEquals(messageTypeWithIds, messageTypeWithIdsFromNameMapping);
+  }
+
+  @Test
   public void testSchemaConversionWithoutAssigningIds() {
     MessageType messageType =
         new MessageType(


### PR DESCRIPTION
We will encounter failures if we read the parquet data and the field names stored in the name mapping doesn't match the cases of the field names stored in parquet file schema. 

When the mismatch happens, Iceberg will not assign the id to the case mismatch columns in the parquet file schema thus causing mismatching columns to be pruned later on.

This diff takes `caseSensitive` which is already presented in `ReadConf` into consideration, and passes it down into `applyNameMapping` to support case insensitive id assignment.  

