### PR TITLE
Spark: Fixed Typo in Spark Read Option Vectorization Javadoc

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -44,7 +44,7 @@ public class SparkReadOptions {
   // Overrides the table's read.split.open-file-cost
   public static final String FILE_OPEN_COST = "file-open-cost";
 
-  // Overrides the table's read.split.open-file-cost
+  //Overrides the table's read.parquet.vectorization.vectorization-enabled
   public static final String VECTORIZATION_ENABLED = "vectorization-enabled";
 
   // Overrides the table's read.parquet.vectorization.batch-size

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -50,7 +50,7 @@ public class SparkReadOptions {
   // Overrides the table's read.split.open-file-cost
   public static final String FILE_OPEN_COST = "file-open-cost";
 
-  // Overrides the table's read.split.open-file-cost
+  // Overrides the table's read.parquet.vectorization.vectorization-enabled
   public static final String VECTORIZATION_ENABLED = "vectorization-enabled";
 
   // Overrides the table's read.parquet.vectorization.batch-size

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -56,7 +56,7 @@ public class SparkReadOptions {
   // Overrides the table's read.split.open-file-cost
   public static final String FILE_OPEN_COST = "file-open-cost";
 
-  // Overrides the table's read.split.open-file-cost
+  // Overrides the table's read.parquet.vectorization.vectorization-enabled
   public static final String VECTORIZATION_ENABLED = "vectorization-enabled";
 
   // Overrides the table's read.parquet.vectorization.batch-size

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -56,7 +56,7 @@ public class SparkReadOptions {
   // Overrides the table's read.split.open-file-cost
   public static final String FILE_OPEN_COST = "file-open-cost";
 
-  // Overrides the table's read.split.open-file-cost
+  // Overrides the table's read.parquet.vectorization.vectorization-enabled
   public static final String VECTORIZATION_ENABLED = "vectorization-enabled";
 
   // Overrides the table's read.parquet.vectorization.batch-size


### PR DESCRIPTION
Closes #7438