### PR TITLE
Spark 3.4: IcebergSource extends SessionConfigSupport

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -169,6 +169,7 @@ than options explicitly passed to DataFrameReader.
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
 | stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 
+
 ### Write options
 
 Spark write options are passed when configuring the DataFrameWriterV2, like this:

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -154,6 +154,10 @@ spark.read
     .table("catalog.db.table")
 ```
 
+Iceberg 1.8.0 and later support setting read options by Spark session configuration `spark.datasource.iceberg.<key>=<value>`
+when using DataFrame to read Iceberg tables, for example: `spark.datasource.iceberg.split-size=512m`, it has lower priority
+than options explicitly passed to DataFrameReader.
+
 | Spark option    | Default               | Description                                                                               |
 | --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
 | snapshot-id     | (latest)              | Snapshot ID of the table snapshot to read                                                 |
@@ -165,17 +169,22 @@ spark.read
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
 | stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 
+
 ### Write options
 
-Spark write options are passed when configuring the DataFrameWriter, like this:
+Spark write options are passed when configuring the DataFrameWriterV2, like this:
 
 ```scala
 // write with Avro instead of Parquet
-df.write
+df.writeTo("catalog.db.table")
     .option("write-format", "avro")
     .option("snapshot-property.key", "value")
-    .insertInto("catalog.db.table")
+    .append()
 ```
+
+Iceberg 1.8.0 and later support setting write options by Spark session configuration `spark.datasource.iceberg.<key>=<value>`
+when using DataFrame to write Iceberg tables, for example: `spark.datasource.iceberg.write-format=orc`, it has lower priority
+than options explicitly passed to DataFrameWriterV2.
 
 | Spark option           | Default                    | Description                                                  |
 | ---------------------- | -------------------------- | ------------------------------------------------------------ |

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -169,7 +169,6 @@ than options explicitly passed to DataFrameReader.
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
 | stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 
-
 ### Write options
 
 Spark write options are passed when configuring the DataFrameWriterV2, like this:

--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -154,10 +154,6 @@ spark.read
     .table("catalog.db.table")
 ```
 
-Iceberg 1.8.0 and later support setting read options by Spark session configuration `spark.datasource.iceberg.<key>=<value>`
-when using DataFrame to read Iceberg tables, for example: `spark.datasource.iceberg.split-size=512m`, it has lower priority
-than options explicitly passed to DataFrameReader.
-
 | Spark option    | Default               | Description                                                                               |
 | --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
 | snapshot-id     | (latest)              | Snapshot ID of the table snapshot to read                                                 |
@@ -169,22 +165,17 @@ than options explicitly passed to DataFrameReader.
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
 | stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 
-
 ### Write options
 
-Spark write options are passed when configuring the DataFrameWriterV2, like this:
+Spark write options are passed when configuring the DataFrameWriter, like this:
 
 ```scala
 // write with Avro instead of Parquet
-df.writeTo("catalog.db.table")
+df.write
     .option("write-format", "avro")
     .option("snapshot-property.key", "value")
-    .append()
+    .insertInto("catalog.db.table")
 ```
-
-Iceberg 1.8.0 and later support setting write options by Spark session configuration `spark.datasource.iceberg.<key>=<value>`
-when using DataFrame to write Iceberg tables, for example: `spark.datasource.iceberg.write-format=orc`, it has lower priority
-than options explicitly passed to DataFrameWriterV2.
 
 | Spark option           | Default                    | Description                                                  |
 | ---------------------- | -------------------------- | ------------------------------------------------------------ |

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SessionConfigSupport;
 import org.apache.spark.sql.connector.catalog.SupportsCatalogOptions;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -61,7 +62,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * <p>The above list is in order of priority. For example: a matching catalog will take priority
  * over any namespace resolution.
  */
-public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions {
+public class IcebergSource
+    implements DataSourceRegister, SupportsCatalogOptions, SessionConfigSupport {
   private static final String DEFAULT_CATALOG_NAME = "default_iceberg";
   private static final String DEFAULT_CACHE_CATALOG_NAME = "default_cache_iceberg";
   private static final String DEFAULT_CATALOG = "spark.sql.catalog." + DEFAULT_CATALOG_NAME;
@@ -78,6 +80,11 @@ public class IcebergSource implements DataSourceRegister, SupportsCatalogOptions
   @Override
   public String shortName() {
     return "iceberg";
+  }
+
+  @Override
+  public String keyPrefix() {
+    return shortName();
   }
 
   @Override

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -2216,7 +2216,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         });
 
     table.refresh();
-    assertThat(table.currentSnapshot().summary().get("foo")).isEqualTo("bar");
+    assertThat(table.currentSnapshot().summary()).containsEntry("foo", "bar");
 
     withSQLConf(
         // set read option through session configuration

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -2205,15 +2205,15 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     long s1 = table.currentSnapshot().snapshotId();
 
     withSQLConf(
-            // set write option through session configuration
-            ImmutableMap.of("spark.datasource.iceberg.snapshot-property.foo", "bar"),
-            () -> {
-              df.select("id", "data")
-                      .write()
-                      .format("iceberg")
-                      .mode(SaveMode.Append)
-                      .save(loadLocation(tableIdentifier));
-            });
+        // set write option through session configuration
+        ImmutableMap.of("spark.datasource.iceberg.snapshot-property.foo", "bar"),
+        () -> {
+          df.select("id", "data")
+              .write()
+              .format("iceberg")
+              .mode(SaveMode.Append)
+              .save(loadLocation(tableIdentifier));
+        });
 
     table.refresh();
     Assert.assertEquals("bar", table.currentSnapshot().summary().get("foo"));
@@ -2222,8 +2222,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         // set read option through session configuration
         ImmutableMap.of("spark.datasource.iceberg.snapshot-id", String.valueOf(s1)),
         () -> {
-          Dataset<Row> result =
-              spark.read().format("iceberg").load(loadLocation(tableIdentifier));
+          Dataset<Row> result = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
           List<SimpleRecord> actual = result.as(Encoders.bean(SimpleRecord.class)).collectAsList();
           Assert.assertEquals("Number of rows should match", initialRecords.size(), actual.size());
           Assert.assertEquals("Result rows should match", initialRecords, actual);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -2216,7 +2216,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         });
 
     table.refresh();
-    Assert.assertEquals("bar", table.currentSnapshot().summary().get("foo"));
+    assertThat(table.currentSnapshot().summary().get("foo")).isEqualTo("bar");
 
     withSQLConf(
         // set read option through session configuration
@@ -2224,8 +2224,9 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         () -> {
           Dataset<Row> result = spark.read().format("iceberg").load(loadLocation(tableIdentifier));
           List<SimpleRecord> actual = result.as(Encoders.bean(SimpleRecord.class)).collectAsList();
-          Assert.assertEquals("Number of rows should match", initialRecords.size(), actual.size());
-          Assert.assertEquals("Result rows should match", initialRecords, actual);
+          assertThat(actual)
+              .as("Rows must match")
+              .containsExactlyInAnyOrderElementsOf(initialRecords);
         });
   }
 


### PR DESCRIPTION
This PR aims to make `IcebergSource extends SessionConfigSupport` to improve the Spark DataSource v2 API coverage.
```
/**
 * A mix-in interface for {@link TableProvider}. Data sources can implement this interface to
 * propagate session configs with the specified key-prefix to all data source operations in this
 * session.
 *
 * @since 3.0.0
 */
@Evolving
public interface SessionConfigSupport extends TableProvider {

  /**
   * Key prefix of the session configs to propagate, which is usually the data source name. Spark
   * will extract all session configs that starts with `spark.datasource.$keyPrefix`, turn
   * `spark.datasource.$keyPrefix.xxx -&gt; yyy` into `xxx -&gt; yyy`, and propagate them to all
   * data source operations in this session.
   */
  String keyPrefix();
}
```

It allows to set read/write options by setting Spark session configuration when using the DataFrame API to read/write tables. For examples,


```
// set write option through session configuration
spark.sql("set spark.datasource.iceberg.<write-opt-key>=<value>")

spark.write
  .format("iceberg")
  .option("<write-opt-key>", "<value>") // equivalent w/ the above SET statement
  ...
```
