### PR TITLE
Core, AWS: Add flag to control whether initialization stack trace should be created in S3FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.relocated.com.google.common.collect.SetMultimap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.apache.iceberg.util.Tasks;
@@ -88,16 +89,14 @@ public class S3FileIO
   private transient volatile S3Client client;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
-  private final transient StackTraceElement[] createStack;
+  private transient StackTraceElement[] createStack;
 
   /**
    * No-arg constructor to load the FileIO dynamically.
    *
    * <p>All fields are initialized by calling {@link S3FileIO#initialize(Map)} later.
    */
-  public S3FileIO() {
-    this.createStack = Thread.currentThread().getStackTrace();
-  }
+  public S3FileIO() {}
 
   /**
    * Constructor with custom s3 supplier and S3FileIO properties.
@@ -357,6 +356,10 @@ public class S3FileIO
   public void initialize(Map<String, String> props) {
     this.properties = SerializableMap.copyOf(props);
     this.s3FileIOProperties = new S3FileIOProperties(properties);
+    this.createStack =
+        PropertyUtil.propertyAsBoolean(props, "init-creation-stacktrace", true)
+            ? Thread.currentThread().getStackTrace()
+            : null;
 
     // Do not override s3 client if it was provided
     if (s3 == null) {

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -144,7 +144,11 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
       Configuration conf = hadoopConf.get();
 
       try {
-        io = CatalogUtil.loadFileIO(impl, properties, conf);
+        Map<String, String> props = Maps.newHashMap(properties);
+        // ResolvingFileIO is keeping track of the creation stacktrace, so no need to do the same in
+        // S3FileIO.
+        props.put("init-creation-stacktrace", "false");
+        io = CatalogUtil.loadFileIO(impl, props, conf);
       } catch (IllegalArgumentException e) {
         if (impl.equals(FALLBACK_IMPL)) {
           // no implementation to fall back to, throw the exception


### PR DESCRIPTION
When `S3FileIO` gets created through `ResolvingFileIO` then the creation stack
trace is being kept in `ResolvingFileIO`. `ResolvingFileIO` will then
close the underlying `S3FileIO` when `ResolvingFileIO#finalize()` gets
called. Therefore we don't want to issue a `WARN` in `S3FileIO` in case
`S3FileIO#finalize()` gets called before `ResolvingFileIO#finalize()`.