### PR TITLE
Core: Introduce CompositeMetricsReporter

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/LoggingMetricsReporter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.metrics;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,6 @@ public class LoggingMetricsReporter implements MetricsReporter {
 
   @Override
   public void report(MetricsReport report) {
-    Preconditions.checkArgument(null != report, "Invalid metrics report: null");
     LOG.info("Received metrics report: {}", report);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
 import org.apache.iceberg.metrics.ImmutableScanReport;
-import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.ScanMetrics;
 import org.apache.iceberg.metrics.ScanMetricsResult;
 import org.apache.iceberg.metrics.ScanReport;
@@ -145,9 +144,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
                   .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                   .metadata(metadata)
                   .build();
-          for (MetricsReporter metricsReporter : context().metricsReporters()) {
-            metricsReporter.report(scanReport);
-          }
+          context().metricsReporter().report(scanReport);
         });
   }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Collections;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility class that allows combining two given {@link MetricsReporter} instances. */
+public class MetricsReporters {
+  private static final Logger LOG = LoggerFactory.getLogger(MetricsReporters.class);
+
+  private MetricsReporters() {}
+
+  public static MetricsReporter combine(MetricsReporter first, MetricsReporter second) {
+    if (null == first) {
+      return second;
+    } else if (null == second || first == second) {
+      return first;
+    }
+
+    Set<MetricsReporter> reporters = Sets.newIdentityHashSet();
+
+    if (first instanceof CompositeMetricsReporter) {
+      reporters.addAll(((CompositeMetricsReporter) first).reporters());
+    } else {
+      reporters.add(first);
+    }
+
+    if (second instanceof CompositeMetricsReporter) {
+      reporters.addAll(((CompositeMetricsReporter) second).reporters());
+    } else {
+      reporters.add(second);
+    }
+
+    return new CompositeMetricsReporter(reporters);
+  }
+
+  @VisibleForTesting
+  static class CompositeMetricsReporter implements MetricsReporter {
+    private final Set<MetricsReporter> reporters;
+
+    private CompositeMetricsReporter(Set<MetricsReporter> reporters) {
+      this.reporters = reporters;
+    }
+
+    @Override
+    public void report(MetricsReport report) {
+      for (MetricsReporter reporter : reporters) {
+        try {
+          reporter.report(report);
+        } catch (Exception e) {
+          LOG.warn(
+              "Could not report {} to {}",
+              report.getClass().getName(),
+              reporter.getClass().getName(),
+              e);
+        }
+      }
+    }
+
+    Set<MetricsReporter> reporters() {
+      return Collections.unmodifiableSet(reporters);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.ScanMetricsResult;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.Test;
 
 public class TestScanPlanningAndReporting extends TableTestBase {
@@ -41,6 +42,34 @@ public class TestScanPlanningAndReporting extends TableTestBase {
 
   public TestScanPlanningAndReporting() {
     super(2);
+  }
+
+  @Test
+  public void noDuplicatesInScanContext() {
+    TableScanContext context = new TableScanContext();
+    assertThat(context.metricsReporter()).isInstanceOf(LoggingMetricsReporter.class);
+
+    MetricsReporter first = report -> {};
+    MetricsReporter second = report -> {};
+
+    context = context.reportWith(first).reportWith(first);
+    assertThat(context.metricsReporter()).isSameAs(first);
+
+    context = context.reportWith(second);
+    assertThat(context.metricsReporter())
+        .as("should be a CompositeMetricsReporter")
+        .extracting("reporters")
+        .asInstanceOf(InstanceOfAssertFactories.collection(MetricsReporter.class))
+        .hasSize(2)
+        .containsExactlyInAnyOrder(first, second);
+
+    context = context.reportWith(LoggingMetricsReporter.instance()).reportWith(second);
+    assertThat(context.metricsReporter())
+        .as("should be a CompositeMetricsReporter")
+        .extracting("reporters")
+        .asInstanceOf(InstanceOfAssertFactories.collection(MetricsReporter.class))
+        .hasSize(3)
+        .containsExactlyInAnyOrder(LoggingMetricsReporter.instance(), first, second);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/metrics/TestMetricsReporters.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestMetricsReporters.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class TestMetricsReporters {
+  @Test
+  public void combineWithNullReporter() {
+    MetricsReporter reporter = report -> {};
+    assertThat(MetricsReporters.combine(null, null)).isNull();
+    assertThat(MetricsReporters.combine(null, reporter)).isSameAs(reporter);
+    assertThat(MetricsReporters.combine(reporter, null)).isSameAs(reporter);
+  }
+
+  @Test
+  public void combineSameInstances() {
+    MetricsReporter reporter = LoggingMetricsReporter.instance();
+    assertThat(MetricsReporters.combine(reporter, reporter)).isSameAs(reporter);
+  }
+
+  @Test
+  public void combineSameClassButDifferentInstances() {
+    MetricsReporter first = LoggingMetricsReporter.instance();
+    MetricsReporter second = new LoggingMetricsReporter();
+
+    MetricsReporter combined = MetricsReporters.combine(first, second);
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(first, second);
+  }
+
+  @Test
+  public void combineSimpleReporters() {
+    MetricsReporter first = report -> {};
+    MetricsReporter second = report -> {};
+
+    MetricsReporter combined = MetricsReporters.combine(first, second);
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters())
+        .hasSize(2)
+        .containsExactlyInAnyOrder(first, second);
+  }
+
+  @Test
+  public void combineComposites() {
+    MetricsReporter one = report -> {};
+    MetricsReporter two = report -> {};
+    MetricsReporter firstComposite =
+        MetricsReporters.combine(one, LoggingMetricsReporter.instance());
+    MetricsReporter secondComposite =
+        MetricsReporters.combine(two, LoggingMetricsReporter.instance());
+
+    MetricsReporter combined = MetricsReporters.combine(firstComposite, two);
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters())
+        .hasSize(3)
+        .containsExactlyInAnyOrder(one, two, LoggingMetricsReporter.instance());
+
+    combined = MetricsReporters.combine(firstComposite, secondComposite);
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters())
+        .hasSize(3)
+        .containsExactlyInAnyOrder(one, two, LoggingMetricsReporter.instance());
+  }
+
+  @Test
+  public void reportWithMultipleMetricsReporters() {
+    AtomicInteger counter = new AtomicInteger();
+    MetricsReporter combined =
+        MetricsReporters.combine(
+            report -> counter.incrementAndGet(), report -> counter.incrementAndGet());
+
+    combined.report(new MetricsReport() {});
+
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters()).hasSize(2);
+    assertThat(counter.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void reportWithMultipleMetricsReportersOneFails() {
+    AtomicInteger counter = new AtomicInteger();
+    MetricsReporter combined =
+        MetricsReporters.combine(
+            MetricsReporters.combine(
+                report -> counter.incrementAndGet(),
+                report -> {
+                  throw new RuntimeException("invalid report");
+                }),
+            report -> counter.incrementAndGet());
+
+    combined.report(new MetricsReport() {});
+
+    assertThat(combined).isInstanceOf(MetricsReporters.CompositeMetricsReporter.class);
+    assertThat(((MetricsReporters.CompositeMetricsReporter) combined).reporters()).hasSize(3);
+    assertThat(counter.get()).isEqualTo(2);
+  }
+}


### PR DESCRIPTION
This introduces a `CompositeMetricsReporter` that allows registering multiple (simple) `MetricsReporter` instances that all get notified whenever a new `MetricsReport` is available.

This also switches from a collection of reporters to the `CompositeMetricsReporter` in `TableScanContext` to fix an issue where duplicate reporters were not handled (see https://github.com/apache/iceberg/pull/7337#discussion_r1165597698 for details).