### PR TITLE
Fix typos and improve wording in dell, delta-lake, data

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapper.java
+++ b/data/src/main/java/org/apache/iceberg/data/InternalRecordWrapper.java
@@ -92,7 +92,7 @@ public class InternalRecordWrapper implements StructLike {
     if (transforms[pos] != null) {
       Object value = wrapped.get(pos, Object.class);
       if (value == null) {
-        // transforms function don't allow to handle null values, so just return null here.
+        // transforms function doesn't allow to handle null values, so just return null here.
         return null;
       } else {
         return javaClass.cast(transforms[pos].apply(value));

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -60,8 +60,8 @@ public class TableMigrationUtil {
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics are set to null.
    *
-   * <p>Note: certain metrics, like NaN counts, are only supported by iceberg file writers but
-   * file footers, will not be populated.
+   * <p>Note: certain metrics, like NaN counts, are only supported by iceberg file writers, but
+   * file footers are not populated.
    *
    * @param partition partition key, e.g., "a=1/b=2"
    * @param uri partition location URI

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -60,8 +60,8 @@ public class TableMigrationUtil {
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics are set to null.
    *
-   * <p>Note: certain metrics, like NaN counts, that are only supported by iceberg file writers but
-   * not file footers, will not be populated.
+   * <p>Note: certain metrics, like NaN counts, are only supported by iceberg file writers but
+   * file footers, will not be populated.
    *
    * @param partition partition key, e.g., "a=1/b=2"
    * @param uri partition location URI

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -60,8 +60,8 @@ public class TableMigrationUtil {
    * <p>For Parquet and ORC partitions, this will read metrics from the file footer. For Avro
    * partitions, metrics are set to null.
    *
-   * <p>Note: certain metrics, like NaN counts, are only supported by iceberg file writers, but
-   * file footers are not populated.
+   * <p>Note: certain metrics, like NaN counts, are only supported by iceberg file writers, but file
+   * footers are not populated.
    *
    * @param partition partition key, e.g., "a=1/b=2"
    * @param uri partition location URI

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsAppendOutputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsAppendOutputStream.java
@@ -36,13 +36,13 @@ class EcsAppendOutputStream extends PositionOutputStream {
   private final EcsURI uri;
 
   /**
-   * Local bytes cache that avoid too many requests
+   * Local bytes cache that avoids too many requests
    *
    * <p>Use {@link ByteBuffer} to maintain offset.
    */
   private final ByteBuffer localCache;
 
-  /** A marker for data file to put first part instead of append first part. */
+  /** A marker for data file to put the first part instead of append the first part. */
   private boolean firstPart = true;
 
   /** Pos for {@link PositionOutputStream} */

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -71,7 +71,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
   /** Suffix of namespace metadata object */
   private static final String NAMESPACE_OBJECT_SUFFIX = ".namespace";
 
-  /** Key of properties version in ECS object user metadata. */
+  /** Key of properties version in ECS objects user metadata. */
   private static final String PROPERTIES_VERSION_USER_METADATA_KEY = "iceberg_properties_version";
 
   private static final Logger LOG = LoggerFactory.getLogger(EcsCatalog.class);
@@ -80,7 +80,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
   private Object hadoopConf;
   private String catalogName;
 
-  /** Warehouse is unified with other catalog that without delimiter. */
+  /** Warehouse is unified with other catalogs without delimiter. */
   private EcsURI warehouseLocation;
 
   private FileIO fileIO;
@@ -219,7 +219,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
   }
 
   /**
-   * Table rename will only move table object, the data objects will still be in-place.
+   * Renaming a table only moves the table object. The data objects remain in place.
    *
    * @param from identifier of the table to rename
    * @param to new table name
@@ -387,7 +387,7 @@ public class EcsCatalog extends BaseMetastoreCatalog
         warehouseLocation.name());
   }
 
-  /** Get S3 object metadata which include E-Tag, user metadata and so on. */
+  /** Get S3 object metadata which includes E-Tag, user metadata and so on. */
   public Optional<S3ObjectMetadata> objectMetadata(EcsURI uri) {
     checkURI(uri);
     try {

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -87,7 +87,7 @@ public class EcsFileIO implements FileIO {
     this.dellClientFactory = DellClientFactories.from(properties);
     this.s3 = dellClientFactory::ecsS3;
 
-    // Report Hadoop metrics if Hadoop is available
+    // Report on Hadoop metrics if Hadoop is available
     try {
       DynConstructors.Ctor<MetricsContext> ctor =
           DynConstructors.builder(MetricsContext.class)

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.metrics.MetricsContext.Unit;
  * String, Range)}
  *
  * <ol>
- *   <li>The stream is only be loaded when start reading.
+ *   <li>The stream is only loaded when start reading.
  *   <li>This class won't cache any bytes of content. It only maintains pos of {@link
  *       SeekableInputStream}
  *   <li>This class is not thread-safe.

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -224,7 +224,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
    * Commit the initial delta snapshot to iceberg transaction. It tries the snapshot starting from
    * {@code deltaStartVersion} to {@code latestVersion} and commit the first constructable one.
    *
-   * <p>There are two cases that the delta snapshot is not constructable:
+   * <p>There are two cases that the delta snapshot is not constructible:
    *
    * <ul>
    *   <li>the version is earlier than the earliest checkpoint
@@ -281,7 +281,7 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
    * <p>2. DeleteFiles - when there are only RemoveFile instances (a DELETE where all the records of
    * file(s) were removed)
    *
-   * <p>3. OverwriteFiles - when there are a mix of AddFile and RemoveFile (a DELETE/UPDATE)
+   * <p>3. OverwriteFiles - when there is a mix of AddFile and RemoveFile (a DELETE/UPDATE)
    *
    * @param versionLog the delta log version to commit to iceberg table transaction
    * @param transaction the iceberg table transaction to commit to

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/DeltaLakeToIcebergMigrationActionsProvider.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/DeltaLakeToIcebergMigrationActionsProvider.java
@@ -19,9 +19,9 @@
 package org.apache.iceberg.delta;
 
 /**
- * An API that provide actions for migration from a delta lake table to an iceberg table. Query
+ * An API that provides actions for migration from a delta lake table to an iceberg table. Query
  * engines can use {@code defaultActions()} to access default action implementations, or implement
- * this provider to supply a different implementation if necessary.
+ * this provider is to supply a different implementation if necessary.
  */
 public interface DeltaLakeToIcebergMigrationActionsProvider {
 

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java
@@ -76,13 +76,13 @@ public interface SnapshotDeltaLakeTable
 
   /**
    * Sets the Hadoop configuration used to access delta lake table's logs and datafiles. This is
-   * required to be set before execute the action.
+   * required to be set before executing the action.
    *
    * @param conf a Hadoop configuration @Returns this for method chaining
    */
   SnapshotDeltaLakeTable deltaLakeConfiguration(Configuration conf);
 
-  /** The action result that contains a summary of the execution. */
+  /** The action result contains a summary of the execution. */
   @Value.Immutable
   interface Result {
 

--- a/docs/dell.md
+++ b/docs/dell.md
@@ -91,7 +91,7 @@ The related problems of catalog usage:
 Use the Dell ECS catalog with Flink, you first must create a Flink environment.
 
 ```bash
-# HADOOP_HOME is your hadoop root directory after unpack the binary package.
+# HADOOP_HOME is your hadoop root directory after unpacking the binary package.
 export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`
 
 # download Iceberg dependency

--- a/docs/delta-lake-migration.md
+++ b/docs/delta-lake-migration.md
@@ -47,7 +47,7 @@ The module is built and tested with `Delta Standalone:0.6.0` and supports Delta 
 Please refer to [Delta Lake Table Protocol Versioning](https://docs.delta.io/latest/versioning.html) for more details about Delta Lake protocol versions.
 
 ### API
-The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that helps converting from Delta Lake to Iceberg.
+The `iceberg-delta-lake` module provides an interface named `DeltaLakeToIcebergMigrationActionsProvider`, which contains actions that help convert from Delta Lake to Iceberg.
 The supported actions are:
 * `snapshotDeltaLakeTable`: snapshot an existing Delta Lake table to an Iceberg table
 
@@ -64,12 +64,12 @@ The original Delta Lake table remains unchanged.
 The newly created table can be changed or written to without affecting the source table, but the snapshot uses the original table's data files.
 Existing data files are added to the Iceberg table's metadata and can be read using a name-to-id mapping created from the original table schema.
 
-When inserts or overwrites run on the snapshot, new files are placed in the snapshot table's location. The location is default to be the same as that
+When inserts or overwrites run on the snapshot, new files are placed in the snapshot table's location. The location is defaulted to be the same as that
 of the source Delta Lake Table. Users can also specify a different location for the snapshot table.
 
 {{< hint info >}}
 Because tables created by `snapshotDeltaLakeTable` are not the sole owners of their data files, they are prohibited from
-actions like `expire_snapshots` which would physically delete data files. Iceberg deletes, which only effect metadata,
+actions like `expire_snapshots` which would physically delete data files. Iceberg deletes, which only affect metadata,
 are still allowed. In addition, any operations which affect the original data files will disrupt the Snapshot's
 integrity. DELETE statements executed against the original Delta Lake table will remove original data files and the
 `snapshotDeltaLakeTable` table will no longer be able to access them.
@@ -110,7 +110,7 @@ String sourceDeltaLakeTableLocation = "s3://my-bucket/delta-table";
 String destTableLocation = "s3://my-bucket/iceberg-table";
 TableIdentifier destTableIdentifier = TableIdentifier.of("my_db", "my_table");
 Catalog icebergCatalog = ...; // Iceberg Catalog fetched from engines like Spark or created via CatalogUtil.loadCatalog
-Configuration hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and have proper file system configuration to access the Delta Lake table.
+Configuration hadoopConf = ...; // Hadoop Configuration fetched from engines like Spark and has proper file system configuration to access the Delta Lake table.
     
 DeltaLakeToIcebergMigrationActionsProvider.defaultActions()
     .snapshotDeltaLakeTable(sourceDeltaLakeTableLocation)


### PR DESCRIPTION
I fixed typos and made some sentences more readable in the comments of all files in the dell, delta-lake, and data folders.
I also fixed typos in the dell, delta-lake migration files in the docs folder.