### PR TITLE
Python: Make Glue catalog configurable

### DIFF
--- a/python/mkdocs/docs/configuration.md
+++ b/python/mkdocs/docs/configuration.md
@@ -119,13 +119,27 @@ catalog:
 
 ## Glue Catalog
 
-If you want to use AWS Glue as the catalog, you can use the last two ways to configure the pyiceberg and refer
+Your AWS credentials can be passed directly through the Python API.
+Otherwise, please refer to
 [How to configure AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) to set your AWS account credentials locally.
+If you did not set up a default AWS profile, you can configure the `profile_name`.
 
 ```yaml
 catalog:
   default:
     type: glue
+    aws_access_key_id: <ACCESS_KEY_ID>
+    aws_secret_access_key: <SECRET_ACCESS_KEY>
+    aws_session_token: <SESSION_TOKEN>
+    region_name: <REGION_NAME>
+```
+
+```yaml
+catalog:
+  default:
+    type: glue
+    profile_name: <PROFILE_NAME>
+    region_name: <REGION_NAME>
 ```
 
 ## DynamoDB Catalog

--- a/python/pyiceberg/catalog/glue.py
+++ b/python/pyiceberg/catalog/glue.py
@@ -56,13 +56,7 @@ from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
 
-BOTO_SESSION_CONFIG_KEYS = [
-    "aws_secret_key_id",
-    "aws_secret_access_key",
-    "aws_session_token",
-    "region_name",
-    "profile_name"
-]
+BOTO_SESSION_CONFIG_KEYS = ["aws_secret_key_id", "aws_secret_access_key", "aws_session_token", "region_name", "profile_name"]
 
 GLUE_CLIENT = "glue"
 

--- a/python/pyiceberg/catalog/glue.py
+++ b/python/pyiceberg/catalog/glue.py
@@ -56,7 +56,16 @@ from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
 
+BOTO_SESSION_CONFIG_KEYS = [
+    "aws_secret_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "region_name",
+    "profile_name"
+]
+
 GLUE_CLIENT = "glue"
+
 
 PROP_GLUE_TABLE = "Table"
 PROP_GLUE_TABLE_TYPE = "TableType"
@@ -131,7 +140,10 @@ def _construct_database_input(database_name: str, properties: Properties) -> Dic
 class GlueCatalog(Catalog):
     def __init__(self, name: str, **properties: str):
         super().__init__(name, **properties)
-        self.glue = boto3.client(GLUE_CLIENT)
+
+        session_config = {k: v for k, v in properties.items() if k in BOTO_SESSION_CONFIG_KEYS}
+        session = boto3.Session(**session_config)
+        self.glue = session.client(GLUE_CLIENT)
 
     def _convert_glue_to_iceberg(self, glue_table: Dict[str, Any]) -> Table:
         properties: Properties = glue_table.get(PROP_GLUE_TABLE_PARAMETERS, {})

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 from typing import List
+from unittest import mock
 
 import pytest
 from moto import mock_glue
@@ -421,3 +422,22 @@ def test_update_namespace_properties_overlap_update_removal(
         test_catalog.update_namespace_properties(database_name, removals, updates)
     # should not modify the properties
     assert test_catalog.load_namespace_properties(database_name) == test_properties
+
+
+@mock_glue
+def test_passing_profile_name():
+    session_properties = {
+        "aws_secret_key_id": "abc",
+        "aws_secret_access_key": "def",
+        "aws_session_token": "ghi",
+        "region_name": "eu-central-1",
+        "profile_name": "sandbox",
+    }
+    test_properties = {"type": "glue"}
+    test_properties.update(session_properties)
+
+    with mock.patch("boto3.Session") as mock_session:
+        test_catalog = GlueCatalog("glue", **test_properties)
+
+    mock_session.assert_called_with(**session_properties)
+    assert test_catalog.glue is mock_session().client()

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -425,7 +425,7 @@ def test_update_namespace_properties_overlap_update_removal(
 
 
 @mock_glue
-def test_passing_profile_name():
+def test_passing_profile_name() -> None:
     session_properties = {
         "aws_secret_key_id": "abc",
         "aws_secret_access_key": "def",


### PR DESCRIPTION
This PR concerns issue https://github.com/apache/iceberg/issues/7777.

It makes it possible to pass AWS credentials directly through the Python API, when loading a Glue catalog. Additionally, the `profile_name` of the desired AWS profile can be selected. Currently, the default profile is used.