### PR TITLE
Core: Switch tests to Junit5 in catalog,encryption,inmemory,io,view

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -62,8 +62,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
@@ -168,70 +166,71 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testCreateNamespace() {
     C catalog = catalog();
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
 
     catalog.createNamespace(NS);
-    Assert.assertTrue(
-        "Catalog should have the created namespace", catalog.listNamespaces().contains(NS));
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.listNamespaces())
+        .as("Catalog should have the created namespace")
+        .contains(NS);
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
   }
 
   @Test
   public void testCreateExistingNamespace() {
     C catalog = catalog();
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
 
     catalog.createNamespace(NS);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
 
     Assertions.assertThatThrownBy(() -> catalog.createNamespace(NS))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("Namespace already exists");
 
-    Assert.assertTrue("Namespace should still exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should still exist").isTrue();
   }
 
   @Test
   public void testCreateNamespaceWithProperties() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
 
     Map<String, String> createProps = ImmutableMap.of("prop", "val");
     catalog.createNamespace(NS, createProps);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
 
     Map<String, String> props = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Create properties should be a subset of returned properties",
-        createProps.entrySet(),
-        Sets.intersection(createProps.entrySet(), props.entrySet()));
+
+    Assertions.assertThat(Sets.intersection(createProps.entrySet(), props.entrySet()))
+        .as("Create properties should be a subset of returned properties")
+        .containsExactlyInAnyOrderElementsOf(createProps.entrySet());
   }
 
   @Test
   public void testLoadNamespaceMetadata() {
     C catalog = catalog();
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
 
     Assertions.assertThatThrownBy(() -> catalog.loadNamespaceMetadata(NS))
         .isInstanceOf(NoSuchNamespaceException.class)
         .hasMessage("Namespace does not exist: newdb");
 
     catalog.createNamespace(NS);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
-
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
     Map<String, String> props = catalog.loadNamespaceMetadata(NS);
-    Assert.assertNotNull("Should return non-null property map", props);
+    Assertions.assertThat(props).as("Should return non-null property map").isNotNull();
     // note that there are no requirements for the properties returned by the catalog
   }
 
   @Test
   public void testSetNamespaceProperties() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -241,15 +240,14 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, properties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Set properties should be a subset of returned properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), actualProperties.entrySet()));
+    Assertions.assertThat(Sets.intersection(properties.entrySet(), actualProperties.entrySet()))
+        .as("Set properties should be a subset of returned properties")
+        .isEqualTo(properties.entrySet());
   }
 
   @Test
   public void testUpdateNamespaceProperties() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -259,25 +257,25 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, initialProperties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Set properties should be a subset of returned properties",
-        initialProperties.entrySet(),
-        Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()));
+    Assertions.assertThat(
+            Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()))
+        .as("Set properties should be a subset of returned properties")
+        .isEqualTo(initialProperties.entrySet());
 
     Map<String, String> updatedProperties = ImmutableMap.of("owner", "newuser");
 
     catalog.setProperties(NS, updatedProperties);
 
     Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Updated properties should be a subset of returned properties",
-        updatedProperties.entrySet(),
-        Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()));
+    Assertions.assertThat(
+            Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()))
+        .as("Updated properties should be a subset of returned properties")
+        .isEqualTo(updatedProperties.entrySet());
   }
 
   @Test
   public void testUpdateAndSetNamespaceProperties() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -287,10 +285,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, initialProperties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Set properties should be a subset of returned properties",
-        initialProperties.entrySet(),
-        Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()));
+    Assertions.assertThat(
+            Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()))
+        .as("Set properties should be a subset of returned properties")
+        .isEqualTo(initialProperties.entrySet());
 
     Map<String, String> updatedProperties =
         ImmutableMap.of("owner", "newuser", "last-modified-at", "now");
@@ -298,15 +296,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, updatedProperties);
 
     Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertEquals(
-        "Updated properties should be a subset of returned properties",
-        updatedProperties.entrySet(),
-        Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()));
+    Assertions.assertThat(
+            Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()))
+        .as("Updated properties should be a subset of returned properties")
+        .isEqualTo(updatedProperties.entrySet());
   }
 
   @Test
   public void testSetNamespacePropertiesNamespaceDoesNotExist() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -317,7 +315,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testRemoveNamespaceProperties() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -328,17 +326,17 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.removeProperties(NS, ImmutableSet.of("created-at"));
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assert.assertFalse(
-        "Should not contain deleted property key", actualProperties.containsKey("created-at"));
-    Assert.assertEquals(
-        "Expected properties should be a subset of returned properties",
-        ImmutableMap.of("owner", "user").entrySet(),
-        Sets.intersection(properties.entrySet(), actualProperties.entrySet()));
+    Assertions.assertThat(actualProperties.containsKey("created-at"))
+        .as("Should not contain deleted property key")
+        .isFalse();
+    Assertions.assertThat(Sets.intersection(properties.entrySet(), actualProperties.entrySet()))
+        .as("Expected properties should be a subset of returned properties")
+        .containsExactlyInAnyOrderElementsOf(ImmutableMap.of("owner", "user").entrySet());
   }
 
   @Test
   public void testRemoveNamespacePropertiesNamespaceDoesNotExist() {
-    Assume.assumeTrue(supportsNamespaceProperties());
+    Assumptions.assumeTrue(supportsNamespaceProperties());
 
     C catalog = catalog();
 
@@ -351,22 +349,23 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testDropNamespace() {
     C catalog = catalog();
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
 
     catalog.createNamespace(NS);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
-
-    Assert.assertTrue(
-        "Dropping an existing namespace should return true", catalog.dropNamespace(NS));
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
+    Assertions.assertThat(catalog.dropNamespace(NS))
+        .as("Dropping an existing namespace should return true")
+        .isTrue();
+    Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should not exist").isFalse();
   }
 
   @Test
   public void testDropNonexistentNamespace() {
     C catalog = catalog();
 
-    Assert.assertFalse(
-        "Dropping a nonexistent namespace should return false", catalog.dropNamespace(NS));
+    Assertions.assertThat(catalog.dropNamespace(NS))
+        .as("Dropping a nonexistent namespace should return false")
+        .isFalse();
   }
 
   @Test
@@ -394,14 +393,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .hasSameElementsAs(concat(starting, ns2));
 
     catalog.dropNamespace(ns2);
-    Assert.assertTrue(
-        "Should include only starting namespaces", catalog.listNamespaces().containsAll(starting));
+    Assertions.assertThat(catalog.listNamespaces().containsAll(starting))
+        .as("Should include only starting namespaces")
+        .isTrue();
   }
 
   @Test
   public void testListNestedNamespaces() {
-    Assume.assumeTrue(
-        "Only valid when the catalog supports nested namespaces", supportsNestedNamespaces());
+    Assumptions.assumeTrue(
+        supportsNestedNamespaces(), "Only valid when the catalog supports nested namespaces");
 
     C catalog = catalog();
 
@@ -448,22 +448,27 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testNamespaceWithSlash() {
-    Assume.assumeTrue(supportsNamesWithSlashes());
+    Assumptions.assumeTrue(supportsNamesWithSlashes());
 
     C catalog = catalog();
 
     Namespace withSlash = Namespace.of("new/db");
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
+    Assertions.assertThat(catalog.namespaceExists(withSlash))
+        .as("Namespace should not exist")
+        .isFalse();
 
     catalog.createNamespace(withSlash);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withSlash));
+    Assertions.assertThat(catalog.namespaceExists(withSlash)).as("Namespace should exist").isTrue();
 
     Map<String, String> properties = catalog.loadNamespaceMetadata(withSlash);
-    Assert.assertNotNull("Properties should be accessible", properties);
-
-    Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withSlash));
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
+    Assertions.assertThat(properties).as("Properties should be accessible").isNotNull();
+    Assertions.assertThat(catalog.dropNamespace(withSlash))
+        .as("Dropping the namespace should succeed")
+        .isTrue();
+    Assertions.assertThat(catalog.namespaceExists(withSlash))
+        .as("Namespace should not exist")
+        .isFalse();
   }
 
   @Test
@@ -472,16 +477,21 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Namespace withDot = Namespace.of("new.db");
 
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withDot));
+    Assertions.assertThat(catalog.namespaceExists(withDot))
+        .as("Namespace should not exist")
+        .isFalse();
 
     catalog.createNamespace(withDot);
-    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withDot));
+    Assertions.assertThat(catalog.namespaceExists(withDot)).as("Namespace should exist").isTrue();
 
     Map<String, String> properties = catalog.loadNamespaceMetadata(withDot);
-    Assert.assertNotNull("Properties should be accessible", properties);
-
-    Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withDot));
-    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withDot));
+    Assertions.assertThat(properties).as("Properties should be accessible").isNotNull();
+    Assertions.assertThat(catalog.dropNamespace(withDot))
+        .as("Dropping the namespace should succeed")
+        .isTrue();
+    Assertions.assertThat(catalog.namespaceExists(withDot))
+        .as("Namespace should not exist")
+        .isFalse();
   }
 
   @Test
@@ -490,31 +500,31 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     TableIdentifier ident = TableIdentifier.of("ns", "table");
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(ident.namespace());
     }
 
     Table table = catalog.buildTable(ident, SCHEMA).create();
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     // validate table settings
-    Assert.assertEquals(
-        "Table name should report its full name", catalog.name() + "." + ident, table.name());
-    Assert.assertEquals(
-        "Schema should match expected ID assignment",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertNotNull("Should have a location", table.location());
-    Assert.assertTrue("Should be unpartitioned", table.spec().isUnpartitioned());
-    Assert.assertTrue("Should be unsorted", table.sortOrder().isUnsorted());
-    Assert.assertNotNull("Should have table properties", table.properties());
+    Assertions.assertThat(table.name())
+        .as("Table name should report its full name")
+        .isEqualTo(catalog.name() + "." + ident);
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Schema should match expected ID assignment")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.location()).as("Should have a location").isNotNull();
+    Assertions.assertThat(table.spec().isUnpartitioned()).as("Should be unpartitioned").isTrue();
+    Assertions.assertThat(table.sortOrder().isUnsorted()).as("Should be unsorted").isTrue();
+    Assertions.assertThat(table.properties()).as("Should have table properties").isNotNull();
   }
 
   @Test
   public void testTableNameWithSlash() {
-    Assume.assumeTrue(supportsNamesWithSlashes());
+    Assumptions.assumeTrue(supportsNamesWithSlashes());
 
     C catalog = catalog();
 
@@ -523,20 +533,19 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(Namespace.of("ns"));
     }
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     catalog.buildTable(ident, SCHEMA).create();
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     Table loaded = catalog.loadTable(ident);
-    Assert.assertEquals(
-        "Schema should match expected ID assignment",
-        TABLE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Schema should match expected ID assignment")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
 
     catalog.dropTable(ident);
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
   }
 
   @Test
@@ -548,20 +557,20 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(Namespace.of("ns"));
     }
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     catalog.buildTable(ident, SCHEMA).create();
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     Table loaded = catalog.loadTable(ident);
-    Assert.assertEquals(
-        "Schema should match expected ID assignment",
-        TABLE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Schema should match expected ID assignment")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
 
     catalog.dropTable(ident);
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
   }
 
   @Test
@@ -574,20 +583,19 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(ident.namespace());
     }
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     catalog.buildTable(ident, SCHEMA).create();
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     Assertions.assertThatThrownBy(() -> catalog.buildTable(ident, OTHER_SCHEMA).create())
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessage("Table already exists: ns.table");
 
     Table table = catalog.loadTable(ident);
-    Assert.assertEquals(
-        "Schema should match original table schema",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Schema should match original table schema")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
   }
 
   @Test
@@ -600,7 +608,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(ident.namespace());
     }
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
@@ -614,20 +622,23 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .create();
 
     // validate table settings
-    Assert.assertEquals(
-        "Table name should report its full name", catalog.name() + "." + ident, table.name());
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
-    Assert.assertEquals(
-        "Schema should match expected ID assignment",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertNotNull("Should have a location", table.location());
-    Assert.assertEquals("Should use requested partition spec", TABLE_SPEC, table.spec());
-    Assert.assertEquals("Should use requested write order", TABLE_WRITE_ORDER, table.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
+    Assertions.assertThat(table.name())
+        .as("Table name should report its full name")
+        .isEqualTo(catalog.name() + "." + ident);
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Schema should match expected ID assignment")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.location()).as("Should have a location").isNotNull();
+    Assertions.assertThat(table.spec())
+        .as("Should use requested partition spec")
+        .isEqualTo(TABLE_SPEC);
+    Assertions.assertThat(table.sortOrder())
+        .as("Should use requested write order")
+        .isEqualTo(TABLE_WRITE_ORDER);
+    Assertions.assertThat(table.properties().entrySet())
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(properties.entrySet());
   }
 
   @Test
@@ -640,7 +651,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(ident.namespace());
     }
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
@@ -651,24 +662,27 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .withSortOrder(WRITE_ORDER)
         .withProperties(properties)
         .create();
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     Table table = catalog.loadTable(ident);
     // validate table settings
-    Assert.assertEquals(
-        "Table name should report its full name", catalog.name() + "." + ident, table.name());
-    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
-    Assert.assertEquals(
-        "Schema should match expected ID assignment",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertNotNull("Should have a location", table.location());
-    Assert.assertEquals("Should use requested partition spec", TABLE_SPEC, table.spec());
-    Assert.assertEquals("Should use requested write order", TABLE_WRITE_ORDER, table.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
+    Assertions.assertThat(table.name())
+        .as("Table name should report its full name")
+        .isEqualTo(catalog.name() + "." + ident);
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Schema should match expected ID assignment")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.location()).as("Should have a location").isNotNull();
+    Assertions.assertThat(table.spec())
+        .as("Should use requested partition spec")
+        .isEqualTo(TABLE_SPEC);
+    Assertions.assertThat(table.sortOrder())
+        .as("Should use requested write order")
+        .isEqualTo(TABLE_WRITE_ORDER);
+    Assertions.assertThat(table.properties().entrySet())
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(properties.entrySet());
   }
 
   @Test
@@ -700,7 +714,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     TableIdentifier ident = TableIdentifier.of("ns", "table");
 
-    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+    Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
     Assertions.assertThatThrownBy(() -> catalog.loadTable(ident))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessage("Table does not exist: ns.table");
@@ -714,17 +728,26 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Source table should not exist before create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Source table should not exist before create")
+        .isFalse();
 
     catalog.buildTable(TABLE, SCHEMA).create();
-    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after create")
+        .isTrue();
 
-    Assert.assertFalse(
-        "Destination table should not exist before rename", catalog.tableExists(RENAMED_TABLE));
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should not exist before rename")
+        .isFalse();
 
     catalog.renameTable(TABLE, RENAMED_TABLE);
-    Assert.assertTrue("Table should exist with new name", catalog.tableExists(RENAMED_TABLE));
-    Assert.assertFalse("Original table should no longer exist", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Table should exist with new name")
+        .isTrue();
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Original table should no longer exist")
+        .isFalse();
 
     catalog.dropTable(RENAMED_TABLE);
     assertEmpty("Should not contain table after drop", catalog, NS);
@@ -738,17 +761,20 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Source table should not exist before rename", catalog.tableExists(TABLE));
-    Assert.assertFalse(
-        "Destination table should not exist before rename", catalog.tableExists(RENAMED_TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Source table should not exist before rename")
+        .isFalse();
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should not exist before rename")
+        .isFalse();
 
     Assertions.assertThatThrownBy(() -> catalog.renameTable(TABLE, RENAMED_TABLE))
         .isInstanceOf(NoSuchTableException.class)
         .hasMessageContaining("Table does not exist");
 
-    Assert.assertFalse(
-        "Destination table should not exist after failed rename",
-        catalog.tableExists(RENAMED_TABLE));
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should not exist after failed rename")
+        .isFalse();
   }
 
   @Test
@@ -759,34 +785,40 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Source table should not exist before create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Source table should not exist before create")
+        .isFalse();
+
     catalog.buildTable(TABLE, SCHEMA).create();
-    Assert.assertTrue("Source table should exist after create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Source table should exist after create")
+        .isTrue();
 
-    Assert.assertFalse(
-        "Destination table should not exist before create", catalog.tableExists(RENAMED_TABLE));
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should not exist before create")
+        .isFalse();
+
     catalog.buildTable(RENAMED_TABLE, SCHEMA).create();
-    Assert.assertTrue(
-        "Destination table should exist after create", catalog.tableExists(RENAMED_TABLE));
-
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should exist after create")
+        .isTrue();
     Assertions.assertThatThrownBy(() -> catalog.renameTable(TABLE, RENAMED_TABLE))
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("Table already exists");
-
-    Assert.assertTrue(
-        "Source table should still exist after failed rename", catalog.tableExists(TABLE));
-    Assert.assertTrue(
-        "Destination table should still exist after failed rename",
-        catalog.tableExists(RENAMED_TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Source table should still exist after failed rename")
+        .isTrue();
+    Assertions.assertThat(catalog.tableExists(RENAMED_TABLE))
+        .as("Destination table should still exist after failed rename")
+        .isTrue();
 
     String sourceTableUUID =
         ((HasTableOperations) catalog.loadTable(TABLE)).operations().current().uuid();
     String destinationTableUUID =
         ((HasTableOperations) catalog.loadTable(RENAMED_TABLE)).operations().current().uuid();
-    Assert.assertNotEquals(
-        "Source and destination table should remain distinct after failed rename",
-        sourceTableUUID,
-        destinationTableUUID);
+    Assertions.assertThat(sourceTableUUID)
+        .as("Source and destination table should remain distinct after failed rename")
+        .isNotEqualTo(destinationTableUUID);
   }
 
   @Test
@@ -797,14 +829,20 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Table should not exist before create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist before create")
+        .isFalse();
 
     catalog.buildTable(TABLE, SCHEMA).create();
-    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after create")
+        .isTrue();
 
     boolean dropped = catalog.dropTable(TABLE);
-    Assert.assertTrue("Should drop a table that does exist", dropped);
-    Assert.assertFalse("Table should not exist after drop", catalog.tableExists(TABLE));
+    Assertions.assertThat(dropped).as("Should drop a table that does exist").isTrue();
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after drop")
+        .isFalse();
   }
 
   @Test
@@ -815,14 +853,20 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Table should not exist before create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist before create")
+        .isFalse();
 
     catalog.buildTable(TABLE, SCHEMA).create();
-    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after create")
+        .isTrue();
 
     boolean dropped = catalog.dropTable(TABLE, true);
-    Assert.assertTrue("Should drop a table that does exist", dropped);
-    Assert.assertFalse("Table should not exist after drop", catalog.tableExists(TABLE));
+    Assertions.assertThat(dropped).as("Should drop a table that does exist").isTrue();
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after drop")
+        .isFalse();
   }
 
   @Test
@@ -833,15 +877,21 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       catalog.createNamespace(NS);
     }
 
-    Assert.assertFalse("Table should not exist before create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist before create")
+        .isFalse();
 
     Table table = catalog.buildTable(TABLE, SCHEMA).create();
-    Assert.assertTrue("Table should exist after create", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after create")
+        .isTrue();
     Set<String> actualMetadataFileLocations = ReachableFileUtil.metadataFileLocations(table, false);
 
     boolean dropped = catalog.dropTable(TABLE, false);
-    Assert.assertTrue("Should drop a table that does exist", dropped);
-    Assert.assertFalse("Table should not exist after drop", catalog.tableExists(TABLE));
+    Assertions.assertThat(dropped).as("Should drop a table that does exist").isTrue();
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after drop")
+        .isFalse();
     Set<String> expectedMetadataFileLocations =
         ReachableFileUtil.metadataFileLocations(table, false);
     Assertions.assertThat(actualMetadataFileLocations)
@@ -859,9 +909,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     }
 
     TableIdentifier noSuchTableIdent = TableIdentifier.of(NS, "notable");
-    Assert.assertFalse("Table should not exist", catalog.tableExists(noSuchTableIdent));
-    Assert.assertFalse(
-        "Should not drop a table that does not exist", catalog.dropTable(noSuchTableIdent));
+    Assertions.assertThat(catalog.tableExists(noSuchTableIdent))
+        .as("Table should not exist")
+        .isFalse();
+    Assertions.assertThat(catalog.dropTable(noSuchTableIdent))
+        .as("Should not drop a table that does not exist")
+        .isFalse();
   }
 
   @Test
@@ -885,50 +938,43 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     catalog.buildTable(ns1Table1, SCHEMA).create();
 
-    Assert.assertEquals(
-        "Should contain ns_1.table_1 after create",
-        ImmutableSet.of(ns1Table1),
-        Sets.newHashSet(catalog.listTables(ns1)));
+    Assertions.assertThat(catalog.listTables(ns1))
+        .as("Should contain ns_1.table_1 after create")
+        .containsExactlyInAnyOrder(ns1Table1);
 
     catalog.buildTable(ns2Table1, SCHEMA).create();
 
-    Assert.assertEquals(
-        "Should contain ns_2.table_1 after create",
-        ImmutableSet.of(ns2Table1),
-        Sets.newHashSet(catalog.listTables(ns2)));
-    Assert.assertEquals(
-        "Should not show changes to ns_2 in ns_1",
-        ImmutableSet.of(ns1Table1),
-        Sets.newHashSet(catalog.listTables(ns1)));
+    Assertions.assertThat(catalog.listTables(ns2))
+        .as("Should contain ns_2.table_1 after create")
+        .containsExactlyInAnyOrder(ns2Table1);
+    Assertions.assertThat(catalog.listTables(ns1))
+        .as("Should not show changes to ns_2 in ns_1")
+        .containsExactlyInAnyOrder(ns1Table1);
 
     catalog.buildTable(ns1Table2, SCHEMA).create();
 
-    Assert.assertEquals(
-        "Should not show changes to ns_1 in ns_2",
-        ImmutableSet.of(ns2Table1),
-        Sets.newHashSet(catalog.listTables(ns2)));
-    Assert.assertEquals(
-        "Should contain ns_1.table_2 after create",
-        ImmutableSet.of(ns1Table1, ns1Table2),
-        Sets.newHashSet(catalog.listTables(ns1)));
+    Assertions.assertThat(catalog.listTables(ns2))
+        .as("Should not show changes to ns_1 in ns_2")
+        .containsExactlyInAnyOrder(ns2Table1);
+    Assertions.assertThat(catalog.listTables(ns1))
+        .as("Should contain ns_1.table_2 after create")
+        .containsExactlyInAnyOrder(ns1Table1, ns1Table2);
 
     catalog.dropTable(ns1Table1);
 
-    Assert.assertEquals(
-        "Should not show changes to ns_1 in ns_2",
-        ImmutableSet.of(ns2Table1),
-        Sets.newHashSet(catalog.listTables(ns2)));
-    Assert.assertEquals(
-        "Should not contain ns_1.table_1 after drop",
-        ImmutableSet.of(ns1Table2),
-        Sets.newHashSet(catalog.listTables(ns1)));
+    Assertions.assertThat(catalog.listTables(ns2))
+        .as("Should not show changes to ns_1 in ns_2")
+        .containsExactlyInAnyOrder(ns2Table1);
+    Assertions.assertThat(catalog.listTables(ns1))
+        .as("Should not contain ns_1.table_1 after drop")
+        .containsExactlyInAnyOrder(ns1Table2);
 
     catalog.dropTable(ns1Table2);
 
-    Assert.assertEquals(
-        "Should not show changes to ns_1 in ns_2",
-        ImmutableSet.of(ns2Table1),
-        Sets.newHashSet(catalog.listTables(ns2)));
+    Assertions.assertThat(catalog.listTables(ns2))
+        .as("Should not show changes to ns_1 in ns_2")
+        .containsExactlyInAnyOrder(ns2Table1);
+
     assertEmpty("Should not contain ns_1.table_2 after drop", catalog, ns1);
 
     catalog.dropTable(ns2Table1);
@@ -952,10 +998,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        expected.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -969,7 +1014,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table = catalog.buildTable(TABLE, SCHEMA).create();
     UpdateSchema update = table.updateSchema().addColumn("new_col", Types.LongType.get());
 
-    Assert.assertTrue("Should successfully drop table", catalog.dropTable(TABLE));
+    Assertions.assertThat(catalog.dropTable(TABLE)).as("Should successfully drop table").isTrue();
     catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
     String expectedMessage =
@@ -979,17 +1024,16 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .hasMessageContaining(expectedMessage);
 
     Table loaded = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        OTHER_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
   }
 
   @Test
   public void testUpdateTableSchemaServerSideRetry() {
-    Assume.assumeTrue(
-        "Schema update recovery is only supported with server-side retry",
-        supportsServerSideRetry());
+    Assumptions.assumeTrue(
+        supportsServerSideRetry(),
+        "Schema update recovery is only supported with server-side retry");
     C catalog = catalog();
 
     if (requiresNamespaceCreate()) {
@@ -1008,10 +1052,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     update.commit();
 
     Table loaded = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        expected.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1039,10 +1082,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .hasMessageContaining(expectedMessage);
 
     Table loaded = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        expected.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1073,10 +1115,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .hasMessageContaining(expectedMessage);
 
     Table loaded = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        expected.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(expected.asStruct());
   }
 
   @Test
@@ -1098,10 +1139,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     table.updateSchema().deleteColumn("col1").deleteColumn("col2").deleteColumn("col3").commit();
 
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
   }
 
   @Test
@@ -1122,14 +1162,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the spec ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected spec", expected.fields(), loaded.spec().fields());
+    Assertions.assertThat(loaded.spec().fields())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(expected.fields());
   }
 
   @Test
   public void testUpdateTableSpecServerSideRetry() {
-    Assume.assumeTrue(
-        "Spec update recovery is only supported with server-side retry", supportsServerSideRetry());
+    Assumptions.assumeTrue(
+        supportsServerSideRetry(), "Spec update recovery is only supported with server-side retry");
     C catalog = catalog();
 
     if (requiresNamespaceCreate()) {
@@ -1154,8 +1195,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the spec ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected spec", expected.fields(), loaded.spec().fields());
+    Assertions.assertThat(loaded.spec().fields())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(expected.fields());
   }
 
   @Test
@@ -1189,8 +1231,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the spec ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected spec", expected.fields(), loaded.spec().fields());
+    Assertions.assertThat(loaded.spec().fields())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(expected.fields());
   }
 
   @Test
@@ -1223,8 +1266,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the spec ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected spec", expected.fields(), loaded.spec().fields());
+    Assertions.assertThat(loaded.spec().fields())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(expected.fields());
   }
 
   @Test
@@ -1243,14 +1287,17 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withPartitionSpec(SPEC)
             .withProperty("format-version", "2")
             .create();
-    Assert.assertEquals(
-        "Should be a v2 table", 2, ((BaseTable) table).operations().current().formatVersion());
+    Assertions.assertThat(((BaseTable) table).operations().current().formatVersion())
+        .as("Should be a v2 table")
+        .isEqualTo(2);
 
     table.updateSpec().addField("id").commit();
 
     table.updateSpec().removeField("id").commit();
 
-    Assert.assertEquals("Loaded table should have expected spec", TABLE_SPEC, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(TABLE_SPEC);
   }
 
   @Test
@@ -1271,15 +1318,16 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the sort order ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected order", expected.fields(), loaded.sortOrder().fields());
+    Assertions.assertThat(loaded.sortOrder().fields())
+        .as("Loaded table should have expected order")
+        .isEqualTo(expected.fields());
   }
 
   @Test
   public void testUpdateTableSortOrderServerSideRetry() {
-    Assume.assumeTrue(
-        "Sort order update recovery is only supported with server-side retry",
-        supportsServerSideRetry());
+    Assumptions.assumeTrue(
+        supportsServerSideRetry(),
+        "Sort order update recovery is only supported with server-side retry");
     C catalog = catalog();
 
     if (requiresNamespaceCreate()) {
@@ -1304,8 +1352,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table loaded = catalog.loadTable(TABLE);
 
     // the sort order ID may not match, so check equality of the fields
-    Assert.assertEquals(
-        "Loaded table should have expected order", expected.fields(), loaded.sortOrder().fields());
+    Assertions.assertThat(loaded.sortOrder().fields())
+        .as("Loaded table should have expected order")
+        .isEqualTo(expected.fields());
   }
 
   @Test
@@ -1322,8 +1371,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     table.replaceSortOrder().asc(Expressions.bucket("id", 16)).asc("id").commit();
 
-    Assert.assertEquals(
-        "Loaded table should have expected order", TABLE_WRITE_ORDER, table.sortOrder());
+    Assertions.assertThat(table.sortOrder())
+        .as("Loaded table should have expected order")
+        .isEqualTo(TABLE_WRITE_ORDER);
   }
 
   @Test
@@ -1337,7 +1387,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Table table = catalog.buildTable(TABLE, SCHEMA).withPartitionSpec(SPEC).create();
 
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-      Assert.assertFalse("Should contain no files", tasks.iterator().hasNext());
+      Assertions.assertThat(tasks.iterator().hasNext()).as("Should contain no files").isFalse();
     }
 
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -1424,12 +1474,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Loaded table should have expected schema",
-        expectedSchema.asStruct(),
-        loaded.schema().asStruct());
-    Assert.assertEquals(
-        "Loaded table should have expected spec", expectedSpec.fields(), loaded.spec().fields());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Loaded table should have expected schema")
+        .isEqualTo(expectedSchema.asStruct());
+    Assertions.assertThat(loaded.spec().fields())
+        .as("Loaded table should have expected spec")
+        .isEqualTo(expectedSpec.fields());
 
     assertPreviousMetadataFileCount(loaded, 1);
   }
@@ -1444,16 +1494,21 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Transaction create = catalog.buildTable(TABLE, SCHEMA).createTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     create.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     Table table = catalog.loadTable(TABLE);
     assertFiles(table, FILE_A);
     assertPreviousMetadataFileCount(table, 0);
@@ -1478,33 +1533,39 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .createTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     create.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
-    Table table = catalog.loadTable(TABLE);
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertEquals(
-        "Table should have create partition spec", TABLE_SPEC.fields(), table.spec().fields());
-    Assert.assertEquals(
-        "Table should have create sort order", TABLE_WRITE_ORDER, table.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
+    Table table = catalog.loadTable(TABLE);
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.spec().fields())
+        .as("Table should have create partition spec")
+        .isEqualTo(TABLE_SPEC.fields());
+    Assertions.assertThat(table.sortOrder())
+        .as("Table should have create sort order")
+        .isEqualTo(TABLE_WRITE_ORDER);
+    Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
+        .as("Table properties should be a superset of the requested properties")
+        .isEqualTo(properties.entrySet());
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should match requested", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should match requested")
+          .isEqualTo("file:/tmp/ns/table");
     }
     assertFiles(table, FILE_A);
     assertFilesPartitionSpec(table);
@@ -1530,8 +1591,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .createTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
@@ -1557,11 +1619,16 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     create.newFastAppend().appendFile(anotherFile).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     create.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
+
     Table table = catalog.loadTable(TABLE);
 
     // initial IDs taken from TableMetadata constants
@@ -1572,27 +1639,31 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     final int updateSpecId = initialSpecId + 1;
     final int updateOrderId = initialOrderId + 1;
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        newSchema.asStruct(),
-        table.schema().asStruct());
-    Assert.assertEquals(
-        "Table schema should match the new schema ID", updateSchemaId, table.schema().schemaId());
-    Assert.assertEquals(
-        "Table should have updated partition spec", newSpec.fields(), table.spec().fields());
-    Assert.assertEquals(
-        "Table should have updated partition spec ID", updateSpecId, table.spec().specId());
-    Assert.assertEquals(
-        "Table should have updated sort order", newSortOrder.fields(), table.sortOrder().fields());
-    Assert.assertEquals(
-        "Table should have updated sort order ID", updateOrderId, table.sortOrder().orderId());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(newSchema.asStruct());
+    Assertions.assertThat(table.schema().schemaId())
+        .as("Table schema should match the new schema ID")
+        .isEqualTo(updateSchemaId);
+    Assertions.assertThat(table.spec().fields())
+        .as("Table should have updated partition spec")
+        .isEqualTo(newSpec.fields());
+    Assertions.assertThat(table.spec().specId())
+        .as("Table should have updated partition spec ID")
+        .isEqualTo(updateSpecId);
+    Assertions.assertThat(table.sortOrder().fields())
+        .as("Table should have updated sort order")
+        .isEqualTo(newSortOrder.fields());
+    Assertions.assertThat(table.sortOrder().orderId())
+        .as("Table should have updated sort order ID")
+        .isEqualTo(updateOrderId);
+    Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
+        .as("Table properties should be a superset of the requested properties")
+        .isEqualTo(properties.entrySet());
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should match requested", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should match requested")
+          .isEqualTo("file:/tmp/ns/table");
     }
     assertFiles(table, FILE_A, anotherFile);
     assertFilePartitionSpec(table, FILE_A, initialSpecId);
@@ -1621,41 +1692,48 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .createTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     create.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     Table table = catalog.loadTable(TABLE);
 
     Map<String, String> expectedProps = Maps.newHashMap(properties);
+
     expectedProps.remove("format-version");
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertEquals(
-        "Table should have create partition spec", TABLE_SPEC.fields(), table.spec().fields());
-    Assert.assertEquals(
-        "Table should have create sort order", TABLE_WRITE_ORDER, table.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        expectedProps.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
-    Assert.assertEquals(
-        "Sequence number should start at 1 for v2 format",
-        1,
-        table.currentSnapshot().sequenceNumber());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.spec().fields())
+        .as("Table should have create partition spec")
+        .isEqualTo(TABLE_SPEC.fields());
+    Assertions.assertThat(table.sortOrder())
+        .as("Table should have create sort order")
+        .isEqualTo(TABLE_WRITE_ORDER);
+    Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(expectedProps.entrySet());
+    Assertions.assertThat(table.currentSnapshot().sequenceNumber())
+        .as("Sequence number should start at 1 for v2 format")
+        .isEqualTo(1);
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should match requested", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should match requested")
+          .isEqualTo("file:/tmp/ns/table");
     }
+
     assertFiles(table, FILE_A);
     assertFilesPartitionSpec(table);
     assertPreviousMetadataFileCount(table, 0);
@@ -1671,12 +1749,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Transaction create = catalog.buildTable(TABLE, SCHEMA).createTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
@@ -1691,10 +1772,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     // validate the concurrently created table is unmodified
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
     assertNoFiles(table);
   }
 
@@ -1708,16 +1788,22 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Transaction create = catalog.buildTable(TABLE, SCHEMA).createOrReplaceTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     create.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     create.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
+
     Table table = catalog.loadTable(TABLE);
     assertFiles(table, FILE_A);
     assertPreviousMetadataFileCount(table, 0);
@@ -1742,34 +1828,42 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .createOrReplaceTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     createOrReplace.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     createOrReplace.commitTransaction();
 
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
+
     Table table = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        TABLE_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertEquals(
-        "Table should have create partition spec", TABLE_SPEC.fields(), table.spec().fields());
-    Assert.assertEquals(
-        "Table should have create sort order", TABLE_WRITE_ORDER, table.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), table.properties().entrySet()));
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(TABLE_SCHEMA.asStruct());
+    Assertions.assertThat(table.spec().fields())
+        .as("Table should have create partition spec")
+        .isEqualTo(TABLE_SPEC.fields());
+    Assertions.assertThat(table.sortOrder())
+        .as("Table should have create sort order")
+        .isEqualTo(TABLE_WRITE_ORDER);
+    Assertions.assertThat(table.properties().entrySet())
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(properties.entrySet());
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should match requested", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should match requested")
+          .isEqualTo("file:/tmp/ns/table");
     }
+
     assertFiles(table, FILE_A);
     assertFilesPartitionSpec(table);
     assertPreviousMetadataFileCount(table, 0);
@@ -1785,36 +1879,41 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table original = catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
-    Assert.assertTrue("Table should exist before replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist before replaceTransaction")
+        .isTrue();
 
     Transaction createOrReplace = catalog.buildTable(TABLE, SCHEMA).createOrReplaceTransaction();
 
-    Assert.assertTrue(
-        "Table should still exist after replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should still exist after replaceTransaction")
+        .isTrue();
 
     createOrReplace.newFastAppend().appendFile(FILE_A).commit();
 
     // validate table has not changed
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
+
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
+
     assertUUIDsMatch(original, table);
     assertNoFiles(table);
 
     createOrReplace.commitTransaction();
 
     // validate the table after replace
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     table.refresh(); // refresh should work with UUID validation
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
     assertUUIDsMatch(original, loaded);
     assertFiles(loaded, FILE_A);
     assertPreviousMetadataFileCount(loaded, 1);
@@ -1830,7 +1929,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table original = catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
-    Assert.assertTrue("Table should exist before replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist before replaceTransaction")
+        .isTrue();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
@@ -1843,47 +1944,55 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .createOrReplaceTransaction();
 
-    Assert.assertTrue(
-        "Table should still exist after replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should still exist after replaceTransaction")
+        .isTrue();
 
     createOrReplace.newFastAppend().appendFile(FILE_A).commit();
 
     // validate table has not changed
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertTrue("Table should be unpartitioned", table.spec().isUnpartitioned());
-    Assert.assertTrue("Table should be unsorted", table.sortOrder().isUnsorted());
-    Assert.assertNotEquals(
-        "Created at should not match", table.properties().get("created-at"), "2022-02-25T00:38:19");
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
+    Assertions.assertThat(table.sortOrder().isUnsorted()).as("Table should be unsorted").isTrue();
+    Assertions.assertThat(table.properties().get("created-at"))
+        .as("Created at should not match")
+        .isNotEqualTo("2022-02-25T00:38:19");
     assertUUIDsMatch(original, table);
     assertNoFiles(table);
 
     createOrReplace.commitTransaction();
 
     // validate the table after replace
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     table.refresh(); // refresh should work with UUID validation
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
-    Assert.assertEquals("Table should have replace partition spec", REPLACE_SPEC, loaded.spec());
-    Assert.assertEquals(
-        "Table should have replace sort order", REPLACE_WRITE_ORDER, loaded.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), loaded.properties().entrySet()));
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
+    Assertions.assertThat(loaded.spec())
+        .as("Table should have replace partition spec")
+        .isEqualTo(REPLACE_SPEC);
+    Assertions.assertThat(loaded.sortOrder())
+        .as("Table should have replace sort order")
+        .isEqualTo(REPLACE_WRITE_ORDER);
+    Assertions.assertThat(loaded.properties().entrySet())
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(properties.entrySet());
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should be replaced", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should be replaced")
+          .isEqualTo("file:/tmp/ns/table");
     }
+
     assertUUIDsMatch(original, loaded);
     assertFiles(loaded, FILE_A);
     assertPreviousMetadataFileCount(loaded, 1);
@@ -1891,9 +2000,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testCreateOrReplaceTransactionConcurrentCreate() {
-    Assume.assumeTrue(
-        "Conversion to replace transaction is not supported by REST catalog",
-        supportsServerSideRetry());
+    Assumptions.assumeTrue(
+        supportsServerSideRetry(),
+        "Conversion to replace transaction is not supported by REST catalog");
 
     C catalog = catalog();
 
@@ -1903,12 +2012,15 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Transaction createOrReplace = catalog.buildTable(TABLE, SCHEMA).createOrReplaceTransaction();
 
-    Assert.assertFalse(
-        "Table should not exist after createTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after createTransaction")
+        .isFalse();
 
     createOrReplace.newFastAppend().appendFile(FILE_A).commit();
 
-    Assert.assertFalse("Table should not exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should not exist after append commit")
+        .isFalse();
 
     catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
@@ -1922,10 +2034,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     // validate the concurrently created table is unmodified
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
     assertNoFiles(table);
   }
 
@@ -1939,36 +2050,40 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table original = catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
-    Assert.assertTrue("Table should exist before replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist before replaceTransaction")
+        .isTrue();
 
     Transaction replace = catalog.buildTable(TABLE, SCHEMA).replaceTransaction();
 
-    Assert.assertTrue(
-        "Table should still exist after replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should still exist after replaceTransaction")
+        .isTrue();
 
     replace.newFastAppend().appendFile(FILE_A).commit();
 
     // validate table has not changed
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
     assertUUIDsMatch(original, table);
     assertNoFiles(table);
 
     replace.commitTransaction();
 
     // validate the table after replace
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     table.refresh(); // refresh should work with UUID validation
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
+
     assertUUIDsMatch(original, loaded);
     assertFiles(loaded, FILE_A);
     assertPreviousMetadataFileCount(loaded, 1);
@@ -1984,7 +2099,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Table original = catalog.buildTable(TABLE, OTHER_SCHEMA).create();
 
-    Assert.assertTrue("Table should exist before replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist before replaceTransaction")
+        .isTrue();
 
     Map<String, String> properties =
         ImmutableMap.of("user", "someone", "created-at", "2022-02-25T00:38:19");
@@ -1997,47 +2114,57 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
             .withProperties(properties)
             .replaceTransaction();
 
-    Assert.assertTrue(
-        "Table should still exist after replaceTransaction", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should still exist after replaceTransaction")
+        .isTrue();
 
     replace.newFastAppend().appendFile(FILE_A).commit();
 
     // validate table has not changed
     Table table = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match concurrent create",
-        OTHER_SCHEMA.asStruct(),
-        table.schema().asStruct());
-    Assert.assertTrue("Table should be unpartitioned", table.spec().isUnpartitioned());
-    Assert.assertTrue("Table should be unsorted", table.sortOrder().isUnsorted());
-    Assert.assertNotEquals(
-        "Created at should not match", table.properties().get("created-at"), "2022-02-25T00:38:19");
+
+    Assertions.assertThat(table.schema().asStruct())
+        .as("Table schema should match concurrent create")
+        .isEqualTo(OTHER_SCHEMA.asStruct());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
+    Assertions.assertThat(table.sortOrder().isUnsorted()).as("Table should be unsorted").isTrue();
+    Assertions.assertThat(table.properties().get("created-at"))
+        .as("Created at should not match")
+        .isNotEqualTo("2022-02-25T00:38:19");
+
     assertUUIDsMatch(original, table);
     assertNoFiles(table);
 
     replace.commitTransaction();
 
     // validate the table after replace
-    Assert.assertTrue("Table should exist after append commit", catalog.tableExists(TABLE));
+    Assertions.assertThat(catalog.tableExists(TABLE))
+        .as("Table should exist after append commit")
+        .isTrue();
     table.refresh(); // refresh should work with UUID validation
 
     Table loaded = catalog.loadTable(TABLE);
 
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        loaded.schema().asStruct());
-    Assert.assertEquals("Table should have replace partition spec", REPLACE_SPEC, loaded.spec());
-    Assert.assertEquals(
-        "Table should have replace sort order", REPLACE_WRITE_ORDER, loaded.sortOrder());
-    Assert.assertEquals(
-        "Table properties should be a superset of the requested properties",
-        properties.entrySet(),
-        Sets.intersection(properties.entrySet(), loaded.properties().entrySet()));
+    Assertions.assertThat(loaded.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
+    Assertions.assertThat(loaded.spec())
+        .as("Table should have replace partition spec")
+        .isEqualTo(REPLACE_SPEC);
+    Assertions.assertThat(loaded.sortOrder())
+        .as("Table should have replace sort order")
+        .isEqualTo(REPLACE_WRITE_ORDER);
+    Assertions.assertThat(loaded.properties().entrySet())
+        .as("Table properties should be a superset of the requested properties")
+        .containsAll(properties.entrySet());
     if (!overridesRequestedLocation()) {
-      Assert.assertEquals(
-          "Table location should be replaced", "file:/tmp/ns/table", table.location());
+      Assertions.assertThat(table.location())
+          .as("Table location should be replaced")
+          .isEqualTo("file:/tmp/ns/table");
     }
+
     assertUUIDsMatch(original, loaded);
     assertFiles(loaded, FILE_A);
     assertPreviousMetadataFileCount(loaded, 1);
@@ -2079,24 +2206,30 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the original schema",
-        original.schema().asStruct(),
-        afterFirstReplace.schema().asStruct());
-    Assert.assertTrue("Table should be unpartitioned", afterFirstReplace.spec().isUnpartitioned());
-    Assert.assertTrue("Table should be unsorted", afterFirstReplace.sortOrder().isUnsorted());
+    Assertions.assertThat(afterFirstReplace.schema().asStruct())
+        .as("Table schema should match the original schema")
+        .isEqualTo(original.schema().asStruct());
+    Assertions.assertThat(afterFirstReplace.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
+    Assertions.assertThat(afterFirstReplace.sortOrder().isUnsorted())
+        .as("Table should be unsorted")
+        .isTrue();
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the original schema",
-        original.schema().asStruct(),
-        afterSecondReplace.schema().asStruct());
-    Assert.assertTrue("Table should be unpartitioned", afterSecondReplace.spec().isUnpartitioned());
-    Assert.assertTrue("Table should be unsorted", afterSecondReplace.sortOrder().isUnsorted());
+    Assertions.assertThat(afterSecondReplace.schema().asStruct())
+        .as("Table schema should match the original schema")
+        .isEqualTo(original.schema().asStruct());
+    Assertions.assertThat(afterSecondReplace.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
+    Assertions.assertThat(afterSecondReplace.sortOrder().isUnsorted())
+        .as("Table should be unsorted")
+        .isTrue();
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
@@ -2124,20 +2257,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        afterFirstReplace.schema().asStruct());
+    Assertions.assertThat(afterFirstReplace.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the original schema",
-        original.schema().asStruct(),
-        afterSecondReplace.schema().asStruct());
+    Assertions.assertThat(afterSecondReplace.schema().asStruct())
+        .as("Table schema should match the original schema")
+        .isEqualTo(original.schema().asStruct());
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
@@ -2165,27 +2296,25 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the original schema",
-        original.schema().asStruct(),
-        afterFirstReplace.schema().asStruct());
+    Assertions.assertThat(afterFirstReplace.schema().asStruct())
+        .as("Table schema should match the original schema")
+        .isEqualTo(original.schema().asStruct());
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the new schema",
-        REPLACE_SCHEMA.asStruct(),
-        afterSecondReplace.schema().asStruct());
+    Assertions.assertThat(afterSecondReplace.schema().asStruct())
+        .as("Table schema should match the new schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
 
   @Test
   public void testConcurrentReplaceTransactionSchemaConflict() {
-    Assume.assumeTrue("Schema conflicts are detected server-side", supportsServerSideRetry());
+    Assumptions.assumeTrue(supportsServerSideRetry(), "Schema conflicts are detected server-side");
 
     C catalog = catalog();
 
@@ -2208,10 +2337,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table schema should match the original schema",
-        REPLACE_SCHEMA.asStruct(),
-        afterFirstReplace.schema().asStruct());
+    Assertions.assertThat(afterFirstReplace.schema().asStruct())
+        .as("Table schema should match the original schema")
+        .isEqualTo(REPLACE_SCHEMA.asStruct());
+
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
@@ -2247,17 +2376,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table spec should match the new spec",
-        TABLE_SPEC.fields(),
-        afterFirstReplace.spec().fields());
+    Assertions.assertThat(afterFirstReplace.spec().fields())
+        .as("Table spec should match the new spec")
+        .isEqualTo(TABLE_SPEC.fields());
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertTrue("Table should be unpartitioned", afterSecondReplace.spec().isUnpartitioned());
+    Assertions.assertThat(afterSecondReplace.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
@@ -2286,24 +2416,25 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertTrue("Table should be unpartitioned", afterFirstReplace.spec().isUnpartitioned());
+    Assertions.assertThat(afterFirstReplace.spec().isUnpartitioned())
+        .as("Table should be unpartitioned")
+        .isTrue();
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table spec should match the new spec",
-        TABLE_SPEC.fields(),
-        afterSecondReplace.spec().fields());
+    Assertions.assertThat(afterSecondReplace.spec().fields())
+        .as("Table spec should match the new spec")
+        .isEqualTo(TABLE_SPEC.fields());
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
 
   @Test
   public void testConcurrentReplaceTransactionPartitionSpecConflict() {
-    Assume.assumeTrue("Spec conflicts are detected server-side", supportsServerSideRetry());
+    Assumptions.assumeTrue(supportsServerSideRetry(), "Spec conflicts are detected server-side");
     C catalog = catalog();
 
     if (requiresNamespaceCreate()) {
@@ -2327,10 +2458,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table spec should match the new spec",
-        TABLE_SPEC.fields(),
-        afterFirstReplace.spec().fields());
+    Assertions.assertThat(afterFirstReplace.spec().fields())
+        .as("Table spec should match the new spec")
+        .isEqualTo(TABLE_SPEC.fields());
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
@@ -2366,15 +2496,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table order should match the new order", TABLE_WRITE_ORDER, afterFirstReplace.sortOrder());
+    Assertions.assertThat(afterFirstReplace.sortOrder())
+        .as("Table order should match the new order")
+        .isEqualTo(TABLE_WRITE_ORDER);
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertTrue("Table should be unsorted", afterSecondReplace.sortOrder().isUnsorted());
+    Assertions.assertThat(afterSecondReplace.sortOrder().isUnsorted())
+        .as("Table should be unsorted")
+        .isTrue();
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
@@ -2408,17 +2541,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     firstReplace.commitTransaction();
 
     Table afterFirstReplace = catalog.loadTable(TABLE);
-    Assert.assertTrue("Table order should be set", afterFirstReplace.sortOrder().isSorted());
+    Assertions.assertThat(afterFirstReplace.sortOrder().isSorted())
+        .as("Table order should be set")
+        .isTrue();
     assertUUIDsMatch(original, afterFirstReplace);
     assertFiles(afterFirstReplace, FILE_B);
 
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = catalog.loadTable(TABLE);
-    Assert.assertEquals(
-        "Table order should match the new order",
-        TABLE_WRITE_ORDER.fields(),
-        afterSecondReplace.sortOrder().fields());
+    Assertions.assertThat(afterSecondReplace.sortOrder().fields())
+        .as("Table order should match the new order")
+        .isEqualTo(TABLE_WRITE_ORDER.fields());
     assertUUIDsMatch(original, afterSecondReplace);
     assertFiles(afterSecondReplace, FILE_C);
   }
@@ -2489,30 +2623,28 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   private static void assertEmpty(String context, Catalog catalog, Namespace ns) {
     try {
-      Assert.assertEquals(context, 0, catalog.listTables(ns).size());
+      Assertions.assertThat(catalog.listTables(ns).size()).as("context").isEqualTo(0);
     } catch (NoSuchNamespaceException e) {
       // it is okay if the catalog throws NoSuchNamespaceException when it is empty
     }
   }
 
   public void assertUUIDsMatch(Table expected, Table actual) {
-    Assert.assertEquals(
-        "Table UUID should not change",
-        ((BaseTable) expected).operations().current().uuid(),
-        ((BaseTable) actual).operations().current().uuid());
+    Assertions.assertThat(((BaseTable) actual).operations().current().uuid())
+        .as("Table UUID should not change")
+        .isEqualTo(((BaseTable) expected).operations().current().uuid());
   }
 
   public void assertPreviousMetadataFileCount(Table table, int metadataFileCount) {
     TableOperations ops = ((BaseTable) table).operations();
-    Assert.assertEquals(
-        "Table should have correct number of previous metadata locations",
-        metadataFileCount,
-        ops.current().previousFiles().size());
+    Assertions.assertThat(ops.current().previousFiles().size())
+        .as("Table should have correct number of previous metadata locations")
+        .isEqualTo(metadataFileCount);
   }
 
   public void assertNoFiles(Table table) {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-      Assert.assertFalse("Should contain no files", tasks.iterator().hasNext());
+      Assertions.assertThat(tasks).as("Should contain no files").isEmpty();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -2525,12 +2657,12 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
               .map(FileScanTask::file)
               .map(DataFile::path)
               .collect(Collectors.toList());
-      Assert.assertEquals(
-          "Should contain expected number of data files", files.length, paths.size());
-      Assert.assertEquals(
-          "Should contain correct file paths",
-          CharSequenceSet.of(Iterables.transform(Arrays.asList(files), DataFile::path)),
-          CharSequenceSet.of(paths));
+      Assertions.assertThat(paths.size())
+          .as("Should contain expected number of data files")
+          .isEqualTo(files.length);
+      Assertions.assertThat(CharSequenceSet.of(paths))
+          .as("Should contain correct file paths")
+          .isEqualTo(CharSequenceSet.of(Iterables.transform(Arrays.asList(files), DataFile::path)));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -2541,7 +2673,11 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
       Streams.stream(tasks)
           .map(FileScanTask::file)
           .filter(file -> file.path().equals(dataFile.path()))
-          .forEach(file -> Assert.assertEquals(specId, file.specId()));
+          .forEach(
+              file ->
+                  Assertions.assertThat(file.specId())
+                      .as("Spec ID should match")
+                      .isEqualTo(specId));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -2551,7 +2687,11 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       Streams.stream(tasks)
           .map(FileScanTask::file)
-          .forEach(file -> Assert.assertEquals(table.spec().specId(), file.specId()));
+          .forEach(
+              file ->
+                  Assertions.assertThat(file.specId())
+                      .as("Spec ID should match")
+                      .isEqualTo(table.spec().specId()));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -239,9 +239,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, properties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assertions.assertThat(Sets.intersection(properties.entrySet(), actualProperties.entrySet()))
+    Assertions.assertThat(actualProperties.entrySet())
         .as("Set properties should be a subset of returned properties")
-        .isEqualTo(properties.entrySet());
+        .containsAll(properties.entrySet());
   }
 
   @Test
@@ -256,20 +256,18 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, initialProperties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assertions.assertThat(
-            Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()))
+    Assertions.assertThat(actualProperties.entrySet())
         .as("Set properties should be a subset of returned properties")
-        .isEqualTo(initialProperties.entrySet());
+        .containsAll(initialProperties.entrySet());
 
     Map<String, String> updatedProperties = ImmutableMap.of("owner", "newuser");
 
     catalog.setProperties(NS, updatedProperties);
 
     Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
-    Assertions.assertThat(
-            Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()))
+    Assertions.assertThat(finalProperties.entrySet())
         .as("Updated properties should be a subset of returned properties")
-        .isEqualTo(updatedProperties.entrySet());
+        .containsAll(updatedProperties.entrySet());
   }
 
   @Test
@@ -284,10 +282,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, initialProperties);
 
     Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
-    Assertions.assertThat(
-            Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()))
+    Assertions.assertThat(actualProperties.entrySet())
         .as("Set properties should be a subset of returned properties")
-        .isEqualTo(initialProperties.entrySet());
+        .containsAll(initialProperties.entrySet());
 
     Map<String, String> updatedProperties =
         ImmutableMap.of("owner", "newuser", "last-modified-at", "now");
@@ -295,10 +292,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     catalog.setProperties(NS, updatedProperties);
 
     Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
-    Assertions.assertThat(
-            Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()))
+    Assertions.assertThat(finalProperties.entrySet())
         .as("Updated properties should be a subset of returned properties")
-        .isEqualTo(updatedProperties.entrySet());
+        .containsAll(updatedProperties.entrySet());
   }
 
   @Test
@@ -1557,9 +1553,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assertions.assertThat(table.sortOrder())
         .as("Table should have create sort order")
         .isEqualTo(TABLE_WRITE_ORDER);
-    Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
+    Assertions.assertThat(table.properties().entrySet())
         .as("Table properties should be a superset of the requested properties")
-        .isEqualTo(properties.entrySet());
+        .containsAll(properties.entrySet());
     if (!overridesRequestedLocation()) {
       Assertions.assertThat(table.location())
           .as("Table location should match requested")
@@ -1655,9 +1651,9 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assertions.assertThat(table.sortOrder().orderId())
         .as("Table should have updated sort order ID")
         .isEqualTo(updateOrderId);
-    Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
+    Assertions.assertThat(table.properties().entrySet())
         .as("Table properties should be a superset of the requested properties")
-        .isEqualTo(properties.entrySet());
+        .containsAll(properties.entrySet());
     if (!overridesRequestedLocation()) {
       Assertions.assertThat(table.location())
           .as("Table location should match requested")
@@ -1722,7 +1718,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
         .isEqualTo(TABLE_WRITE_ORDER);
     Assertions.assertThat(Sets.intersection(properties.entrySet(), table.properties().entrySet()))
         .as("Table properties should be a superset of the requested properties")
-        .containsAll(expectedProps.entrySet());
+        .containsExactlyInAnyOrderElementsOf(expectedProps.entrySet());
     Assertions.assertThat(table.currentSnapshot().sequenceNumber())
         .as("Sequence number should start at 1 for v2 format")
         .isEqualTo(1);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -201,7 +201,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
     Map<String, String> createProps = ImmutableMap.of("prop", "val");
     catalog.createNamespace(NS, createProps);
-
     Assertions.assertThat(catalog.namespaceExists(NS)).as("Namespace should exist").isTrue();
 
     Map<String, String> props = catalog.loadNamespaceMetadata(NS);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -559,7 +559,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assertions.assertThat(catalog.tableExists(ident)).as("Table should not exist").isFalse();
 
     catalog.buildTable(ident, SCHEMA).create();
-
     Assertions.assertThat(catalog.tableExists(ident)).as("Table should exist").isTrue();
 
     Table loaded = catalog.loadTable(ident);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -2617,7 +2617,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   private static void assertEmpty(String context, Catalog catalog, Namespace ns) {
     try {
-      Assertions.assertThat(catalog.listTables(ns).size()).as("context").isEqualTo(0);
+      Assertions.assertThat(catalog.listTables(ns)).as(context).isEmpty();
     } catch (NoSuchNamespaceException e) {
       // it is okay if the catalog throws NoSuchNamespaceException when it is empty
     }

--- a/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
@@ -19,8 +19,7 @@
 package org.apache.iceberg.catalog;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTableIdentifierParser {
 
@@ -28,40 +27,36 @@ public class TestTableIdentifierParser {
   public void testTableIdentifierToJson() {
     String json = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}";
     TableIdentifier identifier = TableIdentifier.of(Namespace.of("accounting", "tax"), "paid");
-    Assert.assertEquals(
-        "Should be able to serialize a table identifier with both namespace and name",
-        json,
-        TableIdentifierParser.toJson(identifier));
+    Assertions.assertThat(TableIdentifierParser.toJson(identifier))
+        .as("Should be able to serialize a table identifier with both namespace and name")
+        .isEqualTo(json);
 
     TableIdentifier identifierWithEmptyNamespace = TableIdentifier.of(Namespace.empty(), "paid");
     String jsonWithEmptyNamespace = "{\"namespace\":[],\"name\":\"paid\"}";
-    Assert.assertEquals(
-        "Should be able to serialize a table identifier that uses the empty namespace",
-        jsonWithEmptyNamespace,
-        TableIdentifierParser.toJson(identifierWithEmptyNamespace));
+    Assertions.assertThat(TableIdentifierParser.toJson(identifierWithEmptyNamespace))
+        .as("Should be able to serialize a table identifier that uses the empty namespace")
+        .isEqualTo(jsonWithEmptyNamespace);
   }
 
   @Test
   public void testTableIdentifierFromJson() {
     String json = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}";
     TableIdentifier identifier = TableIdentifier.of(Namespace.of("accounting", "tax"), "paid");
-    Assert.assertEquals(
-        "Should be able to deserialize a valid table identifier",
-        identifier,
-        TableIdentifierParser.fromJson(json));
+    Assertions.assertThat(TableIdentifierParser.fromJson(json))
+        .as("Should be able to deserialize a valid table identifier")
+        .isEqualTo(identifier);
 
     TableIdentifier identifierWithEmptyNamespace = TableIdentifier.of(Namespace.empty(), "paid");
     String jsonWithEmptyNamespace = "{\"namespace\":[],\"name\":\"paid\"}";
-    Assert.assertEquals(
-        "Should be able to deserialize a valid multi-level table identifier",
-        identifierWithEmptyNamespace,
-        TableIdentifierParser.fromJson(jsonWithEmptyNamespace));
+    Assertions.assertThat(TableIdentifierParser.fromJson(jsonWithEmptyNamespace))
+        .as("Should be able to deserialize a valid multi-level table identifier")
+        .isEqualTo(identifierWithEmptyNamespace);
 
     String identifierMissingNamespace = "{\"name\":\"paid\"}";
-    Assert.assertEquals(
-        "Should implicitly convert a missing namespace into the the empty namespace when parsing",
-        identifierWithEmptyNamespace,
-        TableIdentifierParser.fromJson(identifierMissingNamespace));
+    Assertions.assertThat(TableIdentifierParser.fromJson(identifierMissingNamespace))
+        .as(
+            "Should implicitly convert a missing namespace into the the empty namespace when parsing")
+        .isEqualTo(identifierWithEmptyNamespace);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/encryption/TestCiphers.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestCiphers.java
@@ -18,10 +18,11 @@
  */
 package org.apache.iceberg.encryption;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestCiphers {
 
@@ -49,7 +50,7 @@ public class TestCiphers {
 
       Ciphers.AesGcmDecryptor decryptor = new Ciphers.AesGcmDecryptor(key);
       byte[] decryptedText = decryptor.decrypt(ciphertext, aad);
-      Assert.assertArrayEquals("Key length " + keyLength, plaintext, decryptedText);
+      assertThat(decryptedText).as("Key length " + keyLength).isEqualTo(plaintext);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -24,7 +24,7 @@ import java.io.OutputStream;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInMemoryFileIO {
   String location = "s3://foo/bar.txt";

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryInputFile.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryInputFile.java
@@ -30,9 +30,7 @@ public class TestInMemoryInputFile {
     InMemoryInputFile inputFile =
         new InMemoryInputFile("abc".getBytes(StandardCharsets.ISO_8859_1));
     InputStream inputStream = inputFile.newStream();
-    Assertions.assertThat(inputStream.read())
-        .as("Checking read value from inputStream")
-        .isEqualTo('a');
+    Assertions.assertThat(inputStream.read()).isEqualTo('a');
     inputStream.close();
     Assertions.assertThatThrownBy(inputStream::read).hasMessage("Stream is closed");
   }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryInputFile.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryInputFile.java
@@ -22,8 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInMemoryInputFile {
   @Test
@@ -31,7 +30,9 @@ public class TestInMemoryInputFile {
     InMemoryInputFile inputFile =
         new InMemoryInputFile("abc".getBytes(StandardCharsets.ISO_8859_1));
     InputStream inputStream = inputFile.newStream();
-    Assert.assertEquals('a', inputStream.read());
+    Assertions.assertThat(inputStream.read())
+        .as("Checking read value from inputStream")
+        .isEqualTo('a');
     inputStream.close();
     Assertions.assertThatThrownBy(inputStream::read).hasMessage("Stream is closed");
   }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryOutputFile.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryOutputFile.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInMemoryOutputFile {
   @Test

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -25,8 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class TestByteBufferInputStreams {
 
@@ -40,12 +39,14 @@ public abstract class TestByteBufferInputStreams {
 
     ByteBufferInputStream stream = newStream();
 
-    Assert.assertEquals("Should read 0 bytes", 0, stream.read(bytes));
+    Assertions.assertThat(stream.read(bytes)).as("Should read 0 bytes").isEqualTo(0);
 
     int bytesRead = stream.read(new byte[100]);
-    Assert.assertTrue("Should read to end of stream", bytesRead < 100);
+    Assertions.assertThat(bytesRead).as("Should read to end of stream").isLessThan(100);
 
-    Assert.assertEquals("Should read 0 bytes at end of stream", 0, stream.read(bytes));
+    Assertions.assertThat(stream.read(bytes))
+        .as("Should read 0 bytes at end of stream")
+        .isEqualTo(0);
   }
 
   @Test
@@ -55,18 +56,22 @@ public abstract class TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     int bytesRead = stream.read(bytes);
-    Assert.assertEquals("Should read the entire buffer", bytes.length, bytesRead);
+    Assertions.assertThat(bytesRead).as("Should read the entire buffer").isEqualTo(bytes.length);
 
     for (int i = 0; i < bytes.length; i += 1) {
-      Assert.assertEquals("Byte i should be i", i, bytes[i]);
-      Assert.assertEquals("Should advance position", 35, stream.getPos());
+      Assertions.assertThat(bytes[i]).as("Byte i should be i").isEqualTo((byte) i);
+      Assertions.assertThat(stream.getPos()).as("Should advance position").isEqualTo(35);
     }
 
-    Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+    Assertions.assertThat(stream.available())
+        .as("Should have no more remaining content")
+        .isEqualTo(0);
 
-    Assert.assertEquals("Should return -1 at end of stream", -1, stream.read(bytes));
+    Assertions.assertThat(stream.read(bytes)).as("Should return -1 at end of stream").isEqualTo(-1);
 
-    Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+    Assertions.assertThat(stream.available())
+        .as("Should have no more remaining content")
+        .isEqualTo(0);
 
     checkOriginalData();
   }
@@ -81,28 +86,37 @@ public abstract class TestByteBufferInputStreams {
 
       int lastBytesRead = bytes.length;
       for (int offset = 0; offset < length; offset += bytes.length) {
-        Assert.assertEquals("Should read requested len", bytes.length, lastBytesRead);
+        Assertions.assertThat(lastBytesRead)
+            .as("Should read requested len")
+            .isEqualTo(bytes.length);
 
         lastBytesRead = stream.read(bytes, 0, bytes.length);
 
-        Assert.assertEquals("Should advance position", offset + lastBytesRead, stream.getPos());
+        Assertions.assertThat(stream.getPos())
+            .as("Should advance position")
+            .isEqualTo(offset + lastBytesRead);
 
         // validate the bytes that were read
         for (int i = 0; i < lastBytesRead; i += 1) {
-          Assert.assertEquals("Byte i should be i", offset + i, bytes[i]);
+          Assertions.assertThat(bytes[i]).as("Byte i should be i").isEqualTo((byte) (offset + i));
         }
       }
 
-      Assert.assertEquals(
-          "Should read fewer bytes at end of buffer",
-          length % bytes.length,
-          lastBytesRead % bytes.length);
+      Assertions.assertThat(lastBytesRead % bytes.length)
+          .as("Should read fewer bytes at end of buffer")
+          .isEqualTo(length % bytes.length);
 
-      Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+      Assertions.assertThat(stream.available())
+          .as("Should have no more remaining content")
+          .isEqualTo(0);
 
-      Assert.assertEquals("Should return -1 at end of stream", -1, stream.read(bytes));
+      Assertions.assertThat(stream.read(bytes))
+          .as("Should return -1 at end of stream")
+          .isEqualTo(-1);
 
-      Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+      Assertions.assertThat(stream.available())
+          .as("Should have no more remaining content")
+          .isEqualTo(0);
     }
 
     checkOriginalData();
@@ -117,32 +131,40 @@ public abstract class TestByteBufferInputStreams {
 
       int lastBytesRead = size;
       for (int offset = 0; offset < bytes.length; offset += size) {
-        Assert.assertEquals("Should read requested len", size, lastBytesRead);
+        Assertions.assertThat(lastBytesRead).as("Should read requested len").isEqualTo(size);
 
         lastBytesRead = stream.read(bytes, offset, Math.min(size, bytes.length - offset));
 
-        Assert.assertEquals(
-            "Should advance position",
-            lastBytesRead > 0 ? offset + lastBytesRead : offset,
-            stream.getPos());
+        Assertions.assertThat(stream.getPos())
+            .as("Should advance position")
+            .isEqualTo(lastBytesRead > 0 ? offset + lastBytesRead : offset);
       }
 
-      Assert.assertEquals(
-          "Should read fewer bytes at end of buffer", bytes.length % size, lastBytesRead % size);
+      Assertions.assertThat(lastBytesRead % size)
+          .as("Should read fewer bytes at end of buffer")
+          .isEqualTo(bytes.length % size);
 
       for (int i = 0; i < bytes.length; i += 1) {
-        Assert.assertEquals("Byte i should be i", i, bytes[i]);
+        Assertions.assertThat(bytes[i]).as("Byte i should be i").isEqualTo((byte) i);
       }
 
-      Assert.assertEquals("Should have no more remaining content", 2, stream.available());
+      Assertions.assertThat(stream.available())
+          .as("Should have no more remaining content")
+          .isEqualTo(2);
 
-      Assert.assertEquals("Should return 2 more bytes", 2, stream.read(bytes));
+      Assertions.assertThat(stream.read(bytes)).as("Should return 2 more bytes").isEqualTo(2);
 
-      Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+      Assertions.assertThat(stream.available())
+          .as("Should have no more remaining content")
+          .isEqualTo(0);
 
-      Assert.assertEquals("Should return -1 at end of stream", -1, stream.read(bytes));
+      Assertions.assertThat(stream.read(bytes))
+          .as("Should return -1 at end of stream")
+          .isEqualTo(-1);
 
-      Assert.assertEquals("Should have no more remaining content", 0, stream.available());
+      Assertions.assertThat(stream.available())
+          .as("Should have no more remaining content")
+          .isEqualTo(0);
     }
 
     checkOriginalData();
@@ -154,8 +176,8 @@ public abstract class TestByteBufferInputStreams {
     int length = stream.available();
 
     for (int i = 0; i < length; i += 1) {
-      Assert.assertEquals("Position should increment", i, stream.getPos());
-      Assert.assertEquals(i, stream.read());
+      Assertions.assertThat(stream.getPos()).as("Position should increment").isEqualTo(i);
+      Assertions.assertThat(stream.read()).isEqualTo(i);
     }
 
     Assertions.assertThatThrownBy(stream::read).isInstanceOf(EOFException.class).hasMessage(null);
@@ -170,10 +192,12 @@ public abstract class TestByteBufferInputStreams {
     int length = stream.available();
 
     ByteBuffer empty = stream.slice(0);
-    Assert.assertNotNull("slice(0) should produce a non-null buffer", empty);
-    Assert.assertEquals("slice(0) should produce an empty buffer", 0, empty.remaining());
 
-    Assert.assertEquals("Position should be at start", 0, stream.getPos());
+    Assertions.assertThat(empty).as("slice(0) should produce a non-null buffer").isNotNull();
+    Assertions.assertThat(empty.remaining())
+        .as("slice(0) should produce an empty buffer")
+        .isEqualTo(0);
+    Assertions.assertThat(stream.getPos()).as("Position should be at start").isEqualTo(0);
 
     int i = 0;
     while (stream.available() > 0) {
@@ -181,13 +205,13 @@ public abstract class TestByteBufferInputStreams {
       ByteBuffer buffer = stream.slice(bytesToSlice);
 
       for (int j = 0; j < bytesToSlice; j += 1) {
-        Assert.assertEquals("Data should be correct", i + j, buffer.get());
+        Assertions.assertThat(buffer.get()).as("Data should be correct").isEqualTo((byte) (i + j));
       }
 
       i += bytesToSlice;
     }
 
-    Assert.assertEquals("Position should be at end", length, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Position should be at end").isEqualTo(length);
 
     checkOriginalData();
   }
@@ -196,8 +220,9 @@ public abstract class TestByteBufferInputStreams {
   public void testSliceBuffers0() throws Exception {
     ByteBufferInputStream stream = newStream();
 
-    Assert.assertEquals(
-        "Should return an empty list", Collections.emptyList(), stream.sliceBuffers(0));
+    Assertions.assertThat(stream.sliceBuffers(0))
+        .as("Should return an empty list")
+        .isEqualTo(Collections.emptyList());
   }
 
   @Test
@@ -207,7 +232,7 @@ public abstract class TestByteBufferInputStreams {
 
     List<ByteBuffer> buffers = stream.sliceBuffers(stream.available());
 
-    Assert.assertEquals("Should consume all buffers", length, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Should consume all buffers").isEqualTo(length);
 
     Assertions.assertThatThrownBy(() -> stream.sliceBuffers(length))
         .isInstanceOf(EOFException.class)
@@ -215,7 +240,7 @@ public abstract class TestByteBufferInputStreams {
 
     ByteBufferInputStream copy = ByteBufferInputStream.wrap(buffers);
     for (int i = 0; i < length; i += 1) {
-      Assert.assertEquals("Slice should have identical data", i, copy.read());
+      Assertions.assertThat(copy.read()).as("Slice should have identical data").isEqualTo(i);
     }
 
     checkOriginalData();
@@ -232,12 +257,12 @@ public abstract class TestByteBufferInputStreams {
         buffers.addAll(stream.sliceBuffers(Math.min(size, stream.available())));
       }
 
-      Assert.assertEquals("Should consume all content", length, stream.getPos());
+      Assertions.assertThat(stream.getPos()).as("Should consume all content").isEqualTo(length);
 
       ByteBufferInputStream newStream = new MultiBufferInputStream(buffers);
 
       for (int i = 0; i < length; i += 1) {
-        Assert.assertEquals("Data should be correct", i, newStream.read());
+        Assertions.assertThat(newStream.read()).as("Data should be correct").isEqualTo(i);
       }
     }
 
@@ -251,27 +276,39 @@ public abstract class TestByteBufferInputStreams {
 
     int sliceLength = 5;
     List<ByteBuffer> buffers = stream.sliceBuffers(sliceLength);
-    Assert.assertEquals(
-        "Should advance the original stream", length - sliceLength, stream.available());
-    Assert.assertEquals(
-        "Should advance the original stream position", sliceLength, stream.getPos());
 
-    Assert.assertEquals("Should return a slice of the first buffer", 1, buffers.size());
+    Assertions.assertThat(stream.available())
+        .as("Should advance the original stream")
+        .isEqualTo(length - sliceLength);
+
+    Assertions.assertThat(stream.getPos())
+        .as("Should advance the original stream position")
+        .isEqualTo(sliceLength);
+
+    Assertions.assertThat(buffers.size())
+        .as("Should return a slice of the first buffer")
+        .isEqualTo(1);
 
     ByteBuffer buffer = buffers.get(0);
-    Assert.assertEquals("Should have requested bytes", sliceLength, buffer.remaining());
+
+    Assertions.assertThat(buffer.remaining())
+        .as("Should have requested bytes")
+        .isEqualTo(sliceLength);
 
     // read the buffer one past the returned limit. this should not change the
     // next value in the original stream
     buffer.limit(sliceLength + 1);
     for (int i = 0; i < sliceLength + 1; i += 1) {
-      Assert.assertEquals("Should have correct data", i, buffer.get());
+      Assertions.assertThat(buffer.get()).as("Should have correct data").isEqualTo((byte) i);
     }
 
-    Assert.assertEquals(
-        "Reading a slice shouldn't advance the original stream", sliceLength, stream.getPos());
-    Assert.assertEquals(
-        "Reading a slice shouldn't change the underlying data", sliceLength, stream.read());
+    Assertions.assertThat(stream.getPos())
+        .as("Reading a slice shouldn't advance the original stream")
+        .isEqualTo(sliceLength);
+
+    Assertions.assertThat(stream.read())
+        .as("Reading a slice shouldn't change the underlying data")
+        .isEqualTo(sliceLength);
 
     // change the underlying data buffer
     buffer.limit(sliceLength + 2);
@@ -281,12 +318,13 @@ public abstract class TestByteBufferInputStreams {
     try {
       buffer.put((byte) 255);
 
-      Assert.assertEquals(
-          "Writing to a slice shouldn't advance the original stream",
-          sliceLength + 1,
-          stream.getPos());
-      Assert.assertEquals(
-          "Writing to a slice should change the underlying data", 255, stream.read());
+      Assertions.assertThat(stream.getPos())
+          .as("Writing to a slice shouldn't advance the original stream")
+          .isEqualTo(sliceLength + 1);
+
+      Assertions.assertThat(stream.read())
+          .as("Writing to a slice should change the underlying data")
+          .isEqualTo(255);
 
     } finally {
       undoBuffer.put((byte) originalValue);
@@ -299,16 +337,20 @@ public abstract class TestByteBufferInputStreams {
 
     while (stream.available() > 0) {
       int bytesToSkip = Math.min(stream.available(), 10);
-      Assert.assertEquals(
-          "Should skip all, regardless of backing buffers", bytesToSkip, stream.skip(bytesToSkip));
+      Assertions.assertThat(stream.skip(bytesToSkip))
+          .as("Should skip all, regardless of backing buffers")
+          .isEqualTo(bytesToSkip);
     }
 
     stream = newStream();
-    Assert.assertEquals(0, stream.skip(0));
+    Assertions.assertThat(stream.skip(0)).isEqualTo(0);
 
     int length = stream.available();
-    Assert.assertEquals("Should stop at end when out of bytes", length, stream.skip(length + 10));
-    Assert.assertEquals("Should return -1 when at end", -1, stream.skip(10));
+    Assertions.assertThat(stream.skip(length + 10))
+        .as("Should stop at end when out of bytes")
+        .isEqualTo(length);
+
+    Assertions.assertThat(stream.skip(10)).as("Should return -1 when at end").isEqualTo(-1);
   }
 
   @Test
@@ -321,17 +363,16 @@ public abstract class TestByteBufferInputStreams {
 
       stream.skipFully(bytesToSkip);
 
-      Assert.assertEquals(
-          "Should skip all, regardless of backing buffers",
-          bytesToSkip,
-          stream.getPos() - lastPosition);
+      Assertions.assertThat(stream.getPos() - lastPosition)
+          .as("Should skip all, regardless of backing buffers")
+          .isEqualTo(bytesToSkip);
 
       lastPosition = stream.getPos();
     }
 
     ByteBufferInputStream stream2 = newStream();
     stream2.skipFully(0);
-    Assert.assertEquals(0, stream2.getPos());
+    Assertions.assertThat(stream2.getPos()).as("Check initial position").isEqualTo(0);
 
     int length = stream2.available();
 
@@ -356,17 +397,20 @@ public abstract class TestByteBufferInputStreams {
 
     stream.reset();
 
-    Assert.assertEquals("Position should return to the mark", mark, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Position should return to the mark").isEqualTo(mark);
 
     byte[] afterReset = new byte[100];
     int bytesReadAfterReset = stream.read(afterReset);
 
-    Assert.assertEquals(
-        "Should read the same number of bytes", expectedBytesRead, bytesReadAfterReset);
+    Assertions.assertThat(bytesReadAfterReset)
+        .as("Should read the same number of bytes")
+        .isEqualTo(expectedBytesRead);
 
-    Assert.assertEquals("Read should end at the same position", end, stream.getPos());
+    Assertions.assertThat(stream.getPos())
+        .as("Read should end at the same position")
+        .isEqualTo(end);
 
-    Assert.assertArrayEquals("Content should be equal", expected, afterReset);
+    Assertions.assertThat(afterReset).as("Content should be equal").isEqualTo(expected);
   }
 
   @Test
@@ -386,17 +430,19 @@ public abstract class TestByteBufferInputStreams {
 
     stream.reset();
 
-    Assert.assertEquals("Position should return to the mark", mark, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Position should return to the mark").isEqualTo(mark);
 
     byte[] afterReset = new byte[100];
     int bytesReadAfterReset = stream.read(afterReset);
+    Assertions.assertThat(bytesReadAfterReset)
+        .as("Should read the same number of bytes")
+        .isEqualTo(expectedBytesRead);
 
-    Assert.assertEquals(
-        "Should read the same number of bytes", expectedBytesRead, bytesReadAfterReset);
+    Assertions.assertThat(stream.getPos())
+        .as("Read should end at the same position")
+        .isEqualTo(end);
 
-    Assert.assertEquals("Read should end at the same position", end, stream.getPos());
-
-    Assert.assertArrayEquals("Content should be equal", expected, afterReset);
+    Assertions.assertThat(afterReset).as("Content should be equal").isEqualTo(expected);
   }
 
   @Test
@@ -408,20 +454,22 @@ public abstract class TestByteBufferInputStreams {
     long mark = stream.getPos();
 
     byte[] expected = new byte[10];
-    Assert.assertEquals("Should read 10 bytes", 10, stream.read(expected));
+    Assertions.assertThat(stream.read(expected)).as("Should read 10 bytes").isEqualTo(10);
 
     long end = stream.getPos();
 
     stream.reset();
 
-    Assert.assertEquals("Position should return to the mark", mark, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Position should return to the mark").isEqualTo(mark);
 
     byte[] afterReset = new byte[10];
-    Assert.assertEquals("Should read 10 bytes", 10, stream.read(afterReset));
+    Assertions.assertThat(stream.read(afterReset)).as("Should read 10 bytes").isEqualTo(10);
 
-    Assert.assertEquals("Read should end at the same position", end, stream.getPos());
+    Assertions.assertThat(stream.getPos())
+        .as("Read should end at the same position")
+        .isEqualTo(end);
 
-    Assert.assertArrayEquals("Content should be equal", expected, afterReset);
+    Assertions.assertThat(afterReset).as("Content should be equal").isEqualTo(expected);
   }
 
   @Test
@@ -429,27 +477,29 @@ public abstract class TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     int bytesRead = stream.read(new byte[100]);
-    Assert.assertTrue("Should read to end of stream", bytesRead < 100);
+    Assertions.assertThat(bytesRead < 100).as("Should read to end of stream").isTrue();
 
     stream.mark(100);
 
     long mark = stream.getPos();
 
     byte[] expected = new byte[10];
-    Assert.assertEquals("Should read 0 bytes", -1, stream.read(expected));
+    Assertions.assertThat(stream.read(expected)).as("Should read 0 bytes").isEqualTo(-1);
 
     long end = stream.getPos();
 
     stream.reset();
 
-    Assert.assertEquals("Position should return to the mark", mark, stream.getPos());
+    Assertions.assertThat(stream.getPos()).as("Position should return to the mark").isEqualTo(mark);
 
     byte[] afterReset = new byte[10];
-    Assert.assertEquals("Should read 0 bytes", -1, stream.read(afterReset));
+    Assertions.assertThat(stream.read(afterReset)).as("Should read 0 bytes").isEqualTo(-1);
 
-    Assert.assertEquals("Read should end at the same position", end, stream.getPos());
+    Assertions.assertThat(stream.getPos())
+        .as("Read should end at the same position")
+        .isEqualTo(end);
 
-    Assert.assertArrayEquals("Content should be equal", expected, afterReset);
+    Assertions.assertThat(afterReset).as("Content should be equal").isEqualTo(expected);
   }
 
   @Test
@@ -467,22 +517,28 @@ public abstract class TestByteBufferInputStreams {
 
     byte[] expected = new byte[6];
     stream.mark(10);
-    Assert.assertEquals("Should read expected bytes", expected.length, stream.read(expected));
+    Assertions.assertThat(stream.read(expected))
+        .as("Should read expected bytes")
+        .isEqualTo(expected.length);
 
     stream.reset();
     stream.mark(10);
 
     byte[] firstRead = new byte[6];
-    Assert.assertEquals("Should read firstRead bytes", firstRead.length, stream.read(firstRead));
+    Assertions.assertThat(stream.read(firstRead))
+        .as("Should read firstRead bytes")
+        .isEqualTo(firstRead.length);
 
     stream.reset();
 
     byte[] secondRead = new byte[6];
-    Assert.assertEquals("Should read secondRead bytes", secondRead.length, stream.read(secondRead));
+    Assertions.assertThat(stream.read(secondRead))
+        .as("Should read secondRead bytes")
+        .isEqualTo(secondRead.length);
 
-    Assert.assertArrayEquals("First read should be correct", expected, firstRead);
+    Assertions.assertThat(firstRead).as("First read should be correct").isEqualTo(expected);
 
-    Assert.assertArrayEquals("Second read should be correct", expected, secondRead);
+    Assertions.assertThat(secondRead).as("Second read should be correct").isEqualTo(expected);
   }
 
   @Test
@@ -490,11 +546,11 @@ public abstract class TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     stream.mark(5);
-    Assert.assertEquals("Should read 5 bytes", 5, stream.read(new byte[5]));
+    Assertions.assertThat(stream.read(new byte[5])).as("Should read 5 bytes").isEqualTo(5);
 
     stream.reset();
 
-    Assert.assertEquals("Should read 6 bytes", 6, stream.read(new byte[6]));
+    Assertions.assertThat(stream.read(new byte[6])).as("Should read 6 bytes").isEqualTo(6);
 
     Assertions.assertThatThrownBy(stream::reset)
         .isInstanceOf(IOException.class)
@@ -506,7 +562,8 @@ public abstract class TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     stream.mark(5);
-    Assert.assertEquals("Should read 5 bytes", 5, stream.read(new byte[5]));
+
+    Assertions.assertThat(stream.read(new byte[5])).as("Should read 5 bytes").isEqualTo(5);
 
     stream.reset();
 

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -562,7 +562,6 @@ public abstract class TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     stream.mark(5);
-
     Assertions.assertThat(stream.read(new byte[5])).as("Should read 5 bytes").isEqualTo(5);
 
     stream.reset();

--- a/core/src/test/java/org/apache/iceberg/io/TestIOUtil.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestIOUtil.java
@@ -26,8 +26,7 @@ import java.util.Arrays;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestIOUtil {
   @Test
@@ -37,11 +36,13 @@ public class TestIOUtil {
     MockInputStream stream = new MockInputStream();
     IOUtil.readFully(stream, buffer, 0, buffer.length);
 
-    Assert.assertArrayEquals(
-        "Byte array contents should match",
-        Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5),
-        buffer);
-    Assert.assertEquals("Stream position should reflect bytes read", 5, stream.getPos());
+    Assertions.assertThat(buffer)
+        .as("Byte array contents should match")
+        .isEqualTo(Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5));
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(5);
   }
 
   @Test
@@ -51,11 +52,13 @@ public class TestIOUtil {
     MockInputStream stream = new MockInputStream(2, 3, 3);
     IOUtil.readFully(stream, buffer, 0, buffer.length);
 
-    Assert.assertArrayEquals(
-        "Byte array contents should match",
-        Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5),
-        buffer);
-    Assert.assertEquals("Stream position should reflect bytes read", 5, stream.getPos());
+    Assertions.assertThat(buffer)
+        .as("Byte array contents should match")
+        .containsExactly(Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5));
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(5);
   }
 
   @Test
@@ -65,9 +68,13 @@ public class TestIOUtil {
     final MockInputStream stream = new MockInputStream(2, 3, 3);
     IOUtil.readFully(stream, buffer, 0, buffer.length);
 
-    Assert.assertArrayEquals(
-        "Byte array contents should match", MockInputStream.TEST_ARRAY, buffer);
-    Assert.assertEquals("Stream position should reflect bytes read", 10, stream.getPos());
+    Assertions.assertThat(buffer)
+        .as("Byte array contents should match")
+        .isEqualTo(MockInputStream.TEST_ARRAY);
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(10);
 
     Assertions.assertThatThrownBy(() -> IOUtil.readFully(stream, buffer, 0, 1))
         .isInstanceOf(EOFException.class)
@@ -84,11 +91,13 @@ public class TestIOUtil {
         .isInstanceOf(EOFException.class)
         .hasMessage("Reached the end of stream with 1 bytes left to read");
 
-    Assert.assertArrayEquals(
-        "Should have consumed bytes",
-        MockInputStream.TEST_ARRAY,
-        Arrays.copyOfRange(buffer, 0, 10));
-    Assert.assertEquals("Stream position should reflect bytes read", 10, stream.getPos());
+    Assertions.assertThat(Arrays.copyOfRange(buffer, 0, 10))
+        .as("Should have consumed bytes")
+        .isEqualTo(MockInputStream.TEST_ARRAY);
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(10);
   }
 
   @Test
@@ -98,11 +107,13 @@ public class TestIOUtil {
     MockInputStream stream = new MockInputStream();
     IOUtil.readFully(stream, buffer, 2, 5);
 
-    Assert.assertArrayEquals(
-        "Byte array contents should match",
-        Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5),
-        Arrays.copyOfRange(buffer, 2, 7));
-    Assert.assertEquals("Stream position should reflect bytes read", 5, stream.getPos());
+    Assertions.assertThat(Arrays.copyOfRange(buffer, 2, 7))
+        .as("Byte array contents should match")
+        .isEqualTo(Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5));
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(5);
   }
 
   @Test
@@ -112,7 +123,9 @@ public class TestIOUtil {
     MockInputStream stream = new MockInputStream();
     IOUtil.readFully(stream, buffer, 0, buffer.length);
 
-    Assert.assertEquals("Stream position should reflect bytes read", 0, stream.getPos());
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(0);
   }
 
   @Test
@@ -122,11 +135,13 @@ public class TestIOUtil {
     MockInputStream stream = new MockInputStream(2, 2, 3);
     IOUtil.readFully(stream, buffer, 2, 5);
 
-    Assert.assertArrayEquals(
-        "Byte array contents should match",
-        Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5),
-        Arrays.copyOfRange(buffer, 2, 7));
-    Assert.assertEquals("Stream position should reflect bytes read", 5, stream.getPos());
+    Assertions.assertThat(Arrays.copyOfRange(buffer, 2, 7))
+        .as("Byte array contents should match")
+        .isEqualTo(Arrays.copyOfRange(MockInputStream.TEST_ARRAY, 0, 5));
+
+    Assertions.assertThat(stream.getPos())
+        .as("Stream position should reflect bytes read")
+        .isEqualTo(5);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/io/TestMultiBufferInputStream.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestMultiBufferInputStream.java
@@ -116,7 +116,6 @@ public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
 
     // five should be a copy of the next 8 bytes
     ByteBuffer five = buffers.get(4);
-
     assertThat(five.remaining()).isEqualTo(3);
     assertThat(five.position()).isEqualTo(0);
     assertThat(five.limit()).isEqualTo(3);

--- a/core/src/test/java/org/apache/iceberg/io/TestMultiBufferInputStream.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestMultiBufferInputStream.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
   private static final List<ByteBuffer> DATA =
@@ -44,8 +45,8 @@ public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
   @Override
   protected void checkOriginalData() {
     for (ByteBuffer buffer : DATA) {
-      Assert.assertEquals("Position should not change", 0, buffer.position());
-      Assert.assertEquals("Limit should not change", buffer.array().length, buffer.limit());
+      assertThat(buffer.position()).as("Position should not change").isEqualTo(0);
+      assertThat(buffer.limit()).as("Limit should not change").isEqualTo(buffer.array().length);
     }
   }
 
@@ -62,62 +63,66 @@ public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
       buffers.add(stream.slice(bytesToSlice));
     }
 
-    Assert.assertEquals("Position should be at end", length, stream.getPos());
-    Assert.assertEquals("Should produce 5 buffers", 5, buffers.size());
+    assertThat(stream.getPos()).as("Position should be at end").isEqualTo(length);
+    assertThat(buffers.size()).as("Should produce 5 buffers").isEqualTo(5);
 
     int i = 0;
 
     // one is a view of the first buffer because it is smaller
     ByteBuffer one = buffers.get(0);
-    Assert.assertSame("Should be a duplicate of the first array", one.array(), DATA.get(0).array());
-    Assert.assertEquals(8, one.remaining());
-    Assert.assertEquals(0, one.position());
-    Assert.assertEquals(8, one.limit());
-    Assert.assertEquals(9, one.capacity());
+    assertThat(DATA.get(0).array())
+        .as("Should be a duplicate of the first array")
+        .isSameAs(one.array());
+    assertThat(one.remaining()).isEqualTo(8);
+    assertThat(one.position()).isEqualTo(0);
+    assertThat(one.limit()).isEqualTo(8);
+    assertThat(one.capacity()).isEqualTo(9);
     for (; i < 8; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, one.get());
+      assertThat(one.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // two should be a copy of the next 8 bytes
     ByteBuffer two = buffers.get(1);
-    Assert.assertEquals(8, two.remaining());
-    Assert.assertEquals(0, two.position());
-    Assert.assertEquals(8, two.limit());
-    Assert.assertEquals(8, two.capacity());
+    assertThat(two.remaining()).isEqualTo(8);
+    assertThat(two.position()).isEqualTo(0);
+    assertThat(two.limit()).isEqualTo(8);
+    assertThat(two.capacity()).isEqualTo(8);
     for (; i < 16; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, two.get());
+      assertThat(two.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // three is a copy of part of the 4th buffer
     ByteBuffer three = buffers.get(2);
-    Assert.assertSame(
-        "Should be a duplicate of the fourth array", three.array(), DATA.get(3).array());
-    Assert.assertEquals(8, three.remaining());
-    Assert.assertEquals(3, three.position());
-    Assert.assertEquals(11, three.limit());
-    Assert.assertEquals(12, three.capacity());
+    assertThat(DATA.get(3).array())
+        .as("Should be a duplicate of the fourth array")
+        .isSameAs(three.array());
+    assertThat(three.remaining()).isEqualTo(8);
+    assertThat(three.position()).isEqualTo(3);
+    assertThat(three.limit()).isEqualTo(11);
+    assertThat(three.capacity()).isEqualTo(12);
     for (; i < 24; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, three.get());
+      assertThat(three.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // four should be a copy of the next 8 bytes
     ByteBuffer four = buffers.get(3);
-    Assert.assertEquals(8, four.remaining());
-    Assert.assertEquals(0, four.position());
-    Assert.assertEquals(8, four.limit());
-    Assert.assertEquals(8, four.capacity());
+    assertThat(four.remaining()).isEqualTo(8);
+    assertThat(four.position()).isEqualTo(0);
+    assertThat(four.limit()).isEqualTo(8);
+    assertThat(four.capacity()).isEqualTo(8);
     for (; i < 32; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, four.get());
+      assertThat(four.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // five should be a copy of the next 8 bytes
     ByteBuffer five = buffers.get(4);
-    Assert.assertEquals(3, five.remaining());
-    Assert.assertEquals(0, five.position());
-    Assert.assertEquals(3, five.limit());
-    Assert.assertEquals(3, five.capacity());
+
+    assertThat(five.remaining()).isEqualTo(3);
+    assertThat(five.position()).isEqualTo(0);
+    assertThat(five.limit()).isEqualTo(3);
+    assertThat(five.capacity()).isEqualTo(3);
     for (; i < 35; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, five.get());
+      assertThat(five.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
   }
 
@@ -133,7 +138,8 @@ public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
       }
     }
 
-    Assert.assertEquals(
-        "Should return duplicates of all non-empty buffers", nonEmptyBuffers, buffers);
+    assertThat(buffers)
+        .as("Should return duplicates of all non-empty buffers")
+        .isEqualTo(nonEmptyBuffers);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/io/TestResolvingIO.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestResolvingIO.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestResolvingIO {
 
@@ -34,8 +35,7 @@ public class TestResolvingIO {
     testResolvingFileIO.initialize(ImmutableMap.of("k1", "v1"));
     FileIO roundTripSerializedFileIO =
         TestHelpers.KryoHelpers.roundTripSerialize(testResolvingFileIO);
-
-    Assert.assertEquals(testResolvingFileIO.properties(), roundTripSerializedFileIO.properties());
+    assertThat(roundTripSerializedFileIO.properties()).isEqualTo(testResolvingFileIO.properties());
   }
 
   @Test
@@ -45,7 +45,6 @@ public class TestResolvingIO {
     // resolving fileIO should be serializable when properties are passed as immutable map
     testResolvingFileIO.initialize(ImmutableMap.of("k1", "v1"));
     FileIO roundTripSerializedFileIO = TestHelpers.roundTripSerialize(testResolvingFileIO);
-
-    Assert.assertEquals(testResolvingFileIO.properties(), roundTripSerializedFileIO.properties());
+    assertThat(roundTripSerializedFileIO.properties()).isEqualTo(testResolvingFileIO.properties());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/io/TestSingleBufferInputStream.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestSingleBufferInputStream.java
@@ -18,12 +18,13 @@
  */
 package org.apache.iceberg.io;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
   private static final ByteBuffer DATA =
@@ -40,8 +41,9 @@ public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
 
   @Override
   protected void checkOriginalData() {
-    Assert.assertEquals("Position should not change", 0, DATA.position());
-    Assert.assertEquals("Limit should not change", DATA.array().length, DATA.limit());
+    assertThat(DATA.position()).as("Position should not change").isEqualTo(0);
+
+    assertThat(DATA.limit()).as("Limit should not change").isEqualTo(DATA.array().length);
   }
 
   @Test
@@ -57,62 +59,61 @@ public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
       buffers.add(stream.slice(bytesToSlice));
     }
 
-    Assert.assertEquals("Position should be at end", length, stream.getPos());
-    Assert.assertEquals("Should produce 5 buffers", 5, buffers.size());
+    assertThat(stream.getPos()).as("Position should be at end").isEqualTo(length);
+    assertThat(buffers.size()).as("Should produce 5 buffers").isEqualTo(5);
 
     int i = 0;
 
     ByteBuffer one = buffers.get(0);
-    Assert.assertSame("Should use the same backing array", one.array(), DATA.array());
-    Assert.assertEquals(8, one.remaining());
-    Assert.assertEquals(0, one.position());
-    Assert.assertEquals(8, one.limit());
-    Assert.assertEquals(35, one.capacity());
+    assertThat(one.array()).isSameAs(DATA.array());
+    assertThat(one.remaining()).isEqualTo(8);
+    assertThat(one.position()).isEqualTo(0);
+    assertThat(one.limit()).isEqualTo(8);
+    assertThat(one.capacity()).isEqualTo(35);
     for (; i < 8; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, one.get());
+      assertThat(one.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     ByteBuffer two = buffers.get(1);
-    Assert.assertSame("Should use the same backing array", two.array(), DATA.array());
-    Assert.assertEquals(8, two.remaining());
-    Assert.assertEquals(8, two.position());
-    Assert.assertEquals(16, two.limit());
-    Assert.assertEquals(35, two.capacity());
+    assertThat(two.array()).as("Should use the same backing array").isSameAs(DATA.array());
+    assertThat(two.remaining()).isEqualTo(8);
+    assertThat(two.position()).isEqualTo(8);
+    assertThat(two.limit()).isEqualTo(16);
+    assertThat(two.capacity()).isEqualTo(35);
     for (; i < 16; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, two.get());
+      assertThat(two.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
-
     // three is a copy of part of the 4th buffer
     ByteBuffer three = buffers.get(2);
-    Assert.assertSame("Should use the same backing array", three.array(), DATA.array());
-    Assert.assertEquals(8, three.remaining());
-    Assert.assertEquals(16, three.position());
-    Assert.assertEquals(24, three.limit());
-    Assert.assertEquals(35, three.capacity());
+    assertThat(three.array()).as("Should use the same backing array").isSameAs(DATA.array());
+    assertThat(three.remaining()).isEqualTo(8);
+    assertThat(three.position()).isEqualTo(16);
+    assertThat(three.limit()).isEqualTo(24);
+    assertThat(three.capacity()).isEqualTo(35);
     for (; i < 24; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, three.get());
+      assertThat(three.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // four should be a copy of the next 8 bytes
     ByteBuffer four = buffers.get(3);
-    Assert.assertSame("Should use the same backing array", four.array(), DATA.array());
-    Assert.assertEquals(8, four.remaining());
-    Assert.assertEquals(24, four.position());
-    Assert.assertEquals(32, four.limit());
-    Assert.assertEquals(35, four.capacity());
+    assertThat(four.array()).as("Should use the same backing array").isSameAs(DATA.array());
+    assertThat(four.remaining()).isEqualTo(8);
+    assertThat(four.position()).isEqualTo(24);
+    assertThat(four.limit()).isEqualTo(32);
+    assertThat(four.capacity()).isEqualTo(35);
     for (; i < 32; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, four.get());
+      assertThat(four.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
 
     // five should be a copy of the next 8 bytes
     ByteBuffer five = buffers.get(4);
-    Assert.assertSame("Should use the same backing array", five.array(), DATA.array());
-    Assert.assertEquals(3, five.remaining());
-    Assert.assertEquals(32, five.position());
-    Assert.assertEquals(35, five.limit());
-    Assert.assertEquals(35, five.capacity());
+    assertThat(five.array()).as("Should use the same backing array").isSameAs(DATA.array());
+    assertThat(five.remaining()).isEqualTo(3);
+    assertThat(five.position()).isEqualTo(32);
+    assertThat(five.limit()).isEqualTo(35);
+    assertThat(five.capacity()).isEqualTo(35);
     for (; i < 35; i += 1) {
-      Assert.assertEquals("Should produce correct values", i, five.get());
+      assertThat(five.get()).as("Should produce correct values").isEqualTo((byte) i);
     }
   }
 
@@ -121,9 +122,8 @@ public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
     ByteBufferInputStream stream = newStream();
 
     List<ByteBuffer> buffers = stream.sliceBuffers(stream.available());
-    Assert.assertEquals(
-        "Should return duplicates of all non-empty buffers",
-        Collections.singletonList(DATA),
-        buffers);
+    assertThat(buffers)
+        .as("Should return duplicates of all non-empty buffers")
+        .isEqualTo(Collections.singletonList(DATA));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/io/TestSingleBufferInputStream.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestSingleBufferInputStream.java
@@ -42,7 +42,6 @@ public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
   @Override
   protected void checkOriginalData() {
     assertThat(DATA.position()).as("Position should not change").isEqualTo(0);
-
     assertThat(DATA.limit()).as("Limit should not change").isEqualTo(DATA.array().length);
   }
 

--- a/core/src/test/java/org/apache/iceberg/view/TestSQLViewRepresentationParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestSQLViewRepresentationParser.java
@@ -21,8 +21,7 @@ package org.apache.iceberg.view;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSQLViewRepresentationParser {
   @Test
@@ -35,10 +34,9 @@ public class TestSQLViewRepresentationParser {
             .dialect("spark-sql")
             .build();
 
-    Assert.assertEquals(
-        "Should be able to parse valid SQL view representation",
-        viewRepresentation,
-        SQLViewRepresentationParser.fromJson(requiredFields));
+    Assertions.assertThat(SQLViewRepresentationParser.fromJson(requiredFields))
+        .as("Should be able to parse valid SQL view representation")
+        .isEqualTo(viewRepresentation);
 
     String requiredAndOptionalFields =
         "{\"type\":\"sql\", \"sql\": \"select * from foo\", \"dialect\": \"spark-sql\", "
@@ -56,10 +54,9 @@ public class TestSQLViewRepresentationParser {
             .fieldComments(ImmutableList.of("Comment col1", "Comment col2"))
             .defaultNamespace(Namespace.of("part1", "part2"))
             .build();
-    Assert.assertEquals(
-        "Should be able to parse valid SQL view representation",
-        viewWithOptionalFields,
-        SQLViewRepresentationParser.fromJson(requiredAndOptionalFields));
+    Assertions.assertThat(SQLViewRepresentationParser.fromJson(requiredAndOptionalFields))
+        .as("Should be able to parse valid SQL view representation")
+        .isEqualTo(viewWithOptionalFields);
   }
 
   @Test
@@ -84,10 +81,9 @@ public class TestSQLViewRepresentationParser {
             .sql("select * from foo")
             .dialect("spark-sql")
             .build();
-    Assert.assertEquals(
-        "Should be able to serialize valid SQL view representation",
-        requiredFields,
-        ViewRepresentationParser.toJson(viewRepresentation));
+    Assertions.assertThat(ViewRepresentationParser.toJson(viewRepresentation))
+        .as("Should be able to serialize valid SQL view representation")
+        .isEqualTo(requiredFields);
 
     String requiredAndOptionalFields =
         "{\"type\":\"sql\",\"sql\":\"select * from foo\",\"dialect\":\"spark-sql\","
@@ -106,10 +102,9 @@ public class TestSQLViewRepresentationParser {
             .defaultNamespace(Namespace.of("part1", "part2"))
             .build();
 
-    Assert.assertEquals(
-        "Should be able to serialize valid SQL view representation",
-        requiredAndOptionalFields,
-        ViewRepresentationParser.toJson(viewWithOptionalFields));
+    Assertions.assertThat(ViewRepresentationParser.toJson(viewWithOptionalFields))
+        .as("Should be able to serialize valid SQL view representation")
+        .isEqualTo(requiredAndOptionalFields);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/view/TestViewHistoryEntryParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewHistoryEntryParser.java
@@ -20,8 +20,7 @@ package org.apache.iceberg.view;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestViewHistoryEntryParser {
 
@@ -30,10 +29,9 @@ public class TestViewHistoryEntryParser {
     String json = "{\"timestamp-ms\":123,\"version-id\":1}";
     ViewHistoryEntry viewHistoryEntry =
         ImmutableViewHistoryEntry.builder().versionId(1).timestampMillis(123).build();
-    Assert.assertEquals(
-        "Should be able to deserialize valid view history entry",
-        viewHistoryEntry,
-        ViewHistoryEntryParser.fromJson(json));
+    Assertions.assertThat(ViewHistoryEntryParser.fromJson(json))
+        .as("Should be able to deserialize valid view history entry")
+        .isEqualTo(viewHistoryEntry);
   }
 
   @Test
@@ -41,10 +39,9 @@ public class TestViewHistoryEntryParser {
     String json = "{\"timestamp-ms\":123,\"version-id\":1}";
     ViewHistoryEntry viewHistoryEntry =
         ImmutableViewHistoryEntry.builder().versionId(1).timestampMillis(123).build();
-    Assert.assertEquals(
-        "Should be able to serialize view history entry",
-        json,
-        ViewHistoryEntryParser.toJson(viewHistoryEntry));
+    Assertions.assertThat(ViewHistoryEntryParser.toJson(viewHistoryEntry))
+        .as("Should be able to serialize view history entry")
+        .isEqualTo(json);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/view/TestViewRepresentationParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewRepresentationParser.java
@@ -19,8 +19,7 @@
 package org.apache.iceberg.view;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestViewRepresentationParser {
 
@@ -28,9 +27,9 @@ public class TestViewRepresentationParser {
   public void testParseUnknownViewRepresentation() {
     String json = "{\"type\":\"unknown-sql-representation\"}";
     ViewRepresentation unknownRepresentation = ViewRepresentationParser.fromJson(json);
-    Assert.assertEquals(
-        unknownRepresentation,
-        ImmutableUnknownViewRepresentation.builder().type("unknown-sql-representation").build());
+    Assertions.assertThat(
+            ImmutableUnknownViewRepresentation.builder().type("unknown-sql-representation").build())
+        .isEqualTo(unknownRepresentation);
 
     Assertions.assertThatThrownBy(() -> ViewRepresentationParser.toJson(unknownRepresentation))
         .isInstanceOf(UnsupportedOperationException.class)

--- a/core/src/test/java/org/apache/iceberg/view/TestViewVersionParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewVersionParser.java
@@ -21,8 +21,7 @@ package org.apache.iceberg.view;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestViewVersionParser {
 
@@ -57,10 +56,9 @@ public class TestViewVersionParser {
             "{\"version-id\":1, \"timestamp-ms\":12345, \"schema-id\":1, \"summary\":{\"operation\":\"create\", \"user\":\"some-user\"}, \"representations\":%s}",
             serializedRepresentations);
 
-    Assert.assertEquals(
-        "Should be able to parse valid view version",
-        expectedViewVersion,
-        ViewVersionParser.fromJson(serializedViewVersion));
+    Assertions.assertThat(ViewVersionParser.fromJson(serializedViewVersion))
+        .as("Should be able to parse valid view version")
+        .isEqualTo(expectedViewVersion);
   }
 
   @Test
@@ -94,10 +92,9 @@ public class TestViewVersionParser {
             "{\"version-id\":1,\"timestamp-ms\":12345,\"schema-id\":1,\"summary\":{\"operation\":\"create\",\"user\":\"some-user\"},\"representations\":%s}",
             expectedRepresentations);
 
-    Assert.assertEquals(
-        "Should be able to serialize valid view version",
-        expectedViewVersion,
-        ViewVersionParser.toJson(viewVersion));
+    Assertions.assertThat(ViewVersionParser.toJson(viewVersion))
+        .as("Should be able to serialize valid view version")
+        .isEqualTo(expectedViewVersion);
   }
 
   @Test


### PR DESCRIPTION
This pull request is related to the issue "Move JUnit4 tests to JUnit5 https://github.com/apache/iceberg/issues/7160".
I switched the files in [catalog,encryption,inmemory,io,view] pakages to JUnit5.