### PR TITLE
Spark 3.2: Fixes bucket on binary column

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
@@ -238,6 +238,23 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
   }
 
   @Test
+  public void testDefaultSortOnBinaryBucketedColumn() {
+    sql(
+        "CREATE TABLE %s (c1 INT, c2 Binary) "
+            + "USING iceberg "
+            + "PARTITIONED BY (bucket(2, c2))",
+        tableName);
+
+    sql("INSERT INTO %s VALUES (1, X'A1B1'), (2, X'A2B2')", tableName);
+
+    byte[] bytes1 = new byte[] {-95, -79};
+    byte[] bytes2 = new byte[] {-94, -78};
+    List<Object[]> expected = ImmutableList.of(row(1, bytes1), row(2, bytes2));
+
+    assertEquals("Rows must match", expected, sql("SELECT * FROM %s ORDER BY c1", tableName));
+  }
+
+  @Test
   public void testDefaultSortOnDecimalTruncatedColumn() {
     sql(
         "CREATE TABLE %s (c1 INT, c2 DECIMAL(20, 2)) "

--- a/spark/v3.2/spark/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
+++ b/spark/v3.2/spark/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
@@ -110,6 +110,9 @@ case class IcebergBucketTransform(numBuckets: Int, child: Expression) extends Ic
       // TODO: pass bytes without the copy out of the InternalRow
       val t = Transforms.bucket[ByteBuffer](Types.BinaryType.get(), numBuckets)
       s: Any => t(ByteBuffer.wrap(s.asInstanceOf[UTF8String].getBytes)).toInt
+    case _: BinaryType =>
+      val t = Transforms.bucket[Any](numBuckets).bind(icebergInputType)
+      b: Any => t(ByteBuffer.wrap(b.asInstanceOf[Array[Byte]])).toInt
     case _ =>
       val t = Transforms.bucket[Any](icebergInputType, numBuckets)
       a: Any => t(a).toInt


### PR DESCRIPTION
This PR backports #7693 to Spark 3.2