### PR TITLE
AWS: Add missing line - assign param S3FileIOProperties inside constructor

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -120,6 +120,7 @@ public class S3FileIO
    */
   public S3FileIO(SerializableSupplier<S3Client> s3, S3FileIOProperties s3FileIOProperties) {
     this.s3 = s3;
+    this.s3FileIOProperties = s3FileIOProperties;
     this.createStack = Thread.currentThread().getStackTrace();
   }
 


### PR DESCRIPTION
This PR adds a line that got removed by mistake when I rebased changes for my earlier [PR](https://github.com/apache/iceberg/pull/7534). 

Ran integ tests in TestS3FileIOIntegration, tests passed. 