### PR TITLE
Delta Migration: Add version and timestamp tags for each Delta Lake transaction when add to Iceberg transaction

### DIFF
--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -424,8 +424,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
       Timestamp deltaVersionTimestamp = deltaLog.getCommitInfoAt(deltaVersion).getTimestamp();
       Assertions.assertThat(deltaVersionTimestamp).isNotNull();
-      long rawDeltaTimestamp = deltaVersionTimestamp.getTime();
-      String expectedTimestampTag = "delta-ts-" + rawDeltaTimestamp;
+      String expectedTimestampTag = "delta-ts-" + deltaVersionTimestamp.getTime();
 
       Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag)).isNotNull();
       Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag).isTag()).isTrue();

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -33,16 +33,23 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.net.URLCodec;
+import org.apache.iceberg.ManageSnapshots;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.util.LocationUtil;
@@ -173,6 +180,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             .execute();
 
     checkSnapshotIntegrity(partitionedLocation, partitionedIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(partitionedLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, partitionedLocation);
   }
 
@@ -193,6 +201,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
     checkSnapshotIntegrity(
         unpartitionedLocation, unpartitionedIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(unpartitionedLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, unpartitionedLocation);
   }
 
@@ -214,6 +223,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             .execute();
 
     checkSnapshotIntegrity(partitionedLocation, partitionedIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(partitionedLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, newIcebergTableLocation);
   }
 
@@ -245,6 +255,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
 
     checkSnapshotIntegrity(
         unpartitionedLocation, unpartitionedIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(unpartitionedLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, unpartitionedLocation);
     checkIcebergTableProperties(
         newTableIdentifier,
@@ -278,6 +289,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             .execute();
     checkSnapshotIntegrity(
         externalDataFilesTableLocation, externalDataFilesIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(externalDataFilesTableLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, externalDataFilesTableLocation);
     checkDataFilePathsIntegrity(newTableIdentifier, externalDataFilesTableLocation);
   }
@@ -295,6 +307,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             .tableProperty(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false")
             .execute();
     checkSnapshotIntegrity(typeTestTableLocation, typeTestIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(typeTestTableLocation, newTableIdentifier, 0);
     checkIcebergTableLocation(newTableIdentifier, typeTestTableLocation);
     checkIcebergTableProperties(
         newTableIdentifier,
@@ -334,6 +347,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
     checkSnapshotIntegrity(
         vacuumTestTableLocation, vacuumTestIdentifier, newTableIdentifier, result);
     checkIcebergTableLocation(newTableIdentifier, vacuumTestTableLocation);
+    checkTagContentAndOrder(vacuumTestTableLocation, newTableIdentifier, 13);
   }
 
   @Test
@@ -366,6 +380,7 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
             .execute();
     checkSnapshotIntegrity(
         logCleanTestTableLocation, logCleanTestIdentifier, newTableIdentifier, result);
+    checkTagContentAndOrder(logCleanTestTableLocation, newTableIdentifier, 10);
     checkIcebergTableLocation(newTableIdentifier, logCleanTestTableLocation);
   }
 
@@ -386,6 +401,45 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
         .hasSize((int) snapshotReport.snapshotDataFilesCount());
     Assertions.assertThat(icebergTableContents)
         .containsExactlyInAnyOrderElementsOf(deltaTableContents);
+  }
+
+  private void checkTagContentAndOrder(
+      String deltaTableLocation,
+      String icebergTableIdentifier,
+      long firstConstructableVersion
+  ) {
+    DeltaLog deltaLog = DeltaLog.forTable(spark.sessionState().newHadoopConf(), deltaTableLocation);
+    long currentVersion = deltaLog.snapshot().getVersion();
+    Table icebergTable = getIcebergTable(icebergTableIdentifier);
+    Map<String, SnapshotRef> icebergSnapshotRefs = icebergTable.refs();
+    List<Snapshot> icebergSnapshots = Lists.newArrayList(icebergTable.snapshots());
+
+    Assertions.assertThat(icebergSnapshots.size()).isEqualTo(currentVersion - firstConstructableVersion + 1);
+
+    for (int i = 0; i < icebergSnapshots.size(); i++) {
+      long deltaVersion = firstConstructableVersion + i;
+      Snapshot currentIcebergSnapshot = icebergSnapshots.get(i);
+
+      String expectedVersionTag = "delta-version-" + deltaVersion;
+      icebergSnapshotRefs.get(expectedVersionTag);
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedVersionTag))
+          .isNotNull();
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedVersionTag).snapshotId())
+          .isEqualTo(currentIcebergSnapshot.snapshotId());
+
+      Timestamp deltaVersionTimestamp = deltaLog.getCommitInfoAt(deltaVersion).getTimestamp();
+      Assertions.assertThat(deltaVersionTimestamp).isNotNull();
+      SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+      dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+      String formattedDeltaTimestamp = dateFormat.format(deltaVersionTimestamp);
+      String expectedTimestampTag = "delta-version-timestamp-" + formattedDeltaTimestamp;
+
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag))
+          .isNotNull();
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag).snapshotId())
+          .isEqualTo(currentIcebergSnapshot.snapshotId());
+
+    }
   }
 
   private void checkIcebergTableLocation(String icebergTableIdentifier, String expectedLocation) {

--- a/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
+++ b/delta-lake/src/integration/java/org/apache/iceberg/delta/TestSnapshotDeltaLakeTable.java
@@ -34,8 +34,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -420,19 +418,17 @@ public class TestSnapshotDeltaLakeTable extends SparkDeltaLakeSnapshotTestBase {
       String expectedVersionTag = "delta-version-" + deltaVersion;
       icebergSnapshotRefs.get(expectedVersionTag);
       Assertions.assertThat(icebergSnapshotRefs.get(expectedVersionTag)).isNotNull();
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedVersionTag).isTag()).isTrue();
       Assertions.assertThat(icebergSnapshotRefs.get(expectedVersionTag).snapshotId())
           .isEqualTo(currentIcebergSnapshot.snapshotId());
 
       Timestamp deltaVersionTimestamp = deltaLog.getCommitInfoAt(deltaVersion).getTimestamp();
       Assertions.assertThat(deltaVersionTimestamp).isNotNull();
-      String formattedDeltaTimestamp =
-          deltaVersionTimestamp
-              .toInstant()
-              .atZone(ZoneId.of("UTC"))
-              .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"));
-      String expectedTimestampTag = "delta-" + formattedDeltaTimestamp;
+      long rawDeltaTimestamp = deltaVersionTimestamp.getTime();
+      String expectedTimestampTag = "delta-ts-" + rawDeltaTimestamp;
 
       Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag)).isNotNull();
+      Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag).isTag()).isTrue();
       Assertions.assertThat(icebergSnapshotRefs.get(expectedTimestampTag).snapshotId())
           .isEqualTo(currentIcebergSnapshot.snapshotId());
     }

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -430,8 +430,8 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
 
     Timestamp deltaVersionTimestamp = deltaLog.getCommitInfoAt(deltaVersion).getTimestamp();
     if (deltaVersionTimestamp != null) {
-      long rawDeltaTimestamp = deltaVersionTimestamp.getTime();
-      manageSnapshots.createTag(DELTA_TIMESTAMP_TAG_PREFIX + rawDeltaTimestamp, currentSnapshotId);
+      manageSnapshots.createTag(
+          DELTA_TIMESTAMP_TAG_PREFIX + deltaVersionTimestamp.getTime(), currentSnapshotId);
     }
     manageSnapshots.commit();
   }

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -27,8 +27,6 @@ import io.delta.standalone.exceptions.DeltaStandaloneException;
 import java.io.File;
 import java.net.URI;
 import java.sql.Timestamp;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -84,9 +82,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
   private static final String ORIGINAL_LOCATION_PROP = "original_location";
   private static final String PARQUET_SUFFIX = ".parquet";
   private static final String DELTA_VERSION_TAG_PREFIX = "delta-version-";
-  private static final String DELTA_TIMESTAMP_TAG_PREFIX = "delta-";
-  private static final String DELTA_TIME_STAMP_ZONE = "UTC";
-  private static final String DELTA_TIME_STAMP_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS";
+  private static final String DELTA_TIMESTAMP_TAG_PREFIX = "delta-ts-";
   private final ImmutableMap.Builder<String, String> additionalPropertiesBuilder =
       ImmutableMap.builder();
   private DeltaLog deltaLog;
@@ -434,13 +430,8 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
 
     Timestamp deltaVersionTimestamp = deltaLog.getCommitInfoAt(deltaVersion).getTimestamp();
     if (deltaVersionTimestamp != null) {
-      String formattedDeltaTimestamp =
-          deltaVersionTimestamp
-              .toInstant()
-              .atZone(ZoneId.of(DELTA_TIME_STAMP_ZONE))
-              .format(DateTimeFormatter.ofPattern(DELTA_TIME_STAMP_FORMAT));
-      manageSnapshots.createTag(
-          DELTA_TIMESTAMP_TAG_PREFIX + formattedDeltaTimestamp, currentSnapshotId);
+      long rawDeltaTimestamp = deltaVersionTimestamp.getTime();
+      manageSnapshots.createTag(DELTA_TIMESTAMP_TAG_PREFIX + rawDeltaTimestamp, currentSnapshotId);
     }
     manageSnapshots.commit();
   }


### PR DESCRIPTION
Fixes #6769 

For each Iceberg transaction migrated, add `delta-version-xxx` and `delta-ts-xxxxx` tag to the snapshot. `delta-version-xxx` represents the logical delta lake version. `delta-ts-xxxxx` represents the commit time of the corresponding delta lake transaction