### PR TITLE
Nessie: Disable table metadata files cleanup during commits

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -100,8 +100,9 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     if (metadataCleanupEnabled) {
       newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
       LOG.warn(
-          "Clean up of table metadata files during commit is disabled as it can be in use by other references."
-              + " Use nessie-gc tool for reference aware GC");
+          "Automatic table metadata files cleanup was requested, but disabled because "
+              + "the Nessie catalog can use historical metadata files from other references. "
+              + "Use the 'nessie-gc' tool for history-aware GC");
     }
 
     TableMetadata.Builder builder =

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -92,6 +92,11 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     // Nessie CLI will provide a reference aware GC functionality for the expired/unreferenced
     // files.
     newProperties.put(TableProperties.GC_ENABLED, "false");
+
+    newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
+    LOG.info(
+        "Clean up of table metadata files during commit is disabled as it can be in use by other references");
+
     TableMetadata.Builder builder =
         TableMetadata.buildFrom(deserialized)
             .setPreviousFileLocation(null)

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -93,9 +93,16 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     // files.
     newProperties.put(TableProperties.GC_ENABLED, "false");
 
-    newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
-    LOG.info(
-        "Clean up of table metadata files during commit is disabled as it can be in use by other references");
+    boolean metadataCleanupEnabled =
+        newProperties
+            .getOrDefault(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false")
+            .equalsIgnoreCase("true");
+    if (metadataCleanupEnabled) {
+      newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
+      LOG.warn(
+          "Clean up of table metadata files during commit is disabled as it can be in use by other references."
+              + " Use nessie-gc tool for reference aware GC");
+    }
 
     TableMetadata.Builder builder =
         TableMetadata.buildFrom(deserialized)

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -588,11 +588,6 @@ public class TestNessieTable extends BaseTestIceberg {
   public void testTableMetadataFilesCleanupDisable() throws NessieNotFoundException {
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
 
-    Assertions.assertThat(
-            icebergTable.properties().get(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED))
-        .isNotNull()
-        .isEqualTo("false");
-
     // Forceful setting of property also should get override with false
     icebergTable
         .updateProperties()

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -25,18 +25,23 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.commons.io.FileUtils;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
@@ -577,6 +582,44 @@ public class TestNessieTable extends BaseTestIceberg {
         .isInstanceOf(ValidationException.class)
         .hasMessage(
             "Cannot expire snapshots: GC is disabled (deleting files may corrupt other tables)");
+  }
+
+  @Test
+  public void testTableMetadataFilesCleanupDisable() {
+    Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
+
+    Assertions.assertThat(
+            icebergTable.properties().get(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED))
+        .isNotNull()
+        .isEqualTo("false");
+
+    icebergTable
+        .updateProperties()
+        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
+        .commit();
+    icebergTable
+        .updateProperties()
+        .set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1")
+        .commit();
+
+    String metadataFileLocation =
+        ((BaseTable) icebergTable).operations().current().metadataFileLocation();
+    Path metadataFileLocationPath = Paths.get(metadataFileLocation.replaceFirst("file:", ""));
+
+    Assertions.assertThat(metadataFileLocationPath).exists();
+
+    icebergTable.updateSchema().addColumn("x1", Types.LongType.get()).commit();
+    icebergTable.updateSchema().addColumn("x2", Types.LongType.get()).commit();
+
+    // old table metadata file should still exist after commits.
+    Assertions.assertThat(metadataFileLocationPath).exists();
+
+    Set<String> tableMetadataFiles =
+        ((BaseTable) icebergTable)
+            .operations().current().previousFiles().stream()
+                .map(TableMetadata.MetadataLogEntry::file)
+                .collect(Collectors.toSet());
+    Assertions.assertThat(tableMetadataFiles).hasSize(1).doesNotContain(metadataFileLocation);
   }
 
   private String getTableBasePath(String tableName) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -593,10 +593,16 @@ public class TestNessieTable extends BaseTestIceberg {
         .isNotNull()
         .isEqualTo("false");
 
+    // Forceful setting of property also should get override with false
     icebergTable
         .updateProperties()
         .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
         .commit();
+    Assertions.assertThat(
+            icebergTable.properties().get(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED))
+        .isNotNull()
+        .isEqualTo("false");
+
     icebergTable
         .updateProperties()
         .set(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1")


### PR DESCRIPTION
Avoid automatic cleanup of table metadata files during commit as it can be in use by other references. 