### PR TITLE
Core: Fixed NPE in SnapshotUtil.ancestorsOf

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -239,6 +239,10 @@ public class SnapshotUtil {
                 return true;
               }
 
+              if (next == null) {
+                return false;
+              }
+
               Long parentId = next.parentId();
               if (parentId == null) {
                 return false;

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -181,7 +182,7 @@ public class TestSnapshotUtil {
     }
 
     // Once snapshot iterator has been exhausted, call hasNext again to make sure it is stable.
-    Assert.assertFalse(snapshotIter.hasNext());
+    Assertions.assertThat(snapshotIter).isExhausted();
   }
 
   private void expectedSnapshots(long[] snapshotIdExpected, Iterable<Snapshot> snapshotsActual) {

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.util;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.File;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.DataFile;
@@ -28,6 +29,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.types.Types;
@@ -60,12 +62,23 @@ public class TestSnapshotUtil {
           .withRecordCount(1)
           .build();
 
-  private long snapshotAId;
+  private long snapshotBaseTimestamp;
+  private long snapshotBaseId;
+  private long snapshotBranchId;
+  private long snapshotMain1Id;
+  private long snapshotMain2Id;
+  private long snapshotFork0Id;
+  private long snapshotFork1Id;
+  private long snapshotFork2Id;
 
-  private long snapshotATimestamp;
-  private long snapshotBId;
-  private long snapshotCId;
-  private long snapshotDId;
+  private Snapshot putSnapshot(String branch) {
+    table.newFastAppend().appendFile(FILE_A).toBranch(branch).commit();
+    return table.snapshot(branch);
+  }
+
+  private Snapshot putSnapshot() {
+    return putSnapshot(SnapshotRef.MAIN_BRANCH);
+  }
 
   @Before
   public void before() throws Exception {
@@ -75,23 +88,25 @@ public class TestSnapshotUtil {
     this.metadataDir = new File(tableDir, "metadata");
 
     this.table = TestTables.create(tableDir, "test", SCHEMA, SPEC, 2);
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snapshotA = table.currentSnapshot();
-    this.snapshotAId = snapshotA.snapshotId();
-    this.snapshotATimestamp = snapshotA.timestampMillis();
+    Snapshot snapshotBase = putSnapshot();
+    this.snapshotBaseId = snapshotBase.snapshotId();
+    this.snapshotBaseTimestamp = snapshotBase.timestampMillis();
+    TestHelpers.waitUntilAfter(snapshotBaseTimestamp);
 
-    TestHelpers.waitUntilAfter(snapshotATimestamp);
-
-    table.newFastAppend().appendFile(FILE_A).commit();
-    this.snapshotBId = table.currentSnapshot().snapshotId();
-
-    table.newFastAppend().appendFile(FILE_A).commit();
-    this.snapshotDId = table.currentSnapshot().snapshotId();
+    this.snapshotMain1Id = putSnapshot().snapshotId();
+    this.snapshotMain2Id = putSnapshot().snapshotId();
 
     String branchName = "b1";
-    table.manageSnapshots().createBranch(branchName, snapshotAId).commit();
-    table.newFastAppend().appendFile(FILE_A).toBranch(branchName).commit();
-    this.snapshotCId = table.snapshot(branchName).snapshotId();
+    table.manageSnapshots().createBranch(branchName, snapshotBaseId).commit();
+    this.snapshotBranchId = putSnapshot(branchName).snapshotId();
+
+    // Create a branch that leads back to an expired snapshot
+    String forkBranch = "fork";
+    table.manageSnapshots().createBranch(forkBranch, snapshotBaseId).commit();
+    this.snapshotFork0Id = putSnapshot(forkBranch).snapshotId();
+    this.snapshotFork1Id = putSnapshot(forkBranch).snapshotId();
+    this.snapshotFork2Id = putSnapshot(forkBranch).snapshotId();
+    table.expireSnapshots().expireSnapshotId(snapshotFork0Id).commit();
   }
 
   @After
@@ -101,54 +116,72 @@ public class TestSnapshotUtil {
 
   @Test
   public void isParentAncestorOf() {
-    Assert.assertTrue(SnapshotUtil.isParentAncestorOf(table, snapshotBId, snapshotAId));
-    Assert.assertFalse(SnapshotUtil.isParentAncestorOf(table, snapshotCId, snapshotBId));
+    Assert.assertTrue(SnapshotUtil.isParentAncestorOf(table, snapshotMain1Id, snapshotBaseId));
+    Assert.assertFalse(SnapshotUtil.isParentAncestorOf(table, snapshotBranchId, snapshotMain1Id));
+    Assert.assertTrue(SnapshotUtil.isParentAncestorOf(table, snapshotFork2Id, snapshotFork0Id));
   }
 
   @Test
   public void isAncestorOf() {
-    Assert.assertTrue(SnapshotUtil.isAncestorOf(table, snapshotBId, snapshotAId));
-    Assert.assertFalse(SnapshotUtil.isAncestorOf(table, snapshotCId, snapshotBId));
+    Assert.assertTrue(SnapshotUtil.isAncestorOf(table, snapshotMain1Id, snapshotBaseId));
+    Assert.assertFalse(SnapshotUtil.isAncestorOf(table, snapshotBranchId, snapshotMain1Id));
+    Assert.assertFalse(SnapshotUtil.isAncestorOf(table, snapshotFork2Id, snapshotFork0Id));
 
-    Assert.assertTrue(SnapshotUtil.isAncestorOf(table, snapshotBId));
-    Assert.assertFalse(SnapshotUtil.isAncestorOf(table, snapshotCId));
+    Assert.assertTrue(SnapshotUtil.isAncestorOf(table, snapshotMain1Id));
+    Assert.assertFalse(SnapshotUtil.isAncestorOf(table, snapshotBranchId));
   }
 
   @Test
   public void currentAncestors() {
     Iterable<Snapshot> snapshots = SnapshotUtil.currentAncestors(table);
-    expectedSnapshots(new long[] {snapshotDId, snapshotBId, snapshotAId}, snapshots);
+    expectedSnapshots(new long[] {snapshotMain2Id, snapshotMain1Id, snapshotBaseId}, snapshots);
 
     List<Long> snapshotList = SnapshotUtil.currentAncestorIds(table);
     Assert.assertArrayEquals(
-        new Long[] {snapshotDId, snapshotBId, snapshotAId}, snapshotList.toArray(new Long[0]));
+        new Long[] {snapshotMain2Id, snapshotMain1Id, snapshotBaseId},
+        snapshotList.toArray(new Long[0]));
   }
 
   @Test
   public void oldestAncestor() {
     Snapshot snapshot = SnapshotUtil.oldestAncestor(table);
-    Assert.assertEquals(snapshotAId, snapshot.snapshotId());
+    Assert.assertEquals(snapshotBaseId, snapshot.snapshotId());
 
-    snapshot = SnapshotUtil.oldestAncestorOf(table, snapshotDId);
-    Assert.assertEquals(snapshotAId, snapshot.snapshotId());
+    snapshot = SnapshotUtil.oldestAncestorOf(table, snapshotMain2Id);
+    Assert.assertEquals(snapshotBaseId, snapshot.snapshotId());
 
-    snapshot = SnapshotUtil.oldestAncestorAfter(table, snapshotATimestamp + 1);
-    Assert.assertEquals(snapshotBId, snapshot.snapshotId());
+    snapshot = SnapshotUtil.oldestAncestorAfter(table, snapshotBaseTimestamp + 1);
+    Assert.assertEquals(snapshotMain1Id, snapshot.snapshotId());
   }
 
   @Test
   public void snapshotsBetween() {
     List<Long> snapshotIdsBetween =
-        SnapshotUtil.snapshotIdsBetween(table, snapshotAId, snapshotDId);
+        SnapshotUtil.snapshotIdsBetween(table, snapshotBaseId, snapshotMain2Id);
     Assert.assertArrayEquals(
-        new Long[] {snapshotDId, snapshotBId}, snapshotIdsBetween.toArray(new Long[0]));
+        new Long[] {snapshotMain2Id, snapshotMain1Id}, snapshotIdsBetween.toArray(new Long[0]));
 
     Iterable<Snapshot> ancestorsBetween =
-        SnapshotUtil.ancestorsBetween(table, snapshotDId, snapshotBId);
-    expectedSnapshots(new long[] {snapshotDId}, ancestorsBetween);
+        SnapshotUtil.ancestorsBetween(table, snapshotMain2Id, snapshotMain1Id);
+    expectedSnapshots(new long[] {snapshotMain2Id}, ancestorsBetween);
 
-    ancestorsBetween = SnapshotUtil.ancestorsBetween(table, snapshotDId, snapshotCId);
-    expectedSnapshots(new long[] {snapshotDId, snapshotBId, snapshotAId}, ancestorsBetween);
+    ancestorsBetween = SnapshotUtil.ancestorsBetween(table, snapshotMain2Id, snapshotBranchId);
+    expectedSnapshots(
+        new long[] {snapshotMain2Id, snapshotMain1Id, snapshotBaseId}, ancestorsBetween);
+  }
+
+  @Test
+  public void ancestorsOf() {
+    Iterable<Snapshot> snapshots = SnapshotUtil.ancestorsOf(snapshotFork2Id, table::snapshot);
+    expectedSnapshots(new long[] {snapshotFork2Id, snapshotFork1Id}, snapshots);
+
+    Iterator<Snapshot> snapshotIter = snapshots.iterator();
+    while (snapshotIter.hasNext()) {
+      snapshotIter.next();
+    }
+
+    // Once snapshot iterator has been exhausted, call hasNext again to make sure it is stable.
+    Assert.assertFalse(snapshotIter.hasNext());
   }
 
   private void expectedSnapshots(long[] snapshotIdExpected, Iterable<Snapshot> snapshotsActual) {

--- a/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSnapshotUtil.java
@@ -71,13 +71,13 @@ public class TestSnapshotUtil {
   private long snapshotFork1Id;
   private long snapshotFork2Id;
 
-  private Snapshot putSnapshot(String branch) {
+  private Snapshot appendFileTo(String branch) {
     table.newFastAppend().appendFile(FILE_A).toBranch(branch).commit();
     return table.snapshot(branch);
   }
 
-  private Snapshot putSnapshot() {
-    return putSnapshot(SnapshotRef.MAIN_BRANCH);
+  private Snapshot appendFileToMain() {
+    return appendFileTo(SnapshotRef.MAIN_BRANCH);
   }
 
   @Before
@@ -88,24 +88,24 @@ public class TestSnapshotUtil {
     this.metadataDir = new File(tableDir, "metadata");
 
     this.table = TestTables.create(tableDir, "test", SCHEMA, SPEC, 2);
-    Snapshot snapshotBase = putSnapshot();
+    Snapshot snapshotBase = appendFileToMain();
     this.snapshotBaseId = snapshotBase.snapshotId();
     this.snapshotBaseTimestamp = snapshotBase.timestampMillis();
     TestHelpers.waitUntilAfter(snapshotBaseTimestamp);
 
-    this.snapshotMain1Id = putSnapshot().snapshotId();
-    this.snapshotMain2Id = putSnapshot().snapshotId();
+    this.snapshotMain1Id = appendFileToMain().snapshotId();
+    this.snapshotMain2Id = appendFileToMain().snapshotId();
 
     String branchName = "b1";
     table.manageSnapshots().createBranch(branchName, snapshotBaseId).commit();
-    this.snapshotBranchId = putSnapshot(branchName).snapshotId();
+    this.snapshotBranchId = appendFileTo(branchName).snapshotId();
 
     // Create a branch that leads back to an expired snapshot
     String forkBranch = "fork";
     table.manageSnapshots().createBranch(forkBranch, snapshotBaseId).commit();
-    this.snapshotFork0Id = putSnapshot(forkBranch).snapshotId();
-    this.snapshotFork1Id = putSnapshot(forkBranch).snapshotId();
-    this.snapshotFork2Id = putSnapshot(forkBranch).snapshotId();
+    this.snapshotFork0Id = appendFileTo(forkBranch).snapshotId();
+    this.snapshotFork1Id = appendFileTo(forkBranch).snapshotId();
+    this.snapshotFork2Id = appendFileTo(forkBranch).snapshotId();
     table.expireSnapshots().expireSnapshotId(snapshotFork0Id).commit();
   }
 


### PR DESCRIPTION
Calling `hasNext()` on the any Iterator returned by the Iterable from `SnapshotUtil.ancestorsOf` throws a NullPointerException if it is called again after the prior call returned false. This only happens if the ancestor chain is broken by an expired snapshot, not if it reaches a snapshot with a null parentId.

This is because when `next.parentId()` returns null the iterator will return false without changing its state, but when the lookup function returns null, as it would when the snapshot's parent is expired, it sets the `next` variable to null as well. The first time this doesn't cause an issue as the next line null-checks it, but if `hasNext()` is called again it will attempt to call `next.parentId()` on the now-null next variable, throwing an NPE.

I considered fixing this by storing the result of `lookup.apply` in an intermediate variable and null-checking it before assigning it to `next`, but if for any reason the lookup function wasn't deterministic this could cause `hasNext()` to return true after it has already returned false, which would be a separate violation of the Iterator API contract from the one this PR aims to fix. Alternatively, if lookup were expensive it would just be wasted effort to call it again.

I added a new test case that replicated the bug in order to validate my change fixed it, and in the process did some refactoring in the unit test to reduce duplicate code and (at least attempted to) give the snapshot id variables more intuitive names. Also added additional assertions to `isParentAncestorOf` and `isAncestorOf` tests to validate they work as intended with expired snapshots as well.