### PR TITLE
Python: fix `mkdocs` warnings from `conversions.py`

### DIFF
--- a/python/pyiceberg/conversions.py
+++ b/python/pyiceberg/conversions.py
@@ -246,8 +246,8 @@ def from_bytes(primitive_type: PrimitiveType, b: bytes) -> L:
     """A generic function which converts bytes to a built-in python value
 
     Args:
-        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
-        b(bytes): The bytes to convert
+        primitive_type (PrimitiveType): An implementation of the PrimitiveType base class
+        b (bytes): The bytes to convert
     """
     raise TypeError(f"Cannot deserialize bytes, type {primitive_type} not supported: {str(b)}")
 

--- a/python/pyiceberg/conversions.py
+++ b/python/pyiceberg/conversions.py
@@ -88,8 +88,8 @@ def partition_to_py(primitive_type: PrimitiveType, value_str: str) -> Union[int,
     """A generic function which converts a partition string to a python built-in
 
     Args:
-        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
-        value_str(str): A string representation of a partition value
+        primitive_type (PrimitiveType): An implementation of the PrimitiveType base class
+        value_str (str): A string representation of a partition value
     """
     raise TypeError(f"Cannot convert '{value_str}' to unsupported type: {primitive_type}")
 
@@ -158,7 +158,7 @@ def to_bytes(primitive_type: PrimitiveType, _: Union[bool, bytes, Decimal, float
     can be found at https://iceberg.apache.org/spec/#appendix-d-single-value-serialization
 
     Args:
-        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
+        primitive_type (PrimitiveType): An implementation of the PrimitiveType base class
         _: The value to convert to bytes (The type of this value depends on which dispatched function is
             used--check dispatchable functions for type hints)
     """


### PR DESCRIPTION
mkdocs was generating a set of warnings for python/pyiceberg/conversions.py - from_bytes(...) function, per issue #7458 I have fixed this issue, following guidance from initial open. Let me know if there are any questions.