### PR TITLE
Core: Refactor naming in MergingSnapshotProducer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -125,7 +125,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles>
       StrictMetricsEvaluator metrics =
           new StrictMetricsEvaluator(base.schema(), rowFilter, isCaseSensitive());
 
-      for (DataFile file : addedFiles()) {
+      for (DataFile file : addedDataFiles()) {
         // the real test is that the strict or metrics test matches the file, indicating that all
         // records in the file match the filter. inclusive is used to avoid testing the metrics,
         // which is more complicated


### PR DESCRIPTION
Our `MergingSnapshotProducer` was initially written purely for data files and then adapted to delete files. This PR renames some variables to match the naming we use for delete files.