### PR TITLE
Spark 3.4: Add tests for SPJ when partition keys mismatch

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestStoragePartitionedJoinsInRowLevelOperations.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.sql.execution.SparkPlan;
 import org.apache.spark.sql.internal.SQLConf;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -137,7 +138,7 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
                       + "dep = 'hr'",
                   tableName, tableName(OTHER_TABLE_NAME));
           String planAsString = plan.toString();
-          Assert.assertFalse("Should be no shuffles with SPJ", planAsString.contains("Exchange"));
+          Assertions.assertThat(planAsString).doesNotContain("Exchange");
         });
 
     ImmutableList<Object[]> expectedRows =
@@ -200,7 +201,7 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
                       + "dep = 'hr'",
                   tableName, tableName(OTHER_TABLE_NAME));
           String planAsString = plan.toString();
-          Assert.assertFalse("Should be no shuffles with SPJ", planAsString.contains("Exchange"));
+          Assertions.assertThat(planAsString).doesNotContain("Exchange");
         });
 
     ImmutableList<Object[]> expectedRows =
@@ -271,11 +272,9 @@ public class TestStoragePartitionedJoinsInRowLevelOperations extends SparkExtens
           if (mode == COPY_ON_WRITE) {
             int actualNumShuffles = StringUtils.countMatches(planAsString, "Exchange");
             Assert.assertEquals("Should be 1 shuffle with SPJ", 1, actualNumShuffles);
-            Assert.assertTrue(
-                "Must only shuffle file names",
-                planAsString.contains("Exchange hashpartitioning(_file"));
+            Assertions.assertThat(planAsString).contains("Exchange hashpartitioning(_file");
           } else {
-            Assert.assertFalse("Should be no shuffles with SPJ", planAsString.contains("Exchange"));
+            Assertions.assertThat(planAsString).doesNotContain("Exchange");
           }
         });
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestStoragePartitionedJoins.java
@@ -60,6 +60,8 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
       ImmutableMap.of(
           SQLConf.V2_BUCKETING_ENABLED().key(),
           "true",
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED().key(),
+          "true",
           SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION().key(),
           "false",
           SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(),
@@ -94,7 +96,6 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
   }
 
   // TODO: add tests for truncate transforms once SPARK-40295 is released
-  // TODO: add tests for cases when one side contains a subset of keys once SPARK-41398 is released
 
   @Test
   public void testJoinsWithBucketingOnByteColumn() throws NoSuchTableException {
@@ -454,6 +455,40 @@ public class TestStoragePartitionedJoins extends SparkTestBaseWithCatalog {
             + "FROM %s t1 "
             + "INNER JOIN %s t2 "
             + "ON t1.id = t2.id AND t1.int_col = t2.int_col AND t1.dep = t2.dep "
+            + "ORDER BY t1.id, t1.int_col, t1.dep, t2.id, t2.int_col, t2.dep",
+        tableName,
+        tableName(OTHER_TABLE_NAME));
+  }
+
+  @Test
+  public void testJoinsWithMismatchingPartitionKeys() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep)"
+            + "TBLPROPERTIES (%s)",
+        tableName, tablePropsAsString(TABLE_PROPERTIES));
+
+    sql("INSERT INTO %s VALUES (1L, 100, 'software')", tableName);
+    sql("INSERT INTO %s VALUES (2L, 100, 'hr')", tableName);
+
+    sql(
+        "CREATE TABLE %s (id BIGINT, int_col INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep)"
+            + "TBLPROPERTIES (%s)",
+        tableName(OTHER_TABLE_NAME), tablePropsAsString(TABLE_PROPERTIES));
+
+    sql("INSERT INTO %s VALUES (1L, 100, 'software')", tableName(OTHER_TABLE_NAME));
+    sql("INSERT INTO %s VALUES (3L, 300, 'hardware')", tableName(OTHER_TABLE_NAME));
+
+    assertPartitioningAwarePlan(
+        1, /* expected num of shuffles with SPJ */
+        3, /* expected num of shuffles without SPJ */
+        "SELECT * "
+            + "FROM %s t1 "
+            + "INNER JOIN %s t2 "
+            + "ON t1.id = t2.id AND t1.dep = t2.dep "
             + "ORDER BY t1.id, t1.int_col, t1.dep, t2.id, t2.int_col, t2.dep",
         tableName,
         tableName(OTHER_TABLE_NAME));


### PR DESCRIPTION
This PR adds tests for SPJ when partition keys mismatch, which was not supported prior to 3.4. Now Iceberg supports SPJ in MERGE without limitations.