### PR TITLE
Build: Add openapi label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -83,3 +83,5 @@ DELL:
   - dell/**/*
 SNOWFLAKE:
   - snowflake/**/*
+OPENAPI:
+  - open-api/**/*


### PR DESCRIPTION
Just realized there's no label correspond to openAPI spec change. I think introducing is would help filter out the spec change  and allow for easier subscription to such change

Appreciate reviews! @Fokko @haizhou-zhao @snazy @rdblue 