### PR TITLE
Core: Switch tests to Junit5 in deletes,expressions,auth packages

### DIFF
--- a/core/src/test/java/org/apache/iceberg/deletes/TestEqualityFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestEqualityFilter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.deletes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.Schema;
@@ -27,8 +29,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestEqualityFilter {
   private static final Schema ROW_SCHEMA =
@@ -63,14 +64,14 @@ public class TestEqualityFilter {
             Row.of(7L, "g", "grizzly"),
             Row.of(8L, "h", null));
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        expected,
+    List<StructLike> actual =
         Lists.newArrayList(
             Deletes.filter(
                 ROWS,
                 row -> Row.of(row.get(0, Long.class)),
-                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("id").asStruct()))));
+                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("id").asStruct())));
+
+    assertThat(actual).as("Filter should produce expected rows").isEqualTo(expected);
   }
 
   @Test
@@ -86,14 +87,14 @@ public class TestEqualityFilter {
             Row.of(6L, "f", new Utf8("teddy")),
             Row.of(7L, "g", "grizzly"));
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        expected,
+    List<StructLike> actual =
         Lists.newArrayList(
             Deletes.filter(
                 ROWS,
                 row -> Row.of(row.get(1, CharSequence.class)),
-                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("name").asStruct()))));
+                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("name").asStruct())));
+
+    assertThat(actual).as("Filter should produce expected rows").isEqualTo(expected);
   }
 
   @Test
@@ -111,14 +112,14 @@ public class TestEqualityFilter {
             Row.of(6L, "f", new Utf8("teddy")),
             Row.of(7L, "g", "grizzly"));
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        expected,
+    List<StructLike> actual =
         Lists.newArrayList(
             Deletes.filter(
                 ROWS,
                 row -> Row.of(row.get(2, CharSequence.class)),
-                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("description").asStruct()))));
+                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("description").asStruct())));
+
+    assertThat(actual).as("Filter should produce expected rows").isEqualTo(expected);
   }
 
   @Test
@@ -136,14 +137,13 @@ public class TestEqualityFilter {
             Row.of(6L, "f", new Utf8("teddy")),
             Row.of(7L, "g", "grizzly"));
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        expected,
+    List<StructLike> actual =
         Lists.newArrayList(
             Deletes.filter(
                 ROWS,
                 row -> Row.of(row.get(0, Long.class), row.get(2, CharSequence.class)),
-                Deletes.toEqualitySet(
-                    deletes, ROW_SCHEMA.select("id", "description").asStruct()))));
+                Deletes.toEqualitySet(deletes, ROW_SCHEMA.select("id", "description").asStruct())));
+
+    assertThat(actual).as("Filter should produce expected rows").isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.deletes;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.function.Predicate;
 import org.apache.avro.util.Utf8;
@@ -27,8 +29,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestPositionFilter {
   @Test
@@ -46,26 +47,23 @@ public class TestPositionFilter {
             Row.of("file_b.avro", 70L),
             Row.of("file_b.avro", 91L));
 
-    Assert.assertEquals(
-        "Should contain only file_a positions",
-        Lists.newArrayList(0L, 3L, 9L, 22L, 56L),
-        Lists.newArrayList(
+    assertThat(
             Deletes.deletePositions(
-                "file_a.avro", CloseableIterable.withNoopClose(positionDeletes))));
+                "file_a.avro", CloseableIterable.withNoopClose(positionDeletes)))
+        .as("Should contain only file_a positions")
+        .containsExactly(0L, 3L, 9L, 22L, 56L);
 
-    Assert.assertEquals(
-        "Should contain only file_b positions",
-        Lists.newArrayList(16L, 19L, 63L, 70L, 91L),
-        Lists.newArrayList(
+    assertThat(
             Deletes.deletePositions(
-                "file_b.avro", CloseableIterable.withNoopClose(positionDeletes))));
+                "file_b.avro", CloseableIterable.withNoopClose(positionDeletes)))
+        .as("Should contain only file_b positions")
+        .containsExactly(16L, 19L, 63L, 70L, 91L);
 
-    Assert.assertEquals(
-        "Should contain no positions for file_c",
-        Lists.newArrayList(),
-        Lists.newArrayList(
+    assertThat(
             Deletes.deletePositions(
-                "file_c.avro", CloseableIterable.withNoopClose(positionDeletes))));
+                "file_c.avro", CloseableIterable.withNoopClose(positionDeletes)))
+        .as("Should contain no positions for file_c")
+        .isEmpty();
   }
 
   @Test
@@ -96,10 +94,9 @@ public class TestPositionFilter {
             CloseableIterable.withNoopClose(positionDeletes2),
             CloseableIterable.withNoopClose(positionDeletes3));
 
-    Assert.assertEquals(
-        "Should merge deletes in order, with duplicates",
-        Lists.newArrayList(0L, 3L, 3L, 9L, 16L, 19L, 19L, 22L, 22L, 56L, 63L, 70L, 91L),
-        Lists.newArrayList(Deletes.deletePositions("file_a.avro", deletes)));
+    assertThat(Deletes.deletePositions("file_a.avro", deletes))
+        .as("Should merge deletes in order, with duplicates")
+        .containsExactly(0L, 3L, 3L, 9L, 16L, 19L, 19L, 22L, 22L, 56L, 63L, 70L, 91L);
   }
 
   @Test
@@ -123,10 +120,10 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual =
         Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 
   @Test
@@ -154,10 +151,11 @@ public class TestPositionFilter {
             row -> row.get(0, Long.class), /* row to position */
             deletes,
             row -> row.set(2, true) /* delete marker */);
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(true, false, false, true, true, false, false, true, false, true),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(2, Boolean.class))));
+
+    assertThat(Iterables.transform(actual, row -> row.get(2, Boolean.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(
+            Lists.newArrayList(true, false, false, true, true, false, false, true, false, true));
   }
 
   @Test
@@ -181,10 +179,10 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual =
         Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 
   @Test
@@ -199,10 +197,10 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual =
         Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(5L, 6L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(5L, 6L));
   }
 
   @Test
@@ -245,10 +243,9 @@ public class TestPositionFilter {
             Deletes.deletePositions(
                 "file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 
   @Test
@@ -273,10 +270,10 @@ public class TestPositionFilter {
     Predicate<StructLike> shouldKeep =
         row -> !Deletes.toPositionIndex(deletes).isDeleted(row.get(0, Long.class));
     CloseableIterable<StructLike> actual = CloseableIterable.filter(rows, shouldKeep);
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 
   @Test
@@ -320,9 +317,8 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual = CloseableIterable.filter(rows, isDeleted.negate());
 
-    Assert.assertEquals(
-        "Filter should produce expected rows",
-        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
-        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+    assertThat(Iterables.transform(actual, row -> row.get(0, Long.class)))
+        .as("Filter should produce expected rows")
+        .containsExactlyElementsOf(Lists.newArrayList(1L, 2L, 5L, 6L, 8L));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -28,8 +28,7 @@ import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestExpressionParser {
 
@@ -102,13 +101,14 @@ public class TestExpressionParser {
       String boundJson = ExpressionParser.toJson(bound, true);
       String unboundJson = ExpressionParser.toJson(expr, true);
 
-      Assert.assertEquals(
-          "Bound and unbound should produce identical json", boundJson, unboundJson);
+      Assertions.assertThat(boundJson)
+          .as("Bound and unbound should produce identical json")
+          .isEqualTo(unboundJson);
 
       Expression parsed = ExpressionParser.fromJson(boundJson, SCHEMA);
-      Assert.assertTrue(
-          "Round-trip value should be equivalent",
-          ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true));
+      Assertions.assertThat(ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true))
+          .as("Round-trip value should be equivalent")
+          .isTrue();
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -20,37 +20,53 @@ package org.apache.iceberg.rest.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestOAuth2Util {
   @Test
   public void testOAuthScopeTokenValidation() {
     // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
     // test characters that are outside of the ! to ~ range and the excluded characters, " and \
-    Assert.assertFalse("Should reject scope token with \\", OAuth2Util.isValidScopeToken("a\\b"));
-    Assert.assertFalse("Should reject scope token with space", OAuth2Util.isValidScopeToken("a b"));
-    Assert.assertFalse("Should reject scope token with \"", OAuth2Util.isValidScopeToken("a\"b"));
-    Assert.assertFalse(
-        "Should reject scope token with DEL", OAuth2Util.isValidScopeToken("\u007F"));
+    assertThat(OAuth2Util.isValidScopeToken("a\\b"))
+        .as("Should reject scope token with \\")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("a b"))
+        .as("Should reject scope token with space")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("a\"b"))
+        .as("Should reject scope token with \"")
+        .isFalse();
+    assertThat(OAuth2Util.isValidScopeToken("\u007F"))
+        .as("Should reject scope token with DEL")
+        .isFalse();
     // test all characters that are inside of the ! to ~ range and are not excluded
-    Assert.assertTrue(
-        "Should accept scope token with !-/", OAuth2Util.isValidScopeToken("!#$%&'()*+,-./"));
-    Assert.assertTrue(
-        "Should accept scope token with 0-9", OAuth2Util.isValidScopeToken("0123456789"));
-    Assert.assertTrue(
-        "Should accept scope token with :-@", OAuth2Util.isValidScopeToken(":;<=>?@"));
-    Assert.assertTrue(
-        "Should accept scope token with A-M", OAuth2Util.isValidScopeToken("ABCDEFGHIJKLM"));
-    Assert.assertTrue(
-        "Should accept scope token with N-Z", OAuth2Util.isValidScopeToken("NOPQRSTUVWXYZ"));
-    Assert.assertTrue(
-        "Should accept scope token with [-`, not \\", OAuth2Util.isValidScopeToken("[]^_`"));
-    Assert.assertTrue(
-        "Should accept scope token with a-m", OAuth2Util.isValidScopeToken("abcdefghijklm"));
-    Assert.assertTrue(
-        "Should accept scope token with n-z", OAuth2Util.isValidScopeToken("nopqrstuvwxyz"));
-    Assert.assertTrue("Should accept scope token with {-~", OAuth2Util.isValidScopeToken("{|}~"));
+    assertThat(OAuth2Util.isValidScopeToken("!#$%&'()*+,-./"))
+        .as("Should accept scope token with !-/")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("0123456789"))
+        .as("Should accept scope token with 0-9")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken(":;<=>?@"))
+        .as("Should accept scope token with :-@")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("ABCDEFGHIJKLM"))
+        .as("Should accept scope token with A-M")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("NOPQRSTUVWXYZ"))
+        .as("Should accept scope token with N-Z")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("[]^_`"))
+        .as("Should accept scope token with [-`, not \\")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("abcdefghijklm"))
+        .as("Should accept scope token with a-m")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("nopqrstuvwxyz"))
+        .as("Should accept scope token with n-z")
+        .isTrue();
+    assertThat(OAuth2Util.isValidScopeToken("{|}~"))
+        .as("Should accept scope token with {-~")
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
This pull request is related to the issue "Move JUnit4 tests to JUnit5 https://github.com/apache/iceberg/issues/7160".
I switched the files in the deletes, expressions, auth packages from JUnit4 to JUnit5.

@nastra I fixed the commit with what you reviewed, but something went wrong with the GitHub push, so I clean up the files and resubmit the PR.
Based on your review, I removed unnecessary parts.