### PR TITLE
[python_legacy] fix evaluator failure to match date column

### DIFF
--- a/python_legacy/iceberg/api/expressions/evaluator.py
+++ b/python_legacy/iceberg/api/expressions/evaluator.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import threading
+from datetime import date, datetime
 
 from .binder import Binder
 from .expressions import ExpressionVisitors
@@ -68,25 +69,31 @@ class Evaluator(object):
             return not (ref.get(self.struct) is None)
 
         def lt(self, ref, lit):
-            return ref.get(self.struct) < lit.value
+            return self.convert_for_lit(ref.get(self.struct)) < lit.value
 
         def lt_eq(self, ref, lit):
-            return ref.get(self.struct) <= lit.value
+            return self.convert_for_lit(ref.get(self.struct)) <= lit.value
 
         def gt(self, ref, lit):
-            return ref.get(self.struct) > lit.value
+            return self.convert_for_lit(ref.get(self.struct)) > lit.value
 
         def gt_eq(self, ref, lit):
-            return ref.get(self.struct) >= lit.value
+            return self.convert_for_lit(ref.get(self.struct)) >= lit.value
 
         def eq(self, ref, lit):
-            return ref.get(self.struct) == lit.value
+            return self.convert_for_lit(ref.get(self.struct)) == lit.value
 
         def not_eq(self, ref, lit):
-            return ref.get(self.struct) != lit.value
+            return self.convert_for_lit(ref.get(self.struct)) != lit.value
 
         def in_(self, ref, lit):
             raise NotImplementedError()
 
         def not_in(self, ref, lit):
             return not self.in_(ref, lit.value)
+
+        def convert_for_lit(self, ref_val):
+            if type(ref_val) == date:
+                return (datetime.combine(ref_val, datetime.min.time()) - datetime.utcfromtimestamp(0)).days
+            else:
+                return ref_val

--- a/python_legacy/tests/api/expressions/test_evaluator.py
+++ b/python_legacy/tests/api/expressions/test_evaluator.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from datetime import datetime, timezone, date
+
+from datetime import date
 
 import iceberg.api.expressions as exp
 from iceberg.api.expressions import Literal
@@ -22,7 +23,8 @@ from iceberg.api.types import (FloatType,
                                IntegerType,
                                NestedField,
                                StringType,
-                               StructType, DateType)
+                               StructType,
+                               DateType)
 from iceberg.core import PartitionData
 from iceberg.exceptions import ValidationException
 from pytest import raises


### PR DESCRIPTION
Date partition column failed to be matched due to `ref.get(self.struct)` is a datetime.date and `lit` is a `DateLiteral`.

This PR adds a conversion method and convert it to a int to match the `DateLiteral.vale`. Also added related unit test.

