### PR TITLE
Fix the dependency exclusion for apache commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,7 @@ project(':iceberg-data') {
 
     implementation("org.apache.orc:orc-core::nohive") {
       exclude group: 'org.apache.hadoop'
-      exclude group: 'commons-lang'
+      exclude group: 'org.apache.commons'
       // These artifacts are shaded and included in the orc-core fat jar
       exclude group: 'com.google.protobuf', module: 'protobuf-java'
       exclude group: 'org.apache.hive', module: 'hive-storage-api'


### PR DESCRIPTION
The group should be org.apache.commons, not commons-lang.

This exclude got broken with https://github.com/apache/orc/commit/bcd1bfb3bdae8306e76f799c402a9cb88d14a097