### PR TITLE
AWS: create HttpClientProperties, move s3 related methods into S3FileIOProperties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -108,8 +108,9 @@ public class AwsClientProperties {
   /**
    * Returns a credentials provider instance. If params were set, we return a new credentials
    * instance. If none of the params are set, we try to dynamically load the provided credentials
-   * provider class. If credential provider class wasn't set, we fallback to default credentials
-   * provider.
+   * provider class. Upon loading the class, we try to invoke {@code create(Map<String, String>)}
+   * static method. If that fails, we fall back to {@code create()}. If credential provider class
+   * wasn't set, we fall back to default credentials provider.
    *
    * @param accessKeyId the AWS access key ID
    * @param secretAccessKey the AWS secret access key
@@ -136,14 +137,6 @@ public class AwsClientProperties {
     return DefaultCredentialsProvider.create();
   }
 
-  /**
-   * Tries to first dynamically load the credentials provider class. If successful, try to invoke
-   * {@code create(Map<String, String>)} static method. If that fails, fallback to {@code create()}
-   * method
-   *
-   * @param credentialsProviderClass the name of the credentials provider class to load
-   * @return credentials provider instance
-   */
   private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {
     Class<?> providerClass;
     try {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -119,7 +119,7 @@ public class AwsClientProperties {
   @SuppressWarnings("checkstyle:HiddenField")
   public AwsCredentialsProvider credentialsProvider(
       String accessKeyId, String secretAccessKey, String sessionToken) {
-    if (!Strings.isNullOrEmpty(accessKeyId) || !Strings.isNullOrEmpty(secretAccessKey)) {
+    if (!Strings.isNullOrEmpty(accessKeyId) && !Strings.isNullOrEmpty(secretAccessKey)) {
       if (Strings.isNullOrEmpty(sessionToken)) {
         return StaticCredentialsProvider.create(
             AwsBasicCredentials.create(accessKeyId, secretAccessKey));

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -42,16 +42,17 @@ public class AwsClientProperties {
    * client.credentials-provider=software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider
    *
    * <p>When set, the default client factory {@link
-   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and other AWS client factory classes will
-   * use this provider to get AWS credentials provided instead of reading the default credential
-   * chain to get AWS access credentials.
+   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and other AWS client factory
+   * classes will use this provider to get AWS credentials provided instead of reading the default
+   * credential chain to get AWS access credentials.
    */
   public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
 
   /**
    * Used by the client.credentials-provider configured value that will be used by {@link
-   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and  other AWS client factory classes to pass
-   * provider-specific properties. Each property consists of a key name and an associated value.
+   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and other AWS client factory
+   * classes to pass provider-specific properties. Each property consists of a key name and an
+   * associated value.
    */
   private static final String CLIENT_CREDENTIAL_PROVIDER_PREFIX = "client.credentials-provider.";
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.common.DynClasses;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+public class AwsClientProperties {
+  /**
+   * Configure the AWS credentials provider used to create AWS clients. A fully qualified concrete
+   * class with package that implements the {@link AwsCredentialsProvider} interface is required.
+   *
+   * <p>Additionally, the implementation class must also have a create() or create(Map) method
+   * implemented, which returns an instance of the class that provides aws credentials provider.
+   *
+   * <p>Example:
+   * client.credentials-provider=software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider
+   *
+   * <p>When set, the default client factory {@link
+   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and other AWS client factory classes will
+   * use this provider to get AWS credentials provided instead of reading the default credential
+   * chain to get AWS access credentials.
+   */
+  public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
+
+  /**
+   * Used by the client.credentials-provider configured value that will be used by {@link
+   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and  other AWS client factory classes to pass
+   * provider-specific properties. Each property consists of a key name and an associated value.
+   */
+  private static final String CLIENT_CREDENTIAL_PROVIDER_PREFIX = "client.credentials-provider.";
+
+  private String clientCredentialsProvider;
+  private final Map<String, String> clientCredentialsProviderProperties;
+
+  public AwsClientProperties() {
+    this.clientCredentialsProvider = null;
+    this.clientCredentialsProviderProperties = null;
+  }
+
+  public AwsClientProperties(Map<String, String> properties) {
+    this.clientCredentialsProvider = properties.get(CLIENT_CREDENTIALS_PROVIDER);
+    this.clientCredentialsProviderProperties =
+        PropertyUtil.propertiesWithPrefix(properties, CLIENT_CREDENTIAL_PROVIDER_PREFIX);
+  }
+
+  @SuppressWarnings("checkstyle:HiddenField")
+  public AwsCredentialsProvider credentialsProvider(
+      String accessKeyId, String secretAccessKey, String sessionToken) {
+    if (accessKeyId != null) {
+      if (sessionToken == null) {
+        return StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKeyId, secretAccessKey));
+      } else {
+        return StaticCredentialsProvider.create(
+            AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
+      }
+    }
+
+    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
+      return credentialsProvider(this.clientCredentialsProvider);
+    }
+
+    return DefaultCredentialsProvider.create();
+  }
+
+  private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {
+    Class<?> providerClass;
+    try {
+      providerClass = DynClasses.builder().impl(credentialsProviderClass).buildChecked();
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot load class %s, it does not exist in the classpath", credentialsProviderClass),
+          e);
+    }
+
+    Preconditions.checkArgument(
+        AwsCredentialsProvider.class.isAssignableFrom(providerClass),
+        String.format(
+            "Cannot initialize %s, it does not implement %s.",
+            credentialsProviderClass, AwsCredentialsProvider.class.getName()));
+
+    AwsCredentialsProvider provider;
+    try {
+      try {
+        provider =
+            DynMethods.builder("create")
+                .hiddenImpl(providerClass, Map.class)
+                .buildStaticChecked()
+                .invoke(clientCredentialsProviderProperties);
+      } catch (NoSuchMethodException e) {
+        provider =
+            DynMethods.builder("create").hiddenImpl(providerClass).buildStaticChecked().invoke();
+      }
+
+      return provider;
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot create an instance of %s, it does not contain a static 'create' or 'create(Map<String, String>)' method",
+              credentialsProviderClass),
+          e);
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -470,7 +470,11 @@ public class AwsProperties implements Serializable {
    * org.apache.iceberg.aws.AwsClientFactories.DefaultAwsClientFactory} and also other client
    * factory classes will use this provider to get AWS credentials provided instead of reading the
    * default credential chain to get AWS access credentials.
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.AwsClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
 
   /**
@@ -478,15 +482,22 @@ public class AwsProperties implements Serializable {
    * org.apache.iceberg.aws.AwsClientFactories.DefaultAwsClientFactory} and also other client
    * factory classes to pass provider-specific properties. Each property consists of a key name and
    * an associated value.
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.AwsClientProperties}
+   *     instead
    */
+  @Deprecated
   private static final String CLIENT_CREDENTIAL_PROVIDER_PREFIX = "client.credentials-provider.";
 
   /**
    * Used by {@link org.apache.iceberg.aws.AwsClientFactories.DefaultAwsClientFactory} and also
    * other client factory classes. If set, all AWS clients except STS client will use the given
    * region instead of the default region chain.
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.AwsClientProperties}
+   *     instead
    */
-  public static final String CLIENT_REGION = "client.region";
+  @Deprecated public static final String CLIENT_REGION = "client.region";
 
   /**
    * The type of {@link software.amazon.awssdk.http.SdkHttpClient} implementation used by {@link
@@ -1582,7 +1593,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyClientRegionConfiguration)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.AwsClientProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends AwsClientBuilder> void applyClientRegionConfiguration(T builder) {
     if (clientRegion != null) {
       builder.region(Region.of(clientRegion));

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -493,24 +493,37 @@ public class AwsProperties implements Serializable {
    * AwsClientFactory} If set, all AWS clients will use this specified HTTP client. If not set,
    * {@link #HTTP_CLIENT_TYPE_DEFAULT} will be used. For specific types supported, see
    * HTTP_CLIENT_TYPE_* defined below.
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
-  public static final String HTTP_CLIENT_TYPE = "http-client.type";
+  @Deprecated public static final String HTTP_CLIENT_TYPE = "http-client.type";
 
   /**
    * If this is set under {@link #HTTP_CLIENT_TYPE}, {@link
    * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} will be used as the HTTP
    * Client in {@link AwsClientFactory}
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
-  public static final String HTTP_CLIENT_TYPE_URLCONNECTION = "urlconnection";
+  @Deprecated public static final String HTTP_CLIENT_TYPE_URLCONNECTION = "urlconnection";
 
   /**
    * If this is set under {@link #HTTP_CLIENT_TYPE}, {@link
    * software.amazon.awssdk.http.apache.ApacheHttpClient} will be used as the HTTP Client in {@link
    * AwsClientFactory}
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
-  public static final String HTTP_CLIENT_TYPE_APACHE = "apache";
+  @Deprecated public static final String HTTP_CLIENT_TYPE_APACHE = "apache";
 
-  public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_APACHE;
+  /**
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
+   */
+  @Deprecated public static final String HTTP_CLIENT_TYPE_DEFAULT = HTTP_CLIENT_TYPE_APACHE;
 
   /**
    * Used to configure the connection timeout in milliseconds for {@link
@@ -519,7 +532,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_URLCONNECTION_CONNECTION_TIMEOUT_MS =
       "http-client.urlconnection.connection-timeout-ms";
 
@@ -530,7 +547,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_URLCONNECTION_SOCKET_TIMEOUT_MS =
       "http-client.urlconnection.socket-timeout-ms";
 
@@ -541,7 +562,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_CONNECTION_TIMEOUT_MS =
       "http-client.apache.connection-timeout-ms";
 
@@ -552,7 +577,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_SOCKET_TIMEOUT_MS =
       "http-client.apache.socket-timeout-ms";
 
@@ -563,7 +592,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_CONNECTION_ACQUISITION_TIMEOUT_MS =
       "http-client.apache.connection-acquisition-timeout-ms";
 
@@ -574,7 +607,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_CONNECTION_MAX_IDLE_TIME_MS =
       "http-client.apache.connection-max-idle-time-ms";
 
@@ -585,7 +622,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_CONNECTION_TIME_TO_LIVE_MS =
       "http-client.apache.connection-time-to-live-ms";
 
@@ -598,7 +639,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_EXPECT_CONTINUE_ENABLED =
       "http-client.apache.expect-continue-enabled";
 
@@ -609,7 +654,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_MAX_CONNECTIONS =
       "http-client.apache.max-connections";
 
@@ -622,7 +671,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_TCP_KEEP_ALIVE_ENABLED =
       "http-client.apache.tcp-keep-alive-enabled";
 
@@ -635,7 +688,11 @@ public class AwsProperties implements Serializable {
    *
    * <p>For more details, see
    * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public static final String HTTP_CLIENT_APACHE_USE_IDLE_CONNECTION_REAPER_ENABLED =
       "http-client.apache.use-idle-connection-reaper-enabled";
   /**
@@ -1505,7 +1562,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyS3CredentialConfigurations)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.s3.S3FileIOProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends S3ClientBuilder> void applyS3CredentialConfigurations(T builder) {
     builder.credentialsProvider(
         s3RemoteSigningEnabled
@@ -1552,7 +1613,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyS3ServiceConfigurations)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.s3.S3FileIOProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends S3ClientBuilder> void applyS3ServiceConfigurations(T builder) {
     builder
         .dualstackEnabled(s3DualStackEnabled)
@@ -1572,7 +1637,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyS3SignerConfiguration)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.s3.S3FileIOProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends S3ClientBuilder> void applyS3SignerConfiguration(T builder) {
     if (s3RemoteSigningEnabled) {
       builder.overrideConfiguration(
@@ -1591,7 +1660,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyHttpClientConfigurations)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends AwsSyncClientBuilder> void applyHttpClientConfigurations(T builder) {
     if (Strings.isNullOrEmpty(httpClientType)) {
       httpClientType = HTTP_CLIENT_TYPE_DEFAULT;
@@ -1620,7 +1693,11 @@ public class AwsProperties implements Serializable {
    * <pre>
    *     S3Client.builder().applyMutation(awsProperties::applyS3EndpointConfigurations)
    * </pre>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.s3.S3FileIOProperties}
+   *     instead
    */
+  @Deprecated
   public <T extends S3ClientBuilder> void applyS3EndpointConfigurations(T builder) {
     configureEndpoint(builder, s3Endpoint);
   }
@@ -1760,7 +1837,11 @@ public class AwsProperties implements Serializable {
    * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} and {@link
    * software.amazon.awssdk.http.apache.ApacheHttpClient}, since including both will cause error
    * described in <a href="https://github.com/apache/iceberg/issues/6715">issue#6715</a>
+   *
+   * @deprecated will be removed in 1.4.0, use {@link org.apache.iceberg.aws.HttpClientProperties}
+   *     instead
    */
+  @Deprecated
   private <T> T loadHttpClientConfigurations(String impl) {
     Object httpClientConfigurations;
     try {

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
+
+public class HttpClientProperties {
+
+  /**
+   * The type of {@link software.amazon.awssdk.http.SdkHttpClient} implementation used by {@link
+   * AwsClientFactory} If set, all AWS clients will use this specified HTTP client. If not set,
+   * {@link #CLIENT_TYPE_DEFAULT} will be used. For specific types supported, see HTTP_CLIENT_TYPE_*
+   * defined below.
+   */
+  public static final String CLIENT_TYPE = "http-client.type";
+
+  /**
+   * If this is set under {@link #CLIENT_TYPE}, {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient} will be used as the HTTP Client in {@link
+   * AwsClientFactory}
+   */
+  public static final String CLIENT_TYPE_APACHE = "apache";
+
+  private static final String CLIENT_PREFIX = "http-client.";
+  /**
+   * If this is set under {@link #CLIENT_TYPE}, {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} will be used as the HTTP
+   * Client in {@link AwsClientFactory}
+   */
+  public static final String CLIENT_TYPE_URLCONNECTION = "urlconnection";
+
+  public static final String CLIENT_TYPE_DEFAULT = CLIENT_TYPE_APACHE;
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder}. This flag only
+   * works when {@link #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String URLCONNECTION_CONNECTION_TIMEOUT_MS =
+      "http-client.urlconnection.connection-timeout-ms";
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder}. This flag only
+   * works when {@link #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_URLCONNECTION}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/urlconnection/UrlConnectionHttpClient.Builder.html
+   */
+  public static final String URLCONNECTION_SOCKET_TIMEOUT_MS =
+      "http-client.urlconnection.socket-timeout-ms";
+  /**
+   * Used to configure the connection timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_TIMEOUT_MS =
+      "http-client.apache.connection-timeout-ms";
+  /**
+   * Used to configure the socket timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_SOCKET_TIMEOUT_MS = "http-client.apache.socket-timeout-ms";
+  /**
+   * Used to configure the connection acquisition timeout in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_ACQUISITION_TIMEOUT_MS =
+      "http-client.apache.connection-acquisition-timeout-ms";
+  /**
+   * Used to configure the connection max idle time in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_MAX_IDLE_TIME_MS =
+      "http-client.apache.connection-max-idle-time-ms";
+  /**
+   * Used to configure the connection time to live in milliseconds for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_CONNECTION_TIME_TO_LIVE_MS =
+      "http-client.apache.connection-time-to-live-ms";
+  /**
+   * Used to configure whether to enable the expect continue setting for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>In default, this is disabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_EXPECT_CONTINUE_ENABLED =
+      "http-client.apache.expect-continue-enabled";
+  /**
+   * Used to configure the max connections number for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_MAX_CONNECTIONS = "http-client.apache.max-connections";
+  /**
+   * Used to configure whether to enable the tcp keep alive setting for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}.
+   *
+   * <p>In default, this is disabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_TCP_KEEP_ALIVE_ENABLED =
+      "http-client.apache.tcp-keep-alive-enabled";
+  /**
+   * Used to configure whether to use idle connection reaper for {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}. This flag only works when {@link
+   * #CLIENT_TYPE} is set to {@link #CLIENT_TYPE_APACHE}.
+   *
+   * <p>In default, this is enabled.
+   *
+   * <p>For more details, see
+   * https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/http/apache/ApacheHttpClient.Builder.html
+   */
+  public static final String APACHE_USE_IDLE_CONNECTION_REAPER_ENABLED =
+      "http-client.apache.use-idle-connection-reaper-enabled";
+
+  private String httpClientType;
+  private final Map<String, String> httpClientProperties;
+
+  public HttpClientProperties() {
+    this.httpClientType = CLIENT_TYPE_DEFAULT;
+    this.httpClientProperties = Collections.emptyMap();
+  }
+
+  public HttpClientProperties(Map<String, String> properties) {
+    this.httpClientType =
+        PropertyUtil.propertyAsString(properties, CLIENT_TYPE, CLIENT_TYPE_DEFAULT);
+    this.httpClientProperties =
+        PropertyUtil.filterProperties(properties, key -> key.startsWith(CLIENT_PREFIX));
+  }
+
+  /**
+   * Configure the httpClient for a client according to the HttpClientType. The two supported
+   * HttpClientTypes are urlconnection and apache
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(awsProperties::applyHttpClientConfigurations)
+   * </pre>
+   */
+  public <T extends AwsSyncClientBuilder> void applyHttpClientConfigurations(T builder) {
+    if (Strings.isNullOrEmpty(httpClientType)) {
+      httpClientType = CLIENT_TYPE_DEFAULT;
+    }
+    switch (httpClientType) {
+      case CLIENT_TYPE_URLCONNECTION:
+        UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =
+            loadHttpClientConfigurations(UrlConnectionHttpClientConfigurations.class.getName());
+        urlConnectionHttpClientConfigurations.configureHttpClientBuilder(builder);
+        break;
+      case CLIENT_TYPE_APACHE:
+        ApacheHttpClientConfigurations apacheHttpClientConfigurations =
+            loadHttpClientConfigurations(ApacheHttpClientConfigurations.class.getName());
+        apacheHttpClientConfigurations.configureHttpClientBuilder(builder);
+        break;
+      default:
+        throw new IllegalArgumentException("Unrecognized HTTP client type " + httpClientType);
+    }
+  }
+
+  /**
+   * Dynamically load the http client builder to avoid runtime deps requirements of both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient}, since including both will cause error
+   * described in <a href="https://github.com/apache/iceberg/issues/6715">issue#6715</a>
+   */
+  private <T> T loadHttpClientConfigurations(String impl) {
+    Object httpClientConfigurations;
+    try {
+      httpClientConfigurations =
+          DynMethods.builder("create")
+              .hiddenImpl(impl, Map.class)
+              .buildStaticChecked()
+              .invoke(httpClientProperties);
+      return (T) httpClientConfigurations;
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot create %s to generate and configure the http client builder", impl),
+          e);
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -195,6 +195,7 @@ public class HttpClientProperties {
     if (Strings.isNullOrEmpty(httpClientType)) {
       httpClientType = CLIENT_TYPE_DEFAULT;
     }
+
     switch (httpClientType) {
       case CLIENT_TYPE_URLCONNECTION:
         UrlConnectionHttpClientConfigurations urlConnectionHttpClientConfigurations =

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -30,7 +30,7 @@ public class HttpClientProperties {
   /**
    * The type of {@link software.amazon.awssdk.http.SdkHttpClient} implementation used by {@link
    * AwsClientFactory} If set, all AWS clients will use this specified HTTP client. If not set,
-   * {@link #CLIENT_TYPE_DEFAULT} will be used. For specific types supported, see HTTP_CLIENT_TYPE_*
+   * {@link #CLIENT_TYPE_DEFAULT} will be used. For specific types supported, see CLIENT_TYPE_*
    * defined below.
    */
   public static final String CLIENT_TYPE = "http-client.type";

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
-import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -721,11 +720,6 @@ public class S3FileIOProperties implements Serializable {
    * </pre>
    */
   public <T extends S3ClientBuilder> void applyEndpointConfigurations(T builder) {
-    configureEndpoint(builder, endpoint);
-  }
-
-  @SuppressWarnings("checkstyle:HiddenField")
-  private <T extends SdkClientBuilder> void configureEndpoint(T builder, String endpoint) {
     if (endpoint != null) {
       builder.endpointOverride(URI.create(endpoint));
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -24,23 +24,16 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
-import org.apache.iceberg.common.DynClasses;
-import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -341,30 +334,6 @@ public class S3FileIOProperties implements Serializable {
 
   public static final boolean PRELOAD_CLIENT_ENABLED_DEFAULT = false;
 
-  /**
-   * Configure the AWS credentials provider used to create AWS clients. A fully qualified concrete
-   * class with package that implements the {@link AwsCredentialsProvider} interface is required.
-   *
-   * <p>Additionally, the implementation class must also have a create() or create(Map) method
-   * implemented, which returns an instance of the class that provides aws credentials provider.
-   *
-   * <p>Example:
-   * client.credentials-provider=software.amazon.awssdk.auth.credentials.SystemPropertyCredentialsProvider
-   *
-   * <p>When set, the default client factory {@link
-   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and S3 client factory class will
-   * use this provider to get AWS credentials provided instead of reading the default credential
-   * chain to get AWS access credentials.
-   */
-  public static final String CLIENT_CREDENTIALS_PROVIDER = "client.credentials-provider";
-
-  /**
-   * Used by the client.credentials-provider configured value that will be used by {@link
-   * org.apache.iceberg.aws.AwsClientFactories#defaultFactory()} and S3 client factory class to pass
-   * provider-specific properties. Each property consists of a key name and an associated value.
-   */
-  private static final String CLIENT_CREDENTIAL_PROVIDER_PREFIX = "client.credentials-provider.";
-
   private String sseType;
   private String sseKey;
   private String sseMd5;
@@ -392,9 +361,6 @@ public class S3FileIOProperties implements Serializable {
   private boolean isAccelerationEnabled;
   private String endpoint;
   private final boolean isRemoteSigningEnabled;
-  private String clientCredentialsProvider;
-  private final Map<String, String> clientCredentialsProviderProperties;
-
   private final Map<String, String> allProperties;
 
   public S3FileIOProperties() {
@@ -425,8 +391,6 @@ public class S3FileIOProperties implements Serializable {
     this.isUseArnRegionEnabled = USE_ARN_REGION_ENABLED_DEFAULT;
     this.isAccelerationEnabled = ACCELERATION_ENABLED_DEFAULT;
     this.isRemoteSigningEnabled = REMOTE_SIGNING_ENABLED_DEFAULT;
-    this.clientCredentialsProvider = null;
-    this.clientCredentialsProviderProperties = null;
     this.allProperties = Maps.newHashMap();
 
     ValidationException.check(
@@ -515,9 +479,6 @@ public class S3FileIOProperties implements Serializable {
     this.isRemoteSigningEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, REMOTE_SIGNING_ENABLED, REMOTE_SIGNING_ENABLED_DEFAULT);
-    this.clientCredentialsProvider = properties.get(CLIENT_CREDENTIALS_PROVIDER);
-    this.clientCredentialsProviderProperties =
-        PropertyUtil.propertiesWithPrefix(properties, CLIENT_CREDENTIAL_PROVIDER_PREFIX);
     this.allProperties = SerializableMap.copyOf(properties);
 
     ValidationException.check(
@@ -703,71 +664,12 @@ public class S3FileIOProperties implements Serializable {
     return (accessKeyId == null) == (secretAccessKey == null);
   }
 
-  public <T extends S3ClientBuilder> void applyS3CredentialConfigurations(T builder) {
+  public <T extends S3ClientBuilder> void applyCredentialConfigurations(
+      AwsClientProperties awsClientProperties, T builder) {
     builder.credentialsProvider(
         isRemoteSigningEnabled
             ? AnonymousCredentialsProvider.create()
-            : credentialsProvider(accessKeyId, secretAccessKey, sessionToken));
-  }
-
-  @SuppressWarnings("checkstyle:HiddenField")
-  private AwsCredentialsProvider credentialsProvider(
-      String accessKeyId, String secretAccessKey, String sessionToken) {
-    if (accessKeyId != null) {
-      if (sessionToken == null) {
-        return StaticCredentialsProvider.create(
-            AwsBasicCredentials.create(accessKeyId, secretAccessKey));
-      } else {
-        return StaticCredentialsProvider.create(
-            AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
-      }
-    }
-
-    if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
-      return credentialsProvider(this.clientCredentialsProvider);
-    }
-
-    return DefaultCredentialsProvider.create();
-  }
-
-  private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {
-    Class<?> providerClass;
-    try {
-      providerClass = DynClasses.builder().impl(credentialsProviderClass).buildChecked();
-    } catch (ClassNotFoundException e) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Cannot load class %s, it does not exist in the classpath", credentialsProviderClass),
-          e);
-    }
-
-    Preconditions.checkArgument(
-        AwsCredentialsProvider.class.isAssignableFrom(providerClass),
-        String.format(
-            "Cannot initialize %s, it does not implement %s.",
-            credentialsProviderClass, AwsCredentialsProvider.class.getName()));
-
-    AwsCredentialsProvider provider;
-    try {
-      try {
-        provider =
-            DynMethods.builder("create")
-                .hiddenImpl(providerClass, Map.class)
-                .buildStaticChecked()
-                .invoke(clientCredentialsProviderProperties);
-      } catch (NoSuchMethodException e) {
-        provider =
-            DynMethods.builder("create").hiddenImpl(providerClass).buildStaticChecked().invoke();
-      }
-
-      return provider;
-    } catch (NoSuchMethodException e) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Cannot create an instance of %s, it does not contain a static 'create' or 'create(Map<String, String>)' method",
-              credentialsProviderClass),
-          e);
-    }
+            : awsClientProperties.credentialsProvider(accessKeyId, secretAccessKey, sessionToken));
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -777,7 +777,7 @@ public class S3FileIOProperties implements Serializable {
    * <p>Sample usage:
    *
    * <pre>
-   *     S3Client.builder().applyMutation(awsProperties::applyS3ServiceConfigurations)
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyS3ServiceConfigurations)
    * </pre>
    */
   public <T extends S3ClientBuilder> void applyServiceConfigurations(T builder) {
@@ -797,7 +797,7 @@ public class S3FileIOProperties implements Serializable {
    * <p>Sample usage:
    *
    * <pre>
-   *     S3Client.builder().applyMutation(awsProperties::applyS3SignerConfiguration)
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyS3SignerConfiguration)
    * </pre>
    */
   public <T extends S3ClientBuilder> void applySignerConfiguration(T builder) {

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
@@ -18,14 +18,37 @@
  */
 package org.apache.iceberg.aws;
 
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
 public class AwsClientPropertiesTest {
+
+  @Test
+  public void testApplyClientRegion() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsClientProperties.CLIENT_REGION, "us-east-1");
+    AwsClientProperties awsClientProperties = new AwsClientProperties(properties);
+
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    ArgumentCaptor<Region> regionArgumentCaptor = ArgumentCaptor.forClass(Region.class);
+
+    awsClientProperties.applyClientRegionConfiguration(mockS3ClientBuilder);
+    Mockito.verify(mockS3ClientBuilder).region(regionArgumentCaptor.capture());
+    Region region = regionArgumentCaptor.getValue();
+    Assertions.assertThat(region.id())
+        .withFailMessage("region parameter should match what is set in CLIENT_REGION")
+        .isEqualTo("us-east-1");
+  }
 
   @Test
   public void testDefaultCredentialsConfiguration() {

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+public class AwsClientPropertiesTest {
+
+  @Test
+  public void testDefaultCredentialsConfiguration() {
+    AwsClientProperties awsClientProperties = new AwsClientProperties();
+    AwsCredentialsProvider credentialsProvider =
+        awsClientProperties.credentialsProvider(null, null, null);
+
+    Assertions.assertThat(credentialsProvider instanceof DefaultCredentialsProvider)
+        .withFailMessage("Should use default credentials if nothing is set")
+        .isTrue();
+  }
+
+  @Test
+  public void testBasicCredentialsConfiguration() {
+    AwsClientProperties awsClientProperties = new AwsClientProperties();
+    // set access key id and secret access key
+    AwsCredentialsProvider credentialsProvider =
+        awsClientProperties.credentialsProvider("key", "secret", null);
+
+    Assertions.assertThat(credentialsProvider.resolveCredentials() instanceof AwsBasicCredentials)
+        .withFailMessage(
+            "Should use basic credentials if access key ID and secret access key are set")
+        .isTrue();
+    Assertions.assertThat(credentialsProvider.resolveCredentials().accessKeyId())
+        .withFailMessage("The access key id should be the same as the one set by tag ACCESS_KEY_ID")
+        .isEqualTo("key");
+
+    Assertions.assertThat(credentialsProvider.resolveCredentials().secretAccessKey())
+        .withFailMessage(
+            "The secret access key should be the same as the one set by tag SECRET_ACCESS_KEY")
+        .isEqualTo("secret");
+  }
+
+  @Test
+  public void testSessionCredentialsConfiguration() {
+    // set access key id, secret access key, and session token
+    AwsClientProperties awsClientProperties = new AwsClientProperties();
+    AwsCredentialsProvider credentialsProvider =
+        awsClientProperties.credentialsProvider("key", "secret", "token");
+
+    Assertions.assertThat(credentialsProvider.resolveCredentials() instanceof AwsSessionCredentials)
+        .withFailMessage("Should use session credentials if session token is set")
+        .isTrue();
+    Assertions.assertThat(credentialsProvider.resolveCredentials().accessKeyId())
+        .withFailMessage("The access key id should be the same as the one set by tag ACCESS_KEY_ID")
+        .isEqualTo("key");
+    Assertions.assertThat(credentialsProvider.resolveCredentials().secretAccessKey())
+        .withFailMessage(
+            "The secret access key should be the same as the one set by tag SECRET_ACCESS_KEY")
+        .isEqualTo("secret");
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/HttpClientPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/HttpClientPropertiesTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+public class HttpClientPropertiesTest {
+
+  @Test
+  public void testUrlHttpClientConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.CLIENT_TYPE, "urlconnection");
+    HttpClientProperties httpClientProperties = new HttpClientProperties(properties);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    ArgumentCaptor<SdkHttpClient.Builder> httpClientBuilderCaptor =
+        ArgumentCaptor.forClass(SdkHttpClient.Builder.class);
+
+    httpClientProperties.applyHttpClientConfigurations(mockS3ClientBuilder);
+    Mockito.verify(mockS3ClientBuilder).httpClientBuilder(httpClientBuilderCaptor.capture());
+    SdkHttpClient.Builder capturedHttpClientBuilder = httpClientBuilderCaptor.getValue();
+
+    Assertions.assertThat(capturedHttpClientBuilder instanceof UrlConnectionHttpClient.Builder)
+        .withFailMessage("Should use url connection http client")
+        .isTrue();
+  }
+
+  @Test
+  public void testApacheHttpClientConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.CLIENT_TYPE, "apache");
+    HttpClientProperties httpClientProperties = new HttpClientProperties(properties);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    ArgumentCaptor<SdkHttpClient.Builder> httpClientBuilderCaptor =
+        ArgumentCaptor.forClass(SdkHttpClient.Builder.class);
+
+    httpClientProperties.applyHttpClientConfigurations(mockS3ClientBuilder);
+    Mockito.verify(mockS3ClientBuilder).httpClientBuilder(httpClientBuilderCaptor.capture());
+    SdkHttpClient.Builder capturedHttpClientBuilder = httpClientBuilderCaptor.getValue();
+    Assertions.assertThat(capturedHttpClientBuilder instanceof ApacheHttpClient.Builder)
+        .withFailMessage("Should use apache http client")
+        .isTrue();
+  }
+
+  @Test
+  public void testInvalidHttpClientType() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(HttpClientProperties.CLIENT_TYPE, "test");
+    HttpClientProperties httpClientProperties = new HttpClientProperties(properties);
+    S3ClientBuilder s3ClientBuilder = S3Client.builder();
+
+    Assertions.assertThatThrownBy(
+            () -> httpClientProperties.applyHttpClientConfigurations(s3ClientBuilder))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unrecognized HTTP client type test");
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -492,18 +492,16 @@ public class TestS3FileIOProperties {
     properties.put(S3FileIOProperties.ACCELERATION_ENABLED, "false");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
     S3ClientBuilder mockA = Mockito.mock(S3ClientBuilder.class);
-    S3ClientBuilder mockB = Mockito.mock(S3ClientBuilder.class);
-    S3ClientBuilder mockC = Mockito.mock(S3ClientBuilder.class);
 
     ArgumentCaptor<S3Configuration> s3ConfigurationCaptor =
         ArgumentCaptor.forClass(S3Configuration.class);
 
-    Mockito.doReturn(mockB).when(mockA).dualstackEnabled(Mockito.anyBoolean());
-    Mockito.doReturn(mockC).when(mockB).serviceConfiguration(Mockito.any(S3Configuration.class));
+    Mockito.doReturn(mockA).when(mockA).dualstackEnabled(Mockito.anyBoolean());
+    Mockito.doReturn(mockA).when(mockA).serviceConfiguration(Mockito.any(S3Configuration.class));
 
     s3FileIOProperties.applyServiceConfigurations(mockA);
 
-    Mockito.verify(mockB).serviceConfiguration(s3ConfigurationCaptor.capture());
+    Mockito.verify(mockA).serviceConfiguration(s3ConfigurationCaptor.capture());
 
     S3Configuration s3Configuration = s3ConfigurationCaptor.getValue();
     Assertions.assertThat(s3Configuration.pathStyleAccessEnabled())


### PR DESCRIPTION
Subtask of #7516 

This PR creates separate class `HttpClientProperties`. Also, move all s3 related methods into `S3FileIOProperties` since we plan to deprecate `AwsProperties`. 

As part of #7156, when `S3FileIOAwsClientFactory` is added for creating S3 client, we will use methods from `S3FileIOProperties` and  `HttpClientProperties`.

Ran integ tests - `TestS3FileIOIntegration`, `TestS3MultipartUpload` and `TestDefaultAwsClientFactory` 