### PR TITLE
Core, Spark: Add configuration to control case sensitivity of CachingCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -41,6 +41,11 @@ public class CatalogProperties {
 
   public static final boolean CACHE_ENABLED_DEFAULT = true;
 
+  /** Controls whether the caching catalog will cache table entries using case-sensitive keys. */
+  public static final String CACHE_CASE_SENSITIVE = "cache.case-sensitive";
+
+  public static final boolean CACHE_CASE_SENSITIVE_DEFAULT = false;
+
   /**
    * Controls the duration for which entries in the catalog are cached.
    *

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -41,10 +41,8 @@ public class CatalogProperties {
 
   public static final boolean CACHE_ENABLED_DEFAULT = true;
 
-  /** Controls whether the caching catalog will cache table entries using case-sensitive keys. */
+  /** Controls whether the caching catalog will cache table entries using case sensitive keys. */
   public static final String CACHE_CASE_SENSITIVE = "cache.case-sensitive";
-
-  public static final boolean CACHE_CASE_SENSITIVE_DEFAULT = false;
 
   /**
    * Controls the duration for which entries in the catalog are cached.

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -459,11 +459,12 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
             options,
             CatalogProperties.CACHE_CASE_SENSITIVE,
-            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+            Boolean.parseBoolean(sparkSession.conf().get("spark.sql.caseSensitive")));
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -480,7 +481,6 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
-    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -90,6 +90,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
+ *       keys
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.
@@ -457,6 +459,12 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    boolean cacheCaseSensitive =
+        PropertyUtil.propertyAsBoolean(
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
             options,
@@ -478,7 +486,9 @@ public class SparkCatalog extends BaseCatalog {
     this.tables =
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
-        cacheEnabled ? CachingCatalog.wrap(catalog, cacheExpirationIntervalMs) : catalog;
+        cacheEnabled
+            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;
       if (options.containsKey("default-namespace")) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -462,9 +462,7 @@ public class SparkCatalog extends BaseCatalog {
     SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options,
-            CatalogProperties.CACHE_CASE_SENSITIVE,
-            Boolean.parseBoolean(sparkSession.conf().get("spark.sql.caseSensitive")));
+            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -90,8 +90,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
- *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
- *       keys
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should compare table
+ *       identifiers in a case sensitive way
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -207,4 +207,8 @@ public class SparkUtil {
   private static String hadoopConfPrefixForCatalog(String catalogName) {
     return String.format(SPARK_CATALOG_HADOOP_CONF_OVERRIDE_FMT_STR, catalogName);
   }
+
+  public static boolean caseSensitive(SparkSession spark) {
+    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+  }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -458,11 +458,10 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options,
-            CatalogProperties.CACHE_CASE_SENSITIVE,
-            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -479,7 +478,6 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
-    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -91,6 +91,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
+ *       keys
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.
@@ -456,6 +458,12 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    boolean cacheCaseSensitive =
+        PropertyUtil.propertyAsBoolean(
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
             options,
@@ -477,7 +485,9 @@ public class SparkCatalog extends BaseCatalog {
     this.tables =
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
-        cacheEnabled ? CachingCatalog.wrap(catalog, cacheExpirationIntervalMs) : catalog;
+        cacheEnabled
+            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;
       if (options.containsKey("default-namespace")) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -91,8 +91,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
- *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
- *       keys
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should compare table
+ *       identifiers in a case sensitive way
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -524,11 +524,10 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options,
-            CatalogProperties.CACHE_CASE_SENSITIVE,
-            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -545,7 +544,6 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
-    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -96,6 +96,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
+ *       keys
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.
@@ -522,6 +524,12 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    boolean cacheCaseSensitive =
+        PropertyUtil.propertyAsBoolean(
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
             options,
@@ -543,7 +551,9 @@ public class SparkCatalog extends BaseCatalog {
     this.tables =
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
-        cacheEnabled ? CachingCatalog.wrap(catalog, cacheExpirationIntervalMs) : catalog;
+        cacheEnabled
+            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;
       if (options.containsKey("default-namespace")) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -96,8 +96,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
- *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
- *       keys
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should compare table
+ *       identifiers in a case sensitive way
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -524,11 +524,10 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options,
-            CatalogProperties.CACHE_CASE_SENSITIVE,
-            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -545,7 +544,6 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
-    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -96,6 +96,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
+ *       keys
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.
@@ -522,6 +524,12 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
+    boolean cacheCaseSensitive =
+        PropertyUtil.propertyAsBoolean(
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
+
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
             options,
@@ -543,7 +551,9 @@ public class SparkCatalog extends BaseCatalog {
     this.tables =
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
-        cacheEnabled ? CachingCatalog.wrap(catalog, cacheExpirationIntervalMs) : catalog;
+        cacheEnabled
+            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;
       if (options.containsKey("default-namespace")) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -96,8 +96,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>catalog-impl</code> - a custom {@link Catalog} implementation to use
  *   <li><code>default-namespace</code> - a namespace to use as the default
  *   <li><code>cache-enabled</code> - whether to enable catalog cache
- *   <li><code>cache.case-sensitive</code> - whether the catalog cache should use case-sensitive
- *       keys
+ *   <li><code>cache.case-sensitive</code> - whether the catalog cache should compare table
+ *       identifiers in a case sensitive way
  *   <li><code>cache.expiration-interval-ms</code> - interval in millis before expiring tables from
  *       catalog cache. Refer to {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for further
  *       details and significant values.


### PR DESCRIPTION
If this configuration is not set, and caching is enabled, the SparkCatalog uses a CachingCatalog with case sensitivity that matches the runtime configuration of `spark.sql.caseSensitive` in the SparkSession.

Motivation:
The `CachingCatalog` has a field that determines if the cache uses case sensitive `TableIdentifier` keys. By default, caching is enabled and the `SparkCatalog` wraps itself in a case sensitive `CachingCatalog`. There is no configuration to allow specifying the use of a case insensitive `CachingCatalog`.
In a customer SQL workload, we discovered that queries used inconsistent case for database and table names. A table is read using an upper case name and is updated using a lower case name. This is not incorrect as SQL is case insensitive for database, table and column names. This is in the **same** Spark session. Normally the new snapshot should be read immediately after the write, but it is not, due to a **different** table being loaded from the cache (two different entries for the table are in the cache, under different keys). As a result, stale data is read until the cache expiration occurs. (Due to repeated reads, the cache keeps getting renewed, exacerbating the problem.)

Note: Currently, in the `CachingCatalog`, the metadata table resolution is already case insensitive for the metadata part of the name.

Closes: https://github.com/apache/iceberg/issues/7474

