### PR TITLE
Spark: Remove deprecated AssertHelpers

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
@@ -51,6 +50,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -366,22 +366,21 @@ public class TestDeleteReachableFilesAction extends SparkTestBase {
   public void testEmptyIOThrowsException() {
     DeleteReachableFiles baseRemoveFilesSparkAction =
         sparkActions().deleteReachableFiles(metadataLocation(table)).io(null);
-    AssertHelpers.assertThrows(
-        "FileIO can't be null in DeleteReachableFiles action",
-        IllegalArgumentException.class,
-        "File IO cannot be null",
-        baseRemoveFilesSparkAction::execute);
+
+    Assertions.assertThatThrownBy(baseRemoveFilesSparkAction::execute)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("File IO cannot be null");
   }
 
   @Test
   public void testRemoveFilesActionWhenGarbageCollectionDisabled() {
     table.updateProperties().set(TableProperties.GC_ENABLED, "false").commit();
 
-    AssertHelpers.assertThrows(
-        "Should complain about removing files when GC is disabled",
-        ValidationException.class,
-        "Cannot delete files: GC is disabled (deleting files may corrupt other tables)",
-        () -> sparkActions().deleteReachableFiles(metadataLocation(table)).execute());
+    Assertions.assertThatThrownBy(
+            () -> sparkActions().deleteReachableFiles(metadataLocation(table)).execute())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Cannot delete files: GC is disabled (deleting files may corrupt other tables)");
   }
 
   private String metadataLocation(Table tbl) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -57,6 +56,7 @@ import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -447,11 +447,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     table.newAppend().appendFile(FILE_A).commit();
 
-    AssertHelpers.assertThrows(
-        "Should complain about expiring snapshots",
-        ValidationException.class,
-        "Cannot expire snapshots: GC is disabled",
-        () -> SparkActions.get().expireSnapshots(table));
+    Assertions.assertThatThrownBy(() -> SparkActions.get().expireSnapshots(table))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
   }
 
   @Test
@@ -529,11 +528,10 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
   @Test
   public void testRetainZeroSnapshots() {
-    AssertHelpers.assertThrows(
-        "Should fail retain 0 snapshots " + "because number of snapshots to retain cannot be zero",
-        IllegalArgumentException.class,
-        "Number of snapshots to retain must be at least 1, cannot be: 0",
-        () -> SparkActions.get().expireSnapshots(table).retainLast(0).execute());
+    Assertions.assertThatThrownBy(
+            () -> SparkActions.get().expireSnapshots(table).retainLast(0).execute())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Number of snapshots to retain must be at least 1, cannot be: 0");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
@@ -57,6 +56,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.TableIdentifier;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -207,11 +207,11 @@ public class TestRewriteManifestsAction extends SparkTestBase {
     Table spyTable = spy(table);
     when(spyTable.rewriteManifests()).thenReturn(spyNewRewriteManifests);
 
-    AssertHelpers.assertThrowsCause(
-        "Should throw a Commit State Unknown Exception",
-        RuntimeException.class,
-        "Datacenter on Fire",
-        () -> actions.rewriteManifests(spyTable).rewriteIf(manifest -> true).execute());
+    Assertions.assertThatThrownBy(
+            () -> actions.rewriteManifests(spyTable).rewriteIf(manifest -> true).execute())
+        .cause()
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Datacenter on Fire");
 
     table.refresh();
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.spark.source;
 
 import java.util.List;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.Spark3Util;
@@ -33,6 +32,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.internal.SQLConf;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -76,18 +76,17 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
 
     // this has a different error message than the case without accept-any-schema because it uses
     // Iceberg checks
-    AssertHelpers.assertThrows(
-        "Should fail when merge-schema is not enabled on the writer",
-        IllegalArgumentException.class,
-        "Field new_col not found in source schema",
-        () -> {
-          try {
-            threeColDF.writeTo(tableName).append();
-          } catch (NoSuchTableException e) {
-            // needed because append has checked exceptions
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                threeColDF.writeTo(tableName).append();
+              } catch (NoSuchTableException e) {
+                // needed because append has checked exceptions
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Field new_col not found in source schema");
   }
 
   @Test
@@ -111,18 +110,18 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
             "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
             "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
 
-    AssertHelpers.assertThrows(
-        "Should fail when accept-any-schema is not enabled on the table",
-        AnalysisException.class,
-        "too many data columns",
-        () -> {
-          try {
-            threeColDF.writeTo(tableName).option("merge-schema", "true").append();
-          } catch (NoSuchTableException e) {
-            // needed because append has checked exceptions
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                threeColDF.writeTo(tableName).option("merge-schema", "true").append();
+              } catch (NoSuchTableException e) {
+                // needed because append has checked exceptions
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith(
+            "Cannot write to 'testhadoop.default.table', too many data columns");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -76,15 +76,7 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
 
     // this has a different error message than the case without accept-any-schema because it uses
     // Iceberg checks
-    Assertions.assertThatThrownBy(
-            () -> {
-              try {
-                threeColDF.writeTo(tableName).append();
-              } catch (NoSuchTableException e) {
-                // needed because append has checked exceptions
-                throw new RuntimeException(e);
-              }
-            })
+    Assertions.assertThatThrownBy(() -> threeColDF.writeTo(tableName).append())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Field new_col not found in source schema");
   }
@@ -111,14 +103,7 @@ public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
             "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
 
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
-                threeColDF.writeTo(tableName).option("merge-schema", "true").append();
-              } catch (NoSuchTableException e) {
-                // needed because append has checked exceptions
-                throw new RuntimeException(e);
-              }
-            })
+            () -> threeColDF.writeTo(tableName).option("merge-schema", "true").append())
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
             "Cannot write to 'testhadoop.default.table', too many data columns");

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -243,15 +243,14 @@ public class TestDataSourceOptions {
 
     // start-snapshot-id and snapshot-id are both configured.
     Assertions.assertThatThrownBy(
-            () -> {
-              spark
-                  .read()
-                  .format("iceberg")
-                  .option("snapshot-id", snapshotIds.get(3).toString())
-                  .option("start-snapshot-id", snapshotIds.get(3).toString())
-                  .load(tableLocation)
-                  .explain();
-            })
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option("snapshot-id", snapshotIds.get(3).toString())
+                    .option("start-snapshot-id", snapshotIds.get(3).toString())
+                    .load(tableLocation)
+                    .explain())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot set start-snapshot-id and end-snapshot-id for incremental scans when either snapshot-id or as-of-timestamp is set");

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
@@ -52,6 +51,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -242,50 +242,50 @@ public class TestDataSourceOptions {
     List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
 
     // start-snapshot-id and snapshot-id are both configured.
-    AssertHelpers.assertThrows(
-        "Check both start-snapshot-id and snapshot-id are configured",
-        IllegalArgumentException.class,
-        "Cannot set start-snapshot-id and end-snapshot-id for incremental scans",
-        () -> {
-          spark
-              .read()
-              .format("iceberg")
-              .option("snapshot-id", snapshotIds.get(3).toString())
-              .option("start-snapshot-id", snapshotIds.get(3).toString())
-              .load(tableLocation)
-              .explain();
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              spark
+                  .read()
+                  .format("iceberg")
+                  .option("snapshot-id", snapshotIds.get(3).toString())
+                  .option("start-snapshot-id", snapshotIds.get(3).toString())
+                  .load(tableLocation)
+                  .explain();
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot set start-snapshot-id and end-snapshot-id for incremental scans when either snapshot-id or as-of-timestamp is set");
 
     // end-snapshot-id and as-of-timestamp are both configured.
-    AssertHelpers.assertThrows(
-        "Check both start-snapshot-id and snapshot-id are configured",
-        IllegalArgumentException.class,
-        "Cannot set start-snapshot-id and end-snapshot-id for incremental scans",
-        () -> {
-          spark
-              .read()
-              .format("iceberg")
-              .option(
-                  SparkReadOptions.AS_OF_TIMESTAMP,
-                  Long.toString(table.snapshot(snapshotIds.get(3)).timestampMillis()))
-              .option("end-snapshot-id", snapshotIds.get(2).toString())
-              .load(tableLocation)
-              .explain();
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              spark
+                  .read()
+                  .format("iceberg")
+                  .option(
+                      SparkReadOptions.AS_OF_TIMESTAMP,
+                      Long.toString(table.snapshot(snapshotIds.get(3)).timestampMillis()))
+                  .option("end-snapshot-id", snapshotIds.get(2).toString())
+                  .load(tableLocation)
+                  .explain();
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot set start-snapshot-id and end-snapshot-id for incremental scans when either snapshot-id or as-of-timestamp is set");
 
     // only end-snapshot-id is configured.
-    AssertHelpers.assertThrows(
-        "Check both start-snapshot-id and snapshot-id are configured",
-        IllegalArgumentException.class,
-        "Cannot set only end-snapshot-id for incremental scans",
-        () -> {
-          spark
-              .read()
-              .format("iceberg")
-              .option("end-snapshot-id", snapshotIds.get(2).toString())
-              .load(tableLocation)
-              .explain();
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              spark
+                  .read()
+                  .format("iceberg")
+                  .option("end-snapshot-id", snapshotIds.get(2).toString())
+                  .load(tableLocation)
+                  .explain();
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot set only end-snapshot-id for incremental scans. Please, set start-snapshot-id too.");
 
     // test (1st snapshot, current snapshot] incremental scan.
     List<SimpleRecord> result =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -257,31 +257,29 @@ public class TestDataSourceOptions {
 
     // end-snapshot-id and as-of-timestamp are both configured.
     Assertions.assertThatThrownBy(
-            () -> {
-              spark
-                  .read()
-                  .format("iceberg")
-                  .option(
-                      SparkReadOptions.AS_OF_TIMESTAMP,
-                      Long.toString(table.snapshot(snapshotIds.get(3)).timestampMillis()))
-                  .option("end-snapshot-id", snapshotIds.get(2).toString())
-                  .load(tableLocation)
-                  .explain();
-            })
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(
+                        SparkReadOptions.AS_OF_TIMESTAMP,
+                        Long.toString(table.snapshot(snapshotIds.get(3)).timestampMillis()))
+                    .option("end-snapshot-id", snapshotIds.get(2).toString())
+                    .load(tableLocation)
+                    .explain())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot set start-snapshot-id and end-snapshot-id for incremental scans when either snapshot-id or as-of-timestamp is set");
 
     // only end-snapshot-id is configured.
     Assertions.assertThatThrownBy(
-            () -> {
-              spark
-                  .read()
-                  .format("iceberg")
-                  .option("end-snapshot-id", snapshotIds.get(2).toString())
-                  .load(tableLocation)
-                  .explain();
-            })
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option("end-snapshot-id", snapshotIds.get(2).toString())
+                    .load(tableLocation)
+                    .explain())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Cannot set only end-snapshot-id for incremental scans. Please, set start-snapshot-id too.");

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -56,6 +55,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.streaming.MemoryStream;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -116,16 +116,15 @@ public class TestForwardCompatibility {
 
     Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
 
-    AssertHelpers.assertThrows(
-        "Should reject write with unsupported transform",
-        UnsupportedOperationException.class,
-        "Cannot write using unsupported transforms: zero",
-        () ->
-            df.select("id", "data")
-                .write()
-                .format("iceberg")
-                .mode("append")
-                .save(location.toString()));
+    Assertions.assertThatThrownBy(
+            () ->
+                df.select("id", "data")
+                    .write()
+                    .format("iceberg")
+                    .mode("append")
+                    .save(location.toString()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageEndingWith("Cannot write using unsupported transforms: zero");
   }
 
   @Test
@@ -155,11 +154,9 @@ public class TestForwardCompatibility {
     List<Integer> batch1 = Lists.newArrayList(1, 2);
     send(batch1, inputStream);
 
-    AssertHelpers.assertThrows(
-        "Should reject streaming write with unsupported transform",
-        StreamingQueryException.class,
-        "Cannot write using unsupported transforms: zero",
-        query::processAllAvailable);
+    Assertions.assertThatThrownBy(query::processAllAvailable)
+        .isInstanceOf(StreamingQueryException.class)
+        .hasMessageEndingWith("Cannot write using unsupported transforms: zero");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -32,7 +32,6 @@ import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
@@ -53,7 +52,8 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
-import org.assertj.core.api.Assertions;import org.junit.After;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -668,8 +668,8 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
     for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES, ENTRIES, ALL_ENTRIES)) {
       Assertions.assertThatThrownBy(() -> loadMetadataTable(tableType))
-              .isInstanceOf(ValidationException.class)
-              .hasMessage("Cannot build table partition type, unknown transforms: [zero]");
+          .isInstanceOf(ValidationException.class)
+          .hasMessage("Cannot build table partition type, unknown transforms: [zero]");
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -53,7 +53,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
-import org.junit.After;
+import org.assertj.core.api.Assertions;import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -667,11 +667,9 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
     sql("REFRESH TABLE %s", tableName);
 
     for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES, ENTRIES, ALL_ENTRIES)) {
-      AssertHelpers.assertThrows(
-          "Should complain about the partition type",
-          ValidationException.class,
-          "Cannot build table partition type, unknown transforms",
-          () -> loadMetadataTable(tableType));
+      Assertions.assertThatThrownBy(() -> loadMetadataTable(tableType))
+              .isInstanceOf(ValidationException.class)
+              .hasMessage("Cannot build table partition type, unknown transforms: [zero]");
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
@@ -163,16 +163,11 @@ public class TestRequiredDistributionAndOrdering extends SparkCatalogTestBase {
 
     // should fail if ordering is disabled
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 inputDF
                     .writeTo(tableName)
                     .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
-                    .append();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .append())
         .cause()
         .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith(

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -29,6 +28,7 @@ import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
 
@@ -162,20 +162,22 @@ public class TestRequiredDistributionAndOrdering extends SparkCatalogTestBase {
     Dataset<Row> inputDF = ds.coalesce(1).sortWithinPartitions("c1");
 
     // should fail if ordering is disabled
-    AssertHelpers.assertThrowsCause(
-        "Should reject writes without ordering",
-        IllegalStateException.class,
-        "Incoming records violate the writer assumption",
-        () -> {
-          try {
-            inputDF
-                .writeTo(tableName)
-                .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
-                .append();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                inputDF
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+                    .append();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith(
+            "Incoming records violate the writer assumption that records are clustered by spec "
+                + "and by partition within each spec. Either cluster the incoming records or switch to fanout writers.");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DeleteFile;
@@ -492,11 +491,10 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
 
     StreamingQuery query = startStream();
 
-    AssertHelpers.assertThrowsCause(
-        "Streaming should fail with IllegalStateException, as the snapshot is not of type APPEND",
-        IllegalStateException.class,
-        "Cannot process overwrite snapshot",
-        () -> query.processAllAvailable());
+    Assertions.assertThatThrownBy(query::processAllAvailable)
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Cannot process overwrite snapshot");
   }
 
   @Test
@@ -533,11 +531,10 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
 
     StreamingQuery query = startStream();
 
-    AssertHelpers.assertThrowsCause(
-        "Streaming should fail with IllegalStateException, as the snapshot is not of type APPEND",
-        IllegalStateException.class,
-        "Cannot process delete snapshot",
-        () -> query.processAllAvailable());
+    Assertions.assertThatThrownBy(query::processAllAvailable)
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Cannot process delete snapshot");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestTimestampWithoutZone.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
@@ -53,6 +52,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -159,21 +159,17 @@ public class TestTimestampWithoutZone extends SparkTestBase {
 
   @Test
   public void testUnpartitionedTimestampWithoutZoneError() {
-    AssertHelpers.assertThrows(
-        String.format(
-            "Read operation performed on a timestamp without timezone field while "
-                + "'%s' set to false should throw exception",
-            SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE),
-        IllegalArgumentException.class,
-        SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR,
-        () ->
-            spark
-                .read()
-                .format("iceberg")
-                .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                .option(SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "false")
-                .load(unpartitioned.toString())
-                .collectAsList());
+    Assertions.assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+                    .option(SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "false")
+                    .load(unpartitioned.toString())
+                    .collectAsList())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
   }
 
   @Test
@@ -198,30 +194,21 @@ public class TestTimestampWithoutZone extends SparkTestBase {
 
   @Test
   public void testUnpartitionedTimestampWithoutZoneWriteError() {
-    String errorMessage =
-        String.format(
-            "Write operation performed on a timestamp without timezone field while "
-                + "'%s' set to false should throw exception",
-            SparkSQLProperties.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE);
-    Runnable writeOperation =
-        () ->
-            spark
-                .read()
-                .format("iceberg")
-                .option(SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true")
-                .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
-                .load(unpartitioned.toString())
-                .write()
-                .format("iceberg")
-                .option(SparkWriteOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "false")
-                .mode(SaveMode.Append)
-                .save(unpartitioned.toString());
-
-    AssertHelpers.assertThrows(
-        errorMessage,
-        IllegalArgumentException.class,
-        SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR,
-        writeOperation);
+    Assertions.assertThatThrownBy(
+            () ->
+                spark
+                    .read()
+                    .format("iceberg")
+                    .option(SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "true")
+                    .option(SparkReadOptions.VECTORIZATION_ENABLED, String.valueOf(vectorized))
+                    .load(unpartitioned.toString())
+                    .write()
+                    .format("iceberg")
+                    .option(SparkWriteOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE, "false")
+                    .mode(SaveMode.Append)
+                    .save(unpartitioned.toString()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestWriteMetricsConfig.java
@@ -27,7 +27,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
@@ -49,6 +48,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -231,11 +231,11 @@ public class TestWriteMetricsConfig {
     properties.put(TableProperties.DEFAULT_WRITE_METRICS_MODE, "counts");
     properties.put("write.metadata.metrics.column.ids", "full");
 
-    AssertHelpers.assertThrows(
-        "Creating a table with invalid metrics should fail",
-        ValidationException.class,
-        null,
-        () -> tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation));
+    Assertions.assertThatThrownBy(
+            () -> tables.create(SIMPLE_SCHEMA, spec, properties, tableLocation))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Invalid metrics config, could not find column ids from table prop write.metadata.metrics.column.ids in schema table");
   }
 
   @Test


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove AssertHelpers in `iceberg-spark` module except `spark.sql` package, which will be resolved in next PR.