### PR TITLE
Implement ReadableMetrics for Entries table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
@@ -33,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.StructProjection;
 
@@ -50,10 +53,10 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     if (partitionType.fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition
       // field (id 102)
-      return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
-    } else {
-      return schema;
+      schema = TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     }
+
+    return TypeUtil.join(schema, MetricsUtil.readableMetricsSchema(table().schema(), schema));
   }
 
   static CloseableIterable<FileScanTask> planFiles(
@@ -92,8 +95,9 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
   }
 
   static class ManifestReadTask extends BaseFileScanTask implements DataTask {
-    private final Schema schema;
+    private final Schema projection;
     private final Schema fileSchema;
+    private final Schema dataTableSchema;
     private final FileIO io;
     private final ManifestFile manifest;
     private final Map<Integer, PartitionSpec> specsById;
@@ -101,17 +105,18 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     ManifestReadTask(
         Table table,
         ManifestFile manifest,
-        Schema schema,
+        Schema projection,
         String schemaString,
         String specString,
         ResidualEvaluator residuals) {
       super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
-      this.schema = schema;
+      this.projection = projection;
       this.io = table.io();
       this.manifest = manifest;
       this.specsById = Maps.newHashMap(table.specs());
+      this.dataTableSchema = table.schema();
 
-      Type fileProjection = schema.findType("data_file");
+      Type fileProjection = projection.findType("data_file");
       this.fileSchema =
           fileProjection != null
               ? new Schema(fileProjection.asStructType().fields())
@@ -125,31 +130,128 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
 
     @Override
     public CloseableIterable<StructLike> rows() {
+      Types.NestedField readableMetricsField = projection.findField(MetricsUtil.READABLE_METRICS);
       // Project data-file fields
       CloseableIterable<StructLike> prunedRows;
-      if (manifest.content() == ManifestContent.DATA) {
-        prunedRows =
-            CloseableIterable.transform(
-                ManifestFiles.read(manifest, io).project(fileSchema).entries(),
-                file -> (GenericManifestEntry<DataFile>) file);
-      } else {
-        prunedRows =
-            CloseableIterable.transform(
-                ManifestFiles.readDeleteManifest(manifest, io, specsById)
-                    .project(fileSchema)
-                    .entries(),
-                file -> (GenericManifestEntry<DeleteFile>) file);
-      }
+      if (readableMetricsField == null) {
+        if (manifest.content() == ManifestContent.DATA) {
+          prunedRows =
+              CloseableIterable.transform(
+                  ManifestFiles.read(manifest, io, specsById).project(fileSchema).entries(),
+                  entry -> (GenericManifestEntry<DataFile>) entry);
+        } else {
+          prunedRows =
+              CloseableIterable.transform(
+                  ManifestFiles.readDeleteManifest(manifest, io, specsById)
+                      .project(fileSchema)
+                      .entries(),
+                  entry -> (GenericManifestEntry<DeleteFile>) entry);
+        }
 
-      // Project non-readable fields
-      Schema readSchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
-      StructProjection projection = StructProjection.create(readSchema, schema);
-      return CloseableIterable.transform(prunedRows, projection::wrap);
+        // Project non-readable fields
+        Schema readSchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
+        StructProjection structProjection = StructProjection.create(readSchema, this.projection);
+        return CloseableIterable.transform(prunedRows, structProjection::wrap);
+      } else {
+        Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
+        int metricsPosition = projection.columns().indexOf(readableMetricsField);
+        // projection minus virtual column such as readableMetrics
+        Schema projectedSchemaMinusReadableMetrics =
+            TypeUtil.selectNot(projection, readableMetricsIds);
+        // Remove virtual columns from the file projection and ensure that the underlying metrics
+        // used to create those columns are part of the file projection
+        Schema projectionForReadableMetrics =
+            new Schema(
+                MetricsUtil.READABLE_METRIC_COLS.stream()
+                    .map(MetricsUtil.ReadableMetricColDefinition::originalCol)
+                    .collect(Collectors.toList()));
+
+        Schema projectionForMetrics = TypeUtil.join(fileSchema, projectionForReadableMetrics);
+        return CloseableIterable.transform(
+            entries(projectionForMetrics),
+            entry ->
+                withReadableMetrics(projectedSchemaMinusReadableMetrics, entry, metricsPosition));
+      }
+    }
+
+    private CloseableIterable<? extends ManifestEntry<? extends ContentFile<?>>> entries(
+        Schema fileProjection) {
+      switch (manifest.content()) {
+        case DATA:
+          return ManifestFiles.read(manifest, io, specsById).project(fileProjection).entries();
+        case DELETES:
+          return ManifestFiles.readDeleteManifest(manifest, io, specsById)
+              .project(fileProjection)
+              .entries();
+        default:
+          throw new IllegalArgumentException(
+              "Unsupported manifest content type:" + manifest.content());
+      }
+    }
+
+    private StructLike withReadableMetrics(
+        Schema projectedSchema,
+        ManifestEntry<? extends ContentFile<?>> entry,
+        int metricsPosition) {
+      int projectionColumnCount = projection.columns().size();
+      StructType projectedMetricType =
+          projection.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+      MetricsUtil.ReadableMetricsStruct readableMetrics =
+          MetricsUtil.readableMetricsStruct(dataTableSchema, entry.file(), projectedMetricType);
+
+      Schema manifestEntrySchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
+      StructProjection entryStruct =
+          StructProjection.create(manifestEntrySchema, projectedSchema).wrap((StructLike) entry);
+
+      return new ManifestEntryStructWithMetrics(
+          projectionColumnCount, metricsPosition, entryStruct, readableMetrics);
     }
 
     @Override
     public Iterable<FileScanTask> split(long splitSize) {
       return ImmutableList.of(this); // don't split
+    }
+  }
+
+  static class ManifestEntryStructWithMetrics implements StructLike {
+    private final StructProjection entryAsStruct;
+    private final MetricsUtil.ReadableMetricsStruct readableMetrics;
+    private final int projectionColumnCount;
+    private final int metricsPosition;
+
+    ManifestEntryStructWithMetrics(
+        int projectionColumnCount,
+        int metricsPosition,
+        StructProjection entryAsStruct,
+        MetricsUtil.ReadableMetricsStruct readableMetrics) {
+      this.entryAsStruct = entryAsStruct;
+      this.readableMetrics = readableMetrics;
+      this.projectionColumnCount = projectionColumnCount;
+      this.metricsPosition = metricsPosition;
+    }
+
+    @Override
+    public int size() {
+      return projectionColumnCount;
+    }
+
+    @Override
+    public <T> T get(int pos, Class<T> javaClass) {
+      if (pos < metricsPosition) {
+        return entryAsStruct.get(pos, javaClass);
+      } else if (pos == metricsPosition) {
+        return javaClass.cast(readableMetrics);
+      } else {
+        // columnCount = fileAsStruct column count + the readable metrics field.
+        // When pos is greater than metricsPosition, the actual position of the field in
+        // fileAsStruct should be subtracted by 1.
+        return entryAsStruct.get(pos - 1, javaClass);
+      }
+    }
+
+    @Override
+    public <T> void set(int pos, T value) {
+      throw new UnsupportedOperationException("ManifestEntryStructWithMetrics is read only");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -138,7 +138,7 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
                 entries(fileSchema),
                 entry -> (GenericManifestEntry<? extends ContentFile<?>>) entry);
 
-        StructProjection structProjection = projectNonReadable(fileSchema, projection);
+        StructProjection structProjection = projectNonReadable(projection);
         return CloseableIterable.transform(entryAsStruct, structProjection::wrap);
       } else {
         Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
@@ -166,9 +166,9 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       return ManifestFiles.open(manifest, io, specsById).project(fileProjection).entries();
     }
 
-    private StructProjection projectNonReadable(Schema fileSchema, Schema projection) {
+    private StructProjection projectNonReadable(Schema projectedSchema) {
       Schema manifestEntrySchema = ManifestEntry.wrapFileSchema(fileSchema.asStruct());
-      return StructProjection.create(manifestEntrySchema, projection);
+      return StructProjection.create(manifestEntrySchema, projectedSchema);
     }
 
     private StructLike withReadableMetrics(
@@ -180,8 +180,7 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
           projection.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
       MetricsUtil.ReadableMetricsStruct readableMetrics =
           MetricsUtil.readableMetricsStruct(dataTableSchema, entry.file(), projectedMetricType);
-      StructProjection entryStruct =
-          projectNonReadable(fileSchema, projectedSchema).wrap((StructLike) entry);
+      StructProjection entryStruct = projectNonReadable(projectedSchema).wrap((StructLike) entry);
 
       return new ManifestEntryStructWithMetrics(
           projectionColumnCount, metricsPosition, entryStruct, readableMetrics);

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -152,8 +152,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     }
 
     /**
-     * Ensure that the underlying metrics used to create those columns are part of the file
-     * projection
+     * Ensure that the underlying metrics used to populate readable metrics column are part of the
+     * file projection
      *
      * @return file projection with required columns to read readable metrics
      */

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -138,12 +138,12 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
                 entries(fileProjection),
                 entry -> (GenericManifestEntry<? extends ContentFile<?>>) entry);
 
-        StructProjection structProjection = projectNonReadable(projection);
+        StructProjection structProjection = structProjection(projection);
         return CloseableIterable.transform(entryAsStruct, structProjection::wrap);
       } else {
         Schema requiredFileProjection = requiredFileProjection();
         Schema actualProjection = removeReadableMetrics(readableMetricsField);
-        StructProjection structProjection = projectNonReadable(actualProjection);
+        StructProjection structProjection = structProjection(actualProjection);
 
         return CloseableIterable.transform(
             entries(requiredFileProjection),
@@ -152,8 +152,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     }
 
     /**
-     * Remove virtual columns from the file projection and ensure that the underlying metrics used
-     * to create those columns are part of the file projection
+     * Ensure that the underlying metrics used to create those columns are part of the file
+     * projection
      *
      * @return file projection with required columns to read readable metrics
      */
@@ -171,7 +171,7 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       return TypeUtil.selectNot(projection, readableMetricsIds);
     }
 
-    private StructProjection projectNonReadable(Schema projectedSchema) {
+    private StructProjection structProjection(Schema projectedSchema) {
       Schema manifestEntrySchema = ManifestEntry.wrapFileSchema(fileProjection.asStruct());
       return StructProjection.create(manifestEntrySchema, projectedSchema);
     }

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.types.TypeUtil;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -46,7 +47,9 @@ public class TestEntriesMetadataTable extends TableTestBase {
 
     Table entriesTable = new ManifestEntriesTable(table);
 
-    Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema readSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema expectedSchema =
+        TypeUtil.join(readSchema, MetricsUtil.readableMetricsSchema(table.schema(), readSchema));
 
     assertEquals(
         "A tableScan.select() should prune the schema",
@@ -61,7 +64,9 @@ public class TestEntriesMetadataTable extends TableTestBase {
     Table entriesTable = new ManifestEntriesTable(table);
     TableScan scan = entriesTable.newScan();
 
-    Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema readSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema expectedSchema =
+        TypeUtil.join(readSchema, MetricsUtil.readableMetricsSchema(table.schema(), readSchema));
 
     assertEquals(
         "A tableScan.select() should prune the schema",
@@ -128,7 +133,7 @@ public class TestEntriesMetadataTable extends TableTestBase {
   }
 
   @Test
-  public void testEntriesTableWithDeleteManifests() throws Exception {
+  public void testEntriesTableWithDeleteManifests() {
     Assume.assumeTrue("Only V2 Tables Support Deletes", formatVersion >= 2);
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
@@ -137,7 +142,9 @@ public class TestEntriesMetadataTable extends TableTestBase {
     Table entriesTable = new ManifestEntriesTable(table);
     TableScan scan = entriesTable.newScan();
 
-    Schema expectedSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema readSchema = ManifestEntry.getSchema(table.spec().partitionType());
+    Schema expectedSchema =
+        TypeUtil.join(readSchema, MetricsUtil.readableMetricsSchema(table.schema(), readSchema));
 
     assertEquals(
         "A tableScan.select() should prune the schema",

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -664,6 +664,93 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @Test
+  public void testEntriesTableReadableMetricsSchema() {
+    Table entriesTable = new ManifestEntriesTable(table);
+    Types.StructType actual = entriesTable.newScan().schema().select("readable_metrics").asStruct();
+    int highestId = entriesTable.schema().highestFieldId();
+
+    Types.StructType expected =
+        Types.StructType.of(
+            optional(
+                highestId,
+                "readable_metrics",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        highestId - 14,
+                        "data",
+                        Types.StructType.of(
+                            Types.NestedField.optional(
+                                highestId - 13,
+                                "column_size",
+                                Types.LongType.get(),
+                                "Total size on disk"),
+                            Types.NestedField.optional(
+                                highestId - 12,
+                                "value_count",
+                                Types.LongType.get(),
+                                "Total count, including null and NaN"),
+                            Types.NestedField.optional(
+                                highestId - 11,
+                                "null_value_count",
+                                Types.LongType.get(),
+                                "Null value count"),
+                            Types.NestedField.optional(
+                                highestId - 10,
+                                "nan_value_count",
+                                Types.LongType.get(),
+                                "NaN value count"),
+                            Types.NestedField.optional(
+                                highestId - 9,
+                                "lower_bound",
+                                Types.StringType.get(),
+                                "Lower bound"),
+                            Types.NestedField.optional(
+                                highestId - 8,
+                                "upper_bound",
+                                Types.StringType.get(),
+                                "Upper bound")),
+                        "Metrics for column data"),
+                    Types.NestedField.optional(
+                        highestId - 7,
+                        "id",
+                        Types.StructType.of(
+                            Types.NestedField.optional(
+                                highestId - 6,
+                                "column_size",
+                                Types.LongType.get(),
+                                "Total size on disk"),
+                            Types.NestedField.optional(
+                                highestId - 5,
+                                "value_count",
+                                Types.LongType.get(),
+                                "Total count, including null and NaN"),
+                            Types.NestedField.optional(
+                                highestId - 4,
+                                "null_value_count",
+                                Types.LongType.get(),
+                                "Null value count"),
+                            Types.NestedField.optional(
+                                highestId - 3,
+                                "nan_value_count",
+                                Types.LongType.get(),
+                                "NaN value count"),
+                            Types.NestedField.optional(
+                                highestId - 2,
+                                "lower_bound",
+                                Types.IntegerType.get(),
+                                "Lower bound"),
+                            Types.NestedField.optional(
+                                highestId - 1,
+                                "upper_bound",
+                                Types.IntegerType.get(),
+                                "Upper bound")),
+                        "Metrics for column id")),
+                "Column metrics in readable form"));
+
+    Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+  }
+
+  @Test
   public void testPartitionSpecEvolutionAdditive() {
     preparePartitionedTable();
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -156,12 +156,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.refresh();
 
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "entries"))
-            .collectAsList();
+    Dataset<Row> entriesTableDs =
+        spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries"));
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     Snapshot snapshot = table.currentSnapshot();
 
@@ -185,7 +182,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Assert.assertEquals("Entries table should have one row", 1, expected.size());
     Assert.assertEquals("Actual results should have one row", 1, actual.size());
-    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.get(0));
+    TestHelpers.assertEqualsSafe(
+        TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(0), actual.get(0));
   }
 
   @Test
@@ -352,13 +350,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // ensure table data isn't stale
     table.refresh();
 
-    List<Row> actual =
+    Dataset<Row> entriesTableDs =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "all_entries"))
-            .orderBy("snapshot_id")
-            .collectAsList();
+            .orderBy("snapshot_id");
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     List<GenericData.Record> expected = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -384,7 +382,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Actual results should have 3 rows", 3, actual.size());
     for (int i = 0; i < expected.size(); i += 1) {
       TestHelpers.assertEqualsSafe(
-          entriesTable.schema().asStruct(), expected.get(i), actual.get(i));
+          TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(i), actual.get(i));
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -158,12 +158,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.refresh();
 
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "entries"))
-            .collectAsList();
+    Dataset<Row> entriesTableDs =
+        spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries"));
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     Snapshot snapshot = table.currentSnapshot();
 
@@ -187,7 +184,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Assert.assertEquals("Entries table should have one row", 1, expected.size());
     Assert.assertEquals("Actual results should have one row", 1, actual.size());
-    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.get(0));
+    TestHelpers.assertEqualsSafe(
+        TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(0), actual.get(0));
   }
 
   @Test
@@ -354,13 +352,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // ensure table data isn't stale
     table.refresh();
 
-    List<Row> actual =
+    Dataset<Row> entriesTableDs =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "all_entries"))
-            .orderBy("snapshot_id")
-            .collectAsList();
+            .orderBy("snapshot_id");
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     List<GenericData.Record> expected = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -386,7 +384,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Actual results should have 3 rows", 3, actual.size());
     for (int i = 0; i < expected.size(); i += 1) {
       TestHelpers.assertEqualsSafe(
-          entriesTable.schema().asStruct(), expected.get(i), actual.get(i));
+          TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(i), actual.get(i));
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -173,12 +173,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     table.refresh();
 
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "entries"))
-            .collectAsList();
+    Dataset<Row> entriesTableDs =
+        spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries"));
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     Snapshot snapshot = table.currentSnapshot();
 
@@ -202,7 +199,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Assert.assertEquals("Entries table should have one row", 1, expected.size());
     Assert.assertEquals("Actual results should have one row", 1, actual.size());
-    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.get(0));
+    TestHelpers.assertEqualsSafe(
+        TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(0), actual.get(0));
   }
 
   @Test
@@ -369,13 +367,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // ensure table data isn't stale
     table.refresh();
 
-    List<Row> actual =
+    Dataset<Row> entriesTableDs =
         spark
             .read()
             .format("iceberg")
             .load(loadLocation(tableIdentifier, "all_entries"))
-            .orderBy("snapshot_id")
-            .collectAsList();
+            .orderBy("snapshot_id");
+    List<Row> actual = TestHelpers.selectNonDerived(entriesTableDs).collectAsList();
 
     List<GenericData.Record> expected = Lists.newArrayList();
     for (ManifestFile manifest :
@@ -401,7 +399,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Actual results should have 3 rows", 3, actual.size());
     for (int i = 0; i < expected.size(); i += 1) {
       TestHelpers.assertEqualsSafe(
-          entriesTable.schema().asStruct(), expected.get(i), actual.get(i));
+          TestHelpers.nonDerivedSchema(entriesTableDs), expected.get(i), actual.get(i));
     }
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -281,22 +281,31 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
             longCol,
             stringCol);
 
-    assertEquals(
-        "Row should match",
-        ImmutableList.of(new Object[] {metrics}),
-        sql("SELECT readable_metrics FROM %s.files", tableName));
+    List<Object[]> expected = ImmutableList.of(new Object[] {metrics});
+    String sql = "SELECT readable_metrics FROM %s.%s";
+    List<Object[]> filesReadableMetrics = sql(String.format(sql, tableName, "files"));
+    List<Object[]> entriesReadableMetrics = sql(String.format(sql, tableName, "entries"));
+    assertEquals("Row should match for files table", expected, filesReadableMetrics);
+    assertEquals("Row should match for entries table", expected, entriesReadableMetrics);
   }
 
   @Test
   public void testSelectPrimitiveValues() throws Exception {
     createPrimitiveTable();
 
+    List<Object[]> expected = ImmutableList.of(row(1, true));
+    String sql =
+        "SELECT readable_metrics.intCol.lower_bound, readable_metrics.booleanCol.upper_bound FROM %s.%s";
+    List<Object[]> filesReadableMetrics = sql(String.format(sql, tableName, "files"));
+    List<Object[]> entriesReadableMetrics = sql(String.format(sql, tableName, "entries"));
     assertEquals(
-        "select of primitive readable_metrics fields should work",
-        ImmutableList.of(row(1, true)),
-        sql(
-            "SELECT readable_metrics.intCol.lower_bound, readable_metrics.booleanCol.upper_bound FROM %s.files",
-            tableName));
+        "select of primitive readable_metrics fields should work for files table",
+        expected,
+        filesReadableMetrics);
+    assertEquals(
+        "select of primitive readable_metrics fields should work for entries table",
+        expected,
+        entriesReadableMetrics);
 
     assertEquals(
         "mixed select of readable_metrics and other field should work",
@@ -307,19 +316,37 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
         "mixed select of readable_metrics and other field should work, in the other order",
         ImmutableList.of(row(4L, 0)),
         sql("SELECT readable_metrics.longCol.value_count, content FROM %s.files", tableName));
+
+    assertEquals(
+        "mixed select of readable_metrics and other field should work for entries table",
+        ImmutableList.of(row(1, 4L)),
+        sql("SELECT status, readable_metrics.longCol.value_count FROM %s.entries", tableName));
+
+    assertEquals(
+        "mixed select of readable_metrics and other field should work, in the other order for entries table",
+        ImmutableList.of(row(4L, 1)),
+        sql("SELECT readable_metrics.longCol.value_count, status FROM %s.entries", tableName));
   }
 
   @Test
   public void testSelectNestedValues() throws Exception {
     createNestedTable();
 
+    List<Object[]> expected = ImmutableList.of(row(0L, 3L));
+    String sql =
+        "SELECT readable_metrics.`nestedStructCol.leafStructCol.leafLongCol`.lower_bound, "
+            + "readable_metrics.`nestedStructCol.leafStructCol.leafDoubleCol`.value_count FROM %s.%s";
+    List<Object[]> filesReadableMetrics = sql(String.format(sql, tableName, "files"));
+    List<Object[]> entriesReadableMetrics = sql(String.format(sql, tableName, "entries"));
+
     assertEquals(
-        "select of nested readable_metrics fields should work",
-        ImmutableList.of(row(0L, 3L)),
-        sql(
-            "SELECT readable_metrics.`nestedStructCol.leafStructCol.leafLongCol`.lower_bound, "
-                + "readable_metrics.`nestedStructCol.leafStructCol.leafDoubleCol`.value_count FROM %s.files",
-            tableName));
+        "select of nested readable_metrics fields should work for files table",
+        expected,
+        filesReadableMetrics);
+    assertEquals(
+        "select of nested readable_metrics fields should work for entries table",
+        expected,
+        entriesReadableMetrics);
   }
 
   @Test
@@ -330,9 +357,11 @@ public class TestMetadataTableReadableMetrics extends SparkTestBaseWithCatalog {
     Object[] leafLongCol = row(54L, 3L, 1L, null, 0L, 1L);
     Object[] metrics = row(leafDoubleCol, leafLongCol);
 
-    assertEquals(
-        "Row should match",
-        ImmutableList.of(new Object[] {metrics}),
-        sql("SELECT readable_metrics FROM %s.files", tableName));
+    List<Object[]> expected = ImmutableList.of(new Object[] {metrics});
+    String sql = "SELECT readable_metrics FROM %s.%s";
+    List<Object[]> filesReadableMetrics = sql(String.format(sql, tableName, "files"));
+    List<Object[]> entriesReadableMetrics = sql(String.format(sql, tableName, "entries"));
+    assertEquals("Row should match for files table", expected, filesReadableMetrics);
+    assertEquals("Row should match for entries table", expected, entriesReadableMetrics);
   }
 }


### PR DESCRIPTION
close #7364 


This enable query readable metrics on entry metadata table, similar to #5376 by @szehon-ho 

Given table schema like below
```schema
table {
  1: id: optional int
  2: data: optional string
}
```

we can query its per column min/max for each manifest entry
```sql

spark
.sql("select snapshot_id, readable_metrics.id.lower_bound, readable_metrics.data.upper_bound")
.show(false)

+-------------------+-----------+-----------+
|snapshot_id        |lower_bound|upper_bound|
+-------------------+-----------+-----------+
|8728349059432389037|1          |1          |
+-------------------+-----------+-----------+
```