### PR TITLE
Flink: Fix Typo in Namespace

### DIFF
--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -37,8 +37,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @After

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -62,8 +62,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogTable(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogTable(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @Override

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -37,8 +37,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @After

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -62,8 +62,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogTable(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogTable(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @Override

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -37,8 +37,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogDatabase(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @After

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -62,8 +62,8 @@ import org.junit.Test;
 
 public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
-  public TestFlinkCatalogTable(String catalogName, Namespace baseNamepace) {
-    super(catalogName, baseNamepace);
+  public TestFlinkCatalogTable(String catalogName, Namespace baseNamespace) {
+    super(catalogName, baseNamespace);
   }
 
   @Override


### PR DESCRIPTION
replace `baseNamepace` with `baseNamespace`