### PR TITLE
Spark 3.4: Allow control locality enabled on reading through session conf

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -73,7 +73,12 @@ public class SparkReadConf {
 
   public boolean localityEnabled() {
     boolean defaultValue = Util.mayHaveBlockLocations(table.io(), table.location());
-    return PropertyUtil.propertyAsBoolean(readOptions, SparkReadOptions.LOCALITY, defaultValue);
+    return confParser
+        .booleanConf()
+        .option(SparkReadOptions.LOCALITY)
+        .sessionConf(SparkSQLProperties.LOCALITY_ENABLED)
+        .defaultValue(defaultValue)
+        .parse();
   }
 
   public Long snapshotId() {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -25,6 +25,9 @@ public class SparkSQLProperties {
   // Controls whether vectorized reads are enabled
   public static final String VECTORIZATION_ENABLED = "spark.sql.iceberg.vectorization.enabled";
 
+  // Controls whether locality reads are enabled
+  public static final String LOCALITY_ENABLED = "spark.sql.iceberg.locality.enabled";
+
   // Controls whether reading/writing timestamps without timezones is allowed
   @Deprecated
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE =


### PR DESCRIPTION
This PR aims to allow user control locality enabled on reading through session conf `spark.sql.iceberg.locality.enabled`.

Previously, it's default enabled for HDFS, and can be disabled by setting read option, but it's is not friendly for SQL cases.

As described in https://github.com/apache/iceberg/pull/2577, the locality calculation may cause significant pressure on NameNode, after this PR, user can conveniently disable it by setting `spark.sql.iceberg.locality.enabled=false`