### PR TITLE
Hive: Remove deprecated AssertHelpers

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
@@ -23,7 +23,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.IOException;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
@@ -37,6 +36,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -97,11 +97,9 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
     catalog.createTable(TABLE_IDENTIFIER, SCHEMA, SPEC);
     Assert.assertTrue("Table should be created", catalog.tableExists(TABLE_IDENTIFIER));
 
-    AssertHelpers.assertThrows(
-        "Create table txn should fail",
-        AlreadyExistsException.class,
-        "Table already exists: hivedb.tbl",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Table already exists: hivedb.tbl");
   }
 
   @Test
@@ -137,13 +135,12 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
     catalog.createTable(TABLE_IDENTIFIER, SCHEMA, SPEC);
     Assert.assertTrue("Table should be created", catalog.tableExists(TABLE_IDENTIFIER));
 
-    AssertHelpers.assertThrows(
-        "Should not be possible to start a new create table txn",
-        AlreadyExistsException.class,
-        "Table already exists: hivedb.tbl",
-        () ->
-            catalog.newCreateTableTransaction(
-                TABLE_IDENTIFIER, SCHEMA, SPEC, tableLocation, Maps.newHashMap()));
+    Assertions.assertThatThrownBy(
+            () ->
+                catalog.newCreateTableTransaction(
+                    TABLE_IDENTIFIER, SCHEMA, SPEC, tableLocation, Maps.newHashMap()))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Table already exists: hivedb.tbl");
   }
 
   @Test
@@ -162,11 +159,10 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
 
   @Test
   public void testReplaceTableTxnTableNotExists() {
-    AssertHelpers.assertThrows(
-        "Should not be possible to start a new replace table txn",
-        NoSuchTableException.class,
-        "Table does not exist: hivedb.tbl",
-        () -> catalog.newReplaceTableTransaction(TABLE_IDENTIFIER, SCHEMA, SPEC, false));
+    Assertions.assertThatThrownBy(
+            () -> catalog.newReplaceTableTransaction(TABLE_IDENTIFIER, SCHEMA, SPEC, false))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessage("Table does not exist: hivedb.tbl");
   }
 
   @Test
@@ -180,11 +176,9 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
 
     txn.updateProperties().set("prop", "value").commit();
 
-    AssertHelpers.assertThrows(
-        "Replace table txn should fail",
-        NoSuchTableException.class,
-        "No such table: hivedb.tbl",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessage("No such table: hivedb.tbl");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -512,13 +511,10 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     Assert.assertEquals(database.getParameters().get("test"), "test");
     Assert.assertEquals(database.getParameters().get("group"), "iceberg");
 
-    AssertHelpers.assertThrows(
-        "Should fail to namespace not exist" + namespace,
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta);
-        });
+    assertThatThrownBy(
+            () -> catalog.setProperties(Namespace.of("db2", "db2", "ns2"), ImmutableMap.of()))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db2.db2.ns2");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -38,14 +38,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -345,13 +342,9 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         database1.getLocationUri(),
         defaultUri(namespace1));
 
-    AssertHelpers.assertThrows(
-        "Should fail to create when namespace already exist " + namespace1,
-        AlreadyExistsException.class,
-        "Namespace '" + namespace1 + "' already exists!",
-        () -> {
-          catalog.createNamespace(namespace1);
-        });
+    assertThatThrownBy(() -> catalog.createNamespace(namespace1))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Namespace '" + namespace1 + "' already exists!");
     String hiveLocalDir = temp.newFolder().toURI().toString();
     // remove the trailing slash of the URI
     hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
@@ -410,39 +403,40 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         "iceberg",
         PrincipalType.GROUP);
 
-    AssertHelpers.assertThrows(
-        String.format(
-            "Create namespace setting %s without setting %s is not allowed",
-            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            createNamespaceAndVerifyOwnership(
-                "create_with_owner_type_alone",
-                ImmutableMap.of(HiveCatalog.HMS_DB_OWNER_TYPE, PrincipalType.USER.name()),
-                "no_post_create_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+    assertThatThrownBy(
+            () -> {
+              try {
+                createNamespaceAndVerifyOwnership(
+                    "create_with_owner_type_alone",
+                    ImmutableMap.of(HiveCatalog.HMS_DB_OWNER_TYPE, PrincipalType.USER.name()),
+                    "no_post_create_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Create namespace setting %s without setting %s is not allowed",
+                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
-    AssertHelpers.assertThrows(
-        "No enum constant " + PrincipalType.class.getCanonicalName(),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            createNamespaceAndVerifyOwnership(
-                "create_with_invalid_owner_type",
-                ImmutableMap.of(
-                    HiveCatalog.HMS_DB_OWNER, "iceberg",
-                    HiveCatalog.HMS_DB_OWNER_TYPE, "invalidOwnerType"),
-                "no_post_create_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+    assertThatThrownBy(
+            () -> {
+              try {
+                createNamespaceAndVerifyOwnership(
+                    "create_with_invalid_owner_type",
+                    ImmutableMap.of(
+                        HiveCatalog.HMS_DB_OWNER, "iceberg",
+                        HiveCatalog.HMS_DB_OWNER_TYPE, "invalidOwnerType"),
+                    "no_post_create_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("No enum constant " + PrincipalType.class.getCanonicalName());
   }
 
   private void createNamespaceAndVerifyOwnership(
@@ -516,13 +510,9 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     Assert.assertEquals(database.getParameters().get("owner"), "alter_apache");
     Assert.assertEquals(database.getParameters().get("test"), "test");
     Assert.assertEquals(database.getParameters().get("group"), "iceberg");
-    AssertHelpers.assertThrows(
-        "Should fail to namespace not exist" + namespace,
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta);
-        });
+    assertThatThrownBy(() -> catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db2.db2.ns2");
   }
 
   @Test
@@ -583,69 +573,68 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         "some_individual_owner",
         PrincipalType.USER);
 
-    AssertHelpers.assertThrows(
-        String.format(
-            "Setting %s and %s has to be performed together or not at all",
-            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            setNamespaceOwnershipAndVerify(
-                "set_owner_without_setting_owner_type",
-                ImmutableMap.of(),
-                ImmutableMap.of(HiveCatalog.HMS_DB_OWNER, "some_individual_owner"),
-                System.getProperty("user.name"),
-                PrincipalType.USER,
-                "no_post_setting_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+    assertThatThrownBy(
+            () -> {
+              try {
+                setNamespaceOwnershipAndVerify(
+                    "set_owner_without_setting_owner_type",
+                    ImmutableMap.of(),
+                    ImmutableMap.of(HiveCatalog.HMS_DB_OWNER, "some_individual_owner"),
+                    System.getProperty("user.name"),
+                    PrincipalType.USER,
+                    "no_post_setting_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Setting %s and %s has to be performed together or not at all",
+                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
-    AssertHelpers.assertThrows(
-        String.format(
-            "Setting %s and %s has to be performed together or not at all",
-            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            setNamespaceOwnershipAndVerify(
-                "set_owner_type_without_setting_owner",
-                ImmutableMap.of(HiveCatalog.HMS_DB_OWNER, "some_owner"),
-                ImmutableMap.of(HiveCatalog.HMS_DB_OWNER_TYPE, PrincipalType.GROUP.name()),
-                "some_owner",
-                PrincipalType.USER,
-                "no_post_setting_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+    assertThatThrownBy(
+            () -> {
+              try {
+                setNamespaceOwnershipAndVerify(
+                    "set_owner_type_without_setting_owner",
+                    ImmutableMap.of(HiveCatalog.HMS_DB_OWNER, "some_owner"),
+                    ImmutableMap.of(HiveCatalog.HMS_DB_OWNER_TYPE, PrincipalType.GROUP.name()),
+                    "some_owner",
+                    PrincipalType.USER,
+                    "no_post_setting_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Setting %s and %s has to be performed together or not at all",
+                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
-    AssertHelpers.assertThrows(
-        HiveCatalog.HMS_DB_OWNER_TYPE
-            + " has an invalid value of: "
-            + meta.get(HiveCatalog.HMS_DB_OWNER_TYPE)
-            + ". Acceptable values are: "
-            + Stream.of(PrincipalType.values()).map(Enum::name).collect(Collectors.joining(", ")),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            setNamespaceOwnershipAndVerify(
-                "set_invalid_owner_type",
-                ImmutableMap.of(),
-                ImmutableMap.of(
-                    HiveCatalog.HMS_DB_OWNER, "iceberg",
-                    HiveCatalog.HMS_DB_OWNER_TYPE, "invalidOwnerType"),
-                System.getProperty("user.name"),
-                PrincipalType.USER,
-                "no_post_setting_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+    assertThatThrownBy(
+            () -> {
+              try {
+                setNamespaceOwnershipAndVerify(
+                    "set_invalid_owner_type",
+                    ImmutableMap.of(),
+                    ImmutableMap.of(
+                        HiveCatalog.HMS_DB_OWNER, "iceberg",
+                        HiveCatalog.HMS_DB_OWNER_TYPE, "invalidOwnerType"),
+                    System.getProperty("user.name"),
+                    PrincipalType.USER,
+                    "no_post_setting_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "No enum constant org.apache.hadoop.hive.metastore.api.PrincipalType.invalidOwnerType");
   }
 
   @Test
@@ -734,14 +723,13 @@ public class TestHiveCatalog extends HiveMetastoreTest {
 
     Assert.assertEquals(database.getParameters().get("owner"), null);
     Assert.assertEquals(database.getParameters().get("group"), "iceberg");
-    AssertHelpers.assertThrows(
-        "Should fail to namespace not exist" + namespace,
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.removeProperties(
-              Namespace.of("db2", "db2", "ns2"), ImmutableSet.of("comment", "owner"));
-        });
+
+    assertThatThrownBy(
+            () ->
+                catalog.removeProperties(
+                    Namespace.of("db2", "db2", "ns2"), ImmutableSet.of("comment", "owner")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db2.db2.ns2");
   }
 
   @Test
@@ -808,53 +796,55 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         "some_group_owner",
         PrincipalType.GROUP);
 
-    AssertHelpers.assertThrows(
-        String.format(
-            "Removing %s and %s has to be performed together or not at all",
-            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            removeNamespaceOwnershipAndVerify(
-                "remove_owner_without_removing_owner_type",
-                ImmutableMap.of(
-                    HiveCatalog.HMS_DB_OWNER,
+    assertThatThrownBy(
+            () -> {
+              try {
+                removeNamespaceOwnershipAndVerify(
+                    "remove_owner_without_removing_owner_type",
+                    ImmutableMap.of(
+                        HiveCatalog.HMS_DB_OWNER,
+                        "some_individual_owner",
+                        HiveCatalog.HMS_DB_OWNER_TYPE,
+                        PrincipalType.USER.name()),
+                    ImmutableSet.of(HiveCatalog.HMS_DB_OWNER),
                     "some_individual_owner",
-                    HiveCatalog.HMS_DB_OWNER_TYPE,
-                    PrincipalType.USER.name()),
-                ImmutableSet.of(HiveCatalog.HMS_DB_OWNER),
-                "some_individual_owner",
-                PrincipalType.USER,
-                "no_post_remove_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+                    PrincipalType.USER,
+                    "no_post_remove_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Removing %s and %s has to be performed together or not at all",
+                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
-    AssertHelpers.assertThrows(
-        String.format(
-            "Removing %s and %s has to be performed together or not at all",
-            HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER),
-        IllegalArgumentException.class,
-        () -> {
-          try {
-            removeNamespaceOwnershipAndVerify(
-                "remove_owner_type_without_removing_owner",
-                ImmutableMap.of(
-                    HiveCatalog.HMS_DB_OWNER,
+    assertThatThrownBy(
+            () -> {
+              try {
+                removeNamespaceOwnershipAndVerify(
+                    "remove_owner_type_without_removing_owner",
+                    ImmutableMap.of(
+                        HiveCatalog.HMS_DB_OWNER,
+                        "some_group_owner",
+                        HiveCatalog.HMS_DB_OWNER_TYPE,
+                        PrincipalType.GROUP.name()),
+                    ImmutableSet.of(HiveCatalog.HMS_DB_OWNER_TYPE),
                     "some_group_owner",
-                    HiveCatalog.HMS_DB_OWNER_TYPE,
-                    PrincipalType.GROUP.name()),
-                ImmutableSet.of(HiveCatalog.HMS_DB_OWNER_TYPE),
-                "some_group_owner",
-                PrincipalType.GROUP,
-                "no_post_remove_expectation_due_to_exception_thrown",
-                null);
-          } catch (TException e) {
-            throw new RuntimeException("Unexpected Exception", e);
-          }
-        });
+                    PrincipalType.GROUP,
+                    "no_post_remove_expectation_due_to_exception_thrown",
+                    null);
+              } catch (TException e) {
+                throw new RuntimeException("Unexpected Exception", e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Removing %s and %s has to be performed together or not at all",
+                HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
   }
 
   private void removeNamespaceOwnershipAndVerify(
@@ -889,26 +879,18 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     Assert.assertTrue(nameMata.get("owner").equals("apache"));
     Assert.assertTrue(nameMata.get("group").equals("iceberg"));
 
-    AssertHelpers.assertThrows(
-        "Should fail to drop namespace is not empty" + namespace,
-        NamespaceNotEmptyException.class,
-        "Namespace dbname_drop is not empty. One or more tables exist.",
-        () -> {
-          catalog.dropNamespace(namespace);
-        });
+    assertThatThrownBy(() -> catalog.dropNamespace(namespace))
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessage("Namespace dbname_drop is not empty. One or more tables exist.");
     Assert.assertTrue(catalog.dropTable(identifier, true));
     Assert.assertTrue(
         "Should fail to drop namespace if it is not empty", catalog.dropNamespace(namespace));
     Assert.assertFalse(
         "Should fail to drop when namespace doesn't exist",
         catalog.dropNamespace(Namespace.of("db.ns1")));
-    AssertHelpers.assertThrows(
-        "Should fail to drop namespace exist" + namespace,
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.loadNamespaceMetadata(namespace);
-        });
+    assertThatThrownBy(() -> catalog.loadNamespaceMetadata(namespace))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: dbname_drop");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -404,17 +404,12 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         PrincipalType.GROUP);
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 createNamespaceAndVerifyOwnership(
                     "create_with_owner_type_alone",
                     ImmutableMap.of(HiveCatalog.HMS_DB_OWNER_TYPE, PrincipalType.USER.name()),
                     "no_post_create_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
@@ -422,19 +417,14 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                 HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 createNamespaceAndVerifyOwnership(
                     "create_with_invalid_owner_type",
                     ImmutableMap.of(
                         HiveCatalog.HMS_DB_OWNER, "iceberg",
                         HiveCatalog.HMS_DB_OWNER_TYPE, "invalidOwnerType"),
                     "no_post_create_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("No enum constant " + PrincipalType.class.getCanonicalName());
   }
@@ -576,8 +566,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         PrincipalType.USER);
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 setNamespaceOwnershipAndVerify(
                     "set_owner_without_setting_owner_type",
                     ImmutableMap.of(),
@@ -585,11 +574,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                     System.getProperty("user.name"),
                     PrincipalType.USER,
                     "no_post_setting_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
@@ -597,8 +582,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                 HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 setNamespaceOwnershipAndVerify(
                     "set_owner_type_without_setting_owner",
                     ImmutableMap.of(HiveCatalog.HMS_DB_OWNER, "some_owner"),
@@ -606,11 +590,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                     "some_owner",
                     PrincipalType.USER,
                     "no_post_setting_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
@@ -618,8 +598,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                 HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 setNamespaceOwnershipAndVerify(
                     "set_invalid_owner_type",
                     ImmutableMap.of(),
@@ -629,11 +608,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                     System.getProperty("user.name"),
                     PrincipalType.USER,
                     "no_post_setting_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "No enum constant org.apache.hadoop.hive.metastore.api.PrincipalType.invalidOwnerType");
@@ -799,8 +774,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         PrincipalType.GROUP);
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 removeNamespaceOwnershipAndVerify(
                     "remove_owner_without_removing_owner_type",
                     ImmutableMap.of(
@@ -812,11 +786,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                     "some_individual_owner",
                     PrincipalType.USER,
                     "no_post_remove_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(
@@ -824,8 +794,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                 HiveCatalog.HMS_DB_OWNER_TYPE, HiveCatalog.HMS_DB_OWNER));
 
     assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 removeNamespaceOwnershipAndVerify(
                     "remove_owner_type_without_removing_owner",
                     ImmutableMap.of(
@@ -837,11 +806,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
                     "some_group_owner",
                     PrincipalType.GROUP,
                     "no_post_remove_expectation_due_to_exception_thrown",
-                    null);
-              } catch (TException e) {
-                throw new RuntimeException("Unexpected Exception", e);
-              }
-            })
+                    null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             String.format(

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -511,9 +512,13 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     Assert.assertEquals(database.getParameters().get("test"), "test");
     Assert.assertEquals(database.getParameters().get("group"), "iceberg");
 
-    assertThatThrownBy(() -> catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta))
-        .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessageStartingWith("Namespace does not exist");
+    AssertHelpers.assertThrows(
+        "Should fail to namespace not exist" + namespace,
+        NoSuchNamespaceException.class,
+        "Namespace does not exist: ",
+        () -> {
+          catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta);
+        });
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -510,9 +510,10 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     Assert.assertEquals(database.getParameters().get("owner"), "alter_apache");
     Assert.assertEquals(database.getParameters().get("test"), "test");
     Assert.assertEquals(database.getParameters().get("group"), "iceberg");
+
     assertThatThrownBy(() -> catalog.setProperties(Namespace.of("db2", "db2", "ns2"), meta))
         .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessage("Namespace does not exist: db2.db2.ns2");
+        .hasMessageStartingWith("Namespace does not exist");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveClientPool.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.hive.metastore.api.FunctionType;
 import org.apache.hadoop.hive.metastore.api.GetAllFunctionsResponse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.thrift.transport.TTransportException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -100,11 +100,9 @@ public class TestHiveClientPool {
   @Test
   public void testNewClientFailure() {
     Mockito.doThrow(new RuntimeException("Connection exception")).when(clients).newClient();
-    AssertHelpers.assertThrows(
-        "Should throw exception",
-        RuntimeException.class,
-        "Connection exception",
-        () -> clients.run(Object::toString));
+    Assertions.assertThatThrownBy(() -> clients.run(Object::toString))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Connection exception");
   }
 
   @Test
@@ -114,11 +112,9 @@ public class TestHiveClientPool {
     Mockito.doThrow(new MetaException("Another meta exception"))
         .when(hmsClient)
         .getTables(Mockito.anyString(), Mockito.anyString());
-    AssertHelpers.assertThrows(
-        "Should throw exception",
-        MetaException.class,
-        "Another meta exception",
-        () -> clients.run(client -> client.getTables("default", "t")));
+    Assertions.assertThatThrownBy(() -> clients.run(client -> client.getTables("default", "t")))
+        .isInstanceOf(MetaException.class)
+        .hasMessage("Another meta exception");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.LockState;
 import org.apache.hadoop.hive.metastore.api.ShowLocksResponse;
 import org.apache.hadoop.hive.metastore.api.ShowLocksResponseElement;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -59,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -280,11 +280,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
     doNothing().when(spyClient).unlock(eq(dummyLockId));
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        RuntimeException.class,
-        "Interrupted while creating lock",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Interrupted while creating lock on table hivedb.tbl");
 
     verify(spyClient, times(1)).unlock(eq(dummyLockId));
     // Make sure that we exit the lock loop on InterruptedException
@@ -304,11 +304,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
     doNothing().when(spyClient).unlock(eq(dummyLockId));
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        RuntimeException.class,
-        "Could not acquire the lock on",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Could not acquire the lock on hivedb.tbl, lock request ended in state WAITING");
 
     verify(spyClient, times(1)).unlock(eq(dummyLockId));
     // Make sure that we exit the checkLock loop on InterruptedException
@@ -328,11 +328,9 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
     doNothing().when(spyClient).unlock(eq(dummyLockId));
     doNothing().when(spyClient).heartbeat(eq(0L), eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        RuntimeException.class,
-        "Interrupted during commit",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Interrupted during commit");
 
     verify(spyClient, times(1)).unlock(eq(dummyLockId));
   }
@@ -365,11 +363,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
   public void testLockFailureAtFirstTime() throws TException {
     doReturn(notAcquiredLockResponse).when(spyClient).lock(any());
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        CommitFailedException.class,
-        "Could not acquire the lock on",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Could not acquire the lock on hivedb.tbl, lock request ended in state NOT_ACQUIRED");
   }
 
   @Test
@@ -383,11 +381,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .when(spyClient)
         .checkLock(eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        CommitFailedException.class,
-        "Could not acquire the lock on",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Could not acquire the lock on hivedb.tbl, lock request ended in state NOT_ACQUIRED");
   }
 
   @Test
@@ -395,11 +393,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
     doReturn(waitLockResponse).when(spyClient).lock(any());
     doReturn(waitLockResponse).when(spyClient).checkLock(eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        CommitFailedException.class,
-        "Timed out after",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageStartingWith("org.apache.iceberg.hive.LockException")
+        .hasMessageContaining("Timed out after")
+        .hasMessageEndingWith("waiting for lock on hivedb.tbl");
   }
 
   @Test
@@ -410,11 +408,10 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .when(spyClient)
         .checkLock(eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        RuntimeException.class,
-        "Metastore operation failed for",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: Metastore operation failed for hivedb.tbl");
   }
 
   @Test
@@ -430,11 +427,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .when(spyClient)
         .checkLock(eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        CommitFailedException.class,
-        "Could not acquire the lock on",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Could not acquire the lock on hivedb.tbl, lock request ended in state WAITING");
   }
 
   @Test
@@ -491,11 +488,11 @@ public class TestHiveCommitLocks extends HiveTableBaseTest {
         .when(spyClient)
         .heartbeat(eq(0L), eq(dummyLockId));
 
-    AssertHelpers.assertThrows(
-        "Expected commit failure due to failure in heartbeat.",
-        CommitFailedException.class,
-        "Failed to heartbeat for hive lock. Failed to heart beat.",
-        () -> spyOps.doCommit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.doCommit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "org.apache.iceberg.hive.LockException: "
+                + "Failed to heartbeat for hive lock. Failed to heart beat.");
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
@@ -40,6 +39,7 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -111,12 +111,9 @@ public class TestHiveCommits extends HiveTableBaseTest {
 
     failCommitAndThrowException(spyOps);
 
-    AssertHelpers.assertThrows(
-        "We should assume commit state is unknown if the "
-            + "new location is not found in history in commit state check",
-        CommitStateUnknownException.class,
-        "Datacenter on fire",
-        () -> spyOps.commit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("Datacenter on fire");
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());
@@ -187,11 +184,9 @@ public class TestHiveCommits extends HiveTableBaseTest {
     failCommitAndThrowException(spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
 
-    AssertHelpers.assertThrows(
-        "Should throw CommitStateUnknownException since the catalog check was blocked",
-        CommitStateUnknownException.class,
-        "Datacenter on fire",
-        () -> spyOps.commit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("Datacenter on fire");
 
     ops.refresh();
 
@@ -228,11 +223,9 @@ public class TestHiveCommits extends HiveTableBaseTest {
     commitAndThrowException(ops, spyOps);
     breakFallbackCatalogCommitCheck(spyOps);
 
-    AssertHelpers.assertThrows(
-        "Should throw CommitStateUnknownException since the catalog check was blocked",
-        CommitStateUnknownException.class,
-        "Datacenter on fire",
-        () -> spyOps.commit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("Datacenter on fire");
 
     ops.refresh();
 
@@ -349,11 +342,9 @@ public class TestHiveCommits extends HiveTableBaseTest {
         .persistTable(any(), anyBoolean(), any());
 
     // Should throw a CommitFailedException so the commit could be retried
-    AssertHelpers.assertThrows(
-        "Should throw CommitFailedException since the table has been modified concurrently",
-        CommitFailedException.class,
-        "has been modified concurrently",
-        () -> spyOps.commit(metadataV2, metadataV1));
+    Assertions.assertThatThrownBy(() -> spyOps.commit(metadataV2, metadataV1))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("The table hivedb.tbl has been modified concurrently");
 
     ops.refresh();
     Assert.assertEquals("Current metadata should not have changed", metadataV2, ops.current());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -27,12 +27,12 @@ import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -147,13 +147,12 @@ public class TestHiveSchemaUtil {
   @Test
   public void testNotSupportedTypes() {
     for (FieldSchema notSupportedField : getNotSupportedFieldSchemas()) {
-      AssertHelpers.assertThrows(
-          "should throw exception",
-          IllegalArgumentException.class,
-          "Unsupported Hive type",
-          () -> {
-            HiveSchemaUtil.convert(Lists.newArrayList(Arrays.asList(notSupportedField)));
-          });
+      Assertions.assertThatThrownBy(
+              () -> {
+                HiveSchemaUtil.convert(Lists.newArrayList(Arrays.asList(notSupportedField)));
+              })
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageStartingWith("Unsupported Hive type");
     }
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -148,9 +148,7 @@ public class TestHiveSchemaUtil {
   public void testNotSupportedTypes() {
     for (FieldSchema notSupportedField : getNotSupportedFieldSchemas()) {
       Assertions.assertThatThrownBy(
-              () -> {
-                HiveSchemaUtil.convert(Lists.newArrayList(Arrays.asList(notSupportedField)));
-              })
+              () -> HiveSchemaUtil.convert(Lists.newArrayList(Arrays.asList(notSupportedField))))
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageStartingWith("Unsupported Hive type");
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.expressions.And;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
@@ -40,6 +39,7 @@ import org.apache.iceberg.expressions.Or;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestHiveIcebergFilterFactory {
@@ -159,12 +159,9 @@ public class TestHiveIcebergFilterFactory {
                 .between("salary", PredicateLeaf.Type.LONG, 9000L, 15000L)
                 .end()
                 .build());
-
-    AssertHelpers.assertThrows(
-        "must throw if leaves are empty in between operator",
-        UnsupportedOperationException.class,
-        "Missing leaf literals",
-        () -> HiveIcebergFilterFactory.generateFilterExpression(arg));
+    Assertions.assertThatThrownBy(() -> HiveIcebergFilterFactory.generateFilterExpression(arg))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Missing leaf literals: Leaf[empty]");
   }
 
   @Test

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.orc;
 
-import static org.apache.iceberg.AssertHelpers.assertThrows;
 import static org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE;
 import static org.apache.iceberg.orc.ORCSchemaUtil.ICEBERG_REQUIRED_ATTRIBUTE;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -37,6 +36,7 @@ import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestORCSchemaUtil {
@@ -232,13 +232,9 @@ public class TestORCSchemaUtil {
     TypeDescription orcSchema = ORCSchemaUtil.convert(originalSchema);
     Schema evolveSchema = new Schema(optional(1, "a", Types.IntegerType.get()));
 
-    assertThrows(
-        "Should not allow invalid type promotion",
-        IllegalArgumentException.class,
-        "Can not promote",
-        () -> {
-          ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema);
-        });
+    Assertions.assertThatThrownBy(() -> ORCSchemaUtil.buildOrcProjection(evolveSchema, orcSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Can not promote LONG type to INTEGER");
   }
 
   @Test


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove AssertHelpers in `iceberg-hive-metastore` module