### PR TITLE
Core: Remove duplicate check for ManifestEntry.dataSequenceNumber()

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -508,10 +508,6 @@ public class TableTestBase {
             "Data sequence number should match expected",
             expectedSequenceNumber,
             entry.dataSequenceNumber());
-        V2Assert.assertEquals(
-            "Sequence number should match expected",
-            expectedSequenceNumber,
-            entry.dataSequenceNumber());
       }
       if (fileSeqs != null) {
         V1Assert.assertEquals(
@@ -548,10 +544,6 @@ public class TableTestBase {
         Long expectedSequenceNumber = dataSeqs.next();
         V2Assert.assertEquals(
             "Data sequence number should match expected",
-            expectedSequenceNumber,
-            entry.dataSequenceNumber());
-        V2Assert.assertEquals(
-            "Sequence number should match expected",
             expectedSequenceNumber,
             entry.dataSequenceNumber());
       }


### PR DESCRIPTION
When dropping ManifestEntry.sequenceNumber in #6274, a new assert was added to TableTestBase.validateManifests(). However, there was a same assert already. Dropping one of them.