### PR TITLE
Allow sparksql to override target split size with session property

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.spark;
 
 import java.util.Map;
-import org.apache.arrow.util.VisibleForTesting;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -183,7 +182,9 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
-        .sessionConf(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
+        .sessionConf(
+            String.format(
+                SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
         .parseOptional();
   }
 
@@ -191,7 +192,9 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
-        .sessionConf(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
+        .sessionConf(
+            String.format(
+                SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -179,13 +179,18 @@ public class SparkReadConf {
   }
 
   public Long splitSizeOption() {
-    return confParser.longConf().option(SparkReadOptions.SPLIT_SIZE).parseOptional();
+    return confParser
+        .longConf()
+        .option(SparkReadOptions.SPLIT_SIZE)
+        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
+        .parseOptional();
   }
 
   public long splitSize() {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
+        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import java.util.Map;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -182,7 +183,7 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
-        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
+        .sessionConf(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
         .parseOptional();
   }
 
@@ -190,7 +191,7 @@ public class SparkReadConf {
     return confParser
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
-        .sessionConf(SparkSQLProperties.SPLIT_SIZE)
+        .sessionConf(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableNameWithoutCatalog(table.name())))
         .tableProperty(TableProperties.SPLIT_SIZE)
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();
@@ -275,5 +276,9 @@ public class SparkReadConf {
         .sessionConf(SparkSQLProperties.AGGREGATE_PUSH_DOWN_ENABLED)
         .defaultValue(SparkSQLProperties.AGGREGATE_PUSH_DOWN_ENABLED_DEFAULT)
         .parse();
+  }
+
+  private static String tableNameWithoutCatalog(String tableName) {
+    return tableName.split("\\.", 2)[1];
   }
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -63,4 +63,7 @@ public class SparkSQLProperties {
   // Controls the WAP branch used for write-audit-publish workflow.
   // When set, new snapshots will be committed to this branch.
   public static final String WAP_BRANCH = "spark.wap.branch";
+
+  // Controls read split size
+  public static final String SPLIT_SIZE = "spark.sql.iceberg.read-split-size";
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -64,6 +64,6 @@ public class SparkSQLProperties {
   // When set, new snapshots will be committed to this branch.
   public static final String WAP_BRANCH = "spark.wap.branch";
 
-  // Controls read split size
-  public static final String SPLIT_SIZE = "spark.sql.iceberg.read-split-size";
+  // Controls read split size for the individual table
+  public static final String TEMPLATED_SPLIT_SIZE = "spark.sql.iceberg.%s.read-split-size";
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -70,7 +70,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -95,7 +95,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithTblPropAndSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "2048"),
+        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "2048"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -111,7 +111,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithWriteOptionAndSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -127,7 +127,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithEverything() {
     withSQLConf(
-        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -70,7 +70,8 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
+        ImmutableMap.of(
+            String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -95,7 +96,8 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithTblPropAndSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "2048"),
+        ImmutableMap.of(
+            String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "2048"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -111,7 +113,8 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithWriteOptionAndSessionConfig() {
     withSQLConf(
-        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
+        ImmutableMap.of(
+            String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 
@@ -127,7 +130,8 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   @Test
   public void testSparkReadConfSplitSizeWithEverything() {
     withSQLConf(
-        ImmutableMap.of(String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
+        ImmutableMap.of(
+            String.format(SparkSQLProperties.TEMPLATED_SPLIT_SIZE, tableIdent.toString()), "1024"),
         () -> {
           Table table = validationCatalog.loadTable(tableIdent);
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
+
+import java.util.Map;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSparkReadConf extends SparkTestBaseWithCatalog {
+
+  @Before
+  public void before() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
+            + "USING iceberg "
+            + "PARTITIONED BY (date, days(ts))",
+        tableName);
+  }
+
+  @After
+  public void after() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testSparkReadConfSplitSizeDefault() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+
+    Assert.assertEquals(TableProperties.SPLIT_SIZE_DEFAULT, readConf.splitSize());
+    Assert.assertNull(readConf.splitSizeOption());
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithWriteOption() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Map<String, String> readOptions = ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, "1024");
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, readOptions);
+
+    Assert.assertEquals(1024, readConf.splitSize());
+    Assert.assertEquals(1024, readConf.splitSizeOption().longValue());
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithSessionConfig() {
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        () -> {
+          Table table = validationCatalog.loadTable(tableIdent);
+
+          SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+
+          Assert.assertEquals(1024, readConf.splitSize());
+          Assert.assertEquals(1024, readConf.splitSizeOption().longValue());
+        });
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithTableProperties() {
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties().set(SPLIT_SIZE, "1024").commit();
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(1024, readConf.splitSize());
+    Assert.assertEquals(null, readConf.splitSizeOption());
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithTblPropAndSessionConfig() {
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "2048"),
+        () -> {
+          Table table = validationCatalog.loadTable(tableIdent);
+
+          table.updateProperties().set(SPLIT_SIZE, "1024").commit();
+
+          SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+          // session config overwrite the table properties
+          Assert.assertEquals(2048, readConf.splitSize());
+          Assert.assertEquals(2048, readConf.splitSizeOption().longValue());
+        });
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithWriteOptionAndSessionConfig() {
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        () -> {
+          Table table = validationCatalog.loadTable(tableIdent);
+
+          Map<String, String> writeOptions = ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, "2048");
+
+          SparkReadConf readConf = new SparkReadConf(spark, table, writeOptions);
+          // read options overwrite the session config
+          Assert.assertEquals(2048, readConf.splitSize());
+          Assert.assertEquals(2048, readConf.splitSizeOption().longValue());
+        });
+  }
+
+  @Test
+  public void testSparkReadConfDistributionModeWithEverything() {
+    withSQLConf(
+        ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
+        () -> {
+          Table table = validationCatalog.loadTable(tableIdent);
+
+          Map<String, String> writeOptions = ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, "2048");
+
+          table.updateProperties().set(SPLIT_SIZE, "512").commit();
+
+          SparkReadConf readConf = new SparkReadConf(spark, table, writeOptions);
+          // read options take the highest priority
+          Assert.assertEquals(2048, readConf.splitSize());
+          Assert.assertEquals(2048, readConf.splitSizeOption().longValue());
+        });
+  }
+}

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -56,7 +56,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithWriteOption() {
+  public void testSparkReadConfSplitSizeWithWriteOption() {
     Table table = validationCatalog.loadTable(tableIdent);
 
     Map<String, String> readOptions = ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, "1024");
@@ -68,7 +68,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithSessionConfig() {
+  public void testSparkReadConfSplitSizeWithSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
         () -> {
@@ -82,7 +82,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithTableProperties() {
+  public void testSparkReadConfSplitSizeWithTableProperties() {
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(SPLIT_SIZE, "1024").commit();
@@ -93,7 +93,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithTblPropAndSessionConfig() {
+  public void testSparkReadConfSplitSizeWithTblPropAndSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "2048"),
         () -> {
@@ -109,7 +109,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithWriteOptionAndSessionConfig() {
+  public void testSparkReadConfSplitSizeWithWriteOptionAndSessionConfig() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
         () -> {
@@ -125,7 +125,7 @@ public class TestSparkReadConf extends SparkTestBaseWithCatalog {
   }
 
   @Test
-  public void testSparkReadConfDistributionModeWithEverything() {
+  public void testSparkReadConfSplitSizeWithEverything() {
     withSQLConf(
         ImmutableMap.of(SparkSQLProperties.SPLIT_SIZE, "1024"),
         () -> {


### PR DESCRIPTION
The target split size can be set in SparkSQL by `spark.sql.iceberg.db.tbl.read-split-size` where such config is a table oriented config.