### PR TITLE
Spark 3.4: Correct the two-stage parsing strategy of antlr parser

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestBranchDDL.java
@@ -217,13 +217,13 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE BRANCH %s RETAIN", tableName, branchName))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input");
+        .hasMessageContaining("no viable alternative at input");
 
     assertThatThrownBy(
             () ->
                 sql("ALTER TABLE %s CREATE BRANCH %s RETAIN %s DAYS", tableName, branchName, "abc"))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input");
+        .hasMessageContaining("no viable alternative at input");
 
     assertThatThrownBy(
             () ->
@@ -273,7 +273,7 @@ public class TestBranchDDL extends SparkExtensionsTestBase {
   public void testDropBranchNonConformingName() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP BRANCH %s", tableName, "123"))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input '123'");
+        .hasMessageContaining("no viable alternative at input '123'");
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -102,12 +102,12 @@ public class TestTagDDL extends SparkExtensionsTestBase {
                     "ALTER TABLE %s CREATE TAG %s AS OF VERSION %d RETAIN",
                     tableName, tagName, firstSnapshotId, maxRefAge))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input");
+        .hasMessageContaining("no viable alternative at input '<EOF>'");
 
     assertThatThrownBy(
             () -> sql("ALTER TABLE %s CREATE TAG %s RETAIN %s DAYS", tableName, tagName, "abc"))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input");
+        .hasMessageContaining("no viable alternative at input 'abc'");
 
     assertThatThrownBy(
             () ->
@@ -152,7 +152,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
 
     assertThatThrownBy(() -> sql("ALTER TABLE %s CREATE TAG %s", tableName, "123"))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input '123'");
+        .hasMessageContaining("no viable alternative at input '123'");
 
     table.manageSnapshots().removeTag(tagName).commit();
     List<SimpleRecord> records =
@@ -306,7 +306,7 @@ public class TestTagDDL extends SparkExtensionsTestBase {
   public void testDropTagNonConformingName() {
     assertThatThrownBy(() -> sql("ALTER TABLE %s DROP TAG %s", tableName, "123"))
         .isInstanceOf(IcebergParseException.class)
-        .hasMessageContaining("mismatched input '123'");
+        .hasMessageContaining("no viable alternative at input '123'");
   }
 
   @Test


### PR DESCRIPTION
As mentioned in https://github.com/antlr/antlr4/issues/192#issuecomment-15238595

> You can save a great deal of time on correct inputs by using a two-stage parsing strategy.
>
> 1. Attempt to parse the input using BailErrorStrategy and PredictionMode.SLL.
>    If no exception is thrown, you know the answer is correct.
> 2. If a ParseCancellationException is thrown, retry the parse using the default
>    settings (DefaultErrorStrategy and PredictionMode.LL).

Iceberg's antlr parser code is derived from Spark, and Spark's one is derived from Presto, the original implementation in Presto is wrong.

It was identified on Spark and got fixed in SPARK-42552 https://github.com/apache/spark/pull/40835

The Iceberg extended syntax is not complicated enough, I suppose this fix does not have functionality impacts.