### PR TITLE
API: Update java doc for listTables and listViews

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -47,7 +47,6 @@ public interface Catalog {
    * @param namespace a namespace
    * @return a list of identifiers for tables
    * @throws NoSuchNamespaceException if the namespace is not found
-   * @throws IllegalArgumentException if the namespace is invalid for the catalog
    */
   List<TableIdentifier> listTables(Namespace namespace);
 

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -26,8 +26,8 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.exceptions.NotFoundException;
 
 /** A Catalog API for table create, drop, and load operations. */
 public interface Catalog {
@@ -46,7 +46,8 @@ public interface Catalog {
    *
    * @param namespace a namespace
    * @return a list of identifiers for tables
-   * @throws NotFoundException if the namespace is not found
+   * @throws NoSuchNamespaceException if the namespace is not found
+   * @throws IllegalArgumentException if the namespace is invalid for the catalog
    */
   List<TableIdentifier> listTables(Namespace namespace);
 

--- a/api/src/main/java/org/apache/iceberg/catalog/ViewCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/ViewCatalog.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.catalog;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewBuilder;
 
@@ -41,7 +41,8 @@ public interface ViewCatalog {
    *
    * @param namespace a namespace
    * @return a list of identifiers for views
-   * @throws NotFoundException if the namespace is not found
+   * @throws NoSuchNamespaceException if the namespace is not found
+   * @throws IllegalArgumentException if the namespace is invalid for the catalog
    */
   List<TableIdentifier> listViews(Namespace namespace);
 

--- a/api/src/main/java/org/apache/iceberg/catalog/ViewCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/ViewCatalog.java
@@ -42,7 +42,6 @@ public interface ViewCatalog {
    * @param namespace a namespace
    * @return a list of identifiers for views
    * @throws NoSuchNamespaceException if the namespace is not found
-   * @throws IllegalArgumentException if the namespace is invalid for the catalog
    */
   List<TableIdentifier> listViews(Namespace namespace);
 


### PR DESCRIPTION
`NotFoundException` is used for file-based operations and no catalog is throwing it for `listTables`.
Hence, updating it based on the current implementations.