### PR TITLE
Spark: Fix Failing SS ratelimit UT

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -52,6 +52,7 @@ import org.apache.spark.api.java.function.VoidFunction2;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.streaming.StreamingQuery;
@@ -59,6 +60,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -109,6 +111,12 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
                   new SimpleRecord(13, "thirteen"), new SimpleRecord(14, "fourteen")),
               Lists.newArrayList(
                   new SimpleRecord(15, "fifteen"), new SimpleRecord(16, "sixteen"))));
+
+  @BeforeClass
+  public static void setupSpark() {
+    // disable AQE as tests assume that writes generate a particular number of files
+    spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false");
+  }
 
   @Before
   public void setupTable() {


### PR DESCRIPTION
### About the change

Post https://github.com/apache/iceberg/pull/7443). The UT of `testReadStreamOnIcebergTableWithMultipleSnapshots_WithNumberOfRows_1` SS started failing, it requires a certain number of files, and hence the same handling as [here](https://github.com/apache/iceberg/pull/7443/files#diff-bd2fb8a4edce59a36cbee408d65ad03b31e1b3431c4aaa180eb4db87755147e8R136) . Since the CI hasn't run post merging [PR](https://github.com/apache/iceberg/pull/7443/) this couldn't be caught. 


cc @jackye1995 @szehon-ho @wypoon