### PR TITLE
API, Core: Make RewriteFiles flexible

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -32,15 +32,93 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * will be resolved by applying the changes to the new latest snapshot and reattempting the commit.
  * If any of the deleted files are no longer in the latest snapshot when reattempting, the commit
  * will throw a {@link ValidationException}.
+ *
+ * <p>Note that the new state of the table after each rewrite must be logically equivalent to the
+ * original table state.
  */
 public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
+  /**
+   * Remove a data file from the current table state.
+   *
+   * <p>This rewrite operation may change the size or layout of the data files. When applicable, it
+   * is also recommended to discard already deleted records while rewriting data files. However, the
+   * set of live data records must never change.
+   *
+   * @param dataFile a rewritten data file
+   * @return this for method chaining
+   */
+  default RewriteFiles deleteFile(DataFile dataFile) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement deleteFile");
+  }
+
+  /**
+   * Remove a delete file from the table state.
+   *
+   * <p>This rewrite operation may change the size or layout of the delete files. When applicable,
+   * it is also recommended to discard delete records for files that are no longer part of the table
+   * state. However, the set of applicable delete records must never change.
+   *
+   * @param deleteFile a rewritten delete file
+   * @return this for method chaining
+   */
+  default RewriteFiles deleteFile(DeleteFile deleteFile) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement deleteFile");
+  }
+
+  /**
+   * Add a new data file.
+   *
+   * <p>This rewrite operation may change the size or layout of the data files. When applicable, it
+   * is also recommended to discard already deleted records while rewriting data files. However, the
+   * set of live data records must never change.
+   *
+   * @param dataFile a new data file
+   * @return this for method chaining
+   */
+  default RewriteFiles addFile(DataFile dataFile) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement addFile");
+  }
+
+  /**
+   * Add a new delete file.
+   *
+   * <p>This rewrite operation may change the size or layout of the delete files. When applicable,
+   * it is also recommended to discard delete records for files that are no longer part of the table
+   * state. However, the set of applicable delete records must never change.
+   *
+   * @param deleteFile a new delete file
+   * @return this for method chaining
+   */
+  default RewriteFiles addFile(DeleteFile deleteFile) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement addFile");
+  }
+
+  /**
+   * Configure the data sequence number for this rewrite operation. This data sequence number will
+   * be used for all new data files that are added in this rewrite. This method is helpful to avoid
+   * commit conflicts between data compaction and adding equality deletes.
+   *
+   * @param sequenceNumber a data sequence number
+   * @return this for method chaining
+   */
+  default RewriteFiles dataSequenceNumber(long sequenceNumber) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement dataSequenceNumber");
+  }
+
   /**
    * Add a rewrite that replaces one set of data files with another set that contains the same data.
    *
    * @param filesToDelete files that will be replaced (deleted), cannot be null or empty.
    * @param filesToAdd files that will be added, cannot be null or empty.
    * @return this for method chaining
+   * @deprecated since 1.3.0, will be removed in 2.0.0
    */
+  @Deprecated
   default RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
     return rewriteFiles(filesToDelete, ImmutableSet.of(), filesToAdd, ImmutableSet.of());
   }
@@ -53,7 +131,9 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @param filesToAdd files that will be added, cannot be null or empty.
    * @param sequenceNumber sequence number to use for all data files added
    * @return this for method chaining
+   * @deprecated since 1.3.0, will be removed in 2.0.0
    */
+  @Deprecated
   RewriteFiles rewriteFiles(
       Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber);
 
@@ -65,7 +145,9 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @param dataFilesToAdd data files that will be added.
    * @param deleteFilesToAdd delete files that will be added.
    * @return this for method chaining.
+   * @deprecated since 1.3.0, will be removed in 2.0.0
    */
+  @Deprecated
   RewriteFiles rewriteFiles(
       Set<DataFile> dataFilesToReplace,
       Set<DeleteFile> deleteFilesToReplace,

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -165,6 +165,12 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     deletePaths.add(path);
   }
 
+  boolean containsDeletes() {
+    return deletePaths.size() > 0
+        || deleteExpression != Expressions.alwaysFalse()
+        || dropPartitions.size() > 0;
+  }
+
   /**
    * Filter deleted files out of a list of manifests.
    *

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -86,7 +86,7 @@ public class TestRewriteFiles extends TableTestBase {
                     .rewriteFiles(
                         ImmutableSet.of(),
                         ImmutableSet.of(FILE_A_DELETES),
-                        ImmutableSet.of(FILE_A),
+                        ImmutableSet.of(),
                         ImmutableSet.of(FILE_B_DELETES)),
                 branch));
   }
@@ -142,7 +142,7 @@ public class TestRewriteFiles extends TableTestBase {
     AssertHelpers.assertThrows(
         "Expected an exception",
         IllegalArgumentException.class,
-        "Files to delete cannot be null or empty",
+        "Files to delete cannot be empty",
         () ->
             apply(
                 table.newRewrite().rewriteFiles(Collections.emptySet(), Sets.newSet(FILE_A)),
@@ -151,7 +151,7 @@ public class TestRewriteFiles extends TableTestBase {
     AssertHelpers.assertThrows(
         "Expected an exception",
         IllegalArgumentException.class,
-        "Files to delete cannot be null or empty",
+        "Files to delete cannot be empty",
         () ->
             apply(
                 table
@@ -166,7 +166,7 @@ public class TestRewriteFiles extends TableTestBase {
     AssertHelpers.assertThrows(
         "Expected an exception",
         IllegalArgumentException.class,
-        "Files to delete cannot be null or empty",
+        "Files to delete cannot be empty",
         () ->
             apply(
                 table


### PR DESCRIPTION
This PR makes `RewriteFiles` more flexible and aligned with other APIs like `OverwriteFiles`. One valid use case is discussed in #7389, where we want to replace one set of delete files with another one. Instead of adding another overloaded method, we should make the interface flexible enough to support various combinations.