### PR TITLE
Open-API: Re-use LoadTableRequest

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -748,8 +748,16 @@ class LoadTableResult(BaseModel):
 
 
 class CommitTableRequest(BaseModel):
+    identifier: Optional[TableIdentifier] = Field(
+        None,
+        description='Table identifier to update; must be present for CommitTransactionRequest',
+    )
     requirements: List[TableRequirement]
     updates: List[TableUpdate]
+
+
+class CommitTransactionRequest(BaseModel):
+    table_changes: List[CommitTableRequest] = Field(..., alias='table-changes')
 
 
 class CreateTableRequest(BaseModel):
@@ -775,11 +783,6 @@ class ScanReport(BaseModel):
     projected_field_names: List[str] = Field(..., alias='projected-field-names')
     metrics: Metrics
     metadata: Optional[Dict[str, str]] = None
-
-
-class CommitTableResponse(BaseModel):
-    metadata_location: str = Field(..., alias='metadata-location')
-    metadata: TableMetadata
 
 
 class Schema(StructType):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -594,7 +594,7 @@ paths:
               $ref: '#/components/schemas/CommitTableRequest'
       responses:
         200:
-          $ref: '#/components/responses/CommitTableResponse'
+          $ref: '#/components/responses/LoadTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -2288,18 +2288,6 @@ components:
             Server's do not need to implement this.
           nullable: true
 
-    CommitTableResponse:
-      type: object
-      required:
-        - metadata-location
-        - metadata
-      properties:
-        metadata-location:
-          type: string
-        metadata:
-          $ref: '#/components/schemas/TableMetadata'
-
-
   #############################
   # Reusable Response Objects #
   #############################
@@ -2523,15 +2511,6 @@ components:
           schema:
             $ref: '#/components/schemas/LoadTableResult'
 
-    CommitTableResponse:
-      description:
-        Response used when a table is successfully updated.
-
-        The table metadata JSON is returned in the metadata field. The corresponding file location of table metadata must be returned in the metadata-location field. Clients can check whether metadata has changed by comparing metadata locations.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CommitTableResponse'
 
   #######################################
   # Common examples of different values #


### PR DESCRIPTION
I noticed that CommitTableRequest is almost identical to the LoadTableRequest. I would suggest adding the `config` object, and sending the same object back to simplify the spec. WDYT? 

cc @rdblue @nastra 