### PR TITLE
Spark 3.4: Codegen support for UpdateRowsExec

### DIFF
--- a/spark/v3.4/spark-extensions/src/jmh/java/org/apache/iceberg/spark/UpdateProjectionBenchmark.java
+++ b/spark/v3.4/spark-extensions/src/jmh/java/org/apache/iceberg/spark/UpdateProjectionBenchmark.java
@@ -146,6 +146,7 @@ public class UpdateProjectionBenchmark {
             .config(SQLConf.DYNAMIC_PARTITION_PRUNING_ENABLED().key(), "false")
             .config(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false")
             .config(SQLConf.SHUFFLE_PARTITIONS().key(), "2")
+            .config(SQLConf.CODEGEN_FACTORY_MODE().key(), "CODEGEN_ONLY")
             .master("local")
             .getOrCreate();
   }

--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateRowsExec.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateRowsExec.scala
@@ -23,9 +23,13 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.AttributeSet
+import org.apache.spark.sql.catalyst.expressions.BindReferences
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
 import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.execution.CodegenSupport
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.UnaryExecNode
 
@@ -33,7 +37,10 @@ case class UpdateRowsExec(
     deleteOutput: Seq[Expression],
     insertOutput: Seq[Expression],
     output: Seq[Attribute],
-    child: SparkPlan) extends UnaryExecNode {
+    child: SparkPlan) extends UnaryExecNode with CodegenSupport {
+
+  assert(deleteOutput.size == output.size)
+  assert(insertOutput.size == output.size)
 
   @transient override lazy val producedAttributes: AttributeSet = {
     AttributeSet(output.filterNot(attr => inputSet.contains(attr)))
@@ -49,6 +56,59 @@ case class UpdateRowsExec(
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan = {
     copy(child = newChild)
+  }
+
+  override def usedInputs: AttributeSet = {
+    // only attributes used at least twice should be evaluated before this plan,
+    // otherwise defer the evaluation until an attribute is actually used
+    val usedExprIds = insertOutput.flatMap(_.collect {
+      case attr: Attribute => attr.exprId
+    })
+    val usedMoreThanOnceExprIds = usedExprIds.groupBy(id => id).filter(_._2.size > 1).keySet
+    references.filter(attr => usedMoreThanOnceExprIds.contains(attr.exprId))
+  }
+
+  override def inputRDDs(): Seq[RDD[InternalRow]] = {
+    child.asInstanceOf[CodegenSupport].inputRDDs()
+  }
+
+  override protected def doProduce(ctx: CodegenContext): String = {
+    child.asInstanceOf[CodegenSupport].produce(ctx, this)
+  }
+
+  override def doConsume(ctx: CodegenContext, input: Seq[ExprCode], row: ExprCode): String = {
+    // no need to perform sub expression elimination for the delete projection as
+    // as it only outputs row ID and metadata attributes without any changes
+    val deleteExprs = BindReferences.bindReferences(deleteOutput, child.output)
+    val deleteOutputVars = deleteExprs.map(_.genCode(ctx))
+
+    val insertExprs = BindReferences.bindReferences(insertOutput, child.output)
+    val (insertSubExprsCode, insertOutputVars, insertLocalInputVars) =
+      if (conf.subexpressionEliminationEnabled) {
+        val subExprs = ctx.subexpressionEliminationForWholeStageCodegen(insertExprs)
+        val subExprsCode = ctx.evaluateSubExprEliminationState(subExprs.states.values)
+        val vars = ctx.withSubExprEliminationExprs(subExprs.states) {
+          insertExprs.map(_.genCode(ctx))
+        }
+        val localInputVars = subExprs.exprCodesNeedEvaluate
+        (subExprsCode, vars, localInputVars)
+      } else {
+        ("", insertExprs.map(_.genCode(ctx)), Seq.empty)
+      }
+
+    val nonDeterministicInsertAttrs = insertOutput.zip(output)
+      .collect { case (expr, attr) if !expr.deterministic => attr }
+    val nonDeterministicInsertAttrSet = AttributeSet(nonDeterministicInsertAttrs)
+
+    s"""
+       |// generate DELETE record
+       |${consume(ctx, deleteOutputVars)}
+       |// generate INSERT records
+       |${evaluateVariables(insertLocalInputVars)}
+       |$insertSubExprsCode
+       |${evaluateRequiredVariables(output, insertOutputVars, nonDeterministicInsertAttrSet)}
+       |${consume(ctx, insertOutputVars)}
+     """.stripMargin
   }
 
   private def processPartition(rowIterator: Iterator[InternalRow]): Iterator[InternalRow] = {


### PR DESCRIPTION
This PR adds codegen support for the newly added `UpdateRowsExec` that splits updates into deletes and inserts. This is a follow-up PR to #7646 that added this node. It is needed to be on par with the initial implementation that used a projection.