### PR TITLE
Core: Deprecate `newOutputFile` from `{ClusteredWriter,FanoutWriter}`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/ClusteredWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredWriter.java
@@ -132,6 +132,8 @@ abstract class ClusteredWriter<T, R> implements PartitioningWriter<T, R> {
     return aggregatedResult();
   }
 
+  /** @deprecated will be removed in 1.4.0 */
+  @Deprecated
   protected EncryptedOutputFile newOutputFile(
       OutputFileFactory fileFactory, PartitionSpec spec, StructLike partition) {
     Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredWriter.java
@@ -132,7 +132,7 @@ abstract class ClusteredWriter<T, R> implements PartitioningWriter<T, R> {
     return aggregatedResult();
   }
 
-  /** @deprecated will be removed in 1.4.0 */
+  /** @deprecated will be removed in 1.5.0 */
   @Deprecated
   protected EncryptedOutputFile newOutputFile(
       OutputFileFactory fileFactory, PartitionSpec spec, StructLike partition) {

--- a/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
@@ -95,7 +95,7 @@ abstract class FanoutWriter<T, R> implements PartitioningWriter<T, R> {
     return aggregatedResult();
   }
 
-  /** @deprecated will be removed in 1.4.0 */
+  /** @deprecated will be removed in 1.5.0 */
   @Deprecated
   protected EncryptedOutputFile newOutputFile(
       OutputFileFactory fileFactory, PartitionSpec spec, StructLike partition) {

--- a/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
@@ -95,6 +95,8 @@ abstract class FanoutWriter<T, R> implements PartitioningWriter<T, R> {
     return aggregatedResult();
   }
 
+  /** @deprecated will be removed in 1.4.0 */
+  @Deprecated
   protected EncryptedOutputFile newOutputFile(
       OutputFileFactory fileFactory, PartitionSpec spec, StructLike partition) {
     Preconditions.checkArgument(


### PR DESCRIPTION
They are not used anymore