### PR TITLE
Spark: Remove deprecated VectorizedSparkParquetReaders#buildReader API for 1.3.0 release

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.slf4j.Logger;
@@ -51,62 +50,6 @@ public class VectorizedSparkParquetReaders {
   }
 
   private VectorizedSparkParquetReaders() {}
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema, MessageType fileSchema, boolean setArrowValidityVector) {
-    return buildReader(expectedSchema, fileSchema, setArrowValidityVector, Maps.newHashMap());
-  }
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema,
-      MessageType fileSchema,
-      boolean setArrowValidityVector,
-      Map<Integer, ?> idToConstant) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new VectorizedReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new));
-  }
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema,
-      MessageType fileSchema,
-      boolean setArrowValidityVector,
-      Map<Integer, ?> idToConstant,
-      DeleteFilter<InternalRow> deleteFilter) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new ReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new,
-                deleteFilter));
-  }
 
   public static ColumnarBatchReader buildReader(
       Schema expectedSchema,

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.DataFile;
@@ -54,7 +53,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -74,7 +72,6 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.assertj.core.api.Assertions;
@@ -103,10 +100,7 @@ public class TestHelpers {
   }
 
   public static void assertEqualsBatch(
-      Types.StructType struct,
-      Iterator<Record> expected,
-      ColumnarBatch batch,
-      boolean checkArrowValidityVector) {
+      Types.StructType struct, Iterator<Record> expected, ColumnarBatch batch) {
     for (int rowId = 0; rowId < batch.numRows(); rowId++) {
       List<Types.NestedField> fields = struct.fields();
       InternalRow row = batch.getRow(rowId);
@@ -116,15 +110,6 @@ public class TestHelpers {
         Object expectedValue = rec.get(i);
         Object actualValue = row.isNullAt(i) ? null : row.get(i, convert(fieldType));
         assertEqualsUnsafe(fieldType, expectedValue, actualValue);
-
-        if (checkArrowValidityVector) {
-          ColumnVector columnVector = batch.column(i);
-          ValueVector arrowVector =
-              ((IcebergArrowColumnVector) columnVector).vectorAccessor().getVector();
-          Assert.assertFalse(
-              "Nullability doesn't match of " + columnVector.dataType(),
-              expectedValue == null ^ arrowVector.isNull(rowId));
-        }
       }
     }
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.arrow.vector.NullCheckingForGet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
@@ -194,11 +193,7 @@ public class TestSparkParquetReadMetadataColumns {
     builder.createBatchedReaderFunc(
         fileSchema ->
             VectorizedSparkParquetReaders.buildReader(
-                PROJECTION_SCHEMA,
-                fileSchema,
-                NullCheckingForGet.NULL_CHECKING_ENABLED,
-                Maps.newHashMap(),
-                deleteFilter));
+                PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), deleteFilter));
     builder.recordsPerBatch(RECORDS_PER_BATCH);
 
     validate(expectedRowsAfterDelete, builder);
@@ -274,7 +269,7 @@ public class TestSparkParquetReadMetadataColumns {
       builder.createBatchedReaderFunc(
           fileSchema ->
               VectorizedSparkParquetReaders.buildReader(
-                  PROJECTION_SCHEMA, fileSchema, NullCheckingForGet.NULL_CHECKING_ENABLED));
+                  PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), null));
       builder.recordsPerBatch(RECORDS_PER_BATCH);
     } else {
       builder =

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -90,7 +90,6 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
         30000,
         FluentIterable.concat(dictionaryEncodableData, nonDictionaryData, dictionaryEncodableData),
         mixedFile,
-        false,
         true,
         BATCH_SIZE);
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTest;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.TestHelpers;
@@ -59,26 +60,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
-    writeAndValidate(schema, getNumRows(), 0L, RandomData.DEFAULT_NULL_PERCENTAGE, false, true);
+    writeAndValidate(schema, getNumRows(), 0L, RandomData.DEFAULT_NULL_PERCENTAGE, true);
   }
 
   private void writeAndValidate(
-      Schema schema,
-      int numRecords,
-      long seed,
-      float nullPercentage,
-      boolean setAndCheckArrowValidityVector,
-      boolean reuseContainers)
+      Schema schema, int numRecords, long seed, float nullPercentage, boolean reuseContainers)
       throws IOException {
     writeAndValidate(
-        schema,
-        numRecords,
-        seed,
-        nullPercentage,
-        setAndCheckArrowValidityVector,
-        reuseContainers,
-        BATCH_SIZE,
-        IDENTITY);
+        schema, numRecords, seed, nullPercentage, reuseContainers, BATCH_SIZE, IDENTITY);
   }
 
   private void writeAndValidate(
@@ -86,7 +75,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       int numRecords,
       long seed,
       float nullPercentage,
-      boolean setAndCheckArrowValidityVector,
       boolean reuseContainers,
       int batchSize,
       Function<GenericData.Record, GenericData.Record> transform)
@@ -109,14 +97,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, testFile)) {
       writer.addAll(expected);
     }
-    assertRecordsMatch(
-        schema,
-        numRecords,
-        expected,
-        testFile,
-        setAndCheckArrowValidityVector,
-        reuseContainers,
-        batchSize);
+    assertRecordsMatch(schema, numRecords, expected, testFile, reuseContainers, batchSize);
   }
 
   protected int getNumRows() {
@@ -153,7 +134,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       int expectedSize,
       Iterable<GenericData.Record> expected,
       File testFile,
-      boolean setAndCheckArrowValidityBuffer,
       boolean reuseContainers,
       int batchSize)
       throws IOException {
@@ -164,7 +144,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             .createBatchedReaderFunc(
                 type ->
                     VectorizedSparkParquetReaders.buildReader(
-                        schema, type, setAndCheckArrowValidityBuffer));
+                        schema, type, Maps.newHashMap(), null));
     if (reuseContainers) {
       readBuilder.reuseContainers();
     }
@@ -175,8 +155,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       while (batches.hasNext()) {
         ColumnarBatch batch = batches.next();
         numRowsRead += batch.numRows();
-        TestHelpers.assertEqualsBatch(
-            schema.asStruct(), expectedIter, batch, setAndCheckArrowValidityBuffer);
+        TestHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
       Assert.assertEquals(expectedSize, numRowsRead);
     }
@@ -230,7 +209,8 @@ public class TestParquetVectorizedReads extends AvroDataTest {
                     new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
                 new MessageType(
                     "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                false));
+                Maps.newHashMap(),
+                null));
   }
 
   @Test
@@ -240,7 +220,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         0.99f,
-        false,
         true);
   }
 
@@ -251,7 +230,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         true);
   }
 
@@ -262,7 +240,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         false);
   }
 
@@ -277,7 +254,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         10,
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         true,
         2,
         record -> {
@@ -314,7 +290,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(102, "float_data", Types.DoubleType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(25, 5)));
 
-    assertRecordsMatch(readSchema, 30000, data, dataFile, false, true, BATCH_SIZE);
+    assertRecordsMatch(readSchema, 30000, data, dataFile, true, BATCH_SIZE);
   }
 
   @Test
@@ -332,7 +308,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
-    assertRecordsMatch(schema, 30000, data, dataFile, false, true, BATCH_SIZE);
+    assertRecordsMatch(schema, 30000, data, dataFile, true, BATCH_SIZE);
   }
 
   @Test
@@ -352,7 +328,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         UnsupportedOperationException.class,
         "Cannot support vectorized reads for column",
         () -> {
-          assertRecordsMatch(schema, 30000, data, dataFile, false, true, BATCH_SIZE);
+          assertRecordsMatch(schema, 30000, data, dataFile, true, BATCH_SIZE);
           return null;
         });
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.slf4j.Logger;
@@ -51,62 +50,6 @@ public class VectorizedSparkParquetReaders {
   }
 
   private VectorizedSparkParquetReaders() {}
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema, MessageType fileSchema, boolean setArrowValidityVector) {
-    return buildReader(expectedSchema, fileSchema, setArrowValidityVector, Maps.newHashMap());
-  }
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema,
-      MessageType fileSchema,
-      boolean setArrowValidityVector,
-      Map<Integer, ?> idToConstant) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new VectorizedReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new));
-  }
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema,
-      MessageType fileSchema,
-      boolean setArrowValidityVector,
-      Map<Integer, ?> idToConstant,
-      DeleteFilter<InternalRow> deleteFilter) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new ReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new,
-                deleteFilter));
-  }
 
   public static ColumnarBatchReader buildReader(
       Schema expectedSchema,

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.DataFile;
@@ -55,7 +54,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -75,7 +73,6 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.assertj.core.api.Assertions;
@@ -104,10 +101,7 @@ public class TestHelpers {
   }
 
   public static void assertEqualsBatch(
-      Types.StructType struct,
-      Iterator<Record> expected,
-      ColumnarBatch batch,
-      boolean checkArrowValidityVector) {
+      Types.StructType struct, Iterator<Record> expected, ColumnarBatch batch) {
     for (int rowId = 0; rowId < batch.numRows(); rowId++) {
       List<Types.NestedField> fields = struct.fields();
       InternalRow row = batch.getRow(rowId);
@@ -117,15 +111,6 @@ public class TestHelpers {
         Object expectedValue = rec.get(i);
         Object actualValue = row.isNullAt(i) ? null : row.get(i, convert(fieldType));
         assertEqualsUnsafe(fieldType, expectedValue, actualValue);
-
-        if (checkArrowValidityVector) {
-          ColumnVector columnVector = batch.column(i);
-          ValueVector arrowVector =
-              ((IcebergArrowColumnVector) columnVector).vectorAccessor().getVector();
-          Assert.assertFalse(
-              "Nullability doesn't match of " + columnVector.dataType(),
-              expectedValue == null ^ arrowVector.isNull(rowId));
-        }
       }
     }
   }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.arrow.vector.NullCheckingForGet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
@@ -194,11 +193,7 @@ public class TestSparkParquetReadMetadataColumns {
     builder.createBatchedReaderFunc(
         fileSchema ->
             VectorizedSparkParquetReaders.buildReader(
-                PROJECTION_SCHEMA,
-                fileSchema,
-                NullCheckingForGet.NULL_CHECKING_ENABLED,
-                Maps.newHashMap(),
-                deleteFilter));
+                PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), deleteFilter));
     builder.recordsPerBatch(RECORDS_PER_BATCH);
 
     validate(expectedRowsAfterDelete, builder);
@@ -274,7 +269,7 @@ public class TestSparkParquetReadMetadataColumns {
       builder.createBatchedReaderFunc(
           fileSchema ->
               VectorizedSparkParquetReaders.buildReader(
-                  PROJECTION_SCHEMA, fileSchema, NullCheckingForGet.NULL_CHECKING_ENABLED));
+                  PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), null));
       builder.recordsPerBatch(RECORDS_PER_BATCH);
     } else {
       builder =

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -90,7 +90,6 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
         30000,
         FluentIterable.concat(dictionaryEncodableData, nonDictionaryData, dictionaryEncodableData),
         mixedFile,
-        false,
         true,
         BATCH_SIZE);
   }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.arrow.vectorized.VectorizedReaderBuilder;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.slf4j.Logger;
@@ -51,38 +50,6 @@ public class VectorizedSparkParquetReaders {
   }
 
   private VectorizedSparkParquetReaders() {}
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema, MessageType fileSchema, boolean setArrowValidityVector) {
-    return buildReader(expectedSchema, fileSchema, setArrowValidityVector, Maps.newHashMap());
-  }
-
-  /**
-   * @deprecated will be removed in 1.3.0, use {@link #buildReader(Schema, MessageType, Map,
-   *     DeleteFilter)} instead.
-   */
-  @Deprecated
-  public static ColumnarBatchReader buildReader(
-      Schema expectedSchema,
-      MessageType fileSchema,
-      boolean setArrowValidityVector,
-      Map<Integer, ?> idToConstant) {
-    return (ColumnarBatchReader)
-        TypeWithSchemaVisitor.visit(
-            expectedSchema.asStruct(),
-            fileSchema,
-            new VectorizedReaderBuilder(
-                expectedSchema,
-                fileSchema,
-                setArrowValidityVector,
-                idToConstant,
-                ColumnarBatchReader::new));
-  }
 
   public static ColumnarBatchReader buildReader(
       Schema expectedSchema,

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.DataFile;
@@ -55,7 +54,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.storage.serde2.io.DateWritable;
@@ -75,7 +73,6 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.assertj.core.api.Assertions;
@@ -104,10 +101,7 @@ public class TestHelpers {
   }
 
   public static void assertEqualsBatch(
-      Types.StructType struct,
-      Iterator<Record> expected,
-      ColumnarBatch batch,
-      boolean checkArrowValidityVector) {
+      Types.StructType struct, Iterator<Record> expected, ColumnarBatch batch) {
     for (int rowId = 0; rowId < batch.numRows(); rowId++) {
       List<Types.NestedField> fields = struct.fields();
       InternalRow row = batch.getRow(rowId);
@@ -117,15 +111,6 @@ public class TestHelpers {
         Object expectedValue = rec.get(i);
         Object actualValue = row.isNullAt(i) ? null : row.get(i, convert(fieldType));
         assertEqualsUnsafe(fieldType, expectedValue, actualValue);
-
-        if (checkArrowValidityVector) {
-          ColumnVector columnVector = batch.column(i);
-          ValueVector arrowVector =
-              ((IcebergArrowColumnVector) columnVector).vectorAccessor().getVector();
-          Assert.assertFalse(
-              "Nullability doesn't match of " + columnVector.dataType(),
-              expectedValue == null ^ arrowVector.isNull(rowId));
-        }
       }
     }
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import org.apache.arrow.vector.NullCheckingForGet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.Files;
@@ -270,7 +269,7 @@ public class TestSparkParquetReadMetadataColumns {
       builder.createBatchedReaderFunc(
           fileSchema ->
               VectorizedSparkParquetReaders.buildReader(
-                  PROJECTION_SCHEMA, fileSchema, NullCheckingForGet.NULL_CHECKING_ENABLED));
+                  PROJECTION_SCHEMA, fileSchema, Maps.newHashMap(), null));
       builder.recordsPerBatch(RECORDS_PER_BATCH);
     } else {
       builder =

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -90,7 +90,6 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
         30000,
         FluentIterable.concat(dictionaryEncodableData, nonDictionaryData, dictionaryEncodableData),
         mixedFile,
-        false,
         true,
         BATCH_SIZE);
   }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Function;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.data.AvroDataTest;
 import org.apache.iceberg.spark.data.RandomData;
 import org.apache.iceberg.spark.data.TestHelpers;
@@ -59,26 +60,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
   @Override
   protected void writeAndValidate(Schema schema) throws IOException {
-    writeAndValidate(schema, getNumRows(), 0L, RandomData.DEFAULT_NULL_PERCENTAGE, false, true);
+    writeAndValidate(schema, getNumRows(), 0L, RandomData.DEFAULT_NULL_PERCENTAGE, true);
   }
 
   private void writeAndValidate(
-      Schema schema,
-      int numRecords,
-      long seed,
-      float nullPercentage,
-      boolean setAndCheckArrowValidityVector,
-      boolean reuseContainers)
+      Schema schema, int numRecords, long seed, float nullPercentage, boolean reuseContainers)
       throws IOException {
     writeAndValidate(
-        schema,
-        numRecords,
-        seed,
-        nullPercentage,
-        setAndCheckArrowValidityVector,
-        reuseContainers,
-        BATCH_SIZE,
-        IDENTITY);
+        schema, numRecords, seed, nullPercentage, reuseContainers, BATCH_SIZE, IDENTITY);
   }
 
   private void writeAndValidate(
@@ -86,7 +75,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       int numRecords,
       long seed,
       float nullPercentage,
-      boolean setAndCheckArrowValidityVector,
       boolean reuseContainers,
       int batchSize,
       Function<GenericData.Record, GenericData.Record> transform)
@@ -109,14 +97,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     try (FileAppender<GenericData.Record> writer = getParquetWriter(schema, testFile)) {
       writer.addAll(expected);
     }
-    assertRecordsMatch(
-        schema,
-        numRecords,
-        expected,
-        testFile,
-        setAndCheckArrowValidityVector,
-        reuseContainers,
-        batchSize);
+    assertRecordsMatch(schema, numRecords, expected, testFile, reuseContainers, batchSize);
   }
 
   protected int getNumRows() {
@@ -153,7 +134,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       int expectedSize,
       Iterable<GenericData.Record> expected,
       File testFile,
-      boolean setAndCheckArrowValidityBuffer,
       boolean reuseContainers,
       int batchSize)
       throws IOException {
@@ -164,7 +144,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             .createBatchedReaderFunc(
                 type ->
                     VectorizedSparkParquetReaders.buildReader(
-                        schema, type, setAndCheckArrowValidityBuffer));
+                        schema, type, Maps.newHashMap(), null));
     if (reuseContainers) {
       readBuilder.reuseContainers();
     }
@@ -175,8 +155,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       while (batches.hasNext()) {
         ColumnarBatch batch = batches.next();
         numRowsRead += batch.numRows();
-        TestHelpers.assertEqualsBatch(
-            schema.asStruct(), expectedIter, batch, setAndCheckArrowValidityBuffer);
+        TestHelpers.assertEqualsBatch(schema.asStruct(), expectedIter, batch);
       }
       Assert.assertEquals(expectedSize, numRowsRead);
     }
@@ -227,7 +206,8 @@ public class TestParquetVectorizedReads extends AvroDataTest {
                         new Schema(required(1, "struct", SUPPORTED_PRIMITIVES))),
                     new MessageType(
                         "struct", new GroupType(Type.Repetition.OPTIONAL, "struct").withId(1)),
-                    false))
+                    Maps.newHashMap(),
+                    null))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Vectorized reads are not supported yet for struct fields");
   }
@@ -239,7 +219,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         0.99f,
-        false,
         true);
   }
 
@@ -250,7 +229,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         true);
   }
 
@@ -261,7 +239,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         getNumRows(),
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         false);
   }
 
@@ -276,7 +253,6 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         10,
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
-        true,
         true,
         2,
         record -> {
@@ -313,7 +289,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
             optional(102, "float_data", Types.DoubleType.get()),
             optional(103, "decimal_data", Types.DecimalType.of(25, 5)));
 
-    assertRecordsMatch(readSchema, 30000, data, dataFile, false, true, BATCH_SIZE);
+    assertRecordsMatch(readSchema, 30000, data, dataFile, false, BATCH_SIZE);
   }
 
   @Test
@@ -334,7 +310,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
     try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
       writer.addAll(data);
     }
-    assertRecordsMatch(schema, 30000, data, dataFile, false, true, BATCH_SIZE);
+    assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE);
   }
 
   @Test
@@ -350,7 +326,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       writer.addAll(data);
     }
     Assertions.assertThatThrownBy(
-            () -> assertRecordsMatch(schema, 30000, data, dataFile, false, true, BATCH_SIZE))
+            () -> assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessageStartingWith("Cannot support vectorized reads for column")
         .hasMessageEndingWith("Disable vectorized reads to read this table/file");


### PR DESCRIPTION
Remove deprecated VectorizedSparkParquetReaders#buildReader API for 1.3.0 release 
cc: @szehon-ho @aokolnychyi @nastra @singhpk234 