### PR TITLE
Add adaptive split size

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -204,6 +204,9 @@ public class TableProperties {
       "write.delete.orc.compression-strategy";
   public static final String ORC_COMPRESSION_STRATEGY_DEFAULT = "speed";
 
+  public static final String ADAPTIVE_SPLIT_PLANNING = "read.split.adaptive-enabled";
+  public static final boolean ADAPTIVE_SPLIT_PLANNING_DEFAULT = true;
+
   public static final String SPLIT_SIZE = "read.split.target-size";
   public static final long SPLIT_SIZE_DEFAULT = 128 * 1024 * 1024; // 128 MB
 
@@ -215,6 +218,9 @@ public class TableProperties {
 
   public static final String SPLIT_OPEN_FILE_COST = "read.split.open-file-cost";
   public static final long SPLIT_OPEN_FILE_COST_DEFAULT = 4 * 1024 * 1024; // 4MB
+
+  public static final String SPLIT_MIN_PARALLELISM = "read.split.min-parallelism";
+  public static final int SPLIT_MIN_PARALLELISM_DEFAULT = 10;
 
   public static final String PARQUET_VECTORIZATION_ENABLED = "read.parquet.vectorization.enabled";
   public static final boolean PARQUET_VECTORIZATION_ENABLED_DEFAULT = true;


### PR DESCRIPTION
This PR adds adaptive split planning to help address issues around small tables being collapsed into a single task due to split combining.  This is achieved by reducing the split size to try to achieve a minimum parallelism based on coarse grain table-level stats.

There are a number of cases this approach cannot account for including the difference between the filtered files/size vs the full table size.  The most benefit is for unpartitioned tables that either have multiple small files or can be split into smaller chunks to achieve higher parallelism.

Alternatives/additions to this approach would be to modify the bin packing algorithm to distribute across the minimum number of bins based on a reduced split size and only combine once the minimum parallelism can be achieved.  This is a more complicated approach and still relies on knowing the right size to split on.  

Additionally, we don't know at the time of calculating the split size whether we have offsets, so we cannot simply reduce the split size to zero (or near zero) because fixed split planning will then create too many splits. 