### PR TITLE
Spark -Simplify checks of output-spec-id in SparkWriteConf

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.spark;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
@@ -50,18 +49,16 @@ import org.apache.spark.sql.SparkSession;
  */
 public class SparkWriteConf {
 
+  private final Table table;
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
-  private final int currentSpecId;
-  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
+    this.table = table;
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
-    this.currentSpecId = table.spec().specId();
-    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -126,10 +123,10 @@ public class SparkWriteConf {
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)
-            .defaultValue(currentSpecId)
+            .defaultValue(table.spec().specId())
             .parse();
     Preconditions.checkArgument(
-        partitionSpecIds.contains(outputSpecId),
+        table.specs().containsKey(outputSpecId),
         "Output spec id %s is not a valid spec id for table",
         outputSpecId);
     return outputSpecId;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -24,7 +24,6 @@ import static org.apache.iceberg.DistributionMode.RANGE;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.IsolationLevel;
@@ -60,16 +59,12 @@ public class SparkWriteConf {
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
-  private final int currentSpecId;
-  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
     this.table = table;
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
-    this.currentSpecId = table.spec().specId();
-    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -134,10 +129,10 @@ public class SparkWriteConf {
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)
-            .defaultValue(currentSpecId)
+            .defaultValue(table.spec().specId())
             .parse();
     Preconditions.checkArgument(
-        partitionSpecIds.contains(outputSpecId),
+        table.specs().containsKey(outputSpecId),
         "Output spec id %s is not a valid spec id for table",
         outputSpecId);
     return outputSpecId;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -24,7 +24,6 @@ import static org.apache.iceberg.DistributionMode.RANGE;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.IsolationLevel;
@@ -63,8 +62,6 @@ public class SparkWriteConf {
   private final RuntimeConfig sessionConf;
   private final Map<String, String> writeOptions;
   private final SparkConfParser confParser;
-  private final int currentSpecId;
-  private final Set<Integer> partitionSpecIds;
 
   public SparkWriteConf(SparkSession spark, Table table, Map<String, String> writeOptions) {
     this(spark, table, null, writeOptions);
@@ -77,8 +74,6 @@ public class SparkWriteConf {
     this.sessionConf = spark.conf();
     this.writeOptions = writeOptions;
     this.confParser = new SparkConfParser(spark, table, writeOptions);
-    this.currentSpecId = table.spec().specId();
-    this.partitionSpecIds = table.specs().keySet();
   }
 
   public boolean checkNullability() {
@@ -152,10 +147,10 @@ public class SparkWriteConf {
         confParser
             .intConf()
             .option(SparkWriteOptions.OUTPUT_SPEC_ID)
-            .defaultValue(currentSpecId)
+            .defaultValue(table.spec().specId())
             .parse();
     Preconditions.checkArgument(
-        partitionSpecIds.contains(outputSpecId),
+        table.specs().containsKey(outputSpecId),
         "Output spec id %s is not a valid spec id for table",
         outputSpecId);
     return outputSpecId;


### PR DESCRIPTION
Rely only on `Table` to verify that `output-spec-id` is valid. This avoids having to keep the partition specs on 3.2 and 3.3 which are already present within the `Table`.

This is a follow-up to comment https://github.com/apache/iceberg/pull/7120#discussion_r1166312659 in the previous PR.