### PR TITLE
Hive: Fix using Date type as partition field

### DIFF
--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -25,6 +25,8 @@ import static org.junit.runners.Parameterized.Parameter;
 import static org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -1208,6 +1210,51 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         customersWithNewFirstNameOnly,
         HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows),
         0);
+  }
+  
+  @Test
+  public void testWriteWithDatePartition() {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema dateSchema = new Schema(
+            optional(1, "id", Types.LongType.get()),
+            optional(2, "part_field", Types.DateType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(dateSchema).identity("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(dateSchema)
+            .add(1L, LocalDate.of(2023, 1, 21))
+            .add(2L, LocalDate.of(2023, 1, 22))
+            .add(3L, LocalDate.of(2022, 1, 21))
+            .build();
+    testTables.createTable(shell, "part_test", dateSchema, spec, FileFormat.PARQUET, records);
+    List<Object[]> result = shell.executeStatement("SELECT * from part_test order by id");
+
+    Assert.assertEquals(records.size(), result.size());
+    Assert.assertEquals("2023-01-21", result.get(0)[1]);
+    Assert.assertEquals("2023-01-22", result.get(1)[1]);
+    Assert.assertEquals("2022-01-21", result.get(2)[1]);
+  }
+
+  @Test
+  public void testWriteWithTimestampPartition() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema dateSchema = new Schema(
+            optional(1, "id", Types.LongType.get()),
+            optional(2, "part_field", Types.TimestampType.withoutZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(dateSchema).identity("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(dateSchema)
+            .add(1L, LocalDateTime.of(2023, 1, 21, 21, 10, 10, 100000000))
+            .add(2L, LocalDateTime.of(2023, 1, 21, 22, 10, 10, 200000000))
+            .add(3L, LocalDateTime.of(2023, 1, 22, 21, 10, 10, 300000000))
+            .build();
+    testTables.createTable(shell, "part_test", dateSchema, spec, FileFormat.PARQUET, records);
+    List<Object[]> result = shell.executeStatement("SELECT * from part_test order by id");
+
+    Assert.assertEquals(records.size(), result.size());
+    Assert.assertEquals("2023-01-21 21:10:10.1", result.get(0)[1]);
+    Assert.assertEquals("2023-01-21 22:10:10.2", result.get(1)[1]);
+    Assert.assertEquals("2023-01-22 21:10:10.3", result.get(2)[1]);
   }
 
   /**


### PR DESCRIPTION
When using date/timestampas a partition field, it will throw IllegalStateException: Not not instance of...

for example:
`create table iceberg_test(id int, name string) partitioned by (dt date) stored by 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler';`

then insert into :
`insert into iceberg_test values(1, 'xxx', '2023-01-01');`

The exception is as follows:
`java.lang.IllegalStateException: Not an instance of java.lang.Integer: 2023-01-01 at org.apache.iceberg.data.GenericRecord.get(GenericRecord.java:123) at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:71) at org.apache.iceberg.Accessors$PositionAccessor.get(Accessors.java:58) at org.apache.iceberg.PartitionKey.partition(PartitionKey.java:104) `

We will need to wrapping the record into an InternalRecordWrapper