### PR TITLE
Build: Fix BrotliCodec class not found failure when using brotli as compression codec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,7 @@ allprojects {
   repositories {
     mavenCentral()
     mavenLocal()
+    maven { url 'https://jitpack.io' }
   }
 }
 
@@ -729,6 +730,7 @@ project(':iceberg-parquet') {
     api project(':iceberg-api')
     implementation project(':iceberg-core')
     implementation project(':iceberg-common')
+    implementation 'com.github.rdblue:brotli-codec:0.1.1'
 
     implementation("org.apache.parquet:parquet-avro") {
       exclude group: 'org.apache.avro', module: 'avro'


### PR DESCRIPTION
### About the change

presently when using brotli as compression codec for parquet it fails with 

```
Caused by: org.apache.parquet.hadoop.BadConfigurationException: Class org.apache.hadoop.io.compress.BrotliCodec was not found
	at org.apache.parquet.hadoop.CodecFactory.getCodec(CodecFactory.java:243)
	at org.apache.parquet.hadoop.CodecFactory$HeapBytesCompressor.<init>(CodecFactory.java:144)
	at org.apache.parquet.hadoop.CodecFactory.createCompressor(CodecFactory.java:208)
	at org.apache.parquet.hadoop.CodecFactory.getCompressor(CodecFactory.java:191)
```

this just makes sure BrotliCodec is available in class path so that it can be loaded and doesn't fails with the error above. 

Alternatively we could also mention in iceberg to install BrotliCodec when selecting brotli as the compression, somewhat spark does (https://spark.apache.org/docs/latest/sql-data-sources-parquet.html, ref: brotli requires BrotliCodec to be installed) rather than taking a new dependency .

cc @rdblue @jackye1995 