### PR TITLE
Core: Fix docstring

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -185,7 +185,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
      * Given content file metadata, append a 'readable_metrics' column that return the file's
      * metrics in human-readable form.
      *
-     * @file content file metadata
+     * @param file content file metadata
      * @param readableMetricsField projected "readable_metrics" field
      * @return struct representing content file, with appended readable_metrics field
      */


### PR DESCRIPTION
```
/Users/fokkodriesprong/Desktop/iceberg/core/src/main/java/org/apache/iceberg/BaseFilesTable.java:188: warning: [InvalidBlockTag] @file is not a valid tag, but is a parameter
name. Use {@code %s} to refer to parameter names inline.
     * @file content file metadata
```