### PR TITLE
Make SparkCatalog use a case sensitive CachingCatalog by default.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -44,6 +44,8 @@ public class CatalogProperties {
   /** Controls whether the caching catalog will cache table entries using case sensitive keys. */
   public static final String CACHE_CASE_SENSITIVE = "cache.case-sensitive";
 
+  public static final boolean CACHE_CASE_SENSITIVE_DEFAULT = true;
+
   /**
    * Controls the duration for which entries in the catalog are cached.
    *

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -459,10 +459,11 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
-    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -479,6 +480,7 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
+    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -458,10 +458,11 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
-    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -478,6 +479,7 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
+    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -531,10 +531,11 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
-    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -551,6 +552,7 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
+    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -531,10 +531,11 @@ public class SparkCatalog extends BaseCatalog {
         PropertyUtil.propertyAsBoolean(
             options, CatalogProperties.CACHE_ENABLED, CatalogProperties.CACHE_ENABLED_DEFAULT);
 
-    SparkSession sparkSession = SparkSession.active();
     boolean cacheCaseSensitive =
         PropertyUtil.propertyAsBoolean(
-            options, CatalogProperties.CACHE_CASE_SENSITIVE, SparkUtil.caseSensitive(sparkSession));
+            options,
+            CatalogProperties.CACHE_CASE_SENSITIVE,
+            CatalogProperties.CACHE_CASE_SENSITIVE_DEFAULT);
 
     long cacheExpirationIntervalMs =
         PropertyUtil.propertyAsLong(
@@ -551,6 +552,7 @@ public class SparkCatalog extends BaseCatalog {
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
+    SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone =
         SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables =


### PR DESCRIPTION
Follow up to https://github.com/apache/iceberg/pull/7469.
To avoid breaking Spark users of Nessie, restore the former default behavior.
The case sensitivity of the CachingCatalog that wraps the SparkCatalog is still configurable, but it defaults to true.