### PR TITLE
API, Flink: StructProjection returns null projection object for null nested struct value

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -174,7 +174,6 @@ public class StructProjection implements StructLike {
   }
 
   public StructProjection wrap(StructLike newStruct) {
-    Preconditions.checkState(newStruct != null, "Invalid root struct for wrapping: null");
     this.struct = newStruct;
     return this;
   }
@@ -190,6 +189,12 @@ public class StructProjection implements StructLike {
 
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
+    // struct can be null if wrap is not called first before the get call
+    // or if a null struct is wrapped.
+    if (struct == null) {
+      return null;
+    }
+
     int structPos = positionMap[pos];
     if (nestedProjections[pos] != null) {
       StructLike nestedStruct = struct.get(structPos, StructLike.class);

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -174,6 +174,7 @@ public class StructProjection implements StructLike {
   }
 
   public StructProjection wrap(StructLike newStruct) {
+    Preconditions.checkState(newStruct != null, "Invalid root struct for wrapping: null");
     this.struct = newStruct;
     return this;
   }
@@ -189,13 +190,6 @@ public class StructProjection implements StructLike {
 
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
-    // Handle the case where the wrapped root struct is null.
-    // Because nested null struct is returned as null projection object,
-    // there won't be nested projection wrapping null struct.
-    if (struct == null) {
-      return null;
-    }
-
     int structPos = positionMap[pos];
     if (nestedProjections[pos] != null) {
       StructLike nestedStruct = struct.get(structPos, StructLike.class);

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -189,16 +189,12 @@ public class StructProjection implements StructLike {
 
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
-    if (struct == null) {
-      // Return a null struct when projecting a nested required field from an optional struct.
-      // See more details in issue #2738.
-      return null;
-    }
-
     int structPos = positionMap[pos];
-
     if (nestedProjections[pos] != null) {
-      return javaClass.cast(nestedProjections[pos].wrap(struct.get(structPos, StructLike.class)));
+      StructLike nestedStruct = struct.get(structPos, StructLike.class);
+      return nestedStruct == null
+          ? null
+          : javaClass.cast(nestedProjections[pos].wrap(nestedStruct));
     }
 
     if (structPos != -1) {

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -189,12 +189,21 @@ public class StructProjection implements StructLike {
 
   @Override
   public <T> T get(int pos, Class<T> javaClass) {
+    // Handle the case where the wrapped root struct is null.
+    // Because nested null struct is returned as null projection object,
+    // there won't be nested projection wrapping null struct.
+    if (struct == null) {
+      return null;
+    }
+
     int structPos = positionMap[pos];
     if (nestedProjections[pos] != null) {
       StructLike nestedStruct = struct.get(structPos, StructLike.class);
-      return nestedStruct == null
-          ? null
-          : javaClass.cast(nestedProjections[pos].wrap(nestedStruct));
+      if (nestedStruct == null) {
+        return null;
+      }
+
+      return javaClass.cast(nestedProjections[pos].wrap(nestedStruct));
     }
 
     if (structPos != -1) {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -105,8 +105,12 @@ public class RowDataProjection implements RowData {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
         return row -> {
-          RowData nestedRow =
-              row.isNullAt(position) ? null : row.getRow(position, nestedRowType.getFieldCount());
+          // null nested struct value
+          if (row.isNullAt(position)) {
+            return null;
+          }
+
+          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
           return RowDataProjection.create(
                   nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
               .wrap(nestedRow);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -105,8 +105,12 @@ public class RowDataProjection implements RowData {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
         return row -> {
-          RowData nestedRow =
-              row.isNullAt(position) ? null : row.getRow(position, nestedRowType.getFieldCount());
+          // null nested struct value
+          if (row.isNullAt(position)) {
+            return null;
+          }
+
+          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
           return RowDataProjection.create(
                   nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
               .wrap(nestedRow);

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -105,8 +105,12 @@ public class RowDataProjection implements RowData {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
         return row -> {
-          RowData nestedRow =
-              row.isNullAt(position) ? null : row.getRow(position, nestedRowType.getFieldCount());
+          // null nested struct value
+          if (row.isNullAt(position)) {
+            return null;
+          }
+
+          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
           return RowDataProjection.create(
                   nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
               .wrap(nestedRow);


### PR DESCRIPTION
Adjusted the same behavior in Flink RowDataProjection.

closes issue #7507 