### PR TITLE
Core: Compacted position delete files should use the max data sequence number of source files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -104,9 +104,9 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * it is also recommended to discard delete records for files that are no longer part of the table
    * state. However, the set of applicable delete records must never change.
    *
-   * <p>To ensure equivalence in the set of applicable delete records, the sequence number of the a
-   * delete file must be the max sequence number of the delete files that it is replacing. It is not
-   * allowed to rewrite equality deletes that belong to different sequence numbers.
+   * <p>To ensure equivalence in the set of applicable delete records, the sequence number of the
+   * delete file must be the max sequence number of the delete files that it is replacing. Rewriting
+   * equality deletes that belong to different sequence numbers is not allowed.
    *
    * @param deleteFile a new delete file
    * @param dataSequenceNumber data sequence number to append on the file

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -98,6 +98,22 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   }
 
   /**
+   * Add a new delete file with the given data sequence number.
+   *
+   * <p>This rewrite operation may change the size or layout of the delete files. When applicable,
+   * it is also recommended to discard delete records for files that are no longer part of the table
+   * state. However, the set of applicable delete records must never change.
+   *
+   * @param deleteFile a new delete file
+   * @param dataSequenceNumber data sequence number to append on the file
+   * @return this for method chaining
+   */
+  default RewriteFiles addFile(DeleteFile deleteFile, long dataSequenceNumber) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement addFile");
+  }
+
+  /**
    * Configure the data sequence number for this rewrite operation. This data sequence number will
    * be used for all new data files that are added in this rewrite. This method is helpful to avoid
    * commit conflicts between data compaction and adding equality deletes.

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -104,6 +104,10 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * it is also recommended to discard delete records for files that are no longer part of the table
    * state. However, the set of applicable delete records must never change.
    *
+   * <p>To ensure equivalence in the set of applicable delete records, the sequence number of the a
+   * delete file must be the max sequence number of the delete files that it is replacing. It is not
+   * allowed to rewrite equality deletes that belong to different sequence numbers.
+   *
    * @param deleteFile a new delete file
    * @param dataSequenceNumber data sequence number to append on the file
    * @return this for method chaining

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -70,6 +70,12 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles addFile(DeleteFile deleteFile, long dataSequenceNumber) {
+    add(deleteFile, dataSequenceNumber);
+    return self();
+  }
+
+  @Override
   public RewriteFiles dataSequenceNumber(long sequenceNumber) {
     setNewDataFilesDataSequenceNumber(sequenceNumber);
     return self();

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -85,7 +85,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   // update data
   private final List<DataFile> newDataFiles = Lists.newArrayList();
   private Long newDataFilesDataSequenceNumber;
-  private final Map<Integer, List<DeleteFile>> newDeleteFilesBySpec = Maps.newHashMap();
+  private final Map<Integer, List<DeleteFileHolder>> newDeleteFilesBySpec = Maps.newHashMap();
   private final List<ManifestFile> appendManifests = Lists.newArrayList();
   private final List<ManifestFile> rewrittenAppendManifests = Lists.newArrayList();
   private final SnapshotSummary.Builder addedFilesSummary = SnapshotSummary.builder();
@@ -246,12 +246,21 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   /** Add a delete file to the new snapshot. */
   protected void add(DeleteFile file) {
-    Preconditions.checkNotNull(file, "Invalid delete file: null");
-    PartitionSpec fileSpec = ops.current().spec(file.specId());
-    List<DeleteFile> deleteFiles =
-        newDeleteFilesBySpec.computeIfAbsent(file.specId(), specId -> Lists.newArrayList());
-    deleteFiles.add(file);
-    addedFilesSummary.addedFile(fileSpec, file);
+    add(new DeleteFileHolder(file));
+  }
+
+  /** Add a delete file to the new snapshot. */
+  protected void add(DeleteFile file, long dataSequenceNumber) {
+    add(new DeleteFileHolder(file, dataSequenceNumber));
+  }
+
+  private void add(DeleteFileHolder fileHolder) {
+    int specId = fileHolder.deleteFile().specId();
+    PartitionSpec fileSpec = ops.current().spec(specId);
+    List<DeleteFileHolder> deleteFiles =
+        newDeleteFilesBySpec.computeIfAbsent(specId, s -> Lists.newArrayList());
+    deleteFiles.add(fileHolder);
+    addedFilesSummary.addedFile(fileSpec, fileHolder.deleteFile());
     hasNewDeleteFiles = true;
   }
 
@@ -1008,7 +1017,14 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
             try {
               ManifestWriter<DeleteFile> writer = newDeleteManifestWriter(spec);
               try {
-                writer.addAll(deleteFiles);
+                deleteFiles.forEach(
+                    df -> {
+                      if (df.dataSequenceNumber() != null) {
+                        writer.add(df.deleteFile(), df.dataSequenceNumber());
+                      } else {
+                        writer.add(df.deleteFile());
+                      }
+                    });
               } finally {
                 writer.close();
               }
@@ -1127,6 +1143,41 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     @Override
     protected ManifestReader<DeleteFile> newManifestReader(ManifestFile manifest) {
       return MergingSnapshotProducer.this.newDeleteManifestReader(manifest);
+    }
+  }
+
+  private static class DeleteFileHolder {
+    private final DeleteFile deleteFile;
+    private final Long dataSequenceNumber;
+
+    /**
+     * Queue a delete file for commit with a given data sequence number
+     *
+     * @param deleteFile delete file
+     * @param dataSequenceNumber data sequence number to apply
+     */
+    DeleteFileHolder(DeleteFile deleteFile, long dataSequenceNumber) {
+      Preconditions.checkNotNull(deleteFile, "Invalid delete file: null");
+      this.deleteFile = deleteFile;
+      this.dataSequenceNumber = dataSequenceNumber;
+    }
+
+    /**
+     * Queue a delete file for commit with the latest sequence number
+     *
+     * @param deleteFile delete file
+     */
+    DeleteFileHolder(DeleteFile deleteFile) {
+      this.deleteFile = deleteFile;
+      this.dataSequenceNumber = null;
+    }
+
+    public DeleteFile deleteFile() {
+      return deleteFile;
+    }
+
+    public Long dataSequenceNumber() {
+      return dataSequenceNumber;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -246,11 +246,13 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   /** Add a delete file to the new snapshot. */
   protected void add(DeleteFile file) {
+    Preconditions.checkNotNull(file, "Invalid delete file: null");
     add(new DeleteFileHolder(file));
   }
 
   /** Add a delete file to the new snapshot. */
   protected void add(DeleteFile file, long dataSequenceNumber) {
+    Preconditions.checkNotNull(file, "Invalid delete file: null");
     add(new DeleteFileHolder(file, dataSequenceNumber));
   }
 
@@ -1151,19 +1153,18 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     private final Long dataSequenceNumber;
 
     /**
-     * Queue a delete file for commit with a given data sequence number
+     * Wrap a delete file for commit with a given data sequence number
      *
      * @param deleteFile delete file
      * @param dataSequenceNumber data sequence number to apply
      */
     DeleteFileHolder(DeleteFile deleteFile, long dataSequenceNumber) {
-      Preconditions.checkNotNull(deleteFile, "Invalid delete file: null");
       this.deleteFile = deleteFile;
       this.dataSequenceNumber = dataSequenceNumber;
     }
 
     /**
-     * Queue a delete file for commit with the latest sequence number
+     * Wrap a delete file for commit with the latest sequence number
      *
      * @param deleteFile delete file
      */

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -55,13 +55,12 @@ public class RewritePositionDeletesCommitManager {
     RewriteFiles rewriteFiles = table.newRewrite().validateFromSnapshot(startingSnapshotId);
 
     for (RewritePositionDeletesGroup group : fileGroups) {
-      long maxSequenceNumber = group.maxRewrittenDataSequenceNumber();
       for (DeleteFile file : group.rewrittenDeleteFiles()) {
         rewriteFiles.deleteFile(file);
       }
 
       for (DeleteFile file : group.addedDeleteFiles()) {
-        rewriteFiles.addFile(file, maxSequenceNumber);
+        rewriteFiles.addFile(file, group.maxRewrittenDataSequenceNumber());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -55,12 +55,13 @@ public class RewritePositionDeletesCommitManager {
     RewriteFiles rewriteFiles = table.newRewrite().validateFromSnapshot(startingSnapshotId);
 
     for (RewritePositionDeletesGroup group : fileGroups) {
+      long maxSequenceNumber = group.maxRewrittenDataSequenceNumber();
       for (DeleteFile file : group.rewrittenDeleteFiles()) {
         rewriteFiles.deleteFile(file);
       }
 
       for (DeleteFile file : group.addedDeleteFiles()) {
-        rewriteFiles.addFile(file);
+        rewriteFiles.addFile(file, maxSequenceNumber);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
@@ -38,12 +38,18 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 public class RewritePositionDeletesGroup {
   private final FileGroupInfo info;
   private final List<PositionDeletesScanTask> tasks;
+  private final long maxRewrittenDataSequenceNumber;
 
   private Set<DeleteFile> addedDeleteFiles = Collections.emptySet();
 
   public RewritePositionDeletesGroup(FileGroupInfo info, List<PositionDeletesScanTask> tasks) {
     this.info = info;
     this.tasks = tasks;
+    this.maxRewrittenDataSequenceNumber =
+        tasks.stream()
+            .map(t -> t.file().dataSequenceNumber())
+            .max(Long::compare)
+            .orElseThrow(() -> new IllegalArgumentException("Empty file group"));
   }
 
   public FileGroupInfo info() {
@@ -56,6 +62,10 @@ public class RewritePositionDeletesGroup {
 
   public void setOutputFiles(Set<DeleteFile> files) {
     addedDeleteFiles = files;
+  }
+
+  public long maxRewrittenDataSequenceNumber() {
+    return maxRewrittenDataSequenceNumber;
   }
 
   public Set<DeleteFile> rewrittenDeleteFiles() {

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
@@ -43,13 +43,11 @@ public class RewritePositionDeletesGroup {
   private Set<DeleteFile> addedDeleteFiles = Collections.emptySet();
 
   public RewritePositionDeletesGroup(FileGroupInfo info, List<PositionDeletesScanTask> tasks) {
+    Preconditions.checkArgument(tasks.size() > 0, "Tasks must not be empty");
     this.info = info;
     this.tasks = tasks;
     this.maxRewrittenDataSequenceNumber =
-        tasks.stream()
-            .map(t -> t.file().dataSequenceNumber())
-            .max(Long::compare)
-            .orElseThrow(() -> new IllegalArgumentException("Empty file group"));
+        tasks.stream().mapToLong(t -> t.file().dataSequenceNumber()).max().getAsLong();
   }
 
   public FileGroupInfo info() {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.Files;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.PositionDeletesScanTask;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.ScanTask;
@@ -63,6 +64,7 @@ import org.apache.iceberg.spark.source.FourColumnRecord;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.StructLikeMap;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.junit.After;
@@ -135,8 +137,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
     Assert.assertEquals(2, deleteFiles.size());
 
     List<Object[]> expectedRecords = records(table);
@@ -154,6 +158,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertLocallySorted(newDeleteFiles);
     assertNotContains(deleteFiles, newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 1);
+    checkSequenceNumbers(table, deleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -166,8 +171,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
     Assert.assertEquals(8, deleteFiles.size());
 
     List<Object[]> expectedRecords = records(table);
@@ -187,6 +194,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
+    checkSequenceNumbers(table, deleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -199,14 +207,16 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
-    Assert.assertEquals(8, deleteFiles.size());
 
     List<Object[]> expectedRecords = records(table);
     List<Object[]> expectedDeletes = deleteRecords(table);
     Assert.assertEquals(12000, expectedRecords.size());
     Assert.assertEquals(4000, expectedDeletes.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
+    Assert.assertEquals(8, deleteFiles.size());
 
     long avgSize = size(deleteFiles) / deleteFiles.size();
 
@@ -221,6 +231,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
+    checkSequenceNumbers(table, deleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -233,8 +244,16 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(
+        table,
+        2,
+        DELETES_SCALE,
+        dataFiles,
+        true /* Disable commit-time ManifestFilterManager removal of dangling deletes */);
+
     Assert.assertEquals(4, dataFiles.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
     Assert.assertEquals(8, deleteFiles.size());
 
     List<Object[]> expectedRecords = records(table);
@@ -257,6 +276,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
+    checkSequenceNumbers(table, deleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -269,8 +289,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Table table = createTablePartitioned(4, 2, SCALE);
 
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
     Assert.assertEquals(8, deleteFiles.size());
 
     List<Object[]> expectedRecords = records(table);
@@ -296,6 +318,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(deleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, deleteFiles, newDeleteFiles, 4);
+    checkSequenceNumbers(table, deleteFiles, newDeleteFiles);
 
     // As only half the files have been rewritten,
     // we expect to retain position deletes only for those not rewritten
@@ -318,9 +341,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
     List<DataFile> unpartitionedDataFiles = dataFiles(table);
-    List<DeleteFile> unpartitionedDeleteFiles =
-        writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
     Assert.assertEquals(2, unpartitionedDataFiles.size());
+
+    List<DeleteFile> unpartitionedDeleteFiles = deleteFiles(table);
     Assert.assertEquals(2, unpartitionedDeleteFiles.size());
 
     List<Object[]> expectedUnpartitionedDeletes = deleteRecords(table);
@@ -331,9 +355,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles = except(dataFiles(table), unpartitionedDataFiles);
-    List<DeleteFile> partitionedDeleteFiles =
-        writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
     Assert.assertEquals(2, partitionedDataFiles.size());
+
+    List<DeleteFile> partitionedDeleteFiles = except(deleteFiles(table), unpartitionedDeleteFiles);
     Assert.assertEquals(4, partitionedDeleteFiles.size());
 
     List<Object[]> expectedDeletes = deleteRecords(table);
@@ -355,6 +380,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(rewrittenDeleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, rewrittenDeleteFiles, newDeleteFiles, 3);
+    checkSequenceNumbers(table, rewrittenDeleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -366,18 +392,20 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
     List<DataFile> dataFilesUnpartitioned = dataFiles(table);
-    List<DeleteFile> deleteFilesUnpartitioned =
-        writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
     Assert.assertEquals(2, dataFilesUnpartitioned.size());
+
+    List<DeleteFile> deleteFilesUnpartitioned = deleteFiles(table);
     Assert.assertEquals(4, deleteFilesUnpartitioned.size());
 
     table.updateSpec().removeField("c1").commit();
 
     writeRecords(table, 2, SCALE);
     List<DataFile> dataFilesPartitioned = except(dataFiles(table), dataFilesUnpartitioned);
-    List<DeleteFile> deleteFilesPartitioned =
-        writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
     Assert.assertEquals(2, dataFilesPartitioned.size());
+
+    List<DeleteFile> deleteFilesPartitioned = except(deleteFiles(table), deleteFilesUnpartitioned);
     Assert.assertEquals(2, deleteFilesPartitioned.size());
 
     List<Object[]> expectedRecords = records(table);
@@ -385,20 +413,21 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     Assert.assertEquals(4000, expectedDeletes.size());
     Assert.assertEquals(8000, expectedRecords.size());
 
+    List<DeleteFile> expectedRewritten = deleteFiles(table);
+    Assert.assertEquals(6, expectedRewritten.size());
+
     Result result =
         SparkActions.get(spark)
             .rewritePositionDeletes(table)
             .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
             .execute();
 
-    List<DeleteFile> expectedRewritten =
-        Stream.concat(deleteFilesUnpartitioned.stream(), deleteFilesPartitioned.stream())
-            .collect(Collectors.toList());
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
     Assert.assertEquals("Should have 3 new delete files", 3, newDeleteFiles.size());
     assertNotContains(expectedRewritten, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, expectedRewritten, newDeleteFiles, 3);
+    checkSequenceNumbers(table, expectedRewritten, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     List<Object[]> actualDeletes = deleteRecords(table);
@@ -410,8 +439,10 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
     List<DataFile> dataFiles = dataFiles(table);
-    List<DeleteFile> deleteFiles = writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
+
+    List<DeleteFile> deleteFiles = deleteFiles(table);
     Assert.assertEquals(4, deleteFiles.size());
 
     table.updateSchema().addColumn("c4", Types.StringType.get()).commit();
@@ -422,8 +453,9 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
         dataFiles(table).stream()
             .filter(f -> f.upperBounds().containsKey(newColId))
             .collect(Collectors.toList());
-    List<DeleteFile> newSchemaDeleteFiles =
-        writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);
+    writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);
+
+    List<DeleteFile> newSchemaDeleteFiles = except(deleteFiles(table), deleteFiles);
     Assert.assertEquals(4, newSchemaDeleteFiles.size());
 
     table.refresh();
@@ -446,6 +478,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     assertNotContains(rewrittenDeleteFiles, newDeleteFiles);
     assertLocallySorted(newDeleteFiles);
     checkResult(result, rewrittenDeleteFiles, newDeleteFiles, 4);
+    checkSequenceNumbers(table, rewrittenDeleteFiles, newDeleteFiles);
 
     List<Object[]> actualRecords = records(table);
     assertEquals("Rows must match", expectedRecords, actualRecords);
@@ -582,13 +615,23 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
             .collectAsList());
   }
 
-  private List<DeleteFile> writePosDeletesForFiles(
+  private void writePosDeletesForFiles(
       Table table, int deleteFilesPerPartition, int deletesPerDataFile, List<DataFile> files)
+      throws IOException {
+    writePosDeletesForFiles(table, deleteFilesPerPartition, deletesPerDataFile, files, false);
+  }
+
+  private void writePosDeletesForFiles(
+      Table table,
+      int deleteFilesPerPartition,
+      int deletesPerDataFile,
+      List<DataFile> files,
+      boolean transactional)
       throws IOException {
 
     Map<StructLike, List<DataFile>> filesByPartition =
         files.stream().collect(Collectors.groupingBy(ContentFile::partition));
-    List<DeleteFile> results =
+    List<DeleteFile> deleteFiles =
         Lists.newArrayListWithCapacity(deleteFilesPerPartition * filesByPartition.size());
 
     for (Map.Entry<StructLike, List<DataFile>> filesByPartitionEntry :
@@ -614,7 +657,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           if (counter == deleteFileSize) {
             // Dump to file and reset variables
             OutputFile output = Files.localOutput(temp.newFile());
-            results.add(FileHelpers.writeDeleteFile(table, output, partition, deletes).first());
+            deleteFiles.add(FileHelpers.writeDeleteFile(table, output, partition, deletes).first());
             counter = 0;
             deletes.clear();
           }
@@ -622,11 +665,18 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
       }
     }
 
-    RowDelta rowDelta = table.newRowDelta();
-    results.forEach(rowDelta::addDeletes);
-    rowDelta.commit();
-
-    return results;
+    if (transactional) {
+      RowDelta rowDelta = table.newRowDelta();
+      deleteFiles.forEach(rowDelta::addDeletes);
+      rowDelta.commit();
+    } else {
+      deleteFiles.forEach(
+          deleteFile -> {
+            RowDelta rowDelta = table.newRowDelta();
+            rowDelta.addDeletes(deleteFile);
+            rowDelta.commit();
+          });
+    }
   }
 
   private List<DataFile> dataFiles(Table table) {
@@ -738,5 +788,44 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
         "Expected added delete bytes in all groups to match",
         size(newDeletes),
         result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+  }
+
+  private void checkSequenceNumbers(
+      Table table, List<DeleteFile> rewrittenDeletes, List<DeleteFile> addedDeletes) {
+    StructLikeMap<List<DeleteFile>> rewrittenFilesPerPartition =
+        groupPerPartition(table, rewrittenDeletes);
+    StructLikeMap<List<DeleteFile>> addedFilesPerPartition = groupPerPartition(table, addedDeletes);
+    for (StructLike partition : rewrittenFilesPerPartition.keySet()) {
+      Long maxRewrittenSeq =
+          rewrittenFilesPerPartition.get(partition).stream()
+              .map(ContentFile::dataSequenceNumber)
+              .max(Long::compare)
+              .get();
+      List<DeleteFile> addedPartitionFiles = addedFilesPerPartition.get(partition);
+      if (addedPartitionFiles != null) {
+        addedPartitionFiles.forEach(
+            d ->
+                Assert.assertEquals(
+                    "Sequence number should be max of rewritten set",
+                    d.dataSequenceNumber(),
+                    maxRewrittenSeq));
+      }
+    }
+  }
+
+  private StructLikeMap<List<DeleteFile>> groupPerPartition(
+      Table table, List<DeleteFile> deleteFiles) {
+    StructLikeMap<List<DeleteFile>> result =
+        StructLikeMap.create(Partitioning.partitionType(table));
+    for (DeleteFile deleteFile : deleteFiles) {
+      StructLike partition = deleteFile.partition();
+      List<DeleteFile> partitionFiles = result.get(partition);
+      if (partitionFiles == null) {
+        partitionFiles = Lists.newArrayList();
+      }
+      partitionFiles.add(deleteFile);
+      result.put(partition, partitionFiles);
+    }
+    return result;
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -798,9 +798,9 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     for (StructLike partition : rewrittenFilesPerPartition.keySet()) {
       Long maxRewrittenSeq =
           rewrittenFilesPerPartition.get(partition).stream()
-              .map(ContentFile::dataSequenceNumber)
-              .max(Long::compare)
-              .get();
+              .mapToLong(ContentFile::dataSequenceNumber)
+              .max()
+              .getAsLong();
       List<DeleteFile> addedPartitionFiles = addedFilesPerPartition.get(partition);
       if (addedPartitionFiles != null) {
         addedPartitionFiles.forEach(


### PR DESCRIPTION
Fixes: #7624