### PR TITLE
Core: Implement adaptive split planning in core.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -206,6 +206,10 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
     };
   }
 
+  static <E> CloseableIterable<E> concat(CloseableIterable<E> i1, CloseableIterable<E> i2) {
+    return concat(ImmutableList.of(i1, i2));
+  }
+
   static <E> CloseableIterable<E> concat(Iterable<CloseableIterable<E>> iterable) {
     return new ConcatCloseableIterable<>(iterable);
   }


### PR DESCRIPTION
This adds utility methods for adaptive split planning to `TableScanUtil` in core.

The adaptive size is determined by eagerly loading file tasks up to the target parallelism * the requested split size. If that size is reached, then the requested split size is used. Otherwise, all files in the scan were loaded and the total size of the scan is used to create the split size by dividing the total size by the parallelism. If the resulting split size is too low, a minimum of 16MB is applied.

This differs from #7688 because that PR uses the total table size rather than a size specific to the scan. It also differs from #7714 because this is in core and is not specific to Spark. Any engine could set the scan parallelism and use adaptive split planning.