### PR TITLE
Hive: Support connecting to multiple Hive-Catalog

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -59,10 +59,9 @@ import org.immutables.value.Value;
  *       UserGroupInformation#getUserName.
  *   <li>conf - name of an arbitrary configuration. The value of the configuration will be extracted
  *       from catalog properties and added to the cache key. A conf element should start with a
- *       "conf:" prefix which is followed by the configuration name. E.g. specifying
- *       "conf:metastore.catalog.default" will add "metastore.catalog.default" to the key, and so
- *       that configurations with different default catalog wouldn't share the same client pool.
- *       Multiple conf elements can be specified.
+ *       "conf:" prefix which is followed by the configuration name. E.g. specifying "conf:a.b.c"
+ *       will add "a.b.c" to the key, and so that configurations with different default catalog
+ *       wouldn't share the same client pool. Multiple conf elements can be specified.
  * </ul>
  */
 public class CachedClientPool implements ClientPool<IMetaStoreClient, TException> {
@@ -134,6 +133,7 @@ public class CachedClientPool implements ClientPool<IMetaStoreClient, TException
     // generate key elements in a certain order, so that the Key instances are comparable
     List<Object> elements = Lists.newArrayList();
     elements.add(conf.get(HiveConf.ConfVars.METASTOREURIS.varname, ""));
+    elements.add(conf.get(HiveCatalog.HIVE_CONF_CATALOG, "hive"));
     if (cacheKeys == null || cacheKeys.isEmpty()) {
       return Key.of(elements);
     }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -64,8 +64,6 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   public static final String LIST_ALL_TABLES = "list-all-tables";
   public static final String LIST_ALL_TABLES_DEFAULT = "false";
 
-  public static final String HMS_CATALOG = "hive-catalog";
-
   public static final String HMS_TABLE_OWNER = "hive.metastore.table.owner";
   public static final String HMS_DB_OWNER = "hive.metastore.database.owner";
   public static final String HMS_DB_OWNER_TYPE = "hive.metastore.database.owner-type";
@@ -101,10 +99,6 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
       this.conf.set(
           HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
           LocationUtil.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
-    }
-
-    if (properties.containsKey(HiveCatalog.HMS_CATALOG)) {
-      this.conf.set(HIVE_CONF_CATALOG, properties.get(HiveCatalog.HMS_CATALOG));
     }
 
     this.listAllTables =

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -64,9 +64,14 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   public static final String LIST_ALL_TABLES = "list-all-tables";
   public static final String LIST_ALL_TABLES_DEFAULT = "false";
 
+  public static final String HMS_CATALOG = "hive-catalog";
+
   public static final String HMS_TABLE_OWNER = "hive.metastore.table.owner";
   public static final String HMS_DB_OWNER = "hive.metastore.database.owner";
   public static final String HMS_DB_OWNER_TYPE = "hive.metastore.database.owner-type";
+
+  // MetastoreConf is not available with current Hive version
+  static final String HIVE_CONF_CATALOG = "metastore.catalog.default";
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
@@ -96,6 +101,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
       this.conf.set(
           HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
           LocationUtil.stripTrailingSlash(properties.get(CatalogProperties.WAREHOUSE_LOCATION)));
+    }
+
+    if (properties.containsKey(HiveCatalog.HMS_CATALOG)) {
+      this.conf.set(HIVE_CONF_CATALOG, properties.get(HiveCatalog.HMS_CATALOG));
     }
 
     this.listAllTables =

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
@@ -163,5 +163,9 @@ public class TestCachedClientPool extends HiveMetastoreTest {
     Assert.assertEquals("foo", pool1.hiveConf().get(HiveCatalog.HIVE_CONF_CATALOG));
     Assert.assertEquals("bar", pool3.hiveConf().get(HiveCatalog.HIVE_CONF_CATALOG));
     Assert.assertNull(pool4.hiveConf().get(HiveCatalog.HIVE_CONF_CATALOG));
+
+    pool1.close();
+    pool3.close();
+    pool4.close();
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestCachedClientPool.java
@@ -18,12 +18,16 @@
  */
 package org.apache.iceberg.hive;
 
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE;
+import static org.apache.iceberg.CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE;
+
 import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hive.CachedClientPool.Key;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -122,35 +126,27 @@ public class TestCachedClientPool extends HiveMetastoreTest {
 
   @Test
   public void testHmsCatalog() {
-    Map<String, String> properties1 =
+    Map<String, String> properties =
         ImmutableMap.of(
             String.valueOf(EVICTION_INTERVAL),
             String.valueOf(Integer.MAX_VALUE),
-            HiveCatalog.HMS_CATALOG,
-            "foo");
-    Map<String, String> properties2 =
-        ImmutableMap.of(
-            String.valueOf(EVICTION_INTERVAL),
-            String.valueOf(Integer.MAX_VALUE),
-            HiveCatalog.HMS_CATALOG,
-            "foo");
-    Map<String, String> properties3 =
-        ImmutableMap.of(
-            String.valueOf(EVICTION_INTERVAL),
-            String.valueOf(Integer.MAX_VALUE),
-            HiveCatalog.HMS_CATALOG,
-            "bar");
-    Map<String, String> properties4 =
-        ImmutableMap.of(String.valueOf(EVICTION_INTERVAL), String.valueOf(Integer.MAX_VALUE));
+            ICEBERG_CATALOG_TYPE,
+            ICEBERG_CATALOG_TYPE_HIVE);
 
-    HiveCatalog catalog1 = new HiveCatalog();
-    catalog1.initialize("foo", properties1);
-    HiveCatalog catalog2 = new HiveCatalog();
-    catalog2.initialize("foo", properties2);
-    HiveCatalog catalog3 = new HiveCatalog();
-    catalog3.initialize("bar", properties3);
-    HiveCatalog catalog4 = new HiveCatalog();
-    catalog4.initialize("none", properties4);
+    Configuration conf1 = new Configuration();
+    conf1.set(HiveCatalog.HIVE_CONF_CATALOG, "foo");
+
+    Configuration conf2 = new Configuration();
+    conf2.set(HiveCatalog.HIVE_CONF_CATALOG, "foo");
+
+    Configuration conf3 = new Configuration();
+    conf3.set(HiveCatalog.HIVE_CONF_CATALOG, "bar");
+
+    HiveCatalog catalog1 = (HiveCatalog) CatalogUtil.buildIcebergCatalog("1", properties, conf1);
+    HiveCatalog catalog2 = (HiveCatalog) CatalogUtil.buildIcebergCatalog("2", properties, conf2);
+    HiveCatalog catalog3 = (HiveCatalog) CatalogUtil.buildIcebergCatalog("3", properties, conf3);
+    HiveCatalog catalog4 =
+        (HiveCatalog) CatalogUtil.buildIcebergCatalog("4", properties, new Configuration());
 
     HiveClientPool pool1 = ((CachedClientPool) catalog1.clientPool()).clientPool();
     HiveClientPool pool2 = ((CachedClientPool) catalog2.clientPool()).clientPool();


### PR DESCRIPTION
_Note:   As the term Hive-Catalog is overloaded across, I'll use "Iceberg-HiveCatalog" to refer to Iceberg's HiveCatalog class and "HMS Catalog" to refer to Hive specific concept._

https://issues.apache.org/jira/browse/HIVE-18685 added support for HMS catalogs, ie different namespaces for dbs/tables in the metastore.

However, the Iceberg-HiveCatalog uses a global cache of HMS connections based on Hive-Metastore-URI.  This prevents different Iceberg-HiveCatalogs existing in same JVM from talking to different HMS Catalogs on same HMS.  See issue:  https://github.com/apache/iceberg/pull/5378.  This is important for example in Spark, where user may try to configure different SparkCatalog pointing to separate catalog on same HMS.   

This change takes advantage of https://github.com/apache/iceberg/pull/6698 to fix this.  It does two things:

- Add a 'hive-catalog'  flag on Iceberg-HiveCatalog (similar to "uri" and "warehouse"), which automatically sets this on HMS client to point to right HMS Catalog.  
- Adds the HMS client config "metastore.catalog.default" to the list of HMS Client cache keys.

From Spark point of view, user can configure 'spark.sql.catalog.$cat1.hive-catalog=foo', 'spark.sql.catalog.$cat2.hive-catalog=bar'.

Note; @RussellSpitzer pointed to me that setting  spark.sql.catalog.$myCatalog.hadoop.metastore.catalog.default=foo seems to work to configure each SparkCatalog.  But it is a bit clunky and undocumented, and hence the proposal to add 'hive_catalog' shorthand.

In either case, the second change is needed to allow different cached connections on same HMS to go to different HMS-catalogs. 
