### PR TITLE
Docs: Fix SQL formatting in Flink docs

### DIFF
--- a/docs/flink-ddl.md
+++ b/docs/flink-ddl.md
@@ -168,8 +168,8 @@ To create a partition table, use `PARTITIONED BY`:
 
 ```sql
 CREATE TABLE `hive_catalog`.`default`.`sample` (
-                                                   id BIGINT COMMENT 'unique id',
-                                                   data STRING
+    id BIGINT COMMENT 'unique id',
+    data STRING
 ) PARTITIONED BY (data);
 ```
 
@@ -181,8 +181,8 @@ To create a table with the same schema, partitioning, and table properties as an
 
 ```sql
 CREATE TABLE `hive_catalog`.`default`.`sample` (
-                                                   id BIGINT COMMENT 'unique id',
-                                                   data STRING
+    id BIGINT COMMENT 'unique id',
+    data STRING
 );
 
 CREATE TABLE  `hive_catalog`.`default`.`sample_like` LIKE `hive_catalog`.`default`.`sample`;

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -77,7 +77,7 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 ./bin/start-cluster.sh
 ```
 
-Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{% icebergVersion %}}/).
+Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository] (https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{%icebergVersion%}}/).
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -399,4 +399,4 @@ There are some features that are do not yet supported in the current Flink Icebe
 * Don't support creating iceberg table with computed column.
 * Don't support creating iceberg table with watermark.
 * Don't support adding columns, removing columns, renaming columns, changing columns. [FLINK-19062](https://issues.apache.org/jira/browse/FLINK-19062) is tracking this.
-* 
+*

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -77,7 +77,7 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 ./bin/start-cluster.sh
 ```
 
-Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{%icebergVersion%}}/).
+Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{% icebergVersion %}}/).
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -399,4 +399,4 @@ There are some features that are do not yet supported in the current Flink Icebe
 * Don't support creating iceberg table with computed column.
 * Don't support creating iceberg table with watermark.
 * Don't support adding columns, removing columns, renaming columns, changing columns. [FLINK-19062](https://issues.apache.org/jira/browse/FLINK-19062) is tracking this.
-*
+* 

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -77,7 +77,7 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 ./bin/start-cluster.sh
 ```
 
-Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository] (https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{%icebergVersion%}}/).
+Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{% icebergVersion %}}/).
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -77,7 +77,7 @@ export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 ./bin/start-cluster.sh
 ```
 
-Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{% icebergVersion %}}/).
+Start the Flink SQL client. There is a separate `flink-runtime` module in the Iceberg project to generate a bundled jar, which could be loaded by Flink SQL client directly. To build the `flink-runtime` bundled jar manually, build the `iceberg` project, and it will generate the jar under `<iceberg-root-dir>/flink-runtime/build/libs`. Or download the `flink-runtime` jar from the [Apache repository](https://repo.maven.apache.org/maven2/org/apache/iceberg/iceberg-flink-runtime-1.16/{{%icebergVersion%}}/).
 
 ```bash
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.


### PR DESCRIPTION
1.Fix URL link in flink-getting-started.md
Before：
<img width="1141" alt="1685806883434" src="https://github.com/apache/iceberg/assets/45089228/a31f1740-b3c8-46c8-94e3-e9d0de59e65e">
After：
<img width="875" alt="9ad0fc83646b9595fcec533150e740c" src="https://github.com/apache/iceberg/assets/45089228/429cda07-8460-41a9-aa47-acb646c8a486">

2.Fix docs format in flink-ddl.md
Before：
<img width="880" alt="d0ebe493d93bbf01d345eca3d3b15b5" src="https://github.com/apache/iceberg/assets/45089228/74d33047-92dc-49bb-87ce-e466d8fde6f0">
After：
<img width="579" alt="163ad880a116c75d7f2c13cfd57bbf5" src="https://github.com/apache/iceberg/assets/45089228/9937ebee-ee1c-489b-9fdf-6a4ae180054c">
