### PR TITLE
Core: Table metadata file deletion should check `gc.enabled` property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -420,6 +420,16 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
             TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT);
 
     if (deleteAfterCommit) {
+      boolean gcEnabled =
+          metadata.propertyAsBoolean(
+              TableProperties.GC_ENABLED, TableProperties.GC_ENABLED_DEFAULT);
+      if (!gcEnabled) {
+        LOG.warn(
+            "Ignoring the {} property as GC is disabled",
+            TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED);
+        return;
+      }
+
       Set<TableMetadata.MetadataLogEntry> removedPreviousMetadataFiles =
           Sets.newHashSet(base.previousFiles());
       // TableMetadata#addPreviousFile builds up the metadata log and uses

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -424,6 +424,16 @@ public class HadoopTableOperations implements TableOperations {
             TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT);
 
     if (deleteAfterCommit) {
+      boolean gcEnabled =
+          metadata.propertyAsBoolean(
+              TableProperties.GC_ENABLED, TableProperties.GC_ENABLED_DEFAULT);
+      if (!gcEnabled) {
+        LOG.warn(
+            "Ignoring the {} property as GC is disabled",
+            TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED);
+        return;
+      }
+
       Set<TableMetadata.MetadataLogEntry> removedPreviousMetadataFiles =
           Sets.newHashSet(base.previousFiles());
       removedPreviousMetadataFiles.removeAll(metadata.previousFiles());


### PR DESCRIPTION
Table metadata files are getting deleted even when the gc is disabled (along with `TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED` is set to true)

This behaviour should be unified with the other Iceberg metadata file deletion (that is honouring the `gc.enabled` property). 