### PR TITLE
Spark 3.3,3.4: Add back log making it clearer when we are not pushing down filters

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -171,7 +171,10 @@ public class SparkScanBuilder
         }
 
       } catch (Exception e) {
-        LOG.warn("Failed to check if {} can be pushed down: {}", filter, e.getMessage());
+        LOG.warn(
+            "Failed to check if {} can be pushed down: {}, skipping push down for this expression",
+            filter,
+            e.getMessage());
         postScanFilters.add(filter);
       }
     }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -171,7 +171,10 @@ public class SparkScanBuilder
         }
 
       } catch (Exception e) {
-        LOG.warn("Failed to check if {} can be pushed down: {}", filter, e.getMessage());
+        LOG.warn(
+            "Failed to check if {} can be pushed down: {}, skipping push down for this expression",
+            filter,
+            e.getMessage());
         postScanFilters.add(filter);
       }
     }


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/6524 changed the log pattern a little bit.

In previous versions, we logged ' skipping push down for this expression' when failing to pushdown.

As its important for users to see when pushdown filters are skipped, I think its easier to have the user just grep the same expression across versions.  So be consistent with older Spark versions (3.2) and also previous release of Iceberg before #6524 across Spark versions, I think we can add back this to the sentence to clarify that the filter is indeed being skipped.