### PR TITLE
Hive: Clean up expired metastore clients

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
+++ b/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
@@ -147,4 +147,8 @@ public abstract class ClientPoolImpl<C, E extends Exception>
   public int poolSize() {
     return poolSize;
   }
+
+  public boolean isClosed() {
+    return closed;
+  }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
@@ -43,6 +42,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.ThreadPools;
 import org.apache.thrift.TException;
 import org.immutables.value.Value;
 
@@ -105,7 +105,9 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
           Caffeine.newBuilder()
               .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)
               .removalListener((ignored, value, cause) -> ((HiveClientPool) value).close())
-              .scheduler(Scheduler.forScheduledExecutorService(Executors.newScheduledThreadPool(2)))
+              .scheduler(
+                  Scheduler.forScheduledExecutorService(
+                      ThreadPools.newScheduledPool("hive-metastore-cleaner", 2)))
               .build();
     }
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -107,7 +107,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
               .removalListener((ignored, value, cause) -> ((HiveClientPool) value).close())
               .scheduler(
                   Scheduler.forScheduledExecutorService(
-                      ThreadPools.newScheduledPool("hive-metastore-cleaner", 2)))
+                      ThreadPools.newScheduledPool("hive-metastore-cleaner", 1)))
               .build();
     }
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -100,7 +100,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
   private synchronized void init() {
     if (clientPoolCache == null) {
       // Since Caffeine does not ensure that removalListener will be involved after expiration
-      // We use a scheduler with 2 threads to clean up expired clients.
+      // We use a scheduler with one thread to clean up expired clients.
       clientPoolCache =
           Caffeine.newBuilder()
               .expireAfterAccess(evictionInterval, TimeUnit.MILLISECONDS)

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
@@ -46,6 +46,10 @@ public class TestCachedClientPool extends HiveMetastoreTest {
     Assert.assertNull(
         CachedClientPool.clientPoolCache()
             .getIfPresent(CachedClientPool.extractKey(null, hiveConf)));
+
+    // The client has been really closed.
+    Assert.assertTrue(clientPool1.isClosed());
+    Assert.assertTrue(clientPool2.isClosed());
   }
 
   @Test


### PR DESCRIPTION
Fixed a bug that could leak hive client connections.

Caffeine cache will not always call removelistener by default, so an extra scheduler is required to invoke removelistener.

See: https://github.com/google/guava/issues/3295. 