### PR TITLE
API: Binder should not simplify isNull and notNull when their reference …

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Binder.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Binder.java
@@ -43,7 +43,7 @@ public class Binder {
    * allowed, a {@link ValidationException validation exception} is thrown.
    *
    * <p>The result expression may be simplified when constructed. For example, {@code isNull("a")}
-   * is replaced with {@code alwaysFalse()} when {@code "a"} is resolved to a required field.
+   * is replaced with {@code alwaysFalse()} when {@code "a"} is resolved to be always non-null.
    *
    * <p>The expression cannot contain references that are already bound, or an {@link
    * IllegalStateException} will be thrown.
@@ -71,7 +71,7 @@ public class Binder {
    * allowed, a {@link ValidationException validation exception} is thrown.
    *
    * <p>The result expression may be simplified when constructed. For example, {@code isNull("a")}
-   * is replaced with {@code alwaysFalse()} when {@code "a"} is resolved to a required field.
+   * is replaced with {@code alwaysFalse()} when {@code "a"} is resolved to be always non-null.
    *
    * <p>The expression cannot contain references that are already bound, or an {@link
    * IllegalStateException} will be thrown.

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestBloomRowGroupFilter.java
@@ -320,8 +320,8 @@ public class TestBloomRowGroupFilter {
         new ParquetBloomRowGroupFilter(SCHEMA, isNull("struct_not_null.int_field"))
             .shouldRead(parquetSchema, rowGroupMetadata, bloomStore);
     assertThat(shouldRead)
-        .as("Should skip: this field is required and are always not-null")
-        .isFalse();
+        .as("Should read: this field may contain nulls and bloom filter doesn't help")
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
…fields are required but nested in optional parents.

Currently, `Binder` will simpify `isNull` and `notNull` to `alwaysFalse` and `alwaysTrue` respectively, when the expressions are to be bound to required fields. However a required field can still be null in the row when it is nested in an optional parent field. Therefore, this causes data to be incorrectly skipped when querying for rows where their nested field(required sub field nested in optional parent) is null.

This changes the `Binder` to only simplify nullability predicates when their target field and all its parents are all required, to fix this issue.