### PR TITLE
Spark: Show Create Round trip tests

### DIFF
--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -232,13 +232,21 @@ public abstract class SparkTestBase extends SparkTestHelperBase {
   }
 
   protected String tablePropsAsString(Map<String, String> tableProps) {
+    return tablePropsAsString(tableProps, "", ", ");
+  }
+
+  protected String tablePropsAsString(
+      Map<String, String> tableProps, String kvSeparator, String propertySeparator) {
     StringBuilder stringBuilder = new StringBuilder();
 
     for (Map.Entry<String, String> property : tableProps.entrySet()) {
       if (stringBuilder.length() > 0) {
-        stringBuilder.append(", ");
+        stringBuilder.append(propertySeparator);
       }
-      stringBuilder.append(String.format("'%s' '%s'", property.getKey(), property.getValue()));
+      stringBuilder.append(
+          String.format(
+              "'%s'%s'%s'",
+              property.getKey(), kvSeparator, property.getValue(), propertySeparator));
     }
 
     return stringBuilder.toString();


### PR DESCRIPTION
Follow up for https://github.com/apache/iceberg/pull/7273 . we are missing `SHOW CREATE` tests for Spark. I'm adding these in TestCreateTable so that we can test round trip behavior for a variety of cases (partitioning, column comments, table comments, table properties etc). 

Let me know what you think @RussellSpitzer @aokolnychyi @jackye1995 @rdblue !