### PR TITLE
Python: Add support for pydocstyle

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -85,3 +85,13 @@ repos:
           - mdformat-admon
           - mdformat-mkdocs
           - mdformat-frontmatter
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        args:
+          [
+            "--ignore=D100,D102,D101,D103,D104,D105,D106,D107,D200,D202,D203,D205,D209,D212,D213,D400,D401,D403,D404,D405,D406,D407,D411,D413,D414,D415,D417",
+          ]
+        additional_dependencies:
+          - tomli==2.0.1


### PR DESCRIPTION
This will make sure that our docstrings are properly formatted.

This is getting important since we also generate docs from the doc strings. This PR is about adding the framework, and then we can follow up in new PRs for each of the error codes.