### PR TITLE
Use fsspec implementation of LocalFileSystem

### DIFF
--- a/python/pyiceberg/io/fsspec.py
+++ b/python/pyiceberg/io/fsspec.py
@@ -31,7 +31,7 @@ import requests
 from botocore import UNSIGNED
 from botocore.awsrequest import AWSRequest
 from fsspec import AbstractFileSystem
-from pyarrow.filesystem import LocalFileSystem
+from fsspec.implementations.local import LocalFileSystem
 from requests import HTTPError
 
 from pyiceberg.catalog import TOKEN


### PR DESCRIPTION
Use fsspec implementation of LocalFileSysteminstead of pyarrow implementation

### Context
the io implementation [prefers ](https://github.com/apache/iceberg/blob/master/python/pyiceberg/io/__init__.py#L264)pyarrow and will [check if the ](https://github.com/apache/iceberg/blob/master/python/pyiceberg/io/__init__.py#L292-L301)pyarrow[ library exists](https://github.com/apache/iceberg/blob/master/python/pyiceberg/io/__init__.py#L292-L301). it then falls back to the fsspec implementation which [currently requires ](https://github.com/apache/iceberg/blob/master/python/pyiceberg/io/fsspec.py#L34)pyarrow[ as well](https://github.com/apache/iceberg/blob/master/python/pyiceberg/io/fsspec.py#L34)
from pyarrow.filesystem import LocalFileSystem

so it looks like theres current no way to use the fsspec io implementation...
