### PR TITLE
Flink: use correct scan mode when in TABLE_SCAN_THEN_INCREMENTAL mode

### DIFF
--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -145,15 +145,7 @@ public class FlinkSplitPlanner {
 
   @VisibleForTesting
   static ScanMode checkScanMode(ScanContext context) {
-    if (context.isStreaming()
-        && context.streamingStartingStrategy()
-            == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL
-        && (context.startSnapshotId() == null || context.startTag() == null)) {
-      return ScanMode.BATCH;
-    }
-
-    if (context.isStreaming()
-        || context.startSnapshotId() != null
+    if (context.startSnapshotId() != null
         || context.endSnapshotId() != null
         || context.startTag() != null
         || context.endTag() != null) {

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.Tasks;
@@ -136,12 +137,21 @@ public class FlinkSplitPlanner {
     }
   }
 
-  private enum ScanMode {
+  @VisibleForTesting
+  enum ScanMode {
     BATCH,
     INCREMENTAL_APPEND_SCAN
   }
 
-  private static ScanMode checkScanMode(ScanContext context) {
+  @VisibleForTesting
+  static ScanMode checkScanMode(ScanContext context) {
+    if (context.isStreaming()
+        && context.streamingStartingStrategy()
+            == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL
+        && (context.startSnapshotId() == null || context.startTag() == null)) {
+      return ScanMode.BATCH;
+    }
+
     if (context.isStreaming()
         || context.startSnapshotId() != null
         || context.endSnapshotId() != null

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -166,7 +166,9 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
     if (scanContext.streamingStartingStrategy()
         == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL) {
       // do a batch table scan first
-      splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext, workerPool);
+      splits =
+          FlinkSplitPlanner.planIcebergSourceSplits(
+              table, scanContext.copyWithSnapshotId(startSnapshot.snapshotId()), workerPool);
       LOG.info(
           "Discovered {} splits from initial batch table scan with snapshot Id {}",
           splits.size(),


### PR DESCRIPTION
When consuming a table in `TABLE_SCAN_THEN_INCREMENTAL` mode and its snapshot history has expired, data can be lost. This is because `checkScanMode` returns incremental mode when the scan context is streaming. To address this issue, we have added a case to handle the `TABLE_SCAN_THEN_INCREMENTAL` mode.