### PR TITLE
Core: Include all reachable snapshots with v1 format and REF snapshot mode

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -499,11 +499,6 @@ public class TableMetadata implements Serializable {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
       loadedSnapshots.removeIf(s -> s.sequenceNumber() > lastSequenceNumber);
 
-      // Format version 1 does not have accurate sequence numbering, so remove based on timestamp
-      if (this.formatVersion == 1) {
-        loadedSnapshots.removeIf(s -> s.timestampMillis() > currentSnapshot().timestampMillis());
-      }
-
       this.snapshots = ImmutableList.copyOf(loadedSnapshots);
       this.snapshotsById = indexAndValidateSnapshots(snapshots, lastSequenceNumber);
       validateCurrentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.assertj.core.api.Assumptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,6 +132,10 @@ public class TestSnapshotLoading extends TableTestBase {
 
   @Test
   public void testFutureSnapshotsAreRemoved() {
+    Assumptions.assumeThat(formatVersion)
+        .as("Future snapshots are only removed for V2 tables")
+        .isGreaterThan(1);
+
     table.newFastAppend().appendFile(FILE_C).commit();
 
     TableMetadata futureTableMetadata =


### PR DESCRIPTION
I noticed that not all relevant snapshots are being retained with a V1 table and when using branches. I added a test that reproduces this issue and would fail with 
```
Snapshot for reference SnapshotRef{snapshotId=7532742534704478452, type=BRANCH, minSnapshotsToKeep=null, maxSnapshotAgeMs=null, maxRefAgeMs=null} does not exist in the existing snapshots list
java.lang.IllegalArgumentException: Snapshot for reference SnapshotRef{snapshotId=7532742534704478452, type=BRANCH, minSnapshotsToKeep=null, maxSnapshotAgeMs=null, maxRefAgeMs=null} does not exist in the existing snapshots list
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)
	at org.apache.iceberg.TableMetadata.validateRefs(TableMetadata.java:835)
	at org.apache.iceberg.TableMetadata.ensureSnapshotsLoaded(TableMetadata.java:528)
	at org.apache.iceberg.TableMetadata.snapshots(TableMetadata.java:493)
	at org.apache.iceberg.BaseTable.snapshots(BaseTable.java:140)
	at org.apache.iceberg.rest.TestRESTCatalog.testTableSnapshotLoadingWithDivergedBranches(TestRESTCatalog.java:953)
```

This is because with V1 tables we removed non-relevant snapshots only based on timestamp.