### PR TITLE
Spark 3.4: Fix NPE when create branch and tag on table without snapshot

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceBranchExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceBranchExec.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions
 import org.apache.iceberg.spark.source.SparkTable
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -45,6 +46,9 @@ case class CreateOrReplaceBranchExec(
           .orElse(Option(iceberg.table.currentSnapshot()).map(_.snapshotId()))
           .map(java.lang.Long.valueOf)
           .orNull
+
+        Preconditions.checkArgument(snapshotId != null,
+          "Cannot complete create or replace branch operation on %s, no valid snapshotId found", ident)
 
         val manageSnapshots = iceberg.table().manageSnapshots()
         if (!replace) {

--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceBranchExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceBranchExec.scala
@@ -48,7 +48,7 @@ case class CreateOrReplaceBranchExec(
           .orNull
 
         Preconditions.checkArgument(snapshotId != null,
-          "Cannot complete create or replace branch operation on %s, no valid snapshotId found", ident)
+          "Cannot complete create or replace branch operation on %s, main has no snapshot", ident)
 
         val manageSnapshots = iceberg.table().manageSnapshots()
         if (!replace) {

--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceTagExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceTagExec.scala
@@ -47,7 +47,7 @@ case class CreateOrReplaceTagExec(
           .orNull
 
         Preconditions.checkArgument(snapshotId != null,
-          "Cannot complete create or replace tag operation on %s, no valid snapshotId found", ident)
+          "Cannot complete create or replace tag operation on %s, main has no snapshot", ident)
 
         val manageSnapshot = iceberg.table.manageSnapshots()
         if (!replace) {

--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceTagExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateOrReplaceTagExec.scala
@@ -19,6 +19,7 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions
 import org.apache.iceberg.spark.source.SparkTable
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -44,6 +45,9 @@ case class CreateOrReplaceTagExec(
           .orElse(Option(iceberg.table.currentSnapshot()).map(_.snapshotId()))
           .map(java.lang.Long.valueOf)
           .orNull
+
+        Preconditions.checkArgument(snapshotId != null,
+          "Cannot complete create or replace tag operation on %s, no valid snapshotId found", ident)
 
         val manageSnapshot = iceberg.table.manageSnapshots()
         if (!replace) {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -94,8 +93,10 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
   @Test
   public void testCreateBranchOnEmptyTable() {
     Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, "b1"))
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining("Cannot set b1 to unknown snapshot");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot complete create or replace branch operation on %s, no valid snapshotId found",
+            tableName);
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
@@ -95,7 +95,7 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
     Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, "b1"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Cannot complete create or replace branch operation on %s, no valid snapshotId found",
+            "Cannot complete create or replace branch operation on %s, main has no snapshot",
             tableName);
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.source.SimpleRecord;
@@ -31,6 +32,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -87,6 +89,13 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
         IllegalArgumentException.class,
         "Ref b1 already exists",
         () -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName));
+  }
+
+  @Test
+  public void testCreateBranchOnEmptyTable() {
+    Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s", tableName, "b1"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot set b1 to unknown snapshot");
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -33,6 +33,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -117,6 +118,13 @@ public class TestTagDDL extends SparkExtensionsTestBase {
             sql(
                 "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN %d SECONDS",
                 tableName, tagName, firstSnapshotId, maxRefAge));
+  }
+
+  @Test
+  public void testCreateTagOnEmptyTable() {
+    Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, "abc"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot set abc to unknown snapshot");
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -125,7 +125,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
     Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, "abc"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Cannot complete create or replace tag operation on %s, no valid snapshotId found",
+            "Cannot complete create or replace tag operation on %s, main has no snapshot",
             tableName);
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -123,8 +123,10 @@ public class TestTagDDL extends SparkExtensionsTestBase {
   @Test
   public void testCreateTagOnEmptyTable() {
     Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, "abc"))
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining("Cannot set abc to unknown snapshot");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Cannot complete create or replace tag operation on %s, no valid snapshotId found",
+            tableName);
   }
 
   @Test


### PR DESCRIPTION
This fix help throw proper validation exception instead of NullPointerException when create branch or tag on iceberg table without any snapshot. 

## Before
```scala

Before
```scala
scala> val snapshotId = branchOptions.snapshotId.getOrElse(table.currentSnapshot().snapshotId())
java.lang.NullPointerException
  at $anonfun$res38$1(<console>:47)
  at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
  at scala.Option.getOrElse(Option.scala:189)
  ... 51 elided
```


After
```scala
scala> val snapshotId: java.lang.Long = branchOptions.snapshotId
          .orElse(Option(iceberg.table.currentSnapshot()).map(_.snapshotId()))
          .map(java.lang.Long.valueOf)
          .orNull
snapshotId: Long = null
```

CC @amogh-jahagirdar @zhangbutao 

