### PR TITLE
Build: skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   run-benchmark:
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,6 +28,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v8.0.0


### PR DESCRIPTION
i got the following email today:
```
[XN137/iceberg] Run failed: Recurring JMH Benchmarks - master (b88951b)
```

it seems unintentional to me that these workflows also get scheduled on github repo forks...
especially assuming any substantial work on forks is done on branches other than `master`.

note the snapshot publish workflow gets scheduled but is then skipped immediately on forks already:
https://github.com/apache/iceberg/blob/8aefc6925fdd8501040dfaf7d8ee0cdfec60a92d/.github/workflows/publish-snapshot.yml#L28-L31