### PR TITLE
Core: Remove deprecated AssertHelpers usage

### DIFF
--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MockFileScanTask;
@@ -33,6 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -307,46 +307,51 @@ public class TestBinPackStrategy extends TableTestBase {
 
   @Test
   public void testInvalidOptions() {
-    AssertHelpers.assertThrows(
-        "Should not allow max size smaller than target",
-        IllegalArgumentException.class,
-        () -> {
-          defaultBinPack()
-              .options(ImmutableMap.of(BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(1 * MB)));
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                defaultBinPack()
+                    .options(
+                        ImmutableMap.of(
+                            BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(1 * MB))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Cannot set min-file-size-bytes greater than or equal to max-file-size-bytes");
 
-    AssertHelpers.assertThrows(
-        "Should not allow min size larger than target",
-        IllegalArgumentException.class,
-        () -> {
-          defaultBinPack()
-              .options(
-                  ImmutableMap.of(BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(1000 * MB)));
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                defaultBinPack()
+                    .options(
+                        ImmutableMap.of(
+                            BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(1000 * MB))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Cannot set min-file-size-bytes greater than or equal to max-file-size-bytes");
 
-    AssertHelpers.assertThrows(
-        "Should not allow min input size smaller than 1",
-        IllegalArgumentException.class,
-        () -> {
-          defaultBinPack()
-              .options(ImmutableMap.of(BinPackStrategy.MIN_INPUT_FILES, Long.toString(-5)));
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                defaultBinPack()
+                    .options(ImmutableMap.of(BinPackStrategy.MIN_INPUT_FILES, Long.toString(-5))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Cannot set min-input-files is less than 1. All values less than 1 have the same effect as 1");
 
-    AssertHelpers.assertThrows(
-        "Should not allow min deletes per file smaller than 1",
-        IllegalArgumentException.class,
-        () -> {
-          defaultBinPack()
-              .options(ImmutableMap.of(BinPackStrategy.DELETE_FILE_THRESHOLD, Long.toString(-5)));
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                defaultBinPack()
+                    .options(
+                        ImmutableMap.of(BinPackStrategy.DELETE_FILE_THRESHOLD, Long.toString(-5))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Cannot set delete-file-threshold is less than 1. All values less than 1 have the same effect as 1");
 
-    AssertHelpers.assertThrows(
-        "Should not allow negative target size",
-        IllegalArgumentException.class,
-        () -> {
-          defaultBinPack()
-              .options(ImmutableMap.of(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(-5)));
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                defaultBinPack()
+                    .options(
+                        ImmutableMap.of(
+                            RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(-5))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot set min-file-size-bytes to a negative number");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSortStrategy.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MockFileScanTask;
@@ -34,6 +33,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,24 +85,24 @@ public class TestSortStrategy extends TableTestBase {
 
   @Test
   public void testInvalidSortOrder() {
-    AssertHelpers.assertThrows(
-        "Should not allow an unsorted Sort order",
-        IllegalArgumentException.class,
-        () -> defaultSort().sortOrder(SortOrder.unsorted()).options(Collections.emptyMap()));
+    Assertions.assertThatThrownBy(
+            () -> defaultSort().sortOrder(SortOrder.unsorted()).options(Collections.emptyMap()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot set strategy sort order: unsorted");
 
-    AssertHelpers.assertThrows(
-        "Should not allow a Sort order with bad columns",
-        ValidationException.class,
-        () -> {
-          Schema badSchema =
-              new Schema(
-                  ImmutableList.of(
-                      Types.NestedField.required(0, "nonexistant", Types.IntegerType.get())));
+    Assertions.assertThatThrownBy(
+            () -> {
+              Schema badSchema =
+                  new Schema(
+                      ImmutableList.of(
+                          Types.NestedField.required(0, "nonexistant", Types.IntegerType.get())));
 
-          defaultSort()
-              .sortOrder(SortOrder.builderFor(badSchema).asc("nonexistant").build())
-              .options(Collections.emptyMap());
-        });
+              defaultSort()
+                  .sortOrder(SortOrder.builderFor(badSchema).asc("nonexistant").build())
+                  .options(Collections.emptyMap());
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot find field 'nonexistant' in struct");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -159,10 +159,7 @@ public abstract class TestByteBufferInputStreams {
       Assert.assertEquals(i, stream.read());
     }
 
-    AssertHelpers.assertThrows(
-        "Should throw EOFException at end of stream",
-        EOFException.class,
-        (Callable<Integer>) stream::read);
+    Assertions.assertThatThrownBy(stream::read).isInstanceOf(EOFException.class).hasMessage(null);
 
     checkOriginalData();
   }
@@ -339,13 +336,10 @@ public abstract class TestByteBufferInputStreams {
     Assert.assertEquals(0, stream2.getPos());
 
     int length = stream2.available();
-    AssertHelpers.assertThrows(
-        "Should throw when out of bytes",
-        EOFException.class,
-        () -> {
-          stream2.skipFully(length + 10);
-          return null;
-        });
+
+    Assertions.assertThatThrownBy(() -> stream2.skipFully(length + 10))
+        .isInstanceOf(EOFException.class)
+        .hasMessageStartingWith("Not enough bytes to skip");
   }
 
   @Test
@@ -464,13 +458,9 @@ public abstract class TestByteBufferInputStreams {
   public void testMarkUnset() {
     ByteBufferInputStream stream = newStream();
 
-    AssertHelpers.assertThrows(
-        "Should throw an error for reset() without mark()",
-        IOException.class,
-        () -> {
-          stream.reset();
-          return null;
-        });
+    Assertions.assertThatThrownBy(stream::reset)
+        .isInstanceOf(IOException.class)
+        .hasMessageStartingWith("No mark defined");
   }
 
   @Test
@@ -508,13 +498,9 @@ public abstract class TestByteBufferInputStreams {
 
     Assert.assertEquals("Should read 6 bytes", 6, stream.read(new byte[6]));
 
-    AssertHelpers.assertThrows(
-        "Should throw an error for reset() after limit",
-        IOException.class,
-        () -> {
-          stream.reset();
-          return null;
-        });
+    Assertions.assertThatThrownBy(stream::reset)
+        .isInstanceOf(IOException.class)
+        .hasMessageStartingWith("No mark defined");
   }
 
   @Test
@@ -526,12 +512,8 @@ public abstract class TestByteBufferInputStreams {
 
     stream.reset();
 
-    AssertHelpers.assertThrows(
-        "Should throw an error for double reset()",
-        IOException.class,
-        () -> {
-          stream.reset();
-          return null;
-        });
+    Assertions.assertThatThrownBy(stream::reset)
+        .isInstanceOf(IOException.class)
+        .hasMessageStartingWith("No mark defined");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/mapping/TestNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/mapping/TestNameMapping.java
@@ -20,9 +20,9 @@ package org.apache.iceberg.mapping;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -176,23 +176,21 @@ public class TestNameMapping {
   @Test
   public void testFailsDuplicateId() {
     // the schema can be created because ID indexing is lazy
-    AssertHelpers.assertThrows(
-        "Should fail if IDs are reused",
-        IllegalArgumentException.class,
-        "Multiple entries with same",
-        () ->
-            new Schema(
-                required(1, "id", Types.LongType.get()),
-                required(1, "data", Types.StringType.get())));
+    Assertions.assertThatThrownBy(
+            () ->
+                new Schema(
+                    required(1, "id", Types.LongType.get()),
+                    required(1, "data", Types.StringType.get())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Multiple entries with same key: 1=id and 1=data");
   }
 
   @Test
   public void testFailsDuplicateName() {
-    AssertHelpers.assertThrows(
-        "Should fail if names are reused",
-        IllegalArgumentException.class,
-        "Multiple entries with same key",
-        () -> new NameMapping(MappedFields.of(MappedField.of(1, "x"), MappedField.of(2, "x"))));
+    Assertions.assertThatThrownBy(
+            () -> new NameMapping(MappedFields.of(MappedField.of(1, "x"), MappedField.of(2, "x"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Multiple entries with same key: x=2 and x=1");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -39,11 +39,11 @@ import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
 import org.apache.hc.core5.http.protocol.HttpContext;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -171,12 +171,11 @@ public class TestHTTPClient {
 
     String path = addRequestTestCaseAndGetPath(method, body, statusCode);
 
-    AssertHelpers.assertThrows(
-        "A response indicating a failed request should throw",
-        RuntimeException.class,
-        String.format(
-            "Called error handler for method %s due to status code: %d", method, statusCode),
-        () -> doExecuteRequest(method, path, body, onError, h -> {}));
+    Assertions.assertThatThrownBy(() -> doExecuteRequest(method, path, body, onError, h -> {}))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage(
+            String.format(
+                "Called error handler for method %s due to status code: %d", method, statusCode));
 
     verify(onError).accept(any());
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileScanTask;
@@ -289,17 +288,14 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   @Test
   public void testInitializeWithBadArguments() throws IOException {
     RESTCatalog restCat = new RESTCatalog();
-    AssertHelpers.assertThrows(
-        "Configuration passed to initialize cannot be null",
-        IllegalArgumentException.class,
-        "Invalid configuration: null",
-        () -> restCat.initialize("prod", null));
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> restCat.initialize("prod", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid configuration: null");
 
-    AssertHelpers.assertThrows(
-        "Configuration passed to initialize must have uri",
-        NullPointerException.class,
-        "Invalid uri for http client: null",
-        () -> restCat.initialize("prod", ImmutableMap.of()));
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> restCat.initialize("prod", ImmutableMap.of()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid uri for http client: null");
 
     restCat.close();
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -24,10 +24,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,11 +58,11 @@ public class TestInMemoryLockManager {
   @Test
   public void testAcquireOnceSingleProcess() {
     lockManager.acquireOnce(lockEntityId, ownerId);
-    AssertHelpers.assertThrows(
-        "should fail when acquire again",
-        IllegalStateException.class,
-        "currently held",
-        () -> lockManager.acquireOnce(lockEntityId, ownerId));
+    Assertions.assertThatThrownBy(() -> lockManager.acquireOnce(lockEntityId, ownerId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageStartingWith("Lock for")
+        .hasMessageContaining("currently held by")
+        .hasMessageContaining("expiration");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestLocationUtil.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.util;
 
-import org.apache.iceberg.AssertHelpers;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -54,11 +54,9 @@ public class TestLocationUtil {
     String[] invalidPaths = new String[] {null, ""};
 
     for (String invalidPath : invalidPaths) {
-      AssertHelpers.assertThrows(
-          "path must be valid",
-          IllegalArgumentException.class,
-          "path must not be null or empty",
-          () -> LocationUtil.stripTrailingSlash(invalidPath));
+      Assertions.assertThatThrownBy(() -> LocationUtil.stripTrailingSlash(invalidPath))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("path must not be null or empty");
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -42,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -237,11 +237,10 @@ public class TestTableScanUtil {
         ImmutableList.of(
             taskWithPartition(SPEC1, PARTITION1, 128), taskWithPartition(SPEC2, PARTITION2, 128));
 
-    AssertHelpers.assertThrows(
-        "Should throw exception",
-        IllegalArgumentException.class,
-        "Cannot find field",
-        () -> TableScanUtil.planTaskGroups(tasks2, 128, 10, 4, SPEC2.partitionType()));
+    Assertions.assertThatThrownBy(
+            () -> TableScanUtil.planTaskGroups(tasks2, 128, 10, 4, SPEC2.partitionType()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot find field");
   }
 
   private PartitionScanTask taskWithPartition(


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove AssertHelpers in iceberg-core module.