### PR TITLE
Add unique JDBC application identifier and user agent header

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -54,9 +54,7 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
   // Add a suffix to user agent header for the web requests made by the jdbc driver.
   private static final String JDBC_USER_AGENT_SUFFIX_PROPERTY = "user_agent_suffix";
   private static final String APP_IDENTIFIER = "iceberg-snowflake-catalog";
-  // Specifies the length of unique id for each catalog initialized session. Should be less than 32
-  // (guid length)
-  private static final int UNIQUE_ID_LENGTH = 20;
+
   // Injectable factory for testing purposes.
   static class FileIOFactory {
     public FileIO newFileIO(String impl, Map<String, String> properties, Object hadoopConf) {
@@ -121,10 +119,9 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
           cnfe);
     }
 
-    String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, UNIQUE_ID_LENGTH);
+    String uniqueId = UUID.randomUUID().toString().replace("-", "");
     String uniqueAppIdentifier = APP_IDENTIFIER + "_" + uniqueId;
-    String icebergVersion = IcebergBuild.fullVersion() + IcebergBuild.gitCommitShortId();
-    String userAgentSuffix = icebergVersion + " " + uniqueAppIdentifier;
+    String userAgentSuffix = IcebergBuild.fullVersion() + " " + uniqueAppIdentifier;
     // Populate application identifier in jdbc client
     properties.put(JdbcCatalog.PROPERTY_PREFIX + JDBC_APPLICATION_PROPERTY, uniqueAppIdentifier);
     // Adds application identifier to the user agent header of the JDBC requests.

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -23,10 +23,12 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -35,6 +37,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -48,8 +51,12 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
   // Specifies the name of a Snowflake's partner application to connect through JDBC.
   // https://docs.snowflake.com/en/user-guide/jdbc-parameters.html#application
   private static final String JDBC_APPLICATION_PROPERTY = "application";
+  // Add a suffix to user agent header for the web requests made by the jdbc driver.
+  private static final String JDBC_USER_AGENT_SUFFIX_PROPERTY = "user_agent_suffix";
   private static final String APP_IDENTIFIER = "iceberg-snowflake-catalog";
-
+  // Specifies the length of unique id for each catalog initialized session. Should be less than 32
+  // (guid length)
+  private static final int UNIQUE_ID_LENGTH = 20;
   // Injectable factory for testing purposes.
   static class FileIOFactory {
     public FileIO newFileIO(String impl, Map<String, String> properties, Object hadoopConf) {
@@ -114,8 +121,14 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
           cnfe);
     }
 
+    String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, UNIQUE_ID_LENGTH);
+    String uniqueAppIdentifier = APP_IDENTIFIER + "_" + uniqueId;
+    String icebergVersion = IcebergBuild.fullVersion() + IcebergBuild.gitCommitShortId();
+    String userAgentSuffix = icebergVersion + " " + uniqueAppIdentifier;
     // Populate application identifier in jdbc client
-    properties.put(JDBC_APPLICATION_PROPERTY, APP_IDENTIFIER);
+    properties.put(JdbcCatalog.PROPERTY_PREFIX + JDBC_APPLICATION_PROPERTY, uniqueAppIdentifier);
+    // Adds application identifier to the user agent header of the JDBC requests.
+    properties.put(JdbcCatalog.PROPERTY_PREFIX + JDBC_USER_AGENT_SUFFIX_PROPERTY, userAgentSuffix);
 
     JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
 

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -54,7 +54,8 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
   // Add a suffix to user agent header for the web requests made by the jdbc driver.
   private static final String JDBC_USER_AGENT_SUFFIX_PROPERTY = "user_agent_suffix";
   private static final String APP_IDENTIFIER = "iceberg-snowflake-catalog";
-
+  // Specifies the max length of unique id for each catalog initialized session.
+  private static final int UNIQUE_ID_LENGTH = 20;
   // Injectable factory for testing purposes.
   static class FileIOFactory {
     public FileIO newFileIO(String impl, Map<String, String> properties, Object hadoopConf) {
@@ -119,7 +120,8 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
           cnfe);
     }
 
-    String uniqueId = UUID.randomUUID().toString().replace("-", "");
+    // The uniqueAppIdentifier should be less than 50 characters, so trimming the guid.
+    String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, UNIQUE_ID_LENGTH);
     String uniqueAppIdentifier = APP_IDENTIFIER + "_" + uniqueId;
     String userAgentSuffix = IcebergBuild.fullVersion() + " " + uniqueAppIdentifier;
     // Populate application identifier in jdbc client

--- a/versions.props
+++ b/versions.props
@@ -28,7 +28,7 @@ org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
 org.immutables:value = 2.9.2
-net.snowflake:snowflake-jdbc = 3.13.22
+net.snowflake:snowflake-jdbc = 3.13.30
 io.delta:delta-standalone_* = 0.6.0
 
 # test deps


### PR DESCRIPTION
This PR makes the JDBC application identifier unique for each catalog initialization and add another JDBC property to include the application identifier in the JDBC web request's user agent header.
Also updating to the latest version of snowflake's JDBC driver.

This PR is continued from https://github.com/apache/iceberg/pull/7176 due to a bad git rebase.