### PR TITLE
Infra: Use the standard shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     gradlePluginPortal()
   }
   dependencies {
-    classpath 'gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0'
+    classpath 'com.github.johnrengelman:shadow:8.1.1'
     classpath 'com.palantir.baseline:gradle-baseline-java:4.42.0'
     // com.palantir.baseline:gradle-baseline-java:4.42.0 (the last version supporting Java 8) pulls
     // in an old version of the errorprone, which doesn't work w/ Gradle 8, so bump errorpone as


### PR DESCRIPTION
Background: 
I tried to bump the Nessie version, which brought the latest Jackson 2.15.x dependency. 
With this, runtime uber jar building is failing as Jackson 2.15.x is [multi-version jar](https://github.com/FasterXML/jackson-core/issues/897) (packs classes of Java 19 also).

After debugging, found that the problem is in shadow jar plugin that Iceberg is using(which also looks fishy with [just one release](https://mvnrepository.com/artifact/gradle.plugin.com.github.jengelman.gradle.plugins/shadow)) and with the [standard shadow jar plugin](https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow) the build can pass even with multi-version jars. 