### PR TITLE
Spark 3.1: Fixes bucket on binary column

### DIFF
--- a/spark/v3.1/spark/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
+++ b/spark/v3.1/spark/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
@@ -96,6 +96,9 @@ case class IcebergBucketTransform(numBuckets: Int, child: Expression) extends Ic
       // TODO: pass bytes without the copy out of the InternalRow
       val t = Transforms.bucket[ByteBuffer](Types.BinaryType.get(), numBuckets)
       s: Any => t(ByteBuffer.wrap(s.asInstanceOf[UTF8String].getBytes)).toInt
+    case _: BinaryType =>
+      val t = Transforms.bucket[Any](numBuckets).bind(icebergInputType)
+      b: Any => t(ByteBuffer.wrap(b.asInstanceOf[Array[Byte]])).toInt
     case _ =>
       val t = Transforms.bucket[Any](icebergInputType, numBuckets)
       a: Any => t(a).toInt

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -172,7 +172,11 @@ public abstract class SparkTestBase {
       Object actualValue = actualRow[col];
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
-        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        if (expectedValue instanceof byte[]) {
+          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+        } else {
+          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        }
       } else if (expectedValue != ANY) {
         Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
       }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -42,6 +42,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ui.SQLExecutionUIData;
 import org.apache.spark.sql.internal.SQLConf;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -173,7 +174,7 @@ public abstract class SparkTestBase {
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
         if (expectedValue instanceof byte[]) {
-          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+          Assertions.assertThat(actualValue).as(newContext).isEqualTo(expectedValue);
         } else {
           assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
         }


### PR DESCRIPTION
This PR backports https://github.com/apache/iceberg/pull/7693 to Spark 3.1. Since `TestRequiredDistributionAndOrdering` is added after Spark 3.1, we put the `testDefaultSortOnBinaryBucketedColumn` in `TestSetWriteDistributionAndOrdering`.