### PR TITLE
Core: Switch tests to Junit5 in rest.auth pakage

### DIFF
--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -20,37 +20,53 @@ package org.apache.iceberg.rest.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOAuth2Util {
   @Test
   public void testOAuthScopeTokenValidation() {
     // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
     // test characters that are outside of the ! to ~ range and the excluded characters, " and \
-    Assert.assertFalse("Should reject scope token with \\", OAuth2Util.isValidScopeToken("a\\b"));
-    Assert.assertFalse("Should reject scope token with space", OAuth2Util.isValidScopeToken("a b"));
-    Assert.assertFalse("Should reject scope token with \"", OAuth2Util.isValidScopeToken("a\"b"));
-    Assert.assertFalse(
-        "Should reject scope token with DEL", OAuth2Util.isValidScopeToken("\u007F"));
+    assertThat(OAuth2Util.isValidScopeToken("a\\b"))
+        .as("Should reject scope token with \\")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("a b"))
+        .as("Should reject scope token with space")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("a\"b"))
+        .as("Should reject scope token with \"")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("\u007F"))
+        .as("Should reject scope token with DEL")
+        .isFalse();
     // test all characters that are inside of the ! to ~ range and are not excluded
-    Assert.assertTrue(
-        "Should accept scope token with !-/", OAuth2Util.isValidScopeToken("!#$%&'()*+,-./"));
-    Assert.assertTrue(
-        "Should accept scope token with 0-9", OAuth2Util.isValidScopeToken("0123456789"));
-    Assert.assertTrue(
-        "Should accept scope token with :-@", OAuth2Util.isValidScopeToken(":;<=>?@"));
-    Assert.assertTrue(
-        "Should accept scope token with A-M", OAuth2Util.isValidScopeToken("ABCDEFGHIJKLM"));
-    Assert.assertTrue(
-        "Should accept scope token with N-Z", OAuth2Util.isValidScopeToken("NOPQRSTUVWXYZ"));
-    Assert.assertTrue(
-        "Should accept scope token with [-`, not \\", OAuth2Util.isValidScopeToken("[]^_`"));
-    Assert.assertTrue(
-        "Should accept scope token with a-m", OAuth2Util.isValidScopeToken("abcdefghijklm"));
-    Assert.assertTrue(
-        "Should accept scope token with n-z", OAuth2Util.isValidScopeToken("nopqrstuvwxyz"));
-    Assert.assertTrue("Should accept scope token with {-~", OAuth2Util.isValidScopeToken("{|}~"));
+    assertThat(OAuth2Util.isValidScopeToken("!#$%&'()*+,-./"))
+        .as("Should accept scope token with !-/")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("0123456789"))
+        .as("Should accept scope token with 0-9")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken(":;<=>?@"))
+        .as("Should accept scope token with :-@")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("ABCDEFGHIJKLM"))
+        .as("Should accept scope token with A-M")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("NOPQRSTUVWXYZ"))
+        .as("Should accept scope token with N-Z")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("[]^_`"))
+        .as("Should accept scope token with [-`, not \\")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("abcdefghijklm"))
+        .as("Should accept scope token with a-m")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("nopqrstuvwxyz"))
+        .as("Should accept scope token with n-z")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("{|}~"))
+        .as("Should accept scope token with {-~")
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
This pull request is related to the issue "Move JUnit4 tests to JUnit5 https://github.com/apache/iceberg/issues/7160".
I switched the file in the auth package(which is  in rest pakage) from JUnit4 to JUnit5. 

