### PR TITLE
Core: Remove deprecated AssertHelpers

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -20,11 +20,11 @@ package org.apache.iceberg.rest.requests;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -77,70 +77,60 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
   public void testDeserializeInvalidRequest() {
     String jsonIncorrectTypeForNamespace =
         "{\"namespace\":\"accounting%1Ftax\",\"properties\":null}";
-    AssertHelpers.assertThrows(
-        "A JSON request with incorrect types for fields should fail to deserialize and validate",
-        JsonProcessingException.class,
-        "Cannot parse string array from non-array",
-        () -> deserialize(jsonIncorrectTypeForNamespace));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonIncorrectTypeForNamespace))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot parse string array from non-array");
 
     String jsonIncorrectTypeForProperties =
         "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":[]}";
-    AssertHelpers.assertThrows(
-        "A JSON request with incorrect types for fields should fail to parse and validate",
-        JsonProcessingException.class,
-        () -> deserialize(jsonIncorrectTypeForProperties));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonIncorrectTypeForProperties))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot deserialize value of type");
 
     String jsonMisspelledKeys =
         "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with the keys spelled incorrectly should fail to deserialize and validate",
-        IllegalArgumentException.class,
-        "Invalid namespace: null",
-        () -> deserialize(jsonMisspelledKeys));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonMisspelledKeys))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace: null");
 
     String emptyJson = "{}";
-    AssertHelpers.assertThrows(
-        "An empty JSON object should not parse into a CreateNamespaceRequest instance that passes validation",
-        IllegalArgumentException.class,
-        "Invalid namespace: null",
-        () -> deserialize(emptyJson));
+    Assertions.assertThatThrownBy(() -> deserialize(emptyJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace: null");
 
-    AssertHelpers.assertThrows(
-        "An empty JSON request should fail to deserialize",
-        IllegalArgumentException.class,
-        () -> deserialize(null));
+    Assertions.assertThatThrownBy(() -> deserialize(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("argument \"content\" is null");
   }
 
   @Test
   public void testBuilderDoesNotBuildInvalidRequests() {
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null for the namespace",
-        NullPointerException.class,
-        "Invalid namespace: null",
-        () -> CreateNamespaceRequest.builder().withNamespace(null).build());
+    Assertions.assertThatThrownBy(
+            () -> CreateNamespaceRequest.builder().withNamespace(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid namespace: null");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a null collection of properties",
-        NullPointerException.class,
-        "Invalid collection of properties: null",
-        () -> CreateNamespaceRequest.builder().setProperties(null).build());
+    Assertions.assertThatThrownBy(
+            () -> CreateNamespaceRequest.builder().setProperties(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid collection of properties: null");
 
     Map<String, String> mapWithNullKey = Maps.newHashMap();
     mapWithNullKey.put(null, "hello");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key in the properties to set",
-        IllegalArgumentException.class,
-        "Invalid property: null",
-        () -> CreateNamespaceRequest.builder().setProperties(mapWithNullKey).build());
+
+    Assertions.assertThatThrownBy(
+            () -> CreateNamespaceRequest.builder().setProperties(mapWithNullKey).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid property: null");
 
     Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
     mapWithMultipleNullValues.put("a", null);
     mapWithMultipleNullValues.put("b", "b");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a value in the properties to set",
-        IllegalArgumentException.class,
-        "Invalid value for properties [a]: null",
-        () -> CreateNamespaceRequest.builder().setProperties(mapWithMultipleNullValues).build());
+
+    Assertions.assertThatThrownBy(
+            () -> CreateNamespaceRequest.builder().setProperties(mapWithMultipleNullValues).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid value for properties [a]: null");
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestRenameTableRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestRenameTableRequest.java
@@ -19,11 +19,11 @@
 package org.apache.iceberg.rest.requests;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
 import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -52,69 +52,56 @@ public class TestRenameTableRequest extends RequestResponseTestBase<RenameTableR
     String jsonSourceNullName =
         "{\"source\":{\"namespace\":[\"accounting\",\"tax\"],\"name\":null},"
             + "\"destination\":{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid_2022\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid source table identifier, with null for the name, should fail to deserialize",
-        JsonProcessingException.class,
-        "Cannot parse to a string value: name: null",
-        () -> deserialize(jsonSourceNullName));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonSourceNullName))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot parse to a string value: name: null");
 
     String jsonDestinationNullName =
         "{\"source\":{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"},"
             + "\"destination\":{\"namespace\":[\"accounting\",\"tax\"],\"name\":null}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid destination table, with null for the name, should fail to deserialize",
-        JsonProcessingException.class,
-        "Cannot parse to a string value: name: null",
-        () -> deserialize(jsonDestinationNullName));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonDestinationNullName))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot parse to a string value: name: null");
 
     String jsonSourceMissingName =
         "{\"source\":{\"namespace\":[\"accounting\",\"tax\"]},"
             + "\"destination\":{\"name\":\"paid_2022\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid source table identifier, with no name, should fail to deserialize",
-        JsonProcessingException.class,
-        "Cannot parse missing string: name",
-        () -> deserialize(jsonSourceMissingName));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonSourceMissingName))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot parse missing string: name");
 
     String jsonDestinationMissingName =
         "{\"source\":{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"},"
             + "\"destination\":{\"namespace\":[\"accounting\",\"tax\"]}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid destination table identifier, with no name, should fail to deserialize",
-        JsonProcessingException.class,
-        "Cannot parse missing string: name",
-        () -> deserialize(jsonDestinationMissingName));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonDestinationMissingName))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot parse missing string: name");
 
     String emptyJson = "{}";
-    AssertHelpers.assertThrows(
-        "An empty JSON object should not parse into a valid RenameTableRequest instance",
-        IllegalArgumentException.class,
-        "Invalid source table: null",
-        () -> deserialize(emptyJson));
+    Assertions.assertThatThrownBy(() -> deserialize(emptyJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid source table: null");
 
-    AssertHelpers.assertThrows(
-        "An empty JSON request should fail to deserialize",
-        IllegalArgumentException.class,
-        () -> deserialize(null));
+    Assertions.assertThatThrownBy(() -> deserialize(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("argument \"content\" is null");
   }
 
   @Test
   public void testBuilderDoesNotBuildInvalidRequests() {
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null for the source table",
-        NullPointerException.class,
-        "Invalid source table identifier: null",
-        () ->
-            RenameTableRequest.builder()
-                .withSource(null)
-                .withDestination(TAX_PAID_RENAMED)
-                .build());
+    Assertions.assertThatThrownBy(
+            () ->
+                RenameTableRequest.builder()
+                    .withSource(null)
+                    .withDestination(TAX_PAID_RENAMED)
+                    .build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid source table identifier: null");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null for the destination table",
-        NullPointerException.class,
-        "Invalid destination table identifier: null",
-        () -> RenameTableRequest.builder().withSource(TAX_PAID).withDestination(null).build());
+    Assertions.assertThatThrownBy(
+            () -> RenameTableRequest.builder().withSource(TAX_PAID).withDestination(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid destination table identifier: null");
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
@@ -21,13 +21,13 @@ package org.apache.iceberg.rest.requests;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -118,94 +118,82 @@ public class TestUpdateNamespacePropertiesRequest
     // Invalid top-level types
     String jsonInvalidTypeOnRemovalField =
         "{\"removals\":{\"foo\":\"bar\"},\"updates\":{\"owner\":\"Hank\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid type for one of the fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(jsonInvalidTypeOnRemovalField));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonInvalidTypeOnRemovalField))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot deserialize value of type");
 
     String jsonInvalidTypeOnUpdatesField =
         "{\"removals\":[\"foo\":\"bar\"],\"updates\":[\"owner\"]}";
-    AssertHelpers.assertThrows(
-        "A JSON value with an invalid type for one of the fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(jsonInvalidTypeOnUpdatesField));
+    Assertions.assertThatThrownBy(() -> deserialize(jsonInvalidTypeOnUpdatesField))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Unexpected character")
+        .hasMessageContaining("expecting comma to separate Array entries");
 
     // Valid top-level (array) types, but at least one entry in the list is not the expected type
     // NOTE: non-string values that are integral types will still parse into a string list.
     //    e.g. { removals: [ "foo", "bar", 1234 ] } will parse correctly.
     String invalidJsonWrongTypeInRemovalsList =
         "{\"removals\":[\"foo\",\"bar\", {\"owner\": \"Hank\"}],\"updates\":{\"owner\":\"Hank\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON value with an invalid type inside one of the list fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(invalidJsonWrongTypeInRemovalsList));
+    Assertions.assertThatThrownBy(() -> deserialize(invalidJsonWrongTypeInRemovalsList))
+        .isInstanceOf(JsonProcessingException.class)
+        .hasMessageStartingWith("Cannot deserialize value of type");
 
     String nullJson = null;
-    AssertHelpers.assertThrows(
-        "A null JSON should fail to parse",
-        IllegalArgumentException.class,
-        "argument \"content\" is null",
-        () -> deserialize(nullJson));
+    Assertions.assertThatThrownBy(() -> deserialize(nullJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("argument \"content\" is null");
   }
 
   @Test
   public void testBuilderDoesNotCreateInvalidObjects() {
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to remove",
-        NullPointerException.class,
-        "Invalid property to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().remove(null).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().remove(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid property to remove: null");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a null list of properties to remove",
-        NullPointerException.class,
-        "Invalid list of properties to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().removeAll(null).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().removeAll(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid list of properties to remove: null");
 
     List<String> listWithNull = Lists.newArrayList("a", null, null);
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a list of properties to remove with a null element",
-        IllegalArgumentException.class,
-        "Invalid property to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().removeAll(listWithNull).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().removeAll(listWithNull).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid property to remove: null");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to update",
-        NullPointerException.class,
-        "Invalid property to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().update(null, "100").build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().update(null, "100").build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid property to update: null");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a value to update",
-        NullPointerException.class,
-        "Invalid value to update for key [owner]: null. Use remove instead",
-        () -> UpdateNamespacePropertiesRequest.builder().update("owner", null).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().update("owner", null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid value to update for key [owner]: null. Use remove instead");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a null collection of properties to update",
-        NullPointerException.class,
-        "Invalid collection of properties to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().updateAll(null).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().updateAll(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid collection of properties to update: null");
 
     Map<String, String> mapWithNullKey = Maps.newHashMap();
     mapWithNullKey.put(null, "hello");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to update from a collection of updates",
-        IllegalArgumentException.class,
-        "Invalid property to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithNullKey).build());
+    Assertions.assertThatThrownBy(
+            () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithNullKey).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid property to update: null");
 
     Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
     mapWithMultipleNullValues.put("a", null);
     mapWithMultipleNullValues.put("b", "b");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a value to update from a collection of updates",
-        IllegalArgumentException.class,
-        "Invalid value to update for properties [a]: null. Use remove instead",
-        () ->
-            UpdateNamespacePropertiesRequest.builder()
-                .updateAll(mapWithMultipleNullValues)
-                .build());
+    Assertions.assertThatThrownBy(
+            () ->
+                UpdateNamespacePropertiesRequest.builder()
+                    .updateAll(mapWithMultipleNullValues)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid value to update for properties [a]: null. Use remove instead");
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateRequirementParser.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.rest.requests;
 
 import java.util.List;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.rest.requests.UpdateTableRequest.UpdateRequirement;
 import org.assertj.core.api.Assertions;
@@ -36,11 +35,9 @@ public class TestUpdateRequirementParser {
             "{\"uuid\":\"2cc52516-5e73-41f2-b139-545d41a4e151\"}");
 
     for (String json : invalidJson) {
-      AssertHelpers.assertThrows(
-          "UpdateRequirement without a recognized requirement type should fail to deserialize",
-          IllegalArgumentException.class,
-          "Cannot parse update requirement. Missing field: type",
-          () -> UpdateRequirementParser.fromJson(json));
+      Assertions.assertThatThrownBy(() -> UpdateRequirementParser.fromJson(json))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Cannot parse update requirement. Missing field: type");
     }
   }
 


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in iceberg-core-request module.