### PR TITLE
Spark: Added count check in Spark incremental scan test

### DIFF
--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -300,17 +300,17 @@ public class TestDataSourceOptions {
     Assert.assertEquals("Records should match", expectedRecords.subList(1, 4), result);
 
     // test (2nd snapshot, 3rd snapshot] incremental scan.
-    List<SimpleRecord> result1 =
+    Dataset<Row> resultDf =
         spark
             .read()
             .format("iceberg")
             .option("start-snapshot-id", snapshotIds.get(2).toString())
             .option("end-snapshot-id", snapshotIds.get(1).toString())
-            .load(tableLocation)
-            .orderBy("id")
-            .as(Encoders.bean(SimpleRecord.class))
-            .collectAsList();
+            .load(tableLocation);
+    List<SimpleRecord> result1 =
+        resultDf.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Records should match", expectedRecords.subList(2, 3), result1);
+    Assert.assertEquals("Unprocessed count should match record count", 1, resultDf.count());
   }
 
   @Test

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -300,17 +300,17 @@ public class TestDataSourceOptions {
     Assert.assertEquals("Records should match", expectedRecords.subList(1, 4), result);
 
     // test (2nd snapshot, 3rd snapshot] incremental scan.
-    List<SimpleRecord> result1 =
+    Dataset<Row> resultDf =
         spark
             .read()
             .format("iceberg")
             .option("start-snapshot-id", snapshotIds.get(2).toString())
             .option("end-snapshot-id", snapshotIds.get(1).toString())
-            .load(tableLocation)
-            .orderBy("id")
-            .as(Encoders.bean(SimpleRecord.class))
-            .collectAsList();
+            .load(tableLocation);
+    List<SimpleRecord> result1 =
+        resultDf.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Records should match", expectedRecords.subList(2, 3), result1);
+    Assert.assertEquals("Unprocessed count should match record count", 1, resultDf.count());
   }
 
   @Test

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -300,17 +300,17 @@ public class TestDataSourceOptions {
     Assert.assertEquals("Records should match", expectedRecords.subList(1, 4), result);
 
     // test (2nd snapshot, 3rd snapshot] incremental scan.
-    List<SimpleRecord> result1 =
+    Dataset<Row> resultDf =
         spark
             .read()
             .format("iceberg")
             .option("start-snapshot-id", snapshotIds.get(2).toString())
             .option("end-snapshot-id", snapshotIds.get(1).toString())
-            .load(tableLocation)
-            .orderBy("id")
-            .as(Encoders.bean(SimpleRecord.class))
-            .collectAsList();
+            .load(tableLocation);
+    List<SimpleRecord> result1 =
+        resultDf.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Records should match", expectedRecords.subList(2, 3), result1);
+    Assert.assertEquals("Unprocessed count should match record count", 1, resultDf.count());
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -297,17 +297,17 @@ public class TestDataSourceOptions {
     Assert.assertEquals("Records should match", expectedRecords.subList(1, 4), result);
 
     // test (2nd snapshot, 3rd snapshot] incremental scan.
-    List<SimpleRecord> result1 =
+    Dataset<Row> resultDf =
         spark
             .read()
             .format("iceberg")
             .option("start-snapshot-id", snapshotIds.get(2).toString())
             .option("end-snapshot-id", snapshotIds.get(1).toString())
-            .load(tableLocation)
-            .orderBy("id")
-            .as(Encoders.bean(SimpleRecord.class))
-            .collectAsList();
+            .load(tableLocation);
+    List<SimpleRecord> result1 =
+        resultDf.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Records should match", expectedRecords.subList(2, 3), result1);
+    Assert.assertEquals("Unprocessed count should match record count", 1, resultDf.count());
   }
 
   @Test


### PR DESCRIPTION
This test fails in Spark 3.3 and Spark 3.4 but passes in Spark 3.1 and Spark 3.2. This used to work properly in Iceberg 1.1.0 on Spark 3.3, so this assertion failing marks a regression.

Failure log:
```
> Task :iceberg-spark:iceberg-spark-3.3_2.12:test

TestDataSourceOptions > testIncrementalScanOptions FAILED
    java.lang.AssertionError: Unprocessed count should match record count expected:<1> but was:<4>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.apache.iceberg.spark.source.TestDataSourceOptions.testIncrementalScanOptions(TestDataSourceOptions.java:313)

> Task :iceberg-spark:iceberg-spark-3.4_2.12:test

TestDataSourceOptions > testIncrementalScanOptions FAILED
    java.lang.AssertionError: Unprocessed count should match record count expected:<1> but was:<4>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.apache.iceberg.spark.source.TestDataSourceOptions.testIncrementalScanOptions(TestDataSourceOptions.java:310)

```