### PR TITLE
Support other FileIO implementations with InMemoryCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -88,7 +88,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
-    this.io = new InMemoryFileIO();
+    String ioImpl =
+        properties.getOrDefault(CatalogProperties.FILE_IO_IMPL, InMemoryFileIO.class.getName());
+    this.io = CatalogUtil.loadFileIO(ioImpl, properties, null);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);


### PR DESCRIPTION
Currently `InMemoryCatalog` is only supporting, it will be nice to support other File-Io implementations like S3FileIO + Minio. 

https://github.com/apache/iceberg/blob/601c5af9b6abded79dabeba177331310d5487f43/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java#L83


cc: @nastra do you see any potential issue combining InMemoryCatalog with other FileIo implementations?