### PR TITLE
Build: Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -36,7 +36,9 @@ concurrency:
 
 jobs:
   revapi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04}
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -62,6 +62,7 @@ jobs:
         jvm: [8, 11, 17]
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -91,6 +92,7 @@ jobs:
         jvm: [8, 11, 17]
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -65,6 +65,7 @@ jobs:
         flink: ['1.15', '1.16', '1.17']
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -60,6 +60,7 @@ jobs:
         jvm: [8, 11, 17]
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -86,6 +87,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -57,6 +57,7 @@ jobs:
         jvm: [8, 11, 17]
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -81,6 +82,8 @@ jobs:
 
   build-checks:
     runs-on: ubuntu-22.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
@@ -91,6 +94,8 @@ jobs:
 
   build-javadoc:
     runs-on: ubuntu-22.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-java@v3

--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -74,6 +74,7 @@ jobs:
         benchmark: ${{ fromJson(needs.matrix.outputs.matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -29,6 +29,8 @@ jobs:
   publish-snapshot:
     if: github.repository_owner == 'apache'
     runs-on: ubuntu-22.04
+    env:
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -44,6 +44,7 @@ jobs:
         spark_version: ['iceberg-spark-3.4']
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -63,6 +63,7 @@ jobs:
         spark: ['3.1', '3.2', '3.3', '3.4']
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -93,6 +94,7 @@ jobs:
         spark: ['3.2','3.3','3.4']
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -123,6 +125,7 @@ jobs:
         scala-version: ['2.12', '2.13']
     env:
       SPARK_LOCAL_IP: localhost
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,8 +17,8 @@
  * under the License.
  */
 plugins {
-  id 'com.gradle.enterprise' version '3.13.4'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.1'
+  id 'com.gradle.enterprise' version '3.15.1'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.3'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+plugins {
+  id 'com.gradle.enterprise' version '3.13.4'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.11.1'
+}
+
+def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
+def isJenkins = System.getenv('JENKINS_URL') != null
+def isCI = isGithubActions || isJenkins
+
+gradleEnterprise {
+  server = "https://ge.apache.org"
+  buildScan {
+    capture { taskInputFiles = true }
+    uploadInBackground = !isCI
+    publishAlways()
+    publishIfAuthenticated()
+    obfuscation {
+      // This obfuscates the IP addresses of the build machine in the build scan.
+      // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
+      ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+    }
+  }
+}
+
+buildCache {
+  local {
+    enabled = !isCI
+  }
+
+  remote(gradleEnterprise.buildCache) {
+    enabled = false
+  }
+}
 
 rootProject.name = 'iceberg'
 include 'api'


### PR DESCRIPTION
This PR publishes a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

The build scans of the Apache Iceberg project are published to the Gradle Enterprise instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by the Apache Iceberg project and all other Apache projects.

This pull request enhances the functionality of publishing build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/) by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Gradle Enterprise instance, Apache Iceberg will have access not only to all of the published build scans but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

If interested in exploring a fully populated Gradle Enterprise instance, please explore the builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Gradle Enterprise.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.