### PR TITLE
Core: Simplify Partitions table partition-coercion code

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionUtil.java
@@ -91,7 +91,7 @@ public class PartitionUtil {
   }
 
   // adapts the provided partition data to match the table partition type
-  private static StructLike coercePartition(
+  public static StructLike coercePartition(
       Types.StructType partitionType, PartitionSpec spec, StructLike partition) {
     StructProjection projection =
         StructProjection.createAllowMissing(spec.partitionType(), partitionType);


### PR DESCRIPTION
This code was added in https://github.com/apache/iceberg/pull/4560.

I now realize I could have used an existing util class for coercing (normalizing) partition data to the final type, instead of writing my own method.