### PR TITLE
Spark 3.4: Time range rewrite data files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -121,6 +121,30 @@ public interface RewriteDataFiles
   String REWRITE_JOB_ORDER_DEFAULT = RewriteJobOrder.NONE.orderName();
 
   /**
+   * The start snapshot id to use for the rewrite operation (exclusive). Cannot be used with
+   * start-timestamp.
+   */
+  String START_SNAPSHOT_ID = "start-snapshot-id";
+
+  /**
+   * The end snapshot id to use for the rewrite operation (inclusive). Cannot be used with
+   * end-timestamp.
+   */
+  String END_SNAPSHOT_ID = "end-snapshot-id";
+
+  /**
+   * The start timestamp to use for the rewrite operation (exclusive). Cannot be used with
+   * start-snapshot-id.
+   */
+  String START_TIMESTAMP = "start-timestamp";
+
+  /**
+   * The end timestamp to use for the rewrite operation (inclusive). Cannot be used with
+   * end-snapshot-id.
+   */
+  String END_TIMESTAMP = "end-timestamp";
+
+  /**
    * Choose BINPACK as a strategy for this rewrite operation
    *
    * @return this for method chaining
@@ -171,6 +195,50 @@ public interface RewriteDataFiles
    * @return this for chaining
    */
   RewriteDataFiles filter(Expression expression);
+
+  /**
+   * Specify the start snapshot id to use for the rewrite operation. Cannot be used with
+   * start-timestamp.
+   *
+   * @param newStartSnapshotId the snapshot id to start the rewrite from (exclusive)
+   * @return this for chaining
+   */
+  default RewriteDataFiles startSnapshotId(Long newStartSnapshotId) {
+    throw new UnsupportedOperationException("Start Snapshot id not implemented for this framework");
+  }
+
+  /**
+   * Specify the end snapshot id to use for the rewrite operation. Cannot be used with
+   * end-timestamp.
+   *
+   * @param newEndSnapshotId the snapshot id to end the rewrite at (inclusive)
+   * @return this for chaining
+   */
+  default RewriteDataFiles endSnapshotId(Long newEndSnapshotId) {
+    throw new UnsupportedOperationException("End Snapshot id not implemented for this framework");
+  }
+
+  /**
+   * Specify the start timestamp to use for the rewrite operation. Cannot be used with
+   * start-snapshot-id.
+   *
+   * @param newStartTimestamp the timestamp to start the rewrite from (exclusive)
+   * @return this for chaining
+   */
+  default RewriteDataFiles startTimestamp(Long newStartTimestamp) {
+    throw new UnsupportedOperationException("Start timestamp not implemented for this framework");
+  }
+
+  /**
+   * Specify the end timestamp to use for the rewrite operation. Cannot be used with
+   * end-snapshot-id.
+   *
+   * @param newEndTimestamp the timestamp to end the rewrite at (inclusive)
+   * @return this for chaining
+   */
+  default RewriteDataFiles endTimestamp(Long newEndTimestamp) {
+    throw new UnsupportedOperationException("End timestamp not implemented for this framework");
+  }
 
   /**
    * A map of file group information to the results of rewriting that file group. If the results are

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -34,7 +34,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.RewriteJobOrder;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -62,6 +64,7 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecut
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.StructLikeMap;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.SparkSession;
@@ -81,7 +84,11 @@ public class RewriteDataFilesSparkAction
           PARTIAL_PROGRESS_MAX_COMMITS,
           TARGET_FILE_SIZE_BYTES,
           USE_STARTING_SEQUENCE_NUMBER,
-          REWRITE_JOB_ORDER);
+          REWRITE_JOB_ORDER,
+          START_SNAPSHOT_ID,
+          END_SNAPSHOT_ID,
+          START_TIMESTAMP,
+          END_TIMESTAMP);
 
   private final Table table;
 
@@ -92,6 +99,9 @@ public class RewriteDataFilesSparkAction
   private boolean useStartingSequenceNumber;
   private RewriteJobOrder rewriteJobOrder;
   private FileRewriter<FileScanTask, DataFile> rewriter = null;
+
+  private Long startSnapshotId = null;
+  private Long endSnapshotId = null;
 
   RewriteDataFilesSparkAction(SparkSession spark, Table table) {
     super(spark.cloneSession());
@@ -144,6 +154,34 @@ public class RewriteDataFilesSparkAction
   }
 
   @Override
+  public RewriteDataFiles startSnapshotId(Long newStartSnapshotId) {
+    Preconditions.checkArgument(newStartSnapshotId != null, "start snapshot id cannot be null");
+    option(START_SNAPSHOT_ID, Long.toString(newStartSnapshotId));
+    return this;
+  }
+
+  @Override
+  public RewriteDataFiles endSnapshotId(Long newEndSnapshotId) {
+    Preconditions.checkArgument(newEndSnapshotId != null, "end snapshot id cannot be null");
+    option(END_SNAPSHOT_ID, Long.toString(newEndSnapshotId));
+    return this;
+  }
+
+  @Override
+  public RewriteDataFiles startTimestamp(Long newStartTimestamp) {
+    Preconditions.checkArgument(newStartTimestamp != null, "start timestamp cannot be null");
+    option(START_TIMESTAMP, Long.toString(newStartTimestamp));
+    return this;
+  }
+
+  @Override
+  public RewriteDataFiles endTimestamp(Long newEndTimestamp) {
+    Preconditions.checkArgument(newEndTimestamp != null, "end timestamp cannot be null");
+    option(END_TIMESTAMP, Long.toString(newEndTimestamp));
+    return this;
+  }
+
+  @Override
   public RewriteDataFiles.Result execute() {
     if (table.currentSnapshot() == null) {
       return ImmutableRewriteDataFiles.Result.builder().rewriteResults(ImmutableList.of()).build();
@@ -158,8 +196,13 @@ public class RewriteDataFilesSparkAction
 
     validateAndInitOptions();
 
-    Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition =
-        planFileGroups(startingSnapshotId);
+    Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition;
+    if (startSnapshotId != null || endSnapshotId != null) {
+      fileGroupsByPartition = planIncrementalScanFileGroups();
+    } else {
+      fileGroupsByPartition = planScanFileGroups(startingSnapshotId);
+    }
+
     RewriteExecutionContext ctx = new RewriteExecutionContext(fileGroupsByPartition);
 
     if (ctx.totalGroupCount() == 0) {
@@ -177,7 +220,7 @@ public class RewriteDataFilesSparkAction
     }
   }
 
-  Map<StructLike, List<List<FileScanTask>>> planFileGroups(long startingSnapshotId) {
+  Map<StructLike, List<List<FileScanTask>>> planScanFileGroups(long startingSnapshotId) {
     CloseableIterable<FileScanTask> fileScanTasks =
         table
             .newScan()
@@ -186,6 +229,28 @@ public class RewriteDataFilesSparkAction
             .ignoreResiduals()
             .planFiles();
 
+    return planFileGroups(fileScanTasks);
+  }
+
+  Map<StructLike, List<List<FileScanTask>>> planIncrementalScanFileGroups() {
+    IncrementalAppendScan scan = table.newIncrementalAppendScan();
+
+    if (startSnapshotId != null) {
+      scan = scan.fromSnapshotExclusive(startSnapshotId);
+    }
+
+    if (endSnapshotId == null) {
+      endSnapshotId = table.currentSnapshot().snapshotId();
+    }
+
+    CloseableIterable<FileScanTask> fileScanTasks =
+        scan.toSnapshot(endSnapshotId).filter(filter).ignoreResiduals().planFiles();
+
+    return planFileGroups(fileScanTasks);
+  }
+
+  private StructLikeMap<List<List<FileScanTask>>> planFileGroups(
+      CloseableIterable<FileScanTask> fileScanTasks) {
     try {
       StructType partitionType = table.spec().partitionType();
       StructLikeMap<List<FileScanTask>> filesByPartition = StructLikeMap.create(partitionType);
@@ -444,6 +509,39 @@ public class RewriteDataFilesSparkAction
         RewriteJobOrder.fromName(
             PropertyUtil.propertyAsString(options(), REWRITE_JOB_ORDER, REWRITE_JOB_ORDER_DEFAULT));
 
+    startSnapshotId = PropertyUtil.propertyAsNullableLong(options(), START_SNAPSHOT_ID);
+    Long startTimestamp = PropertyUtil.propertyAsNullableLong(options(), START_TIMESTAMP);
+    endSnapshotId = PropertyUtil.propertyAsNullableLong(options(), END_SNAPSHOT_ID);
+    Long endTimestamp = PropertyUtil.propertyAsNullableLong(options(), END_TIMESTAMP);
+
+    Preconditions.checkArgument(
+        !(startSnapshotId != null && startTimestamp != null),
+        "Cannot set both %s and %s",
+        RewriteDataFiles.START_SNAPSHOT_ID,
+        RewriteDataFiles.START_TIMESTAMP);
+
+    Preconditions.checkArgument(
+        !(endSnapshotId != null && endTimestamp != null),
+        "Cannot set both %s and %s",
+        RewriteDataFiles.END_SNAPSHOT_ID,
+        RewriteDataFiles.END_TIMESTAMP);
+
+    if (startTimestamp != null && endTimestamp != null) {
+      Preconditions.checkArgument(
+          startTimestamp < endTimestamp,
+          "Cannot set %s to be greater than %s",
+          RewriteDataFiles.START_TIMESTAMP,
+          RewriteDataFiles.END_TIMESTAMP);
+    }
+
+    if (startTimestamp != null) {
+      startSnapshotId = getStartSnapshotId(startTimestamp);
+    }
+
+    if (endTimestamp != null) {
+      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp);
+    }
+
     Preconditions.checkArgument(
         maxConcurrentFileGroupRewrites >= 1,
         "Cannot set %s to %s, the value must be positive.",
@@ -456,6 +554,21 @@ public class RewriteDataFilesSparkAction
         PARTIAL_PROGRESS_MAX_COMMITS,
         maxCommits,
         PARTIAL_PROGRESS_ENABLED);
+  }
+
+  private Long getStartSnapshotId(Long startTimestamp) {
+    Snapshot oldestSnapshotAfter = SnapshotUtil.oldestAncestorAfter(table, startTimestamp);
+    Preconditions.checkArgument(
+        oldestSnapshotAfter != null,
+        "Cannot find a snapshot older than %s for table %s",
+        startTimestamp,
+        table.name());
+
+    if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
+      return oldestSnapshotAfter.snapshotId();
+    } else {
+      return oldestSnapshotAfter.parentId();
+    }
   }
 
   private String jobDesc(RewriteFileGroup group, RewriteExecutionContext ctx) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -104,6 +104,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.internal.SQLConf;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -176,6 +177,274 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 1);
     List<Object[]> actual = currentData();
 
+    assertEquals("Rows must match", expectedRecords, actual);
+  }
+
+  @Test
+  public void testIncrementDataRewriteWithStart() {
+    Table table = createTable(4);
+    shouldHaveFiles(table, 4);
+    table.refresh();
+    Snapshot snapshotA = table.currentSnapshot();
+    long snapshotAId = snapshotA.snapshotId();
+    long snapshotATimestamp = snapshotA.timestampMillis();
+    waitUntilAfter(snapshotATimestamp);
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotB = table.currentSnapshot();
+    long snapshotBId = snapshotB.snapshotId();
+    long snapshotBTimestamp = snapshotB.timestampMillis();
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotC = table.currentSnapshot();
+    long snapshotCId = snapshotC.snapshotId();
+
+    List<Object[]> expectedRecords = currentData();
+    long dataSizeBefore =
+        Streams.stream(
+                table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotAId).planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+
+    Result result = basicRewrite(table).startTimestamp(snapshotATimestamp).execute();
+    assertResult(table, expectedRecords, 8 + 8, 4 + 1, dataSizeBefore, result);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result =
+        basicRewrite(table)
+            .option(RewriteDataFiles.START_TIMESTAMP, String.valueOf(snapshotATimestamp))
+            .execute();
+    assertResult(table, expectedRecords, 8 + 8, 4 + 1, dataSizeBefore, result);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result2 = basicRewrite(table).startSnapshotId(snapshotAId).execute();
+    assertResult(table, expectedRecords, 8 + 8, 4 + 1, dataSizeBefore, result2);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result2 =
+        basicRewrite(table)
+            .option(RewriteDataFiles.START_SNAPSHOT_ID, String.valueOf(snapshotAId))
+            .execute();
+    assertResult(table, expectedRecords, 8 + 8, 4 + 1, dataSizeBefore, result2);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    dataSizeBefore =
+        Streams.stream(
+                table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotBId).planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+    Result result3 = basicRewrite(table).startTimestamp(snapshotBTimestamp).execute();
+    assertResult(table, expectedRecords, 8, 4 + 8 + 1, dataSizeBefore, result3);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result4 = basicRewrite(table).startSnapshotId(snapshotBId).execute();
+    assertResult(table, expectedRecords, 8, 4 + 8 + 1, dataSizeBefore, result4);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                basicRewrite(table)
+                    .startSnapshotId(snapshotAId)
+                    .startTimestamp(snapshotATimestamp)
+                    .execute())
+        .hasMessage(
+            "Cannot set both %s and %s",
+            RewriteDataFiles.START_SNAPSHOT_ID, RewriteDataFiles.START_TIMESTAMP);
+
+    Assertions.assertThatThrownBy(() -> basicRewrite(table).startSnapshotId(null).execute())
+        .hasMessage("start snapshot id cannot be null");
+
+    Assertions.assertThatThrownBy(
+            () -> basicRewrite(table).startTimestamp(Long.MAX_VALUE).execute())
+        .hasMessage("Cannot find a snapshot older than %s for table %s", Long.MAX_VALUE, table);
+  }
+
+  @Test
+  public void testIncrementDataRewriteWithEnd() {
+    Table table = createTable(4);
+    shouldHaveFiles(table, 4);
+    table.refresh();
+    Snapshot snapshotA = table.currentSnapshot();
+    long snapshotAId = snapshotA.snapshotId();
+    long snapshotATimestamp = snapshotA.timestampMillis();
+    waitUntilAfter(snapshotATimestamp);
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotB = table.currentSnapshot();
+    long snapshotBId = snapshotB.snapshotId();
+    long snapshotBTimestamp = snapshotB.timestampMillis();
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotC = table.currentSnapshot();
+    long snapshotCId = snapshotC.snapshotId();
+    long snapshotCTimestamp = snapshotC.timestampMillis();
+
+    List<Object[]> expectedRecords = currentData();
+
+    long dataSizeBefore =
+        Streams.stream(table.newIncrementalAppendScan().toSnapshot(snapshotBId).planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+
+    Result result = basicRewrite(table).endTimestamp(snapshotBTimestamp).execute();
+    assertResult(table, expectedRecords, 4 + 8, 1 + 8, dataSizeBefore, result);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result =
+        basicRewrite(table)
+            .option(RewriteDataFiles.END_TIMESTAMP, String.valueOf(snapshotBTimestamp))
+            .execute();
+    assertResult(table, expectedRecords, 4 + 8, 1 + 8, dataSizeBefore, result);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result2 = basicRewrite(table).endSnapshotId(snapshotBId).execute();
+    assertResult(table, expectedRecords, 4 + 8, 1 + 8, dataSizeBefore, result2);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result2 =
+        basicRewrite(table)
+            .option(RewriteDataFiles.END_SNAPSHOT_ID, String.valueOf(snapshotBId))
+            .execute();
+    assertResult(table, expectedRecords, 4 + 8, 1 + 8, dataSizeBefore, result2);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    dataSizeBefore =
+        Streams.stream(table.newIncrementalAppendScan().planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+    Result result3 = basicRewrite(table).endTimestamp(snapshotCTimestamp).execute();
+    assertResult(table, expectedRecords, 4 + 8 + 8, 1, dataSizeBefore, result3);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result4 = basicRewrite(table).endSnapshotId(snapshotCId).execute();
+    assertResult(table, expectedRecords, 4 + 8 + 8, 1, dataSizeBefore, result4);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                basicRewrite(table)
+                    .endSnapshotId(snapshotBId)
+                    .endTimestamp(snapshotBTimestamp)
+                    .execute())
+        .hasMessage(
+            "Cannot set both %s and %s",
+            RewriteDataFiles.END_SNAPSHOT_ID, RewriteDataFiles.END_TIMESTAMP);
+
+    Assertions.assertThatThrownBy(() -> basicRewrite(table).endSnapshotId(null).execute())
+        .hasMessage("end snapshot id cannot be null");
+  }
+
+  @Test
+  public void testIncrementDataRewriteWithStartAndEnd() {
+    Table table = createTable(4);
+    shouldHaveFiles(table, 4);
+    table.refresh();
+    Snapshot snapshotA = table.currentSnapshot();
+    long snapshotAId = snapshotA.snapshotId();
+    long snapshotATimestamp = snapshotA.timestampMillis();
+    waitUntilAfter(snapshotATimestamp);
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotB = table.currentSnapshot();
+    long snapshotBId = snapshotB.snapshotId();
+    long snapshotBTimestamp = snapshotB.timestampMillis();
+
+    writeRecords(8, SCALE);
+    table.refresh();
+    Snapshot snapshotC = table.currentSnapshot();
+    long snapshotCId = snapshotC.snapshotId();
+    long snapshotCTimestamp = snapshotC.timestampMillis();
+
+    List<Object[]> expectedRecords = currentData();
+    long dataSizeBefore =
+        Streams.stream(
+                table
+                    .newIncrementalAppendScan()
+                    .fromSnapshotExclusive(snapshotAId)
+                    .toSnapshot(snapshotBId)
+                    .planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+
+    Result result =
+        basicRewrite(table).startSnapshotId(snapshotAId).endSnapshotId(snapshotBId).execute();
+    assertResult(table, expectedRecords, 8, 4 + 1 + 8, dataSizeBefore, result);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result =
+        basicRewrite(table)
+            .option(RewriteDataFiles.START_SNAPSHOT_ID, String.valueOf(snapshotAId))
+            .option(RewriteDataFiles.END_SNAPSHOT_ID, String.valueOf(snapshotBId))
+            .execute();
+    assertResult(table, expectedRecords, 8, 4 + 1 + 8, dataSizeBefore, result);
+
+    // Roll back the table and using the time range to rewrite the file again.
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result2 =
+        basicRewrite(table)
+            .startTimestamp(snapshotATimestamp)
+            .endTimestamp(snapshotBTimestamp)
+            .execute();
+    assertResult(table, expectedRecords, 8, 4 + 1 + 8, dataSizeBefore, result2);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    result2 =
+        basicRewrite(table)
+            .option(RewriteDataFiles.START_TIMESTAMP, String.valueOf(snapshotATimestamp))
+            .option(RewriteDataFiles.END_TIMESTAMP, String.valueOf(snapshotBTimestamp))
+            .execute();
+    assertResult(table, expectedRecords, 8, 4 + 1 + 8, dataSizeBefore, result2);
+
+    // Roll back the table and using both the snapshot ID and time range rewrite the file again
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    dataSizeBefore =
+        Streams.stream(
+                table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotAId).planFiles())
+            .mapToLong(FileScanTask::length)
+            .sum();
+
+    Result result3 =
+        basicRewrite(table).startTimestamp(snapshotATimestamp).endSnapshotId(snapshotCId).execute();
+    assertResult(table, expectedRecords, 16, 4 + 1, dataSizeBefore, result3);
+
+    table.manageSnapshots().rollbackTo(snapshotCId).commit();
+    Result result4 =
+        basicRewrite(table).startSnapshotId(snapshotAId).endTimestamp(snapshotCTimestamp).execute();
+    assertResult(table, expectedRecords, 16, 4 + 1, dataSizeBefore, result4);
+
+    Assertions.assertThatThrownBy(
+            () ->
+                basicRewrite(table)
+                    .startTimestamp(snapshotBTimestamp)
+                    .endTimestamp(snapshotATimestamp)
+                    .execute())
+        .hasMessage(
+            "Cannot set %s to be greater than %s",
+            RewriteDataFiles.START_TIMESTAMP, RewriteDataFiles.END_TIMESTAMP);
+  }
+
+  private void assertResult(
+      Table table,
+      List<Object[]> expectedRecords,
+      int expectedRewrittenFiles,
+      int expectedTableFiles,
+      long dataSizeBefore,
+      Result result) {
+    Assert.assertEquals(
+        "Action should rewrite 8 data files",
+        expectedRewrittenFiles,
+        result.rewrittenDataFilesCount());
+    assertThat(result.addedDataFilesCount())
+        .as("Action should add 1 data file")
+        .isInstanceOf(Integer.class)
+        .isEqualTo(1);
+    assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+
+    shouldHaveFiles(table, expectedTableFiles);
+    List<Object[]> actual = currentData();
     assertEquals("Rows must match", expectedRecords, actual);
   }
 
@@ -1393,7 +1662,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   private Stream<RewriteFileGroup> toGroupStream(Table table, RewriteDataFilesSparkAction rewrite) {
     rewrite.validateAndInitOptions();
     Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition =
-        rewrite.planFileGroups(table.currentSnapshot().snapshotId());
+        rewrite.planScanFileGroups(table.currentSnapshot().snapshotId());
 
     return rewrite.toGroupStream(
         new RewriteExecutionContext(fileGroupsByPartition), fileGroupsByPartition);


### PR DESCRIPTION
## What is the purpose of the change
support data files rewriting using a time range.
Sometimes, the full table has a very large scale, and we want to do data rewriting on the incremental snapshot regularly.

```
actions().rewriteDataFiles(table)
         .startTimestamp(1682677842000)
         .endTimestamp(1682677843000)
         .execute();

actions().rewriteDataFiles(table)
         .startSnapshotId(1)
         .endSnapshotId(2)
         .execute();


CALL %s.system.rewrite_data_files(
        table => '%s', 
        options => map('start-timestamp','1682677842000', 'end-timestamp','1682677843000')
)

CALL %s.system.rewrite_data_files(
        table => '%s', 
        options => map('start-snapshot-id','1', 'end-snapshot-id','2')
)

```
