### PR TITLE
Fix IcebergGenerics::read to read metadata tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -71,8 +71,10 @@ class StaticDataTask implements DataTask {
 
   @Override
   public CloseableIterable<StructLike> rows() {
-    StructProjection projection = StructProjection.create(tableSchema, projectedSchema);
-    Iterable<StructLike> projectedRows = Iterables.transform(Arrays.asList(rows), projection::wrap);
+    Iterable<StructLike> projectedRows =
+        Iterables.transform(
+            Arrays.asList(rows),
+            r -> StructProjection.create(tableSchema, projectedSchema).wrap(r));
     return CloseableIterable.withNoopClose(projectedRows);
   }
 


### PR DESCRIPTION
Add support on `IcebergGenerics` to read metadata files (e.g. `#partitions`, `#snapshots`, etc) without having to rely on a compute engine (or lower level APIs) to read the metadata of Iceberg tables.

This fixes https://github.com/apache/iceberg/issues/7351 which was throwing an `UnsupportedOperationException` when reading metadata tables.