### PR TITLE
AWS: Add S3FileIOAwsClientFactory with s3.client-factory-impl catalog property for S3FileIO

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -149,7 +149,9 @@ public class TestS3FileIOIntegration {
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO();
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
+    properties.put(
+        S3FileIOProperties.CLIENT_FACTORY,
+        "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
     s3FileIO.initialize(properties);
     validateRead(s3FileIO);
   }
@@ -161,7 +163,9 @@ public class TestS3FileIOIntegration {
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO();
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
+    properties.put(
+        S3FileIOProperties.CLIENT_FACTORY,
+        "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
     s3FileIO.initialize(properties);
     validateRead(s3FileIO);
   }

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -28,6 +28,7 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import javax.crypto.KeyGenerator;
@@ -138,6 +139,30 @@ public class TestS3FileIOIntegration {
         PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));
     S3FileIO s3FileIO = new S3FileIO(clientFactory::s3);
+    validateRead(s3FileIO);
+  }
+
+  @Test
+  public void testS3FileIOWithS3FileIOAwsClientFactoryImpl() throws Exception {
+    s3.putObject(
+        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+        RequestBody.fromBytes(contentBytes));
+    S3FileIO s3FileIO = new S3FileIO();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
+    s3FileIO.initialize(properties);
+    validateRead(s3FileIO);
+  }
+
+  @Test
+  public void testS3FileIOWithDefaultAwsClientFactoryImpl() throws Exception {
+    s3.putObject(
+        PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+        RequestBody.fromBytes(contentBytes));
+    S3FileIO s3FileIO = new S3FileIO();
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
+    s3FileIO.initialize(properties);
     validateRead(s3FileIO);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws;
 
+import java.io.Serializable;
 import java.util.Map;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynMethods;
@@ -32,7 +33,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
 
-public class AwsClientProperties {
+public class AwsClientProperties implements Serializable {
   /**
    * Configure the AWS credentials provider used to create AWS clients. A fully qualified concrete
    * class with package that implements the {@link AwsCredentialsProvider} interface is required.

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.aws;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.iceberg.common.DynMethods;
@@ -25,7 +26,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
 
-public class HttpClientProperties {
+public class HttpClientProperties implements Serializable {
 
   /**
    * The type of {@link software.amazon.awssdk.http.SdkHttpClient} implementation used by {@link

--- a/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
@@ -38,7 +38,7 @@ public class S3FileIOAwsClientFactories {
    * @return an instance of a factory class
    */
   @SuppressWarnings("unchecked")
-  public static <T> T initFactory(Map<String, String> properties) {
+  public static <T> T initialize(Map<String, String> properties) {
     String factoryImpl =
         PropertyUtil.propertyAsString(properties, S3FileIOProperties.CLIENT_FACTORY, null);
     if (Strings.isNullOrEmpty(factoryImpl)) {

--- a/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
@@ -25,8 +25,9 @@ import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.util.PropertyUtil;
 
-@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
 public class S3FileIOAwsClientFactories {
+
+  private S3FileIOAwsClientFactories() {}
 
   /**
    * Attempts to load an AWS client factory class for S3 file IO defined in the catalog property

--- a/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/S3FileIOAwsClientFactories.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+
+@SuppressWarnings("checkstyle:HideUtilityClassConstructor")
+public class S3FileIOAwsClientFactories {
+
+  /**
+   * Attempts to load an AWS client factory class for S3 file IO defined in the catalog property
+   * {@link S3FileIOProperties#CLIENT_FACTORY}. If the property wasn't set, fallback to {@link
+   * AwsClientFactories#from(Map) to intialize an AWS client factory class}
+   *
+   * @param properties catalog properties
+   * @return an instance of a factory class
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T initFactory(Map<String, String> properties) {
+    String factoryImpl =
+        PropertyUtil.propertyAsString(properties, S3FileIOProperties.CLIENT_FACTORY, null);
+    if (Strings.isNullOrEmpty(factoryImpl)) {
+      return (T) AwsClientFactories.from(properties);
+    }
+    return (T) loadClientFactory(factoryImpl, properties);
+  }
+
+  private static S3FileIOAwsClientFactory loadClientFactory(
+      String impl, Map<String, String> properties) {
+    DynConstructors.Ctor<S3FileIOAwsClientFactory> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(S3FileIOAwsClientFactory.class)
+              .loader(S3FileIOAwsClientFactories.class.getClassLoader())
+              .hiddenImpl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize S3FileIOAwsClientFactory, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    S3FileIOAwsClientFactory factory;
+    try {
+      factory = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize S3FileIOAwsClientFactory, %s does not implement S3FileIOAwsClientFactory.",
+              impl),
+          e);
+    }
+
+    factory.initialize(properties);
+    return factory;
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.HttpClientProperties;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
+  private S3FileIOProperties s3FileIOProperties;
+  private HttpClientProperties httpClientProperties;
+  private AwsClientProperties awsClientProperties;
+
+  public DefaultS3FileIOAwsClientFactory() {
+    this.s3FileIOProperties = new S3FileIOProperties();
+    this.httpClientProperties = new HttpClientProperties();
+    this.awsClientProperties = new AwsClientProperties();
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    this.s3FileIOProperties = new S3FileIOProperties(properties);
+    this.awsClientProperties = new AwsClientProperties(properties);
+    this.httpClientProperties = new HttpClientProperties(properties);
+  }
+
+  @Override
+  public S3Client s3() {
+    return S3Client.builder()
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+        .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+        .applyMutation(
+            s3ClientBuilder ->
+                s3FileIOProperties.applyCredentialConfigurations(
+                    awsClientProperties, s3ClientBuilder))
+        .applyMutation(s3FileIOProperties::applySignerConfiguration)
+        .build();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -28,7 +28,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
   private HttpClientProperties httpClientProperties;
   private AwsClientProperties awsClientProperties;
 
-  public DefaultS3FileIOAwsClientFactory() {
+  DefaultS3FileIOAwsClientFactory() {
     this.s3FileIOProperties = new S3FileIOProperties();
     this.httpClientProperties = new HttpClientProperties();
     this.awsClientProperties = new AwsClientProperties();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.HttpClientProperties;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
+class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
   private S3FileIOProperties s3FileIOProperties;
   private HttpClientProperties httpClientProperties;
   private AwsClientProperties awsClientProperties;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -364,7 +364,7 @@ public class S3FileIO
 
     // Do not override s3 client if it was provided
     if (s3 == null) {
-      Object clientFactory = S3FileIOAwsClientFactories.initFactory(props);
+      Object clientFactory = S3FileIOAwsClientFactories.initialize(props);
       if (clientFactory instanceof S3FileIOAwsClientFactory) {
         this.s3 = ((S3FileIOAwsClientFactory) clientFactory)::s3;
       }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -364,14 +364,14 @@ public class S3FileIO
     // Do not override s3 client if it was provided
     if (s3 == null) {
       Object clientFactory = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(props);
-      if (clientFactory instanceof CredentialSupplier) {
-        this.credential = ((CredentialSupplier) clientFactory).getCredential();
-      }
       if (clientFactory instanceof S3FileIOAwsClientFactory) {
         this.s3 = ((S3FileIOAwsClientFactory) clientFactory)::s3;
       }
       if (clientFactory instanceof AwsClientFactory) {
         this.s3 = ((AwsClientFactory) clientFactory)::s3;
+      }
+      if (clientFactory instanceof CredentialSupplier) {
+        this.credential = ((CredentialSupplier) clientFactory).getCredential();
       }
       if (s3FileIOProperties.isPreloadClientEnabled()) {
         client();

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.S3FileIOAwsClientFactories;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.CredentialSupplier;
@@ -363,7 +364,7 @@ public class S3FileIO
 
     // Do not override s3 client if it was provided
     if (s3 == null) {
-      Object clientFactory = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(props);
+      Object clientFactory = S3FileIOAwsClientFactories.initFactory(props);
       if (clientFactory instanceof S3FileIOAwsClientFactory) {
         this.s3 = ((S3FileIOAwsClientFactory) clientFactory)::s3;
       }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
@@ -31,12 +31,6 @@ public class S3FileIOAwsClientFactory {
   private final HttpClientProperties httpClientProperties;
   private final AwsClientProperties awsClientProperties;
 
-  S3FileIOAwsClientFactory() {
-    this.s3FileIOProperties = new S3FileIOProperties();
-    this.httpClientProperties = new HttpClientProperties();
-    this.awsClientProperties = new AwsClientProperties();
-  }
-
   S3FileIOAwsClientFactory(
       S3FileIOProperties s3FileIOProperties,
       HttpClientProperties httpClientProperties,
@@ -59,7 +53,7 @@ public class S3FileIOAwsClientFactory {
     return (T) AwsClientFactories.from(properties);
   }
 
-  S3Client s3Client() {
+  S3Client s3() {
     return S3Client.builder()
         .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientFactories;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.HttpClientProperties;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3FileIOAwsClientFactory {
+  public static final String CLIENT_FACTORY = "s3.client-factory-impl";
+  private final S3FileIOProperties s3FileIOProperties;
+  private final HttpClientProperties httpClientProperties;
+  private final AwsClientProperties awsClientProperties;
+
+  S3FileIOAwsClientFactory() {
+    this.s3FileIOProperties = new S3FileIOProperties();
+    this.httpClientProperties = new HttpClientProperties();
+    this.awsClientProperties = new AwsClientProperties();
+  }
+
+  S3FileIOAwsClientFactory(
+      S3FileIOProperties s3FileIOProperties,
+      HttpClientProperties httpClientProperties,
+      AwsClientProperties awsClientProperties) {
+    this.s3FileIOProperties = s3FileIOProperties;
+    this.httpClientProperties = httpClientProperties;
+    this.awsClientProperties = awsClientProperties;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T getS3ClientFactoryImpl(Map<String, String> properties) {
+    boolean useS3FileIO = PropertyUtil.propertyAsBoolean(properties, CLIENT_FACTORY, false);
+    if (useS3FileIO) {
+      return (T)
+          new S3FileIOAwsClientFactory(
+              new S3FileIOProperties(properties),
+              new HttpClientProperties(properties),
+              new AwsClientProperties(properties));
+    }
+    return (T) AwsClientFactories.from(properties);
+  }
+
+  S3Client s3Client() {
+    return S3Client.builder()
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+        .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+        .applyMutation(
+            s3ClientBuilder ->
+                s3FileIOProperties.applyCredentialConfigurations(
+                    awsClientProperties, s3ClientBuilder))
+        .applyMutation(s3FileIOProperties::applySignerConfiguration)
+        .build();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
@@ -26,7 +26,14 @@ import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3FileIOAwsClientFactory {
+  /**
+   * This property allows customizing AWS client factory implementation class. If this property is
+   * set, only {@link S3FileIOAwsClientFactory} class will be instantiated. If this property wasn't
+   * set, will load one of {@link org.apache.iceberg.aws.AwsClientFactory} factory classes to
+   * provide backward compatibility.
+   */
   public static final String CLIENT_FACTORY = "s3.client-factory-impl";
+
   private final S3FileIOProperties s3FileIOProperties;
   private final HttpClientProperties httpClientProperties;
   private final AwsClientProperties awsClientProperties;
@@ -40,6 +47,16 @@ public class S3FileIOAwsClientFactory {
     this.awsClientProperties = awsClientProperties;
   }
 
+  /**
+   * Returns an instance of a client factory class based on properties. If the {@value
+   * #CLIENT_FACTORY} is set, will return an instance of type {@link S3FileIOAwsClientFactory}.
+   * Otherwise, will return an instance of type {@link org.apache.iceberg.aws.AwsClientFactory} for
+   * backward compatibility. To provide
+   *
+   * @param properties catalog properties
+   * @param <T> a java return type
+   * @return factory class object
+   */
   @SuppressWarnings("unchecked")
   public static <T> T getS3ClientFactoryImpl(Map<String, String> properties) {
     boolean useS3FileIO = PropertyUtil.propertyAsBoolean(properties, CLIENT_FACTORY, false);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOAwsClientFactory.java
@@ -18,69 +18,21 @@
  */
 package org.apache.iceberg.aws.s3;
 
+import java.io.Serializable;
 import java.util.Map;
-import org.apache.iceberg.aws.AwsClientFactories;
-import org.apache.iceberg.aws.AwsClientProperties;
-import org.apache.iceberg.aws.HttpClientProperties;
-import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.services.s3.S3Client;
 
-public class S3FileIOAwsClientFactory {
+public interface S3FileIOAwsClientFactory extends Serializable {
   /**
-   * This property allows customizing AWS client factory implementation class. If this property is
-   * set, only {@link S3FileIOAwsClientFactory} class will be instantiated. If this property wasn't
-   * set, will load one of {@link org.apache.iceberg.aws.AwsClientFactory} factory classes to
-   * provide backward compatibility.
+   * create a Amazon S3 client
+   *
+   * @return s3 client
    */
-  public static final String CLIENT_FACTORY = "s3.client-factory-impl";
-
-  private final S3FileIOProperties s3FileIOProperties;
-  private final HttpClientProperties httpClientProperties;
-  private final AwsClientProperties awsClientProperties;
-
-  S3FileIOAwsClientFactory(
-      S3FileIOProperties s3FileIOProperties,
-      HttpClientProperties httpClientProperties,
-      AwsClientProperties awsClientProperties) {
-    this.s3FileIOProperties = s3FileIOProperties;
-    this.httpClientProperties = httpClientProperties;
-    this.awsClientProperties = awsClientProperties;
-  }
-
+  S3Client s3();
   /**
-   * Returns an instance of a client factory class based on properties. If the {@value
-   * #CLIENT_FACTORY} is set, will return an instance of type {@link S3FileIOAwsClientFactory}.
-   * Otherwise, will return an instance of type {@link org.apache.iceberg.aws.AwsClientFactory} for
-   * backward compatibility. To provide
+   * Initialize AWS client factory from catalog properties.
    *
    * @param properties catalog properties
-   * @param <T> a java return type
-   * @return factory class object
    */
-  @SuppressWarnings("unchecked")
-  public static <T> T getS3ClientFactoryImpl(Map<String, String> properties) {
-    boolean useS3FileIO = PropertyUtil.propertyAsBoolean(properties, CLIENT_FACTORY, false);
-    if (useS3FileIO) {
-      return (T)
-          new S3FileIOAwsClientFactory(
-              new S3FileIOProperties(properties),
-              new HttpClientProperties(properties),
-              new AwsClientProperties(properties));
-    }
-    return (T) AwsClientFactories.from(properties);
-  }
-
-  S3Client s3() {
-    return S3Client.builder()
-        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
-        .applyMutation(httpClientProperties::applyHttpClientConfigurations)
-        .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-        .applyMutation(s3FileIOProperties::applyServiceConfigurations)
-        .applyMutation(
-            s3ClientBuilder ->
-                s3FileIOProperties.applyCredentialConfigurations(
-                    awsClientProperties, s3ClientBuilder))
-        .applyMutation(s3FileIOProperties::applySignerConfiguration)
-        .build();
-  }
+  void initialize(Map<String, String> properties);
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -41,6 +41,14 @@ import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
 public class S3FileIOProperties implements Serializable {
+  /**
+   * This property is used to pass in the aws client factory implementation class for S3 FileIO. The
+   * class should implement {@link S3FileIOAwsClientFactory}. For example, {@link
+   * DefaultS3FileIOAwsClientFactory} implements {@link S3FileIOAwsClientFactory}. If this property
+   * wasn't set, will load one of {@link org.apache.iceberg.aws.AwsClientFactory} factory classes to
+   * provide backward compatibility.
+   */
+  public static final String CLIENT_FACTORY = "s3.client-factory-impl";
 
   /**
    * Type of S3 Server side encryption used, default to {@link S3FileIOProperties#SSE_TYPE_NONE}.

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
@@ -33,7 +33,7 @@ public class TestS3FileIOAwsClientFactories {
     properties.put(
         S3FileIOProperties.CLIENT_FACTORY,
         "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
-    Object factoryImpl = S3FileIOAwsClientFactories.initFactory(properties);
+    Object factoryImpl = S3FileIOAwsClientFactories.initialize(properties);
     Assertions.assertThat(factoryImpl)
         .withFailMessage(
             "should instantiate an object of type S3FileIOAwsClientFactory when s3.client-factory-impl is set")
@@ -44,7 +44,7 @@ public class TestS3FileIOAwsClientFactories {
   public void testS3FileIOImplCatalogPropertyNotDefined() {
     // don't set anything
     Map<String, String> properties = Maps.newHashMap();
-    Object factoryImpl = S3FileIOAwsClientFactories.initFactory(properties);
+    Object factoryImpl = S3FileIOAwsClientFactories.initialize(properties);
     Assertions.assertThat(factoryImpl)
         .withFailMessage(
             "should instantiate an object of type AwsClientFactory when s3.client-factory-impl is not set")

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.aws;
 
 import java.util.Map;
-import org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOAwsClientFactory;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
@@ -37,7 +37,7 @@ public class TestS3FileIOAwsClientFactories {
     Assertions.assertThat(factoryImpl)
         .withFailMessage(
             "should instantiate an object of type S3FileIOAwsClientFactory when s3.client-factory-impl is set")
-        .isInstanceOf(DefaultS3FileIOAwsClientFactory.class);
+        .isInstanceOf(S3FileIOAwsClientFactory.class);
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
@@ -16,43 +16,38 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.aws.s3;
+package org.apache.iceberg.aws;
 
 import java.util.Map;
-import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestS3FileIOAwsClientFactory {
+public class TestS3FileIOAwsClientFactories {
 
   @Test
-  public void testS3FileIOImplSetToTrue() {
+  public void testS3FileIOImplCatalogPropertyDefined() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
-    Object factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
-    Assertions.assertThat(factoryImpl instanceof S3FileIOAwsClientFactory)
+    properties.put(
+        S3FileIOProperties.CLIENT_FACTORY,
+        "org.apache.iceberg.aws.s3.DefaultS3FileIOAwsClientFactory");
+    Object factoryImpl = S3FileIOAwsClientFactories.initFactory(properties);
+    Assertions.assertThat(factoryImpl)
         .withFailMessage(
             "should instantiate an object of type S3FileIOAwsClientFactory when s3.client-factory-impl is set")
-        .isTrue();
-    assert factoryImpl instanceof S3FileIOAwsClientFactory;
-    Assertions.assertThat(((S3FileIOAwsClientFactory) factoryImpl).s3())
-        .withFailMessage("should be able to create s3 client using S3FileIOAwsClientFactory")
-        .isNotNull();
+        .isInstanceOf(DefaultS3FileIOAwsClientFactory.class);
   }
 
   @Test
-  public void testS3FileIOImplSetToFalse() {
+  public void testS3FileIOImplCatalogPropertyNotDefined() {
+    // don't set anything
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
-    Object factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
-    Assertions.assertThat(factoryImpl instanceof AwsClientFactory)
+    Object factoryImpl = S3FileIOAwsClientFactories.initFactory(properties);
+    Assertions.assertThat(factoryImpl)
         .withFailMessage(
             "should instantiate an object of type AwsClientFactory when s3.client-factory-impl is set to false")
-        .isTrue();
-    assert factoryImpl instanceof AwsClientFactory;
-    Assertions.assertThat(((AwsClientFactory) factoryImpl).s3())
-        .withFailMessage("should be able to create s3 client using AwsClientFactory")
-        .isNotNull();
+        .isInstanceOf(AwsClientFactory.class);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestS3FileIOAwsClientFactories.java
@@ -47,7 +47,7 @@ public class TestS3FileIOAwsClientFactories {
     Object factoryImpl = S3FileIOAwsClientFactories.initFactory(properties);
     Assertions.assertThat(factoryImpl)
         .withFailMessage(
-            "should instantiate an object of type AwsClientFactory when s3.client-factory-impl is set to false")
+            "should instantiate an object of type AwsClientFactory when s3.client-factory-impl is not set")
         .isInstanceOf(AwsClientFactory.class);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOAwsClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOAwsClientFactory.java
@@ -1,53 +1,58 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.aws.s3;
 
-
+import java.util.Map;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 public class TestS3FileIOAwsClientFactory {
 
-    @Test
-    public void testS3ClientInitialization() {
-        Map<String, String> properties = Maps.newHashMap();
-        properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
-        S3FileIOAwsClientFactory factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
-        Assertions.assertThat(factoryImpl.s3Client())
-                .withFailMessage("using S3FileIOAwsClientFactory to instantiate s3 client when s3.client-factory-impl is set to true should be non-null")
-                .isNotNull();
-    }
+  @Test
+  public void testS3FileIOImplSetToTrue() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
+    Object factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
+    Assertions.assertThat(factoryImpl instanceof S3FileIOAwsClientFactory)
+        .withFailMessage(
+            "should instantiate an object of type S3FileIOAwsClientFactory when s3.client-factory-impl is set")
+        .isTrue();
+    assert factoryImpl instanceof S3FileIOAwsClientFactory;
+    Assertions.assertThat(((S3FileIOAwsClientFactory) factoryImpl).s3())
+        .withFailMessage("should be able to create s3 client using S3FileIOAwsClientFactory")
+        .isNotNull();
+  }
 
-    @Test
-    public void testDefaultFactoryS3ClientInitialization() {
-        Map<String, String> properties = Maps.newHashMap();
-        properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
-        AwsClientFactory factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
-        Assertions.assertThat(factoryImpl.s3())
-                .withFailMessage("using DefaultAwsClientFactory to instantiate s3 client when s3.client-factory-impl is set to false should be non-null")
-                .isNotNull();
-    }
+  @Test
+  public void testS3FileIOImplSetToFalse() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
+    Object factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
+    Assertions.assertThat(factoryImpl instanceof AwsClientFactory)
+        .withFailMessage(
+            "should instantiate an object of type AwsClientFactory when s3.client-factory-impl is set to false")
+        .isTrue();
+    assert factoryImpl instanceof AwsClientFactory;
+    Assertions.assertThat(((AwsClientFactory) factoryImpl).s3())
+        .withFailMessage("should be able to create s3 client using AwsClientFactory")
+        .isNotNull();
+  }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOAwsClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOAwsClientFactory.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.aws.s3;
+
+
+import org.apache.iceberg.aws.AwsClientFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class TestS3FileIOAwsClientFactory {
+
+    @Test
+    public void testS3ClientInitialization() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "true");
+        S3FileIOAwsClientFactory factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
+        Assertions.assertThat(factoryImpl.s3Client())
+                .withFailMessage("using S3FileIOAwsClientFactory to instantiate s3 client when s3.client-factory-impl is set to true should be non-null")
+                .isNotNull();
+    }
+
+    @Test
+    public void testDefaultFactoryS3ClientInitialization() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(S3FileIOAwsClientFactory.CLIENT_FACTORY, "false");
+        AwsClientFactory factoryImpl = S3FileIOAwsClientFactory.getS3ClientFactoryImpl(properties);
+        Assertions.assertThat(factoryImpl.s3())
+                .withFailMessage("using DefaultAwsClientFactory to instantiate s3 client when s3.client-factory-impl is set to false should be non-null")
+                .isNotNull();
+    }
+}


### PR DESCRIPTION
### Subtask of #7516

This PR adds a new client factory class `S3FileIOAwsClientFactory` with catalog property `s3.client-factory-impl`. When `s3.client-factory-impl` is set to true, we instantiate `S3FileIOAwsClientFactory` class. If the property wasn't set, we fallback to `AwsClientFactory` factory classes. 