### PR TITLE
Build: Fix flaky checkstyle issue

### DIFF
--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -195,10 +195,11 @@ public class TestCloseableIterable {
                   }
                 });
 
+    AtomicInteger consumedCounter = new AtomicInteger(0);
     try (CloseableIterable<Integer> concat = CloseableIterable.concat(transform)) {
-      concat.forEach(c -> c++);
+      concat.forEach(count -> consumedCounter.getAndIncrement());
     }
-    Assertions.assertThat(counter.get()).isEqualTo(items.size());
+    Assertions.assertThat(counter.get()).isEqualTo(items.size()).isEqualTo(consumedCounter.get());
   }
 
   @Test

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -48,7 +48,6 @@ subprojects {
 
   checkstyle {
     toolVersion '9.3'
-    ignoreFailures = true
     configDirectory = file("${rootDir}/.baseline/checkstyle")
   }
 

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -33,11 +33,7 @@ subprojects {
   // ready to enforce linting on.
   apply plugin: 'org.inferred.processors'
   if (!project.hasProperty('quick')) {
-    // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
-    // in an old version of the checkstyle(9.1), which has this OutOfMemory bug https://github.com/checkstyle/checkstyle/issues/10934
-    // So, replace com.palantir.baseline-checkstyle plugin usage with gradle checkstyle plugin
-    // with checkstyle version 9.3 (the latest java 8 supported version) which contains the fix.
-    apply plugin: 'checkstyle'
+    apply plugin: 'com.palantir.baseline-checkstyle'
     apply plugin: 'com.palantir.baseline-error-prone'
   }
   apply plugin: 'com.palantir.baseline-class-uniqueness'
@@ -46,25 +42,14 @@ subprojects {
   apply plugin: 'com.palantir.baseline-release-compatibility'
   apply plugin: 'com.diffplug.spotless'
 
-  checkstyle {
-    toolVersion '9.3'
-    configDirectory = file("${rootDir}/.baseline/checkstyle")
-  }
-
-  // Configure checkstyle to be same as palantir/gradle-baseline
-  pluginManager.withPlugin("java", plugin -> {
-    JavaPluginExtension javaExt = project.getExtensions().getByType(JavaPluginExtension.class)
-    // We use the "JavadocMethod" module in our Checkstyle configuration, making
-    // Java 8+ new doclint compiler feature redundant.
-    if (javaExt.getSourceCompatibility().isJava8Compatible()) {
-      project.getTasks()
-              .withType(Javadoc.class)
-              .configureEach(javadoc ->
-                      javadoc.options(javadocOptions -> ((StandardJavadocDocletOptions) javadocOptions)
-                              .addStringOption("Xdoclint:none", "-quiet")))
+  pluginManager.withPlugin('com.palantir.baseline-checkstyle') {
+    checkstyle {
+      // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
+      // in an old version of the checkstyle(9.1), which has this OutOfMemory bug https://github.com/checkstyle/checkstyle/issues/10934.
+      // So, override its checkstyle version to 9.3 (the latest java 8 supported version) which contains a fix using CheckstyleExtension.
+      toolVersion '9.3'
     }
-  })
-
+  }
 
   pluginManager.withPlugin('com.diffplug.spotless') {
     spotless {

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -33,7 +33,11 @@ subprojects {
   // ready to enforce linting on.
   apply plugin: 'org.inferred.processors'
   if (!project.hasProperty('quick')) {
-    apply plugin: 'com.palantir.baseline-checkstyle'
+    // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
+    // in an old version of the checkstyle(9.1), which has this OutOfMemory bug https://github.com/checkstyle/checkstyle/issues/10934
+    // So, replace com.palantir.baseline-checkstyle plugin usage with gradle checkstyle plugin
+    // with checkstyle version 9.3 (the latest java 8 supported version) which contains the fix.
+    apply plugin: 'checkstyle'
     apply plugin: 'com.palantir.baseline-error-prone'
   }
   apply plugin: 'com.palantir.baseline-class-uniqueness'
@@ -41,6 +45,27 @@ subprojects {
   apply plugin: 'com.palantir.baseline-exact-dependencies'
   apply plugin: 'com.palantir.baseline-release-compatibility'
   apply plugin: 'com.diffplug.spotless'
+
+  checkstyle {
+    toolVersion '9.3'
+    ignoreFailures = true
+    configDirectory = file("${rootDir}/.baseline/checkstyle")
+  }
+
+  // Configure checkstyle to be same as palantir/gradle-baseline
+  pluginManager.withPlugin("java", plugin -> {
+    JavaPluginExtension javaExt = project.getExtensions().getByType(JavaPluginExtension.class)
+    // We use the "JavadocMethod" module in our Checkstyle configuration, making
+    // Java 8+ new doclint compiler feature redundant.
+    if (javaExt.getSourceCompatibility().isJava8Compatible()) {
+      project.getTasks()
+              .withType(Javadoc.class)
+              .configureEach(javadoc ->
+                      javadoc.options(javadocOptions -> ((StandardJavadocDocletOptions) javadocOptions)
+                              .addStringOption("Xdoclint:none", "-quiet")))
+    }
+  })
+
 
   pluginManager.withPlugin('com.diffplug.spotless') {
     spotless {

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -46,7 +46,7 @@ subprojects {
     checkstyle {
       // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
       // in an old version of the checkstyle(9.1), which has this OutOfMemory bug https://github.com/checkstyle/checkstyle/issues/10934.
-      // So, override its checkstyle version to 9.3 (the latest java 8 supported version) which contains a fix using CheckstyleExtension.
+      // So, override its checkstyle version using CheckstyleExtension to 9.3 (the latest java 8 supported version) which contains a fix.
       toolVersion '9.3'
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,6 @@ buildscript {
     // in an old version of the errorprone, which doesn't work w/ Gradle 8, so bump errorpone as
     // well.
     classpath "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
-    // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
-    // in an old version of the checkstyle(9.1), which has this OutOfMemory bug https://github.com/checkstyle/checkstyle/issues/10934
-    // So, bump checkstyle to the latest java 8 supported version(9.3) which contains the fix.
-    classpath "com.puppycrawl.tools:checkstyle:9.3"
 
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:6.13.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -454,7 +454,7 @@ public abstract class TestMetrics {
 
     for (int i = 0; i < recordCount; i++) {
       Record newRecord = GenericRecord.create(SIMPLE_SCHEMA);
-      newRecord.setField("booleanCol", i == 0 ? false : true);
+      newRecord.setField("booleanCol", i != 0);
       newRecord.setField("intCol", i + 1);
       newRecord.setField("longCol", i == 0 ? null : i + 1L);
       newRecord.setField("floatCol", i + 1.0F);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,7 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
-                    org.apache.avro.Schema.Field updatedField;
+                    org.apache.avro.Schema.Field updatedField = field;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -126,8 +126,6 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
-                    } else {
-                      updatedField = field;
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -124,10 +124,10 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      field = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
                     }
 
-                    return new org.apache.avro.Schema.Field(field, field.schema());
+                    return field;
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,6 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
+                    org.apache.avro.Schema.Field updatedField;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -124,10 +125,12 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = field;
                     }
 
-                    return field;
+                    return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,7 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
-                    org.apache.avro.Schema.Field updatedField;
+                    org.apache.avro.Schema.Field updatedField = field;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -126,8 +126,6 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
-                    } else {
-                      updatedField = field;
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -124,10 +124,10 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      field = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
                     }
 
-                    return new org.apache.avro.Schema.Field(field, field.schema());
+                    return field;
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,6 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
+                    org.apache.avro.Schema.Field updatedField;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -124,10 +125,12 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = field;
                     }
 
-                    return field;
+                    return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,7 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
-                    org.apache.avro.Schema.Field updatedField;
+                    org.apache.avro.Schema.Field updatedField = field;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -126,8 +126,6 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
-                    } else {
-                      updatedField = field;
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -124,10 +124,10 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      field = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
                     }
 
-                    return new org.apache.avro.Schema.Field(field, field.schema());
+                    return field;
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -113,6 +113,7 @@ public class DataGenerators {
           schemaConvertedFromIceberg.getFields().stream()
               .map(
                   field -> {
+                    org.apache.avro.Schema.Field updatedField;
                     if (field.name().equals("time_field")) {
                       // Iceberg's AvroSchemaUtil uses timestamp-micros with Long value for time
                       // field, while AvroToRowDataConverters#convertToTime() always looks for
@@ -124,10 +125,12 @@ public class DataGenerators {
                           LogicalTypes.timeMillis()
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
-                      return new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                      updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = field;
                     }
 
-                    return field;
+                    return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
                   })
               .collect(Collectors.toList());
       return org.apache.avro.Schema.createRecord(

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
@@ -248,7 +248,7 @@ public class TestBloomRowGroupFilter {
         structNotNull.put("_int_field", INT_MIN_VALUE + i);
         builder.set("_struct_not_null", structNotNull); // struct with int
         builder.set("_no_stats", TOO_LONG_FOR_STATS); // value longer than 4k will produce no stats
-        builder.set("_boolean", (i % 2 == 0) ? true : false);
+        builder.set("_boolean", i % 2 == 0);
         builder.set("_time", instant.plusSeconds(i * 86400).toEpochMilli());
         builder.set("_date", instant.plusSeconds(i * 86400).getEpochSecond());
         builder.set("_timestamp", instant.plusSeconds(i * 86400).toEpochMilli());

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -140,7 +140,7 @@ public class TestSparkReaderWithBloomFilter {
                   "id_string",
                   BINARY_PREFIX + (INT_MIN_VALUE + i),
                   "id_boolean",
-                  (i % 2 == 0) ? true : false,
+                  i % 2 == 0,
                   "id_date",
                   LocalDate.parse("2021-09-05"),
                   "id_int_decimal",

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderWithBloomFilter.java
@@ -140,7 +140,7 @@ public class TestSparkReaderWithBloomFilter {
                   "id_string",
                   BINARY_PREFIX + (INT_MIN_VALUE + i),
                   "id_boolean",
-                  (i % 2 == 0) ? true : false,
+                  i % 2 == 0,
                   "id_date",
                   LocalDate.parse("2021-09-05"),
                   "id_int_decimal",


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/7024 didn't really fix the issue. 

After analyzing the dependency tree found that `com.palantir.baseline-checkstyle` plugin will always use the checkstyle version from `com.palantir.baseline:gradle-baseline-java:4.42.0` (which is 9.1) even though we override it with some other version (which is 9.3) using classpath.

So, the solution is to override using the toolchain version of the `CheckstyleExtension` as supported from `com.palantir.baseline-checkstyle` instead of classpath.
https://github.com/palantir/gradle-baseline/blob/267dd19dad6dbcc9d9772437340b4abc72deda55/gradle-baseline-java/src/main/groovy/com/palantir/baseline/plugins/BaselineCheckstyle.java#L43-L45

- Executed the dependency tree `gradle iceberg-api:dependencies` and confirmed it is using checkstyle 9.3 which has the fix of OOM issue which is causing build flakiness.
- Fixed the check style errors reported from 9.3 version (which was not present in 9.1 version)
 
 fixes #7292 
