### PR TITLE
Core: Minor metadata table code harmonization for readable_metrics

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -194,16 +194,21 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
         StructProjection structProjection,
         ManifestEntry<? extends ContentFile<?>> entry,
         Types.NestedField readableMetricsField) {
-      int projectionColumnCount = projection.columns().size();
+      StructProjection struct = structProjection.wrap((StructLike) entry);
+      int structSize = projection.columns().size();
+
+      MetricsUtil.ReadableMetricsStruct readableMetrics =
+          readableMetrics(entry.file(), readableMetricsField);
       int metricsPosition = projection.columns().indexOf(readableMetricsField);
 
-      StructProjection entryStruct = structProjection.wrap((StructLike) entry);
-      StructType projectedMetricType = readableMetricsField.type().asStructType();
-      MetricsUtil.ReadableMetricsStruct readableMetrics =
-          MetricsUtil.readableMetricsStruct(dataTableSchema, entry.file(), projectedMetricType);
-
       return new MetricsUtil.StructWithReadableMetrics(
-          entryStruct, readableMetrics, projectionColumnCount, metricsPosition);
+          struct, structSize, readableMetrics, metricsPosition);
+    }
+
+    private MetricsUtil.ReadableMetricsStruct readableMetrics(
+        ContentFile<?> file, Types.NestedField readableMetricsField) {
+      StructType projectedMetricType = readableMetricsField.type().asStructType();
+      return MetricsUtil.readableMetricsStruct(dataTableSchema, file, projectedMetricType);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -51,8 +51,8 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
     StructType partitionType = Partitioning.partitionType(table());
     Schema schema = ManifestEntry.getSchema(partitionType);
     if (partitionType.fields().size() < 1) {
-      // avoid returning an empty struct, which is not always supported. instead, drop the partition
-      // field (id 102)
+      // avoid returning an empty struct, which is not always supported.
+      // instead, drop the partition field (id 102)
       schema = TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     }
 
@@ -133,16 +133,13 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       Types.NestedField readableMetricsField = projection.findField(MetricsUtil.READABLE_METRICS);
 
       if (readableMetricsField == null) {
-        CloseableIterable<StructLike> entryAsStruct =
-            CloseableIterable.transform(
-                entries(fileProjection),
-                entry -> (GenericManifestEntry<? extends ContentFile<?>>) entry);
-
         StructProjection structProjection = structProjection(projection);
-        return CloseableIterable.transform(entryAsStruct, structProjection::wrap);
+
+        return CloseableIterable.transform(
+            entries(fileProjection), entry -> structProjection.wrap((StructLike) entry));
       } else {
         Schema requiredFileProjection = requiredFileProjection();
-        Schema actualProjection = removeReadableMetrics(readableMetricsField);
+        Schema actualProjection = removeReadableMetrics(projection, readableMetricsField);
         StructProjection structProjection = structProjection(actualProjection);
 
         return CloseableIterable.transform(
@@ -153,9 +150,7 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
 
     /**
      * Ensure that the underlying metrics used to populate readable metrics column are part of the
-     * file projection
-     *
-     * @return file projection with required columns to read readable metrics
+     * file projection.
      */
     private Schema requiredFileProjection() {
       Schema projectionForReadableMetrics =
@@ -166,9 +161,10 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       return TypeUtil.join(fileProjection, projectionForReadableMetrics);
     }
 
-    private Schema removeReadableMetrics(Types.NestedField readableMetricsField) {
+    private Schema removeReadableMetrics(
+        Schema projectionSchema, Types.NestedField readableMetricsField) {
       Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
-      return TypeUtil.selectNot(projection, readableMetricsIds);
+      return TypeUtil.selectNot(projectionSchema, readableMetricsIds);
     }
 
     private StructProjection structProjection(Schema projectedSchema) {
@@ -176,11 +172,24 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       return StructProjection.create(manifestEntrySchema, projectedSchema);
     }
 
+    /**
+     * @param fileStructProjection projection to apply on the 'data_files' struct
+     * @return entries of this read task's manifest
+     */
     private CloseableIterable<? extends ManifestEntry<? extends ContentFile<?>>> entries(
-        Schema newFileProjection) {
-      return ManifestFiles.open(manifest, io, specsById).project(newFileProjection).entries();
+        Schema fileStructProjection) {
+      return ManifestFiles.open(manifest, io, specsById).project(fileStructProjection).entries();
     }
 
+    /**
+     * Given a manifest entry and its projection, append a 'readable_metrics' column that returns
+     * the entry's metrics in human-readable form.
+     *
+     * @param entry manifest entry
+     * @param structProjection projection to apply on the manifest entry
+     * @param readableMetricsField projected "readable_metrics" field
+     * @return struct representing projected manifest entry, with appended readable_metrics field
+     */
     private StructLike withReadableMetrics(
         StructProjection structProjection,
         ManifestEntry<? extends ContentFile<?>> entry,
@@ -189,61 +198,17 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
       int metricsPosition = projection.columns().indexOf(readableMetricsField);
 
       StructProjection entryStruct = structProjection.wrap((StructLike) entry);
-
-      StructType projectedMetricType =
-          projection.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+      StructType projectedMetricType = readableMetricsField.type().asStructType();
       MetricsUtil.ReadableMetricsStruct readableMetrics =
           MetricsUtil.readableMetricsStruct(dataTableSchema, entry.file(), projectedMetricType);
 
-      return new ManifestEntryStructWithMetrics(
-          projectionColumnCount, metricsPosition, entryStruct, readableMetrics);
+      return new MetricsUtil.StructWithReadableMetrics(
+          entryStruct, readableMetrics, projectionColumnCount, metricsPosition);
     }
 
     @Override
     public Iterable<FileScanTask> split(long splitSize) {
       return ImmutableList.of(this); // don't split
-    }
-  }
-
-  static class ManifestEntryStructWithMetrics implements StructLike {
-    private final StructProjection entryAsStruct;
-    private final MetricsUtil.ReadableMetricsStruct readableMetrics;
-    private final int projectionColumnCount;
-    private final int metricsPosition;
-
-    ManifestEntryStructWithMetrics(
-        int projectionColumnCount,
-        int metricsPosition,
-        StructProjection entryAsStruct,
-        MetricsUtil.ReadableMetricsStruct readableMetrics) {
-      this.entryAsStruct = entryAsStruct;
-      this.readableMetrics = readableMetrics;
-      this.projectionColumnCount = projectionColumnCount;
-      this.metricsPosition = metricsPosition;
-    }
-
-    @Override
-    public int size() {
-      return projectionColumnCount;
-    }
-
-    @Override
-    public <T> T get(int pos, Class<T> javaClass) {
-      if (pos < metricsPosition) {
-        return entryAsStruct.get(pos, javaClass);
-      } else if (pos == metricsPosition) {
-        return javaClass.cast(readableMetrics);
-      } else {
-        // columnCount = fileAsStruct column count + the readable metrics field.
-        // When pos is greater than metricsPosition, the actual position of the field in
-        // fileAsStruct should be subtracted by 1.
-        return entryAsStruct.get(pos - 1, javaClass);
-      }
-    }
-
-    @Override
-    public <T> void set(int pos, T value) {
-      throw new UnsupportedOperationException("ManifestEntryStructWithMetrics is read only");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -49,8 +49,8 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     StructType partitionType = Partitioning.partitionType(table());
     Schema schema = new Schema(DataFile.getType(partitionType).fields());
     if (partitionType.fields().size() < 1) {
-      // avoid returning an empty struct, which is not always supported. instead, drop the partition
-      // field
+      // avoid returning an empty struct, which is not always supported.
+      // instead, drop the partition field
       schema = TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     }
 
@@ -162,21 +162,10 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       if (readableMetricsField == null) {
         return CloseableIterable.transform(files(projection), file -> (StructLike) file);
       } else {
-        // Remove virtual columns from the file projection and ensure that the underlying metrics
-        // used to create those columns are part of the file projection
-        Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
-        Schema fileProjection = TypeUtil.selectNot(projection, readableMetricsIds);
-        int metricsPosition = projection.columns().indexOf(readableMetricsField);
 
-        Schema projectionForReadableMetrics =
-            new Schema(
-                MetricsUtil.READABLE_METRIC_COLS.stream()
-                    .map(MetricsUtil.ReadableMetricColDefinition::originalCol)
-                    .collect(Collectors.toList()));
-
-        Schema projectionForMetrics = TypeUtil.join(fileProjection, projectionForReadableMetrics);
+        Schema actualProjection = projectionForReadableMetrics(projection, readableMetricsField);
         return CloseableIterable.transform(
-            files(projectionForMetrics), f -> withReadableMetrics(f, metricsPosition));
+            files(actualProjection), f -> withReadableMetrics(f, readableMetricsField));
       }
     }
 
@@ -192,14 +181,46 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       }
     }
 
-    private StructLike withReadableMetrics(ContentFile<?> file, int metricsPosition) {
+    /**
+     * Given content file metadata, append a 'readable_metrics' column that return the file's
+     * metrics in human-readable form.
+     *
+     * @file content file metadata
+     * @param readableMetricsField projected "readable_metrics" field
+     * @return struct representing content file, with appended readable_metrics field
+     */
+    private StructLike withReadableMetrics(
+        ContentFile<?> file, Types.NestedField readableMetricsField) {
+      int metricsPosition = projection.columns().indexOf(readableMetricsField);
       int columnCount = projection.columns().size();
-      StructType projectedMetricType =
-          projection.findField(MetricsUtil.READABLE_METRICS).type().asStructType();
+
+      StructType projectedMetricType = readableMetricsField.type().asStructType();
       MetricsUtil.ReadableMetricsStruct readableMetrics =
           MetricsUtil.readableMetricsStruct(dataTableSchema, file, projectedMetricType);
-      return new ContentFileStructWithMetrics(
-          columnCount, metricsPosition, (StructLike) file, readableMetrics);
+      return new MetricsUtil.StructWithReadableMetrics(
+          (StructLike) file, readableMetrics, columnCount, metricsPosition);
+    }
+
+    /**
+     * Create a projection on content files metadata by removing virtual 'readable_column' and
+     * ensuring that the underlying metrics used to create that column are part of the final
+     * projection.
+     *
+     * @param projectionSchema projection to transform
+     * @param readableMetricsField readable_metrics field
+     * @return actual projection to be used
+     */
+    private Schema projectionForReadableMetrics(
+        Schema projectionSchema, Types.NestedField readableMetricsField) {
+      Set<Integer> readableMetricsIds = TypeUtil.getProjectedIds(readableMetricsField.type());
+      Schema realProjection = TypeUtil.selectNot(projectionSchema, readableMetricsIds);
+
+      Schema requiredMetricsColumns =
+          new Schema(
+              MetricsUtil.READABLE_METRIC_COLS.stream()
+                  .map(MetricsUtil.ReadableMetricColDefinition::originalCol)
+                  .collect(Collectors.toList()));
+      return TypeUtil.join(realProjection, requiredMetricsColumns);
     }
 
     @Override
@@ -210,48 +231,6 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     @VisibleForTesting
     ManifestFile manifest() {
       return manifest;
-    }
-  }
-
-  static class ContentFileStructWithMetrics implements StructLike {
-    private final StructLike fileAsStruct;
-    private final MetricsUtil.ReadableMetricsStruct readableMetrics;
-    private final int columnCount;
-    private final int metricsPosition;
-
-    ContentFileStructWithMetrics(
-        int columnCount,
-        int metricsPosition,
-        StructLike fileAsStruct,
-        MetricsUtil.ReadableMetricsStruct readableMetrics) {
-      this.fileAsStruct = fileAsStruct;
-      this.readableMetrics = readableMetrics;
-      this.columnCount = columnCount;
-      this.metricsPosition = metricsPosition;
-    }
-
-    @Override
-    public int size() {
-      return columnCount;
-    }
-
-    @Override
-    public <T> T get(int pos, Class<T> javaClass) {
-      if (pos < metricsPosition) {
-        return fileAsStruct.get(pos, javaClass);
-      } else if (pos == metricsPosition) {
-        return javaClass.cast(readableMetrics);
-      } else {
-        // columnCount = fileAsStruct column count + the readable metrics field.
-        // When pos is greater than metricsPosition, the actual position of the field in
-        // fileAsStruct should be subtracted by 1.
-        return fileAsStruct.get(pos - 1, javaClass);
-      }
-    }
-
-    @Override
-    public <T> void set(int pos, T value) {
-      throw new UnsupportedOperationException("ContentFileStructWithMetrics is read only");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -367,20 +367,19 @@ public class MetricsUtil {
     /**
      * Constructs a struct with readable metrics column
      *
-     * @param structProjection struct on which to append 'readable_metrics' struct
+     * @param struct struct on which to append 'readable_metrics' struct
+     * @param structSize total number of struct columns, including 'readable_metrics' column
      * @param readableMetrics struct of 'readable_metrics'
-     * @param projectionColumnCount total number of projected columns, including 'readable_metrics'
-     *     column
      * @param metricsPosition position of 'readable_metrics' column
      */
     StructWithReadableMetrics(
-        StructLike structProjection,
+        StructLike struct,
+        int structSize,
         MetricsUtil.ReadableMetricsStruct readableMetrics,
-        int projectionColumnCount,
         int metricsPosition) {
-      this.struct = structProjection;
+      this.struct = struct;
       this.readableMetrics = readableMetrics;
-      this.projectionColumnCount = projectionColumnCount;
+      this.projectionColumnCount = structSize;
       this.metricsPosition = metricsPosition;
     }
 


### PR DESCRIPTION
Some minor cleanup discussed:  https://github.com/apache/iceberg/pull/7539#discussion_r1192497611 ,

Try to make the readable_metrics code of BaseEntriesTable and BaseFilesTable align, by extracting common class and making code more similar.