### PR TITLE
Core: Remove deprecated AssertHelpers in Hadoop

### DIFF
--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.MetadataTableType;
@@ -343,10 +342,11 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   @Test
   public void testCachingCatalogRejectsExpirationIntervalOfZero() {
-    AssertHelpers.assertThrows(
-        "Caching catalog should disallow an expiration interval of zero, as zero signifies not to cache at all",
-        IllegalArgumentException.class,
-        () -> TestableCachingCatalog.wrap(hadoopCatalog(), Duration.ZERO, ticker));
+    Assertions.assertThatThrownBy(
+            () -> TestableCachingCatalog.wrap(hadoopCatalog(), Duration.ZERO, ticker))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "When cache.expiration-interval-ms is set to 0, the catalog cache should be disabled. This indicates a bug.");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -130,27 +129,24 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     HadoopCatalog catalog = hadoopCatalog();
     TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
 
-    AssertHelpers.assertThrows(
-        "Should reject a custom location",
-        IllegalArgumentException.class,
-        "Cannot set a custom location for a path-based table",
-        () -> catalog.buildTable(tableIdent, SCHEMA).withLocation("custom").create());
+    Assertions.assertThatThrownBy(
+            () -> catalog.buildTable(tableIdent, SCHEMA).withLocation("custom").create())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot set a custom location for a path-based table");
 
-    AssertHelpers.assertThrows(
-        "Should reject a custom location",
-        IllegalArgumentException.class,
-        "Cannot set a custom location for a path-based table",
-        () -> catalog.buildTable(tableIdent, SCHEMA).withLocation("custom").createTransaction());
+    Assertions.assertThatThrownBy(
+            () -> catalog.buildTable(tableIdent, SCHEMA).withLocation("custom").createTransaction())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot set a custom location for a path-based table");
 
-    AssertHelpers.assertThrows(
-        "Should reject a custom location",
-        IllegalArgumentException.class,
-        "Cannot set a custom location for a path-based table",
-        () ->
-            catalog
-                .buildTable(tableIdent, SCHEMA)
-                .withLocation("custom")
-                .createOrReplaceTransaction());
+    Assertions.assertThatThrownBy(
+            () ->
+                catalog
+                    .buildTable(tableIdent, SCHEMA)
+                    .withLocation("custom")
+                    .createOrReplaceTransaction())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot set a custom location for a path-based table");
   }
 
   @Test
@@ -251,13 +247,10 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     HadoopCatalog catalog = hadoopCatalog();
     TableIdentifier testTable = TableIdentifier.of("db", "tbl1");
     catalog.createTable(testTable, SCHEMA, PartitionSpec.unpartitioned());
-    AssertHelpers.assertThrows(
-        "should throw exception",
-        UnsupportedOperationException.class,
-        "Cannot rename Hadoop tables",
-        () -> {
-          catalog.renameTable(testTable, TableIdentifier.of("db", "tbl2"));
-        });
+    Assertions.assertThatThrownBy(
+            () -> catalog.renameTable(testTable, TableIdentifier.of("db", "tbl2")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot rename Hadoop tables");
   }
 
   @Test
@@ -282,13 +275,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Assert.assertEquals("table identifiers", 1, tbls2.size());
     Assert.assertEquals("table name", "tbl3", tbls2.get(0).name());
 
-    AssertHelpers.assertThrows(
-        "should throw exception",
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.listTables(Namespace.of("db", "ns1", "ns2"));
-        });
+    Assertions.assertThatThrownBy(() -> catalog.listTables(Namespace.of("db", "ns1", "ns2")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db.ns1.ns2");
   }
 
   @Test
@@ -326,13 +315,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     FileSystem fs2 = Util.getFs(new Path(metaLocation2), catalog.getConf());
     Assert.assertTrue(fs2.isDirectory(new Path(metaLocation2)));
 
-    AssertHelpers.assertThrows(
-        "Should fail to create when namespace already exist: " + tbl1.namespace(),
-        org.apache.iceberg.exceptions.AlreadyExistsException.class,
-        "Namespace already exists: " + tbl1.namespace(),
-        () -> {
-          catalog.createNamespace(tbl1.namespace());
-        });
+    Assertions.assertThatThrownBy(() -> catalog.createNamespace(tbl1.namespace()))
+        .isInstanceOf(org.apache.iceberg.exceptions.AlreadyExistsException.class)
+        .hasMessage("Namespace already exists: " + tbl1.namespace());
   }
 
   @Test
@@ -371,13 +356,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Assert.assertTrue(tblSet3.contains("db"));
     Assert.assertTrue(tblSet3.contains("db2"));
 
-    AssertHelpers.assertThrows(
-        "Should fail to list namespace doesn't exist",
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.listNamespaces(Namespace.of("db", "db2", "ns2"));
-        });
+    Assertions.assertThatThrownBy(() -> catalog.listNamespaces(Namespace.of("db", "db2", "ns2")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db.db2.ns2");
   }
 
   @Test
@@ -393,13 +374,10 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
         .forEach(t -> catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned()));
     catalog.loadNamespaceMetadata(Namespace.of("db"));
 
-    AssertHelpers.assertThrows(
-        "Should fail to load namespace doesn't exist",
-        NoSuchNamespaceException.class,
-        "Namespace does not exist: ",
-        () -> {
-          catalog.loadNamespaceMetadata(Namespace.of("db", "db2", "ns2"));
-        });
+    Assertions.assertThatThrownBy(
+            () -> catalog.loadNamespaceMetadata(Namespace.of("db", "db2", "ns2")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace does not exist: db.db2.ns2");
   }
 
   @Test
@@ -424,14 +402,13 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
   @Test
   public void testAlterNamespaceMeta() throws IOException {
     HadoopCatalog catalog = hadoopCatalog();
-    AssertHelpers.assertThrows(
-        "Should fail to change namespace",
-        UnsupportedOperationException.class,
-        "Cannot set namespace properties db.db2.ns2 : setProperties is not supported",
-        () -> {
-          catalog.setProperties(
-              Namespace.of("db", "db2", "ns2"), ImmutableMap.of("property", "test"));
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              catalog.setProperties(
+                  Namespace.of("db", "db2", "ns2"), ImmutableMap.of("property", "test"));
+            })
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot set namespace properties db.db2.ns2 : setProperties is not supported");
   }
 
   @Test
@@ -450,13 +427,12 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Lists.newArrayList(tbl1, tbl2)
         .forEach(t -> catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned()));
 
-    AssertHelpers.assertThrows(
-        "Should fail to drop namespace is not empty " + namespace1,
-        NamespaceNotEmptyException.class,
-        "Namespace " + namespace1 + " is not empty.",
-        () -> {
-          catalog.dropNamespace(Namespace.of("db"));
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              catalog.dropNamespace(Namespace.of("db"));
+            })
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessage("Namespace " + namespace1 + " is not empty.");
     Assert.assertFalse(
         "Should fail to drop namespace doesn't exist", catalog.dropNamespace(Namespace.of("db2")));
     Assert.assertTrue(catalog.dropTable(tbl1));
@@ -546,11 +522,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     // Check that we got 0 findVersion, and a NoSuchTableException is thrown when trying to load the
     // table
     Assert.assertEquals(0, tableOperations.findVersion());
-    AssertHelpers.assertThrows(
-        "Should not be able to find the table",
-        NoSuchTableException.class,
-        "Table does not exist",
-        () -> TABLES.load(tableLocation));
+    Assertions.assertThatThrownBy(() -> TABLES.load(tableLocation))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageStartingWith("Table does not exist");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -403,10 +403,9 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
   public void testAlterNamespaceMeta() throws IOException {
     HadoopCatalog catalog = hadoopCatalog();
     Assertions.assertThatThrownBy(
-            () -> {
-              catalog.setProperties(
-                  Namespace.of("db", "db2", "ns2"), ImmutableMap.of("property", "test"));
-            })
+            () ->
+                catalog.setProperties(
+                    Namespace.of("db", "db2", "ns2"), ImmutableMap.of("property", "test")))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Cannot set namespace properties db.db2.ns2 : setProperties is not supported");
   }
@@ -427,10 +426,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Lists.newArrayList(tbl1, tbl2)
         .forEach(t -> catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned()));
 
-    Assertions.assertThatThrownBy(
-            () -> {
-              catalog.dropNamespace(Namespace.of("db"));
-            })
+    Assertions.assertThatThrownBy(() -> catalog.dropNamespace(Namespace.of("db")))
         .isInstanceOf(NamespaceNotEmptyException.class)
         .hasMessage("Namespace " + namespace1 + " is not empty.");
     Assert.assertFalse(

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -39,7 +39,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -199,11 +198,9 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     version(2).createNewFile();
 
-    AssertHelpers.assertThrows(
-        "Should fail to commit change based on v1 when v2 exists",
-        CommitFailedException.class,
-        "Version 2 already exists",
-        update::commit);
+    Assertions.assertThatThrownBy(update::commit)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageStartingWith("Version 2 already exists");
 
     List<File> manifests = listManifestFiles();
     Assert.assertEquals("Should contain 0 Avro manifest files", 0, manifests.size());
@@ -235,11 +232,9 @@ public class TestHadoopCommits extends HadoopTableTestBase {
     Assert.assertEquals(
         "Copy should be back in sync", table.schema().asStruct(), tableCopy.schema().asStruct());
 
-    AssertHelpers.assertThrows(
-        "Should fail with stale base metadata",
-        CommitFailedException.class,
-        "based on stale table metadata",
-        updateCopy::commit);
+    Assertions.assertThatThrownBy(updateCopy::commit)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Cannot commit changes based on stale table metadata");
 
     List<File> manifests = listManifestFiles();
     Assert.assertEquals("Should contain 0 Avro manifest files", 0, manifests.size());

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -28,7 +28,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
@@ -41,6 +40,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,11 +75,10 @@ public class TestHadoopTables {
   public void testDropTable() {
     TABLES.create(SCHEMA, tableDir.toURI().toString());
     TABLES.dropTable(tableDir.toURI().toString());
-    AssertHelpers.assertThrows(
-        "Should complain about missing table",
-        NoSuchTableException.class,
-        "Table does not exist",
-        () -> TABLES.load(tableDir.toURI().toString()));
+
+    Assertions.assertThatThrownBy(() -> TABLES.load(tableDir.toURI().toString()))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageStartingWith("Table does not exist");
   }
 
   @Test
@@ -89,11 +88,9 @@ public class TestHadoopTables {
     createDummyTable(tableDir, dataDir);
 
     TABLES.dropTable(tableDir.toURI().toString(), true);
-    AssertHelpers.assertThrows(
-        "Should complain about missing table",
-        NoSuchTableException.class,
-        "Table does not exist",
-        () -> TABLES.load(tableDir.toURI().toString()));
+    Assertions.assertThatThrownBy(() -> TABLES.load(tableDir.toURI().toString()))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageStartingWith("Table does not exist");
 
     Assert.assertEquals(0, dataDir.listFiles().length);
     Assert.assertFalse(tableDir.exists());
@@ -108,11 +105,9 @@ public class TestHadoopTables {
     createDummyTable(tableDir, dataDir);
 
     TABLES.dropTable(tableDir.toURI().toString(), false);
-    AssertHelpers.assertThrows(
-        "Should complain about missing table",
-        NoSuchTableException.class,
-        "Table does not exist",
-        () -> TABLES.load(tableDir.toURI().toString()));
+    Assertions.assertThatThrownBy(() -> TABLES.load(tableDir.toURI().toString()))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageStartingWith("Table does not exist");
 
     Assert.assertEquals(1, dataDir.listFiles().length);
     Assert.assertFalse(tableDir.exists());

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -18,12 +18,12 @@
  */
 package org.apache.iceberg.hadoop;
 
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,20 +49,18 @@ public class TestStaticTable extends HadoopTableTestBase {
   @Test
   public void testCannotBeAddedTo() {
     Table staticTable = getStaticTable();
-    AssertHelpers.assertThrows(
-        "Cannot modify a static table",
-        UnsupportedOperationException.class,
-        () -> staticTable.newOverwrite().addFile(FILE_A).commit());
+    Assertions.assertThatThrownBy(() -> staticTable.newOverwrite().addFile(FILE_A).commit())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot modify a static table");
   }
 
   @Test
   public void testCannotBeDeletedFrom() {
     table.newAppend().appendFile(FILE_A).commit();
     Table staticTable = getStaticTable();
-    AssertHelpers.assertThrows(
-        "Cannot modify a static table",
-        UnsupportedOperationException.class,
-        () -> staticTable.newDelete().deleteFile(FILE_A).commit());
+    Assertions.assertThatThrownBy(() -> staticTable.newDelete().deleteFile(FILE_A).commit())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot modify a static table");
   }
 
   @Test
@@ -73,17 +71,13 @@ public class TestStaticTable extends HadoopTableTestBase {
       Table staticTable = getStaticTable(type);
 
       if (type.equals(MetadataTableType.POSITION_DELETES)) {
-        AssertHelpers.assertThrows(
-            "POSITION_DELETES table does not support TableScan",
-            UnsupportedOperationException.class,
-            "Cannot create TableScan from table of type POSITION_DELETES",
-            staticTable::newScan);
+        Assertions.assertThatThrownBy(staticTable::newScan)
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot create TableScan from table of type POSITION_DELETES");
       } else {
-        AssertHelpers.assertThrows(
-            "Static tables do not support incremental scans",
-            UnsupportedOperationException.class,
-            String.format("Cannot incrementally scan table of type %s", type),
-            () -> staticTable.newScan().appendsAfter(1));
+        Assertions.assertThatThrownBy(() -> staticTable.newScan().appendsAfter(1))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessage(String.format("Cannot incrementally scan table of type %s", type));
       }
     }
   }


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in iceberg-core-hadoop module.