### PR TITLE
Spark 3.3: Surface better error message during streaming planning when checkpoint snapshot not found

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -212,7 +212,16 @@ public class SparkMicroBatchStream implements MicroBatchStream {
         currentOffset = new StreamingOffset(snapshotAfter.snapshotId(), 0L, false);
       }
 
-      if (!shouldProcess(table.snapshot(currentOffset.snapshotId()))) {
+      Snapshot snapshot = table.snapshot(currentOffset.snapshotId());
+
+      if (snapshot == null) {
+        throw new IllegalStateException(
+            String.format(
+                "Cannot load current offset at snapshot %d, the snapshot was expired or removed",
+                currentOffset.snapshotId()));
+      }
+
+      if (!shouldProcess(snapshot)) {
         LOG.debug("Skipping snapshot: {} of table {}", currentOffset.snapshotId(), table.name());
         continue;
       }


### PR DESCRIPTION
This PR backports #6480 to 3.3 as it is part of 3.4 after PR #7378.