### PR TITLE
Spark: Update ANTLR to match Spark 3.4

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -165,8 +165,8 @@ project(":iceberg-spark:iceberg-spark-extensions-${sparkMajorVersion}_${scalaVer
     testImplementation "org.apache.parquet:parquet-hadoop"
 
     // Required because we remove antlr plugin dependencies from the compile configuration, see note above
-    runtimeOnly "org.antlr:antlr4-runtime:4.8"
-    antlr "org.antlr:antlr4:4.8"
+    runtimeOnly "org.antlr:antlr4-runtime:4.9.3"
+    antlr "org.antlr:antlr4:4.9.3"
   }
 
   generateGrammarSource {


### PR DESCRIPTION
This PR updates the ANTLR version to match that in Spark 3.4. Currently, when Spark extensions are first loaded, you will see the following error message: `ANTLR Tool version 4.8 used for code generation does not match the current runtime version 4.9.3`.