### PR TITLE
Core, Spark: Make ObjectStoreLocationProvider serializable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -109,7 +109,7 @@ public class LocationProviders {
 
     private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
     private static final BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
-    private static final ThreadLocal<byte[]> temp = ThreadLocal.withInitial(() -> new byte[4]);
+    private static final ThreadLocal<byte[]> TEMP = ThreadLocal.withInitial(() -> new byte[4]);
     private final String storageLocation;
     private final String context;
 
@@ -172,7 +172,7 @@ public class LocationProviders {
     }
 
     private String computeHash(String fileName) {
-      byte[] bytes = temp.get();
+      byte[] bytes = TEMP.get();
       HashCode hash = HASH_FUNC.hashString(fileName, StandardCharsets.UTF_8);
       hash.writeBytesTo(bytes, 0, 4);
       return BASE64_ENCODER.encode(bytes);

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -109,7 +109,7 @@ public class LocationProviders {
 
     private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
     private static final BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
-    private transient ThreadLocal<byte[]> temp;
+    private static final ThreadLocal<byte[]> temp = ThreadLocal.withInitial(() -> new byte[4]);
     private final String storageLocation;
     private final String context;
 
@@ -172,9 +172,6 @@ public class LocationProviders {
     }
 
     private String computeHash(String fileName) {
-      if (temp == null) {
-        temp = ThreadLocal.withInitial(() -> new byte[4]);
-      }
       byte[] bytes = temp.get();
       HashCode hash = HASH_FUNC.hashString(fileName, StandardCharsets.UTF_8);
       hash.writeBytesTo(bytes, 0, 4);

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -109,7 +109,7 @@ public class LocationProviders {
 
     private static final HashFunction HASH_FUNC = Hashing.murmur3_32_fixed();
     private static final BaseEncoding BASE64_ENCODER = BaseEncoding.base64Url().omitPadding();
-    private final ThreadLocal<byte[]> temp = ThreadLocal.withInitial(() -> new byte[4]);
+    private transient ThreadLocal<byte[]> temp;
     private final String storageLocation;
     private final String context;
 
@@ -172,6 +172,9 @@ public class LocationProviders {
     }
 
     private String computeHash(String fileName) {
+      if (temp == null) {
+        temp = ThreadLocal.withInitial(() -> new byte[4]);
+      }
       byte[] bytes = temp.get();
       HashCode hash = HASH_FUNC.hashString(fileName, StandardCharsets.UTF_8);
       hash.writeBytesTo(bytes, 0, 4);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -33,10 +33,24 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class TestTableSerialization {
 
+  public TestTableSerialization(String isObjectStoreEnabled) {
+    this.isObjectStoreEnabled = isObjectStoreEnabled;
+  }
+
+  @Parameterized.Parameters(name = "isObjectStoreEnabled = {0}")
+  public static Object[] parameters() {
+    return new Object[] {"true", "false"};
+  }
+
   private static final HadoopTables TABLES = new HadoopTables();
+
+  private final String isObjectStoreEnabled;
 
   private static final Schema SCHEMA =
       new Schema(
@@ -55,7 +69,8 @@ public class TestTableSerialization {
 
   @Before
   public void initTable() throws IOException {
-    Map<String, String> props = ImmutableMap.of("k1", "v1", "k2", "v2");
+    Map<String, String> props =
+        ImmutableMap.of("k1", "v1", TableProperties.OBJECT_STORE_ENABLED, isObjectStoreEnabled);
 
     File tableLocation = temp.newFolder();
     Assert.assertTrue(tableLocation.delete());


### PR DESCRIPTION
### About the change

ThreadLocal is not serializable, hence using this in serializing the ObjectStoreLocationProvider makes it non-serializable which is used in creating the Serializable instance of table fail (which is used by spark to broadcast this instance to the executor, while doing read / write). Since by default ObjectLocationProvider was disabled hence this couldn't be caught by serialization tests automatically. 

Thanks @nastra for reporting this issue via https://github.com/apache/iceberg/issues/7345.

This change makes the ThreadLocal obj static, as well as make table serialization test run with / without obj store enabled property. 

cc @rdblue @jackye1995 @nastra 