### PR TITLE
Core: Check for all specs in partitionsTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -36,6 +36,8 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private final Schema schema;
 
+  private final boolean isUnpartitionedTable;
+
   PartitionsTable(Table table) {
     this(table, table.name() + ".partitions");
   }
@@ -71,6 +73,7 @@ public class PartitionsTable extends BaseMetadataTable {
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
                 "Count of equality delete files"));
+    this.isUnpartitionedTable = Partitioning.partitionType(table).fields().size() < 1;
   }
 
   @Override
@@ -80,7 +83,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   @Override
   public Schema schema() {
-    if (table().spec().fields().size() < 1) {
+    if (isUnpartitionedTable) {
       return schema.select(
           "record_count",
           "file_count",
@@ -99,7 +102,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private DataTask task(StaticTableScan scan) {
     Iterable<Partition> partitions = partitions(table(), scan);
-    if (table().spec().fields().size() < 1) {
+    if (isUnpartitionedTable) {
       // the table is unpartitioned, partitions contains only the root partition
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -36,7 +36,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private final Schema schema;
 
-  private final boolean isUnpartitionedTable;
+  private final boolean unpartitionedTable;
 
   PartitionsTable(Table table) {
     this(table, table.name() + ".partitions");
@@ -73,7 +73,7 @@ public class PartitionsTable extends BaseMetadataTable {
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
                 "Count of equality delete files"));
-    this.isUnpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
+    this.unpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
   }
 
   @Override
@@ -83,7 +83,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   @Override
   public Schema schema() {
-    if (isUnpartitionedTable) {
+    if (unpartitionedTable) {
       return schema.select(
           "record_count",
           "file_count",
@@ -102,7 +102,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private DataTask task(StaticTableScan scan) {
     Iterable<Partition> partitions = partitions(table(), scan);
-    if (isUnpartitionedTable) {
+    if (unpartitionedTable) {
       // the table is unpartitioned, partitions contains only the root partition
       return StaticDataTask.of(
           io().newInputFile(table().operations().current().metadataFileLocation()),

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -73,7 +73,7 @@ public class PartitionsTable extends BaseMetadataTable {
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
                 "Count of equality delete files"));
-    this.isUnpartitionedTable = Partitioning.partitionType(table).fields().size() < 1;
+    this.isUnpartitionedTable = Partitioning.partitionType(table).fields().isEmpty();
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -802,6 +804,50 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
       // The Partition table final schema is a union of fields of all specs, including dropped
       // fields.
       Assert.assertEquals(4, Iterables.size(files));
+    }
+  }
+
+  @Test
+  public void testPartitionSpecEvolutionToUnpartitioned() throws IOException {
+    preparePartitionedTable();
+
+    // Remove partition field
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+
+    DataFile data10 =
+        DataFiles.builder(table.spec())
+            .withPath("/path/to/data-10.parquet")
+            .withRecordCount(10)
+            .withFileSizeInBytes(10)
+            .build();
+    table.newFastAppend().appendFile(data10).commit();
+
+    PartitionsTable partitionsTable = new PartitionsTable(table);
+    // must contain the partition column even the current spec is non-partitioned.
+    Assertions.assertThat(partitionsTable.schema().findField("partition")).isNotNull();
+
+    TableScan scanNoFilter = partitionsTable.newScan().select("partition");
+    try (CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) scanNoFilter)) {
+      if (formatVersion == 2) {
+        // four partitioned data files, four partitioned delete files and one non-partitioned data
+        // file.
+        Assert.assertEquals(9, Iterators.size(files.iterator()));
+      } else {
+        // four partitioned data files and one non-partitioned data file.
+        Assert.assertEquals(5, Iterators.size(files.iterator()));
+      }
+
+      // check for null partition value.
+      Assert.assertTrue(
+          "File scan tasks do not include correct file",
+          StreamSupport.stream(files.spliterator(), false)
+              .anyMatch(
+                  file -> {
+                    StructLike partition = file.partition();
+
+                    return Objects.equals(null, partition.get(0, Object.class));
+                  }));
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -25,7 +25,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -223,11 +225,35 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
   }
 
   @Test
-  public void testPartitionSpecEvolutionToUnpartitioned() {
+  public void testPartitionSpecEvolutionToUnpartitioned() throws IOException {
     // Remove all the partition fields
     table.updateSpec().removeField("id").removeField("nested.id").commit();
+
+    DataFile dataFile =
+        DataFiles.builder(table.spec())
+            .withPath("/path/to/data-10.parquet")
+            .withRecordCount(10)
+            .withFileSizeInBytes(10)
+            .build();
+    table.newFastAppend().appendFile(dataFile).commit();
+
+    PartitionsTable partitionsTable = new PartitionsTable(table);
     // must contain the partition column even when the current spec is non-partitioned.
-    Assertions.assertThat(new PartitionsTable(table).schema().findField("partition")).isNotNull();
+    Assertions.assertThat(partitionsTable.schema().findField("partition")).isNotNull();
+
+    try (CloseableIterable<ContentFile<?>> files =
+        PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan())) {
+      // four partitioned data files and one non-partitioned data file.
+      Assertions.assertThat(files).hasSize(5);
+
+      // check for null partition value.
+      Assertions.assertThat(StreamSupport.stream(files.spliterator(), false))
+          .anyMatch(
+              file -> {
+                StructLike partition = file.partition();
+                return Objects.equals(null, partition.get(0, Object.class));
+              });
+    }
   }
 
   private Stream<StructLike> allRows(Iterable<FileScanTask> tasks) {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -222,6 +222,14 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
         constantsMap(posDeleteTask, partitionType).get(MetadataColumns.FILE_PATH.fieldId()));
   }
 
+  @Test
+  public void testPartitionSpecEvolutionToUnpartitioned() {
+    // Remove all the partition fields
+    table.updateSpec().removeField("id").removeField("nested.id").commit();
+    // must contain the partition column even when the current spec is non-partitioned.
+    Assertions.assertThat(new PartitionsTable(table).schema().findField("partition")).isNotNull();
+  }
+
   private Stream<StructLike> allRows(Iterable<FileScanTask> tasks) {
     return Streams.stream(tasks).flatMap(task -> Streams.stream(task.asDataTask().rows()));
   }


### PR DESCRIPTION
Partitions Table schema checks only current spec to decide if partition column is returned or not. We should actually check historical specs to see if it was ever partitioned, similar to Files/Entries and other metadata tables.

Fixes #7533 