### PR TITLE
Add last updated timestamp and snapshotId for partition table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -77,7 +77,7 @@ public class PartitionsTable extends BaseMetadataTable {
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
+                "Commit time of snapshot that last updated this partition"),
             Types.NestedField.optional(
                 10,
                 "last_updated_snapshot_id",
@@ -285,8 +285,6 @@ public class PartitionsTable extends BaseMetadataTable {
       this.posDeleteFileCount = 0;
       this.eqDeleteRecordCount = 0L;
       this.eqDeleteFileCount = 0;
-      this.lastUpdatedMs = null;
-      this.lastUpdatedSnapshotId = null;
     }
 
     void update(ContentFile<?> file, Snapshot snapshot) {

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -51,14 +51,14 @@ public class PartitionsTable extends BaseMetadataTable {
             Types.NestedField.required(4, "spec_id", Types.IntegerType.get()),
             Types.NestedField.required(
                 9,
-                "last_updated",
+                "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             Types.NestedField.required(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Partition last updated snapshot id"),
+                "Id of snapshot that last updated this partition"),
             Types.NestedField.required(
                 2, "record_count", Types.LongType.get(), "Count of records in data files"),
             Types.NestedField.required(
@@ -95,7 +95,7 @@ public class PartitionsTable extends BaseMetadataTable {
   public Schema schema() {
     if (unpartitionedTable) {
       return schema.select(
-          "last_updated",
+          "last_updated_ms",
           "last_updated_snapshot_id",
           "record_count",
           "file_count",

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -81,7 +81,7 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
   }
 
   protected void validateSingleFieldPartition(
-      CloseableIterable<ManifestEntry<? extends ContentFile<?>>> files, int partitionValue) {
+      CloseableIterable<ManifestEntry<?>> files, int partitionValue) {
     validatePartition(files, 0, partitionValue);
   }
 

--- a/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/MetadataTableScanTestBase.java
@@ -81,18 +81,20 @@ public abstract class MetadataTableScanTestBase extends TableTestBase {
   }
 
   protected void validateSingleFieldPartition(
-      CloseableIterable<ContentFile<?>> files, int partitionValue) {
+      CloseableIterable<ManifestEntry<? extends ContentFile<?>>> files, int partitionValue) {
     validatePartition(files, 0, partitionValue);
   }
 
   protected void validatePartition(
-      CloseableIterable<ContentFile<?>> files, int position, int partitionValue) {
+      CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries,
+      int position,
+      int partitionValue) {
     Assert.assertTrue(
         "File scan tasks do not include correct file",
-        StreamSupport.stream(files.spliterator(), false)
+        StreamSupport.stream(entries.spliterator(), false)
             .anyMatch(
-                file -> {
-                  StructLike partition = file.partition();
+                entry -> {
+                  StructLike partition = entry.file().partition();
                   if (position >= partition.size()) {
                     return false;
                   }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -317,18 +317,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
 
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanNoFilter);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(files.iterator()));
+      Assert.assertEquals(8, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
-    validateSingleFieldPartition(files, 1);
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 0);
+    validateSingleFieldPartition(entries, 1);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -342,18 +342,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanWithProjection);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(files.iterator()));
+      Assert.assertEquals(8, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
-    validateSingleFieldPartition(files, 1);
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 0);
+    validateSingleFieldPartition(entries, 1);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -361,14 +361,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 
     Table partitionsTable = new PartitionsTable(table);
-    CloseableIterable<ContentFile<?>> tasksAndEq =
-        PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan());
-    for (ContentFile<?> file : tasksAndEq) {
-      Assert.assertNull(file.columnSizes());
-      Assert.assertNull(file.valueCounts());
-      Assert.assertNull(file.nullValueCounts());
-      Assert.assertNull(file.lowerBounds());
-      Assert.assertNull(file.upperBounds());
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> tasksAndEq =
+        PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan());
+    for (ManifestEntry<? extends ContentFile<?>> task : tasksAndEq) {
+      Assert.assertNull(task.file().columnSizes());
+      Assert.assertNull(task.file().valueCounts());
+      Assert.assertNull(task.file().nullValueCounts());
+      Assert.assertNull(task.file().nanValueCounts());
+      Assert.assertNull(task.file().lowerBounds());
+      Assert.assertNull(task.file().upperBounds());
     }
   }
 
@@ -383,15 +384,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanAndEq);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanAndEq);
     if (formatVersion == 2) {
-      Assert.assertEquals(2, Iterators.size(files.iterator()));
+      Assert.assertEquals(2, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(1, Iterators.size(files.iterator()));
+      Assert.assertEquals(1, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
+    validateSingleFieldPartition(entries, 0);
   }
 
   @Test
@@ -405,16 +406,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.lessThan("partition.data_bucket", 2),
             Expressions.greaterThan("record_count", 0));
     TableScan scanLtAnd = partitionsTable.newScan().filter(ltAnd);
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanLtAnd);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanLtAnd);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(2, Iterators.size(files.iterator()));
+      Assert.assertEquals(2, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
-    validateSingleFieldPartition(files, 1);
+    validateSingleFieldPartition(entries, 0);
+    validateSingleFieldPartition(entries, 1);
   }
 
   @Test
@@ -429,17 +430,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanOr = partitionsTable.newScan().filter(or);
 
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanOr);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanOr);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(files.iterator()));
+      Assert.assertEquals(8, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
-    validateSingleFieldPartition(files, 1);
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 0);
+    validateSingleFieldPartition(entries, 1);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -449,15 +451,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanNot);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanNot);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(2, Iterators.size(files.iterator()));
+      Assert.assertEquals(2, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -468,15 +471,16 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scanSet);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanSet);
     if (formatVersion == 2) {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(2, Iterators.size(files.iterator()));
+      Assert.assertEquals(2, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -487,18 +491,18 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanUnary);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanUnary);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(files.iterator()));
+      Assert.assertEquals(8, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     }
 
-    validateSingleFieldPartition(files, 0);
-    validateSingleFieldPartition(files, 1);
-    validateSingleFieldPartition(files, 2);
-    validateSingleFieldPartition(files, 3);
+    validateSingleFieldPartition(entries, 0);
+    validateSingleFieldPartition(entries, 1);
+    validateSingleFieldPartition(entries, 2);
+    validateSingleFieldPartition(entries, 3);
   }
 
   @Test
@@ -788,13 +792,14 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
       // Four data files and delete files of old spec, one new data file of new spec
-      Assert.assertEquals(9, Iterables.size(files));
+      Assert.assertEquals(9, Iterables.size(entries));
     } else {
       // Four data files of old spec, one new data file of new spec
-      Assert.assertEquals(5, Iterables.size(files));
+      Assert.assertEquals(5, Iterables.size(entries));
     }
 
     filter =
@@ -802,15 +807,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    files = PartitionsTable.planFiles((StaticTableScan) scan);
+    entries = PartitionsTable.planEntries((StaticTableScan) scan);
 
     if (formatVersion == 2) {
       // 1 original data file and delete file written by old spec, plus 1 new data file written by
       // new spec
-      Assert.assertEquals(3, Iterables.size(files));
+      Assert.assertEquals(3, Iterables.size(entries));
     } else {
       // 1 original data file written by old spec, plus 1 new data file written by new spec
-      Assert.assertEquals(2, Iterables.size(files));
+      Assert.assertEquals(2, Iterables.size(entries));
     }
   }
 
@@ -852,14 +857,15 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scan);
 
     if (formatVersion == 2) {
       // Four data and delete files of original spec, one data file written by new spec
-      Assert.assertEquals(9, Iterables.size(files));
+      Assert.assertEquals(9, Iterables.size(entries));
     } else {
       // Four data files of original spec, one data file written by new spec
-      Assert.assertEquals(5, Iterables.size(files));
+      Assert.assertEquals(5, Iterables.size(entries));
     }
 
     // Filter for a dropped partition spec field.  Correct behavior is that only old partitions are
@@ -869,11 +875,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     scan = metadataTable.newScan().filter(filter);
-    files = PartitionsTable.planFiles((StaticTableScan) scan);
+    entries = PartitionsTable.planEntries((StaticTableScan) scan);
 
     if (formatVersion == 1) {
       // 1 original data file written by old spec
-      Assert.assertEquals(1, Iterables.size(files));
+      Assert.assertEquals(1, Iterables.size(entries));
     } else {
       // 1 original data and 1 delete files written by old spec, plus both of new data file/delete
       // file written by new spec
@@ -888,7 +894,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
       // schema.
       // The Partition table final schema is a union of fields of all specs, including dropped
       // fields.
-      Assert.assertEquals(4, Iterables.size(files));
+      Assert.assertEquals(4, Iterables.size(entries));
     }
   }
 
@@ -939,10 +945,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.partition", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanAndEq);
-    Assert.assertEquals(1, Iterators.size(files.iterator()));
-    validateSingleFieldPartition(files, 0);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanAndEq);
+    Assert.assertEquals(1, Iterators.size(entries.iterator()));
+    validateSingleFieldPartition(entries, 0);
   }
 
   @Test
@@ -1010,11 +1016,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    CloseableIterable<ContentFile<?>> files = PartitionsTable.planFiles((StaticTableScan) scan);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
-      Assert.assertEquals(8, Iterators.size(files.iterator()));
+      Assert.assertEquals(8, Iterators.size(entries.iterator()));
     } else {
-      Assert.assertEquals(4, Iterators.size(files.iterator()));
+      Assert.assertEquals(4, Iterators.size(entries.iterator()));
     }
 
     Assert.assertTrue("Thread should be created in provided pool", planThreadsIndex.get() > 0);

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -317,7 +317,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
 
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
     if (formatVersion == 2) {
       Assert.assertEquals(8, Iterators.size(entries.iterator()));
@@ -342,7 +342,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
     if (formatVersion == 2) {
       Assert.assertEquals(8, Iterators.size(entries.iterator()));
@@ -361,7 +361,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
 
     Table partitionsTable = new PartitionsTable(table);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> tasksAndEq =
+    CloseableIterable<ManifestEntry<?>> tasksAndEq =
         PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan());
     for (ManifestEntry<? extends ContentFile<?>> task : tasksAndEq) {
       Assert.assertNull(task.file().columnSizes());
@@ -384,7 +384,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.data_bucket", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanAndEq);
     if (formatVersion == 2) {
       Assert.assertEquals(2, Iterators.size(entries.iterator()));
@@ -406,7 +406,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.lessThan("partition.data_bucket", 2),
             Expressions.greaterThan("record_count", 0));
     TableScan scanLtAnd = partitionsTable.newScan().filter(ltAnd);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanLtAnd);
     if (formatVersion == 2) {
       Assert.assertEquals(4, Iterators.size(entries.iterator()));
@@ -430,7 +430,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.greaterThan("record_count", 0));
     TableScan scanOr = partitionsTable.newScan().filter(or);
 
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanOr);
     if (formatVersion == 2) {
       Assert.assertEquals(8, Iterators.size(entries.iterator()));
@@ -451,7 +451,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scanNot = partitionsTable.newScan().filter(not);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNot);
     if (formatVersion == 2) {
       Assert.assertEquals(4, Iterators.size(entries.iterator()));
@@ -471,7 +471,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scanSet = partitionsTable.newScan().filter(set);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanSet);
     if (formatVersion == 2) {
       Assert.assertEquals(4, Iterators.size(entries.iterator()));
@@ -491,7 +491,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scanUnary = partitionsTable.newScan().filter(unary);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanUnary);
     if (formatVersion == 2) {
       Assert.assertEquals(8, Iterators.size(entries.iterator()));
@@ -792,7 +792,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
       // Four data files and delete files of old spec, one new data file of new spec
@@ -857,7 +857,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
         Expressions.and(
             Expressions.equal("partition.id", 10), Expressions.greaterThan("record_count", 0));
     TableScan scan = metadataTable.newScan().filter(filter);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scan);
 
     if (formatVersion == 2) {
@@ -945,7 +945,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Expressions.equal("partition.partition", 0),
             Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = partitionsTable.newScan().filter(andEquals);
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanAndEq);
     Assert.assertEquals(1, Iterators.size(entries.iterator()));
     validateSingleFieldPartition(entries, 0);
@@ -1016,7 +1016,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                           true); // daemon threads will be terminated abruptly when the JVM exits
                       return thread;
                     }));
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scan);
     if (formatVersion == 2) {
       Assert.assertEquals(8, Iterators.size(entries.iterator()));

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -140,7 +140,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
   }
 
   @Test
-  public void testPartitionsTableScanWithAddPartitionOnNestedField() throws IOException {
+  public void testPartitionsTableScanWithAddPartitionOnNestedField() {
     Table partitionsTable = new PartitionsTable(table);
     Types.StructType idPartition =
         new Schema(
@@ -154,15 +154,15 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
-    CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) scanNoFilter);
-    Assert.assertEquals(4, Iterators.size(files.iterator()));
-    validatePartition(files, 0, 0);
-    validatePartition(files, 0, 1);
-    validatePartition(files, 0, 2);
-    validatePartition(files, 0, 3);
-    validatePartition(files, 1, 2);
-    validatePartition(files, 1, 3);
+    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+        PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
+    Assert.assertEquals(4, Iterators.size(entries.iterator()));
+    validatePartition(entries, 0, 0);
+    validatePartition(entries, 0, 1);
+    validatePartition(entries, 0, 2);
+    validatePartition(entries, 0, 3);
+    validatePartition(entries, 1, 2);
+    validatePartition(entries, 1, 3);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -241,16 +241,16 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
     // must contain the partition column even when the current spec is non-partitioned.
     Assertions.assertThat(partitionsTable.schema().findField("partition")).isNotNull();
 
-    try (CloseableIterable<ContentFile<?>> files =
-        PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan())) {
+    try (CloseableIterable<ManifestEntry<?>> entries =
+        PartitionsTable.planEntries((StaticTableScan) partitionsTable.newScan())) {
       // four partitioned data files and one non-partitioned data file.
-      Assertions.assertThat(files).hasSize(5);
+      Assertions.assertThat(entries).hasSize(5);
 
       // check for null partition value.
-      Assertions.assertThat(StreamSupport.stream(files.spliterator(), false))
+      Assertions.assertThat(StreamSupport.stream(entries.spliterator(), false))
           .anyMatch(
-              file -> {
-                StructLike partition = file.partition();
+              entry -> {
+                StructLike partition = entry.file().partition();
                 return Objects.equals(null, partition.get(0, Object.class));
               });
     }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScansWithPartitionEvolution.java
@@ -154,7 +154,7 @@ public class TestMetadataTableScansWithPartitionEvolution extends MetadataTableS
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition");
     Assert.assertEquals(idPartition, scanNoFilter.schema().asStruct());
-    CloseableIterable<ManifestEntry<? extends ContentFile<?>>> entries =
+    CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanNoFilter);
     Assert.assertEquals(4, Iterators.size(entries.iterator()));
     validatePartition(entries, 0, 0);

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1231,16 +1231,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            optional(
-                9,
-                "last_updated_ms",
-                Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
-            optional(
-                10,
-                "last_updated_snapshot_id",
-                Types.LongType.get(),
-                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1262,7 +1252,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 8,
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
-                "Count of equality delete files"));
+                "Count of equality delete files"),
+            optional(
+                9,
+                "last_updated_ms",
+                Types.TimestampType.withZone(),
+                "Partition last updated timestamp"),
+            optional(
+                10,
+                "last_updated_snapshot_id",
+                Types.LongType.get(),
+                "Id of snapshot that last updated this partition"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1297,158 +1297,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public void testPartitionsTableLastUpdatedSnapshot() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
-    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
-    Table partitionsTable = loadTable(tableIdentifier, "partitions");
-    Dataset<Row> df1 =
-        spark.createDataFrame(
-            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
-            SimpleRecord.class);
-    Dataset<Row> df2 =
-        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
-
-    df1.select("id", "data")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(loadLocation(tableIdentifier));
-
-    table.refresh();
-    long firstCommitId = table.currentSnapshot().snapshotId();
-
-    // add a second file
-    df2.select("id", "data")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(loadLocation(tableIdentifier));
-
-    table.refresh();
-    long secondCommitId = table.currentSnapshot().snapshotId();
-
-    // check if rewrite manifest does not override metadata about data file's creating snapshot
-    RewriteManifests.Result rewriteManifestResult =
-        SparkActions.get().rewriteManifests(table).execute();
-    Assert.assertEquals(
-        "rewrite replaced 2 manifests",
-        2,
-        Iterables.size(rewriteManifestResult.rewrittenManifests()));
-    Assert.assertEquals(
-        "rewrite added 1 manifests", 1, Iterables.size(rewriteManifestResult.addedManifests()));
-
-    List<Row> actual =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .orderBy("partition.id")
-            .collectAsList();
-
-    GenericRecordBuilder builder =
-        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
-    GenericRecordBuilder partitionBuilder =
-        new GenericRecordBuilder(
-            AvroSchemaUtil.convert(
-                partitionsTable.schema().findType("partition").asStructType(), "partition"));
-    List<GenericData.Record> expected = Lists.newArrayList();
-    expected.add(
-        builder
-            .set("partition", partitionBuilder.set("id", 1).build())
-            .set("record_count", 1L)
-            .set("file_count", 1)
-            .set("position_delete_record_count", 0L)
-            .set("position_delete_file_count", 0)
-            .set("equality_delete_record_count", 0L)
-            .set("equality_delete_file_count", 0)
-            .set("spec_id", 0)
-            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
-            .set("last_updated_snapshot_id", firstCommitId)
-            .build());
-    expected.add(
-        builder
-            .set("partition", partitionBuilder.set("id", 2).build())
-            .set("record_count", 2L)
-            .set("file_count", 2)
-            .set("position_delete_record_count", 0L)
-            .set("position_delete_file_count", 0)
-            .set("equality_delete_record_count", 0L)
-            .set("equality_delete_file_count", 0)
-            .set("spec_id", 0)
-            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
-            .set("last_updated_snapshot_id", secondCommitId)
-            .build());
-
-    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
-    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
-    for (int i = 0; i < 2; i += 1) {
-      TestHelpers.assertEqualsSafe(
-          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
-    }
-
-    // check time travel
-    List<Row> actualAfterFirstCommit =
-        spark
-            .read()
-            .format("iceberg")
-            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .orderBy("partition.id")
-            .collectAsList();
-
-    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
-    TestHelpers.assertEqualsSafe(
-        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
-
-    // check predicate push down
-    List<Row> filtered =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .filter("partition.id < 2")
-            .collectAsList();
-    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
-    TestHelpers.assertEqualsSafe(
-        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
-
-    // check for snapshot expiration
-    // if snapshot with firstCommitId is expired,
-    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
-    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
-    GenericData.Record newPartitionRecord =
-        builder
-            .set("partition", partitionBuilder.set("id", 1).build())
-            .set("record_count", 1L)
-            .set("file_count", 1)
-            .set("position_delete_record_count", 0L)
-            .set("position_delete_file_count", 0)
-            .set("equality_delete_record_count", 0L)
-            .set("equality_delete_file_count", 0)
-            .set("spec_id", 0)
-            .set("last_updated_ms", null)
-            .set("last_updated_snapshot_id", null)
-            .build();
-    expected.remove(0);
-    expected.add(0, newPartitionRecord);
-
-    List<Row> actualAfterSnapshotExpiration =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .collectAsList();
-    Assert.assertEquals(
-        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
-    for (int i = 0; i < 2; i += 1) {
-      TestHelpers.assertEqualsSafe(
-          partitionsTable.schema().asStruct(),
-          expected.get(i),
-          actualAfterSnapshotExpiration.get(i));
-    }
-  }
-
-  @Test
   public void testPartitionsTable() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
@@ -1559,10 +1407,148 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .load(loadLocation(tableIdentifier, "partitions"))
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
-    Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableLastUpdatedSnapshot() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(
+            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
+            SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
+    // check if rewrite manifest does not override metadata about data file's creating snapshot
+    RewriteManifests.Result rewriteManifestResult =
+        SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals(
+        "rewrite replaced 2 manifests",
+        2,
+        Iterables.size(rewriteManifestResult.rewrittenManifests()));
+    Assert.assertEquals(
+        "rewrite added 1 manifests", 1, Iterables.size(rewriteManifestResult.addedManifests()));
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 2L)
+            .set("file_count", 2)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
+            .build());
+
+    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check predicate push down
+    List<Row> filtered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id < 2")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
+
+    // check for snapshot expiration
+    // if snapshot with firstCommitId is expired,
+    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
+    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
+    GenericData.Record newPartitionRecord =
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", null)
+            .set("last_updated_snapshot_id", null)
+            .build();
+    expected.remove(0);
+    expected.add(0, newPartitionRecord);
+
+    List<Row> actualAfterSnapshotExpiration =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    Assert.assertEquals(
+        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(),
+          expected.get(i),
+          actualAfterSnapshotExpiration.get(i));
     }
   }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1231,12 +1231,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
+            optional(
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
-            required(
+            optional(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
@@ -1327,7 +1327,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     table.refresh();
     long secondCommitId = table.currentSnapshot().snapshotId();
 
-    // rewrite manifest carry over the data file to its committing snapshot relationship
+    // check if rewrite manifest does not override metadata about data file's creating snapshot
     RewriteManifests.Result rewriteManifestResult =
         SparkActions.get().rewriteManifests(table).execute();
     Assert.assertEquals(
@@ -1426,8 +1426,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_ms", 0L)
-            .set("last_updated_snapshot_id", 0L)
+            .set("last_updated_ms", null)
+            .set("last_updated_snapshot_id", null)
             .build();
     expected.remove(0);
     expected.add(0, newPartitionRecord);

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1232,7 +1232,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated_at",
+                "last_updated",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
@@ -1274,7 +1274,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated_at", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1349,7 +1349,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1362,7 +1362,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1257,7 +1257,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
+                "Commit time of snapshot that last updated this partition"),
             optional(
                 10,
                 "last_updated_snapshot_id",

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -1293,6 +1294,158 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Assert.assertEquals("Unpartitioned partitions table should have one row", 1, actual.size());
     TestHelpers.assertEqualsSafe(expectedSchema, expectedRow, actual.get(0));
+  }
+
+  @Test
+  public void testPartitionsTableLastUpdatedSnapshot() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(
+            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
+            SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
+    // rewrite manifest carry over the data file to its committing snapshot relationship
+    RewriteManifests.Result rewriteManifestResult =
+        SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals(
+        "rewrite replaced 2 manifests",
+        2,
+        Iterables.size(rewriteManifestResult.rewrittenManifests()));
+    Assert.assertEquals(
+        "rewrite added 1 manifests", 1, Iterables.size(rewriteManifestResult.addedManifests()));
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 2L)
+            .set("file_count", 2)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
+            .build());
+
+    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check time travel
+    List<Row> actualAfterFirstCommit =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
+
+    // check predicate push down
+    List<Row> filtered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id < 2")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
+
+    // check for snapshot expiration
+    // if snapshot with firstCommitId is expired,
+    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
+    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
+    GenericData.Record newPartitionRecord =
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", 0L)
+            .set("last_updated_snapshot_id", 0L)
+            .build();
+    expected.remove(0);
+    expected.add(0, newPartitionRecord);
+
+    List<Row> actualAfterSnapshotExpiration =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    Assert.assertEquals(
+        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(),
+          expected.get(i),
+          actualAfterSnapshotExpiration.get(i));
+    }
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1232,14 +1232,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated",
+                "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Partition last updated snapshot id"),
+                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1274,7 +1274,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated_ms", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1349,7 +1349,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1362,7 +1362,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1222,7 +1222,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   @Test
   public void testUnpartitionedPartitionsTable() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "unpartitioned_partitions_test");
-    createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
+    Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     Dataset<Row> df =
         spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
@@ -1235,6 +1235,16 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
+            required(
+                9,
+                "last_updated_at",
+                Types.TimestampType.withZone(),
+                "Partition last updated timestamp"),
+            required(
+                10,
+                "last_updated_snapshot_id",
+                Types.LongType.get(),
+                "Partition last updated snapshot id"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1269,6 +1279,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
+            .set("last_updated_at", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
             .set("position_delete_record_count", 0L)
@@ -1314,6 +1326,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .mode("append")
         .save(loadLocation(tableIdentifier));
 
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
     List<Row> actual =
         spark
             .read()
@@ -1339,6 +1354,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
+            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
         builder
@@ -1350,6 +1367,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
+            .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
     Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
@@ -1416,6 +1435,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
 
     // add a second file
     df2.select("id", "data")
@@ -1428,6 +1448,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
     DeleteFile deleteFile = writePosDeleteFile(table);
     table.newRowDelta().addDeletes(deleteFile).commit();
+    table.refresh();
+    long posDeleteCommitId = table.currentSnapshot().snapshotId();
 
     List<Row> actual =
         spark
@@ -1455,6 +1477,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
+            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
         builder
@@ -1466,7 +1490,10 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
+            .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
+
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1475,6 +1502,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // test equality delete
     DeleteFile eqDeleteFile = writeEqDeleteFile(table);
     table.newRowDelta().addDeletes(eqDeleteFile).commit();
+    table.refresh();
+    long eqDeleteCommitId = table.currentSnapshot().snapshotId();
     actual =
         spark
             .read()
@@ -1495,6 +1524,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
             .set("spec_id", 0)
+            .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1236,12 +1236,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
+            optional(
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
-            required(
+            optional(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
@@ -1450,7 +1450,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     table.refresh();
     long secondCommitId = table.currentSnapshot().snapshotId();
 
-    // rewrite manifest carry over the data file to its committing snapshot relationship
+    // check if rewrite manifest does not override metadata about data file's creating snapshot
     RewriteManifests.Result rewriteManifestResult =
         SparkActions.get().rewriteManifests(table).execute();
     Assert.assertEquals(
@@ -1549,8 +1549,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_ms", 0L)
-            .set("last_updated_snapshot_id", 0L)
+            .set("last_updated_ms", null)
+            .set("last_updated_snapshot_id", null)
             .build();
     expected.remove(0);
     expected.add(0, newPartitionRecord);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1262,7 +1262,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
+                "Commit time of snapshot that last updated this partition"),
             optional(
                 10,
                 "last_updated_snapshot_id",

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1412,7 +1412,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .load(loadLocation(tableIdentifier, "partitions"))
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
-    Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1508,20 +1508,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
-
-    // check time travel
-    List<Row> actualAfterFirstCommit =
-        spark
-            .read()
-            .format("iceberg")
-            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .orderBy("partition.id")
-            .collectAsList();
-
-    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
-    TestHelpers.assertEqualsSafe(
-        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
 
     // check predicate push down
     List<Row> filtered =

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1237,14 +1237,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated",
+                "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Partition last updated snapshot id"),
+                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1279,7 +1279,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated_ms", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1354,7 +1354,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1367,7 +1367,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1415,6 +1415,166 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableLastUpdatedSnapshot() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(
+            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
+            SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
+    // rewrite manifest carry over the data file to its committing snapshot relationship
+    RewriteManifests.Result r = SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals("rewrite replaced 2 manifests", 2, Iterables.size(r.rewrittenManifests()));
+    Assert.assertEquals("rewrite added 1 manifests", 1, Iterables.size(r.addedManifests()));
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 2L)
+            .set("file_count", 2)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
+            .build());
+
+    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check time travel
+    List<Row> actualAfterFirstCommit =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
+
+    // check predicate push down
+    List<Row> filtered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id < 2")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
+
+    List<Row> nonFiltered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id <= 2 or record_count=1")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check for snapshot expiration
+    // if snapshot with firstCommitId is expired,
+    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
+    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
+    GenericData.Record newPartitionRecord =
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", 0L)
+            .set("last_updated_snapshot_id", 0L)
+            .build();
+    expected.remove(0);
+    expected.add(0, newPartitionRecord);
+
+    List<Row> actualAfterSnapshotExpiration =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    Assert.assertEquals(
+        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(),
+          expected.get(i),
+          actualAfterSnapshotExpiration.get(i));
     }
   }
 
@@ -1477,7 +1637,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1490,7 +1650,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1524,7 +1684,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1236,16 +1236,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            optional(
-                9,
-                "last_updated_ms",
-                Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
-            optional(
-                10,
-                "last_updated_snapshot_id",
-                Types.LongType.get(),
-                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1267,7 +1257,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 8,
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
-                "Count of equality delete files"));
+                "Count of equality delete files"),
+            optional(
+                9,
+                "last_updated_ms",
+                Types.TimestampType.withZone(),
+                "Partition last updated timestamp"),
+            optional(
+                10,
+                "last_updated_snapshot_id",
+                Types.LongType.get(),
+                "Id of snapshot that last updated this partition"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1237,7 +1237,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated_at",
+                "last_updated",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
@@ -1279,7 +1279,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated_at", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1354,7 +1354,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1367,7 +1367,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1477,7 +1477,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1490,7 +1490,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1524,7 +1524,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1242,7 +1242,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated_at",
+                "last_updated",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
@@ -1284,7 +1284,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated_at", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1359,7 +1359,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1372,7 +1372,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1482,7 +1482,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1495,7 +1495,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1529,7 +1529,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -1455,9 +1456,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     long secondCommitId = table.currentSnapshot().snapshotId();
 
     // rewrite manifest carry over the data file to its committing snapshot relationship
-    RewriteManifests.Result r = SparkActions.get().rewriteManifests(table).execute();
-    Assert.assertEquals("rewrite replaced 2 manifests", 2, Iterables.size(r.rewrittenManifests()));
-    Assert.assertEquals("rewrite added 1 manifests", 1, Iterables.size(r.addedManifests()));
+    RewriteManifests.Result rewriteManifestResult =
+        SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals(
+        "rewrite replaced 2 manifests",
+        2,
+        Iterables.size(rewriteManifestResult.rewrittenManifests()));
+    Assert.assertEquals(
+        "rewrite added 1 manifests", 1, Iterables.size(rewriteManifestResult.addedManifests()));
 
     List<Row> actual =
         spark
@@ -1533,19 +1539,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Actual results should have one row", 1, filtered.size());
     TestHelpers.assertEqualsSafe(
         partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
-
-    List<Row> nonFiltered =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .filter("partition.id <= 2 or record_count=1")
-            .collectAsList();
-    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
-    for (int i = 0; i < 2; i += 1) {
-      TestHelpers.assertEqualsSafe(
-          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
-    }
 
     // check for snapshot expiration
     // if snapshot with firstCommitId is expired,

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1417,7 +1417,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .load(loadLocation(tableIdentifier, "partitions"))
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
-    Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1513,20 +1513,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
-
-    // check time travel
-    List<Row> actualAfterFirstCommit =
-        spark
-            .read()
-            .format("iceberg")
-            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .orderBy("partition.id")
-            .collectAsList();
-
-    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
-    TestHelpers.assertEqualsSafe(
-        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
 
     // check predicate push down
     List<Row> filtered =

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1267,7 +1267,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
+                "Commit time of snapshot that last updated this partition"),
             optional(
                 10,
                 "last_updated_snapshot_id",

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1242,14 +1242,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated",
+                "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Partition last updated snapshot id"),
+                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1284,7 +1284,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated_ms", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1359,7 +1359,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1372,7 +1372,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1420,6 +1420,166 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableLastUpdatedSnapshot() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(
+            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
+            SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
+    // rewrite manifest carry over the data file to its committing snapshot relationship
+    RewriteManifests.Result r = SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals("rewrite replaced 2 manifests", 2, Iterables.size(r.rewrittenManifests()));
+    Assert.assertEquals("rewrite added 1 manifests", 1, Iterables.size(r.addedManifests()));
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 2L)
+            .set("file_count", 2)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
+            .build());
+
+    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check time travel
+    List<Row> actualAfterFirstCommit =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
+
+    // check predicate push down
+    List<Row> filtered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id < 2")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
+
+    List<Row> nonFiltered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id <= 2 or record_count=1")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check for snapshot expiration
+    // if snapshot with firstCommitId is expired,
+    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
+    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
+    GenericData.Record newPartitionRecord =
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", 0L)
+            .set("last_updated_snapshot_id", 0L)
+            .build();
+    expected.remove(0);
+    expected.add(0, newPartitionRecord);
+
+    List<Row> actualAfterSnapshotExpiration =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    Assert.assertEquals(
+        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(),
+          expected.get(i),
+          actualAfterSnapshotExpiration.get(i));
     }
   }
 
@@ -1482,7 +1642,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1495,7 +1655,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1529,7 +1689,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1241,12 +1241,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
+            optional(
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
-            required(
+            optional(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
@@ -1455,7 +1455,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     table.refresh();
     long secondCommitId = table.currentSnapshot().snapshotId();
 
-    // rewrite manifest carry over the data file to its committing snapshot relationship
+    // check if rewrite manifest does not override metadata about data file's creating snapshot
     RewriteManifests.Result rewriteManifestResult =
         SparkActions.get().rewriteManifests(table).execute();
     Assert.assertEquals(
@@ -1554,8 +1554,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_ms", 0L)
-            .set("last_updated_snapshot_id", 0L)
+            .set("last_updated_ms", null)
+            .set("last_updated_snapshot_id", null)
             .build();
     expected.remove(0);
     expected.add(0, newPartitionRecord);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1241,16 +1241,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            optional(
-                9,
-                "last_updated_ms",
-                Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
-            optional(
-                10,
-                "last_updated_snapshot_id",
-                Types.LongType.get(),
-                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1272,7 +1262,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 8,
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
-                "Count of equality delete files"));
+                "Count of equality delete files"),
+            optional(
+                9,
+                "last_updated_ms",
+                Types.TimestampType.withZone(),
+                "Partition last updated timestamp"),
+            optional(
+                10,
+                "last_updated_snapshot_id",
+                Types.LongType.get(),
+                "Id of snapshot that last updated this partition"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1239,7 +1239,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated_at",
+                "last_updated",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
@@ -1281,7 +1281,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated_at", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1356,7 +1356,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1369,7 +1369,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1479,7 +1479,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1492,7 +1492,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_at", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1525,7 +1525,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
-            .set("last_updated_at", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1453,9 +1453,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     long secondCommitId = table.currentSnapshot().snapshotId();
 
     // rewrite manifest carry over the data file to its committing snapshot relationship
-    RewriteManifests.Result r = SparkActions.get().rewriteManifests(table).execute();
-    Assert.assertEquals("rewrite replaced 2 manifests", 2, Iterables.size(r.rewrittenManifests()));
-    Assert.assertEquals("rewrite added 1 manifests", 1, Iterables.size(r.addedManifests()));
+    RewriteManifests.Result rewriteManifestResult =
+        SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals(
+        "rewrite replaced 2 manifests",
+        2,
+        Iterables.size(rewriteManifestResult.rewrittenManifests()));
+    Assert.assertEquals(
+        "rewrite added 1 manifests", 1, Iterables.size(rewriteManifestResult.addedManifests()));
 
     List<Row> actual =
         spark
@@ -1531,19 +1536,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Actual results should have one row", 1, filtered.size());
     TestHelpers.assertEqualsSafe(
         partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
-
-    List<Row> nonFiltered =
-        spark
-            .read()
-            .format("iceberg")
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .filter("partition.id <= 2 or record_count=1")
-            .collectAsList();
-    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
-    for (int i = 0; i < 2; i += 1) {
-      TestHelpers.assertEqualsSafe(
-          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
-    }
 
     // check for snapshot expiration
     // if snapshot with firstCommitId is expired,

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -1239,14 +1240,14 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         Types.StructType.of(
             required(
                 9,
-                "last_updated",
+                "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
             required(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
-                "Partition last updated snapshot id"),
+                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1281,7 +1282,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
     GenericData.Record expectedRow =
         builder
-            .set("last_updated", table.currentSnapshot().timestampMillis() * 1000)
+            .set("last_updated_ms", table.currentSnapshot().timestampMillis() * 1000)
             .set("last_updated_snapshot_id", table.currentSnapshot().snapshotId())
             .set("record_count", 1L)
             .set("file_count", 1)
@@ -1356,7 +1357,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1369,7 +1370,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", secondCommitId)
             .build());
 
@@ -1417,6 +1418,166 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+  }
+
+  @Test
+  public void testPartitionsTableLastUpdatedSnapshot() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    Table table = createTable(tableIdentifier, SCHEMA, SPEC);
+    Table partitionsTable = loadTable(tableIdentifier, "partitions");
+    Dataset<Row> df1 =
+        spark.createDataFrame(
+            Lists.newArrayList(new SimpleRecord(1, "1"), new SimpleRecord(2, "2")),
+            SimpleRecord.class);
+    Dataset<Row> df2 =
+        spark.createDataFrame(Lists.newArrayList(new SimpleRecord(2, "20")), SimpleRecord.class);
+
+    df1.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long firstCommitId = table.currentSnapshot().snapshotId();
+
+    // add a second file
+    df2.select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    table.refresh();
+    long secondCommitId = table.currentSnapshot().snapshotId();
+
+    // rewrite manifest carry over the data file to its committing snapshot relationship
+    RewriteManifests.Result r = SparkActions.get().rewriteManifests(table).execute();
+    Assert.assertEquals("rewrite replaced 2 manifests", 2, Iterables.size(r.rewrittenManifests()));
+    Assert.assertEquals("rewrite added 1 manifests", 1, Iterables.size(r.addedManifests()));
+
+    List<Row> actual =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    GenericRecordBuilder builder =
+        new GenericRecordBuilder(AvroSchemaUtil.convert(partitionsTable.schema(), "partitions"));
+    GenericRecordBuilder partitionBuilder =
+        new GenericRecordBuilder(
+            AvroSchemaUtil.convert(
+                partitionsTable.schema().findType("partition").asStructType(), "partition"));
+    List<GenericData.Record> expected = Lists.newArrayList();
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", firstCommitId)
+            .build());
+    expected.add(
+        builder
+            .set("partition", partitionBuilder.set("id", 2).build())
+            .set("record_count", 2L)
+            .set("file_count", 2)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", table.snapshot(secondCommitId).timestampMillis() * 1000)
+            .set("last_updated_snapshot_id", secondCommitId)
+            .build());
+
+    Assert.assertEquals("Partitions table should have two rows", 2, expected.size());
+    Assert.assertEquals("Actual results should have two rows", 2, actual.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check time travel
+    List<Row> actualAfterFirstCommit =
+        spark
+            .read()
+            .format("iceberg")
+            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .orderBy("partition.id")
+            .collectAsList();
+
+    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
+
+    // check predicate push down
+    List<Row> filtered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id < 2")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have one row", 1, filtered.size());
+    TestHelpers.assertEqualsSafe(
+        partitionsTable.schema().asStruct(), expected.get(0), filtered.get(0));
+
+    List<Row> nonFiltered =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .filter("partition.id <= 2 or record_count=1")
+            .collectAsList();
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
+    }
+
+    // check for snapshot expiration
+    // if snapshot with firstCommitId is expired,
+    // we expect the partition of id=1 will no longer have last updated timestamp and snapshotId
+    SparkActions.get().expireSnapshots(table).expireSnapshotId(firstCommitId).execute();
+    GenericData.Record newPartitionRecord =
+        builder
+            .set("partition", partitionBuilder.set("id", 1).build())
+            .set("record_count", 1L)
+            .set("file_count", 1)
+            .set("position_delete_record_count", 0L)
+            .set("position_delete_file_count", 0)
+            .set("equality_delete_record_count", 0L)
+            .set("equality_delete_file_count", 0)
+            .set("spec_id", 0)
+            .set("last_updated_ms", 0L)
+            .set("last_updated_snapshot_id", 0L)
+            .build();
+    expected.remove(0);
+    expected.add(0, newPartitionRecord);
+
+    List<Row> actualAfterSnapshotExpiration =
+        spark
+            .read()
+            .format("iceberg")
+            .load(loadLocation(tableIdentifier, "partitions"))
+            .collectAsList();
+    Assert.assertEquals(
+        "Actual results should have two row", 2, actualAfterSnapshotExpiration.size());
+    for (int i = 0; i < 2; i += 1) {
+      TestHelpers.assertEqualsSafe(
+          partitionsTable.schema().asStruct(),
+          expected.get(i),
+          actualAfterSnapshotExpiration.get(i));
     }
   }
 
@@ -1479,7 +1640,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(firstCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(firstCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", firstCommitId)
             .build());
     expected.add(
@@ -1492,7 +1653,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(posDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", posDeleteCommitId)
             .build());
 
@@ -1525,7 +1686,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("position_delete_file_count", 0)
             .set("equality_delete_record_count", 1L) // should be incremented now
             .set("equality_delete_file_count", 1) // should be incremented now
-            .set("last_updated", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
+            .set("last_updated_ms", table.snapshot(eqDeleteCommitId).timestampMillis() * 1000)
             .set("last_updated_snapshot_id", eqDeleteCommitId)
             .build());
     for (int i = 0; i < 2; i += 1) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1264,7 +1264,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
+                "Commit time of snapshot that last updated this partition"),
             optional(
                 10,
                 "last_updated_snapshot_id",

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1414,7 +1414,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .load(loadLocation(tableIdentifier, "partitions"))
             .filter("partition.id < 2 or record_count=1")
             .collectAsList();
-    Assert.assertEquals("Actual results should have one row", 2, nonFiltered.size());
+    Assert.assertEquals("Actual results should have two row", 2, nonFiltered.size());
     for (int i = 0; i < 2; i += 1) {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
@@ -1510,20 +1510,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
       TestHelpers.assertEqualsSafe(
           partitionsTable.schema().asStruct(), expected.get(i), actual.get(i));
     }
-
-    // check time travel
-    List<Row> actualAfterFirstCommit =
-        spark
-            .read()
-            .format("iceberg")
-            .option(SparkReadOptions.SNAPSHOT_ID, String.valueOf(secondCommitId))
-            .load(loadLocation(tableIdentifier, "partitions"))
-            .orderBy("partition.id")
-            .collectAsList();
-
-    Assert.assertEquals("Actual results should have one row", 2, actualAfterFirstCommit.size());
-    TestHelpers.assertEqualsSafe(
-        partitionsTable.schema().asStruct(), expected.get(0), actualAfterFirstCommit.get(0));
 
     // check predicate push down
     List<Row> filtered =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1238,12 +1238,12 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            required(
+            optional(
                 9,
                 "last_updated_ms",
                 Types.TimestampType.withZone(),
                 "Partition last updated timestamp"),
-            required(
+            optional(
                 10,
                 "last_updated_snapshot_id",
                 Types.LongType.get(),
@@ -1452,7 +1452,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     table.refresh();
     long secondCommitId = table.currentSnapshot().snapshotId();
 
-    // rewrite manifest carry over the data file to its committing snapshot relationship
+    // check if rewrite manifest does not override metadata about data file's creating snapshot
     RewriteManifests.Result rewriteManifestResult =
         SparkActions.get().rewriteManifests(table).execute();
     Assert.assertEquals(
@@ -1551,8 +1551,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .set("equality_delete_record_count", 0L)
             .set("equality_delete_file_count", 0)
             .set("spec_id", 0)
-            .set("last_updated_ms", 0L)
-            .set("last_updated_snapshot_id", 0L)
+            .set("last_updated_ms", null)
+            .set("last_updated_snapshot_id", null)
             .build();
     expected.remove(0);
     expected.add(0, newPartitionRecord);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1238,16 +1238,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Types.StructType expectedSchema =
         Types.StructType.of(
-            optional(
-                9,
-                "last_updated_ms",
-                Types.TimestampType.withZone(),
-                "Partition last updated timestamp"),
-            optional(
-                10,
-                "last_updated_snapshot_id",
-                Types.LongType.get(),
-                "Id of snapshot that last updated this partition"),
             required(2, "record_count", Types.LongType.get(), "Count of records in data files"),
             required(3, "file_count", Types.IntegerType.get(), "Count of data files"),
             required(
@@ -1269,7 +1259,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                 8,
                 "equality_delete_file_count",
                 Types.IntegerType.get(),
-                "Count of equality delete files"));
+                "Count of equality delete files"),
+            optional(
+                9,
+                "last_updated_ms",
+                Types.TimestampType.withZone(),
+                "Partition last updated timestamp"),
+            optional(
+                10,
+                "last_updated_snapshot_id",
+                Types.LongType.get(),
+                "Id of snapshot that last updated this partition"));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 


### PR DESCRIPTION
close #7560

## What
add 2 column to partition metadata table
- `last_updated_at` with timestamp with timezone type (similar to `committed_at` in snapshot metadata table)
- `last_updated_snapshot_id` with long type  

## How
In Partition metadata table, we moved from iterating over ContentFiles from ManifestReader to ManifestEntry instead, since entry contain both content file and snapshotId, which are valuable to provide last updated timestamp and snapshot information. We group by file for each partition boundary and get the highest snapshot commit timestamp so that we know when exactly is the partition last modified. 

## Why
This can be potentially useful for iceberg table ingested by streaming application such as flink, to understand which iceberg partition is "sealed" based on timestamp. However, the write such as data compaction can also move the last update timestamp forward without actual data change, which snapshot id here can be useful for further analysis

@szehon-ho if you can help review your idea :)