### PR TITLE
Parquet: Fix possible stream duplicate close issue when using DelegateingOutputStream

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/DelegatingOutputStream.java
+++ b/api/src/main/java/org/apache/iceberg/io/DelegatingOutputStream.java
@@ -22,4 +22,6 @@ import java.io.OutputStream;
 
 public interface DelegatingOutputStream {
   OutputStream getDelegate();
+
+  OutputStream takeDelegate();
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopStreams.java
@@ -143,7 +143,7 @@ public class HadoopStreams {
   /** PositionOutputStream implementation for FSDataOutputStream. */
   private static class HadoopPositionOutputStream extends PositionOutputStream
       implements DelegatingOutputStream {
-    private final FSDataOutputStream stream;
+    private FSDataOutputStream stream;
     private final StackTraceElement[] createStack;
     private boolean closed;
 
@@ -156,6 +156,13 @@ public class HadoopStreams {
     @Override
     public OutputStream getDelegate() {
       return stream;
+    }
+
+    @Override
+    public OutputStream takeDelegate() {
+      OutputStream delegate = stream;
+      this.stream = null;
+      return delegate;
     }
 
     @Override
@@ -193,7 +200,7 @@ public class HadoopStreams {
     @Override
     protected void finalize() throws Throwable {
       super.finalize();
-      if (!closed) {
+      if (!closed && this.stream != null) {
         close(); // releasing resources is more important than printing the warning
         String trace =
             Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -93,7 +93,7 @@ class ParquetIO {
 
   static PositionOutputStream stream(org.apache.iceberg.io.PositionOutputStream stream) {
     if (stream instanceof DelegatingOutputStream) {
-      OutputStream wrapped = ((DelegatingOutputStream) stream).getDelegate();
+      OutputStream wrapped = ((DelegatingOutputStream) stream).takeDelegate();
       if (wrapped instanceof FSDataOutputStream) {
         return HadoopStreams.wrap((FSDataOutputStream) wrapped);
       }


### PR DESCRIPTION
When I used Flink to write to the iceberg table, I made a layer of encapsulation for the outputStream, which will eventually be converted into a HadoopPositionOutputStream object. It implements DelegatingOutputStream, and the HadoopPositionOutputStream object rewrites the finalize method. This method will try to close the stream, but there will be problems in parquetIO:

```
  static PositionOutputStream stream(org.apache.iceberg.io.PositionOutputStream stream) {
    if (stream instanceof DelegatingOutputStream) {
      OutputStream wrapped = ((DelegatingOutputStream) stream).getDelegate();
      if (wrapped instanceof FSDataOutputStream) {
        return HadoopStreams.wrap((FSDataOutputStream) wrapped);
      }
    }
    return new ParquetOutputStreamAdapter(stream);
  }
```
Here, the Delegate will be taken out and repackaged, and the HadoopPositionOutputStream object will be discarded. At this time, the HadoopPositionOutputStream object may not be continuously referenced, and may be recycled during gc. If gc is triggered to recycle the HadoopPositionOutputStream object during the stream writing process, close will be called at this time. The method closes the stream, causing file corruption.

This pr is used to solve this problem. Add takeDelegate to DelegatingOutputStream to take the Delegate out and set it to null to prevent finalize close




