### PR TITLE
Spec: TableRequirement definition and parser mismatch

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1500,6 +1500,9 @@ components:
           properties:
             schema:
               $ref: '#/components/schemas/Schema'
+            last-column-id:
+              type: integer
+              description: The last column ID in the schema
 
     SetCurrentSchemaUpdate:
       allOf:
@@ -1670,9 +1673,9 @@ components:
         - `assert-default-sort-order-id` - the table's default sort order id must match the requirement's `default-sort-order-id`
       type: object
       required:
-        - requirement
+        - type
       properties:
-        requirement:
+        type:
           type: string
           enum:
             - assert-create

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1500,9 +1500,6 @@ components:
           properties:
             schema:
               $ref: '#/components/schemas/Schema'
-            last-column-id:
-              type: integer
-              description: The last column ID in the schema
 
     SetCurrentSchemaUpdate:
       allOf:


### PR DESCRIPTION
Motivation:

Encountering following error when parsing TableRequirement as defined by the existing rest catalog spec

```
Caused by: java.lang.IllegalArgumentException: Cannot parse update requirement. Missing field: type
        at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
        at org.apache.iceberg.rest.requests.UpdateRequirementParser.fromJson(UpdateRequirementParser.java:159)
        at org.apache.iceberg.rest.RESTSerializers$UpdateRequirementDeserializer.deserialize(RESTSerializers.java:95)
        at org.apache.iceberg.rest.RESTSerializers$UpdateRequirementDeserializer.deserialize(RESTSerializers.java:90)
        at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:359)
        ... 54 common frames omitted
```

Change list:
1. Changed the "requirement" field in TableRequirement schema to "type" as defined by the parser: https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/rest/requests/UpdateRequirementParser.java#L35