### PR TITLE
Core, Spark: Fix migrate table in case of partitioned table with partition containing a special character

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -89,6 +89,31 @@ public class DataFiles {
     return data;
   }
 
+  static PartitionData fillFromValues(
+      PartitionSpec spec, List<String> partitionValues, PartitionData reuse) {
+    PartitionData data = reuse;
+    if (data == null) {
+      data = newPartitionData(spec);
+    }
+
+    Preconditions.checkArgument(
+        partitionValues.size() <= spec.fields().size(),
+        "Invalid partition data, too many fields (expecting %s): %s",
+        spec.fields().size(),
+        partitionValues.size());
+    Preconditions.checkArgument(
+        partitionValues.size() >= spec.fields().size(),
+        "Invalid partition data, not enough fields (expecting %s): %s",
+        spec.fields().size(),
+        partitionValues.size());
+
+    for (int i = 0; i < partitionValues.size(); i += 1) {
+      data.set(i, Conversions.fromPartitionString(data.getType(i), partitionValues.get(i)));
+    }
+
+    return data;
+  }
+
   public static PartitionData data(PartitionSpec spec, String partitionPath) {
     return fillFromPath(spec, partitionPath, null);
   }
@@ -244,6 +269,16 @@ public class DataFiles {
           "Cannot add partition data for an unpartitioned table");
       if (!newPartitionPath.isEmpty()) {
         this.partitionData = fillFromPath(spec, newPartitionPath, partitionData);
+      }
+      return this;
+    }
+
+    public Builder withPartitionValues(List<String> partitionValues) {
+      Preconditions.checkArgument(
+          isPartitioned || partitionValues.isEmpty(),
+          "Cannot add partition data for an unpartitioned table");
+      if (!partitionValues.isEmpty()) {
+        this.partitionData = fillFromValues(spec, partitionValues, partitionData);
       }
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -270,8 +270,7 @@ public class DataFiles {
 
     public Builder withPartitionValues(List<String> partitionValues) {
       Preconditions.checkArgument(
-          (isPartitioned && !partitionValues.isEmpty())
-              || (!isPartitioned && partitionValues.isEmpty()),
+          isPartitioned ^ partitionValues.isEmpty(),
           "Table must be partitioned or partition values must be empty");
       if (!partitionValues.isEmpty()) {
         this.partitionData = fillFromValues(spec, partitionValues, partitionData);

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -270,8 +270,9 @@ public class DataFiles {
 
     public Builder withPartitionValues(List<String> partitionValues) {
       Preconditions.checkArgument(
-          isPartitioned || partitionValues.isEmpty(),
-          "Cannot add partition data for an unpartitioned table");
+          (isPartitioned && !partitionValues.isEmpty())
+              || (!isPartitioned && partitionValues.isEmpty()),
+          "Table must be partitioned or partition values must be empty");
       if (!partitionValues.isEmpty()) {
         this.partitionData = fillFromValues(spec, partitionValues, partitionData);
       }

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -97,13 +97,8 @@ public class DataFiles {
     }
 
     Preconditions.checkArgument(
-        partitionValues.size() <= spec.fields().size(),
-        "Invalid partition data, too many fields (expecting %s): %s",
-        spec.fields().size(),
-        partitionValues.size());
-    Preconditions.checkArgument(
-        partitionValues.size() >= spec.fields().size(),
-        "Invalid partition data, not enough fields (expecting %s): %s",
+        partitionValues.size() == spec.fields().size(),
+        "Invalid partition data, expecting %s fields, found %s",
         spec.fields().size(),
         partitionValues.size());
 

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -58,7 +58,7 @@ public class TableMigrationUtil {
    * Returns the data files in a partition by listing the partition location.
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
-   * partitions, metrics are set to null.
+   * partitions, metrics other than row count are set to null.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.
@@ -88,7 +88,7 @@ public class TableMigrationUtil {
    * the files and the file reading is done in parallel by a specified number of threads.
    *
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
-   * partitions, metrics are set to null.
+   * partitions, metrics other than row count are set to null.
    *
    * <p>Note: certain metrics, like NaN counts, that are only supported by Iceberg file writers but
    * not file footers, will not be populated.

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -190,15 +190,15 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
-            + "PARTITIONED BY (data) LOCATION '%s'",
+        "CREATE TABLE %s (id bigint NOT NULL, data string, dt date) USING parquet "
+            + "PARTITIONED BY (data, dt) LOCATION '%s'",
         tableName, location);
-    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30', date '2023-05-30')", tableName);
     Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
 
     assertEquals(
         "Should have expected rows",
-        ImmutableList.of(row(1L, "2023/05/30")),
+        ImmutableList.of(row(1L, "2023/05/30", java.sql.Date.valueOf("2023-05-30"))),
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -184,4 +184,21 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         "Cannot handle an empty identifier",
         () -> sql("CALL %s.system.migrate('')", catalogName));
   }
+
+  @Test
+  public void testMigratePartitionWithSpecialCharacter() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+    String location = temp.newFolder().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
+            + "PARTITIONED BY (data) LOCATION '%s'",
+        tableName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
+
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1L, "2023/05/30")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -190,15 +190,15 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
-            + "PARTITIONED BY (data) LOCATION '%s'",
+        "CREATE TABLE %s (id bigint NOT NULL, data string, dt date) USING parquet "
+            + "PARTITIONED BY (data, dt) LOCATION '%s'",
         tableName, location);
-    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30', date '2023-05-30')", tableName);
     Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
 
     assertEquals(
         "Should have expected rows",
-        ImmutableList.of(row(1L, "2023/05/30")),
+        ImmutableList.of(row(1L, "2023/05/30", java.sql.Date.valueOf("2023-05-30"))),
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -184,4 +184,21 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         "Cannot handle an empty identifier",
         () -> sql("CALL %s.system.migrate('')", catalogName));
   }
+
+  @Test
+  public void testMigratePartitionWithSpecialCharacter() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+    String location = temp.newFolder().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
+            + "PARTITIONED BY (data) LOCATION '%s'",
+        tableName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
+
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1L, "2023/05/30")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -190,15 +190,15 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
-            + "PARTITIONED BY (data) LOCATION '%s'",
+        "CREATE TABLE %s (id bigint NOT NULL, data string, dt date) USING parquet "
+            + "PARTITIONED BY (data, dt) LOCATION '%s'",
         tableName, location);
-    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30', date '2023-05-30')", tableName);
     Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
 
     assertEquals(
         "Should have expected rows",
-        ImmutableList.of(row(1L, "2023/05/30")),
+        ImmutableList.of(row(1L, "2023/05/30", java.sql.Date.valueOf("2023-05-30"))),
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -103,7 +103,7 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         ImmutableList.of(row(1L, "a"), row(1L, "a")),
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
-    sql("DROP TABLE IF EXISTS  %s", tableName + "_BACKUP_");
+    sql("DROP TABLE IF EXISTS %s", tableName + "_BACKUP_");
   }
 
   @Test
@@ -183,5 +183,22 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         IllegalArgumentException.class,
         "Cannot handle an empty identifier",
         () -> sql("CALL %s.system.migrate('')", catalogName));
+  }
+
+  @Test
+  public void testMigratePartitionWithSpecialCharacter() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+    String location = temp.newFolder().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
+            + "PARTITIONED BY (data) LOCATION '%s'",
+        tableName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
+
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1L, "2023/05/30")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -190,15 +190,15 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
     Assume.assumeTrue(catalogName.equals("spark_catalog"));
     String location = temp.newFolder().toString();
     sql(
-        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
-            + "PARTITIONED BY (data) LOCATION '%s'",
+        "CREATE TABLE %s (id bigint NOT NULL, data string, dt date) USING parquet "
+            + "PARTITIONED BY (data, dt) LOCATION '%s'",
         tableName, location);
-    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30', date '2023-05-30')", tableName);
     Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
 
     assertEquals(
         "Should have expected rows",
-        ImmutableList.of(row(1L, "2023/05/30")),
+        ImmutableList.of(row(1L, "2023/05/30", java.sql.Date.valueOf("2023-05-30"))),
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -103,7 +103,7 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         ImmutableList.of(row(1L, "a"), row(1L, "a")),
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
-    sql("DROP TABLE IF EXISTS  %s", tableName + "_BACKUP_");
+    sql("DROP TABLE IF EXISTS %s", tableName + "_BACKUP_");
   }
 
   @Test
@@ -183,5 +183,22 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         IllegalArgumentException.class,
         "Cannot handle an empty identifier",
         () -> sql("CALL %s.system.migrate('')", catalogName));
+  }
+
+  @Test
+  public void testMigratePartitionWithSpecialCharacter() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+    String location = temp.newFolder().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet "
+            + "PARTITIONED BY (data) LOCATION '%s'",
+        tableName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, '2023/05/30')", tableName);
+    Object result = scalarSql("CALL %s.system.migrate('%s')", catalogName, tableName);
+
+    assertEquals(
+        "Should have expected rows",
+        ImmutableList.of(row(1L, "2023/05/30")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 }


### PR DESCRIPTION
This is https://github.com/apache/iceberg/issues/7612 reported by @gaborkaszab.

In this change, we fix the Spark migrate procedure to be able to handle a partition where a partition value contains '/'.
We do this by fixing `TableMigrationUtil.listPartition`. Instead of constructing a partition key (a String like `a=1/b=2`) from the `Map<String, String>` of partition column to partition value that is passed in, and then calling `DataFiles.fillFromPath` (via `DataFiles.Builder#withPartitionPath`) with the partition key String, where it is then split along '/' and the value recovered for each partition column (by further splitting along '='), we simply construct a List of the partition values and hand that off.

(We retain `DataFiles.fillFromPath` and `DataFiles.Builder#withPartitionPath` for other existing callers.)

We add a unit test that shows the problem; without the fix, the test fails with 
```
java.lang.IllegalArgumentException: Invalid partition data, too many fields (expecting 1): data=2023/05/30
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:326)
	at org.apache.iceberg.DataFiles.fillFromPath(DataFiles.java:67)
	at org.apache.iceberg.DataFiles$Builder.withPartitionPath(DataFiles.java:246)
	at org.apache.iceberg.data.TableMigrationUtil.buildDataFile(TableMigrationUtil.java:190)
	at org.apache.iceberg.data.TableMigrationUtil.lambda$listPartition$3(TableMigrationUtil.java:131)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:413)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:219)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:203)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:196)
	at org.apache.iceberg.data.TableMigrationUtil.listPartition(TableMigrationUtil.java:126)
	at org.apache.iceberg.data.TableMigrationUtil.listPartition(TableMigrationUtil.java:83)
	at org.apache.iceberg.spark.SparkTableUtil.listPartition(SparkTableUtil.java:278)
```
