### PR TITLE
Fix SetDefaultPartitionSpec to use specId instead of schemaId

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -126,8 +126,8 @@ public interface MetadataUpdate extends Serializable {
   class SetDefaultPartitionSpec implements MetadataUpdate {
     private final int specId;
 
-    public SetDefaultPartitionSpec(int schemaId) {
-      this.specId = schemaId;
+    public SetDefaultPartitionSpec(int specId) {
+      this.specId = specId;
     }
 
     public int specId() {


### PR DESCRIPTION


Looks like I caught a typo from @rdblue :)