### PR TITLE
Python: Fix D414 and D200 docstring issues

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
       - id: pydocstyle
         args:
           [
-            "--ignore=D100,D102,D101,D103,D104,D105,D106,D107,D200,D202,D203,D205,D209,D212,D213,D400,D401,D404,D405,D406,D407,D411,D413,D414,D415,D417",
+            "--ignore=D100,D102,D101,D103,D104,D105,D106,D107,D202,D203,D205,D209,D212,D213,D400,D401,D404,D405,D406,D407,D411,D413,D415,D417",
           ]
         additional_dependencies:
           - tomli==2.0.1

--- a/python/pyiceberg/avro/decoder.py
+++ b/python/pyiceberg/avro/decoder.py
@@ -38,15 +38,11 @@ class BinaryDecoder:
     _input_stream: InputStream
 
     def __init__(self, input_stream: InputStream) -> None:
-        """
-        Reader is a Python object on which we can call read, seek, and tell.
-        """
+        """Reader is a Python object on which we can call read, seek, and tell."""
         self._input_stream = input_stream
 
     def read(self, n: int) -> bytes:
-        """
-        Read n bytes.
-        """
+        """Read n bytes."""
         if n < 0:
             raise ValueError(f"Requested {n} bytes to read, expected positive integer.")
         data: List[bytes] = []
@@ -122,9 +118,7 @@ class BinaryDecoder:
         return unscaled_to_decimal(unscaled_datum, scale)
 
     def read_bytes(self) -> bytes:
-        """
-        Bytes are encoded as a long followed by that many bytes of data.
-        """
+        """Bytes are encoded as a long followed by that many bytes of data."""
         num_bytes = self.read_int()
         return self.read(num_bytes) if num_bytes > 0 else b""
 

--- a/python/pyiceberg/avro/file.py
+++ b/python/pyiceberg/avro/file.py
@@ -15,9 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint: disable=W0621
-"""
-Avro reader for reading Avro files
-"""
+"""Avro reader for reading Avro files"""
 from __future__ import annotations
 
 import json

--- a/python/pyiceberg/cli/console.py
+++ b/python/pyiceberg/cli/console.py
@@ -83,9 +83,7 @@ def run(ctx: Context, catalog: Optional[str], verbose: bool, output: str, uri: O
 
 
 def _catalog_and_output(ctx: Context) -> Tuple[Catalog, Output]:
-    """
-    Small helper to set the types
-    """
+    """Small helper to set the types"""
     return ctx.obj["catalog"], ctx.obj["output"]
 
 

--- a/python/pyiceberg/partitioning.py
+++ b/python/pyiceberg/partitioning.py
@@ -144,9 +144,7 @@ class PartitionSpec(IcebergBaseModel):
         return self.source_id_to_fields_map.get(field_id, [])
 
     def compatible_with(self, other: "PartitionSpec") -> bool:
-        """
-        Produce a boolean to return True if two PartitionSpec are considered compatible
-        """
+        """Produce a boolean to return True if two PartitionSpec are considered compatible"""
         if self == other:
             return True
         if len(self.fields) != len(other.fields):

--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -14,8 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-"""Helper methods for working with date/time representations
-"""
+"""Helper methods for working with date/time representations"""
 from __future__ import annotations
 
 import re

--- a/python/pyiceberg/utils/decimal.py
+++ b/python/pyiceberg/utils/decimal.py
@@ -15,8 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-"""Helper methods for working with Python Decimals
-"""
+"""Helper methods for working with Python Decimals"""
 from decimal import Decimal
 from typing import Union
 

--- a/python/pyiceberg/utils/schema_conversion.py
+++ b/python/pyiceberg/utils/schema_conversion.py
@@ -276,7 +276,7 @@ class AvroSchemaConversion:
         Args:
             record_type: The record type itself
 
-        Returns:
+        Returns: A StructType
         """
         if record_type["type"] != "record":
             raise ValueError(f"Expected record type, got: {record_type}")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1465,9 +1465,7 @@ def fixture_s3_bucket(_s3) -> None:  # type: ignore
 
 
 def get_bucket_name() -> str:
-    """
-    Set the environment variable AWS_TEST_BUCKET for a default bucket to test
-    """
+    """Set the environment variable AWS_TEST_BUCKET for a default bucket to test"""
     bucket_name = os.getenv("AWS_TEST_BUCKET")
     if bucket_name is None:
         raise ValueError("Please specify a bucket to run the test by setting environment variable AWS_TEST_BUCKET")


### PR DESCRIPTION
https://github.com/apache/iceberg/issues/7776

D414: Section has no content ('Returns')
D200: One-line docstring should fit on one line with quotes