### PR TITLE
Disable containerReuse when building delete filters

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -186,7 +186,9 @@ public abstract class DeleteFilter<T> {
 
       StructLikeSet deleteSet =
           Deletes.toEqualitySet(
-              CloseableIterable.transform(CloseableIterable.concat(deleteRecords), wrapper::copyFor), deleteSchema.asStruct());
+              CloseableIterable.transform(
+                  CloseableIterable.concat(deleteRecords), wrapper::copyFor),
+              deleteSchema.asStruct());
 
       Predicate<T> isInDeleteSet =
           record -> deleteSet.contains(projectRow.wrap(asStructLike(record)));
@@ -271,10 +273,7 @@ public abstract class DeleteFilter<T> {
     InputFile input = getInputFile(deleteFile.path().toString());
     switch (deleteFile.format()) {
       case AVRO:
-        return Avro.read(input)
-            .project(deleteSchema)
-            .createReaderFunc(DataReader::create)
-            .build();
+        return Avro.read(input).project(deleteSchema).createReaderFunc(DataReader::create).build();
 
       case PARQUET:
         Parquet.ReadBuilder builder =

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -273,7 +273,10 @@ public abstract class DeleteFilter<T> {
     InputFile input = getInputFile(deleteFile.path().toString());
     switch (deleteFile.format()) {
       case AVRO:
-        return Avro.read(input).project(deleteSchema).createReaderFunc(DataReader::create).build();
+        return Avro.read(input)
+            .project(deleteSchema)
+            .createReaderFunc(DataReader::create)
+            .build();
 
       case PARQUET:
         Parquet.ReadBuilder builder =

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -52,7 +52,7 @@ public abstract class DeleteReadTests {
       new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "data", Types.StringType.get()),
-          Types.NestedField.required(3, "bin", Types.BinaryType.get())
+          Types.NestedField.optional(3, "bin", Types.BinaryType.get())
           );
 
   public static final Schema DATE_SCHEMA =

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -52,8 +52,7 @@ public abstract class DeleteReadTests {
       new Schema(
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.required(2, "data", Types.StringType.get()),
-          Types.NestedField.optional(3, "bin", Types.BinaryType.get())
-          );
+          Types.NestedField.optional(3, "bin", Types.BinaryType.get()));
 
   public static final Schema DATE_SCHEMA =
       new Schema(
@@ -86,13 +85,13 @@ public abstract class DeleteReadTests {
 
     // records all use IDs that are in bucket id_bucket=0
     GenericRecord record = GenericRecord.create(table.schema());
-    records.add(record.copy("id", 29, "data", "a", "bin", ByteBuffer.allocate(4).putInt(29).flip()));
-    records.add(record.copy("id", 43, "data", "b", "bin", ByteBuffer.allocate(4).putInt(43).flip()));
-    records.add(record.copy("id", 61, "data", "c", "bin", ByteBuffer.allocate(4).putInt(61).flip()));
-    records.add(record.copy("id", 89, "data", "d", "bin", ByteBuffer.allocate(4).putInt(89).flip()));
-    records.add(record.copy("id", 100, "data", "e", "bin", ByteBuffer.allocate(4).putInt(100).flip()));
-    records.add(record.copy("id", 121, "data", "f", "bin", ByteBuffer.allocate(4).putInt(121).flip()));
-    records.add(record.copy("id", 122, "data", "g", "bin", ByteBuffer.allocate(4).putInt(122).flip()));
+    records.add(createDataRecord(record, 29, "a"));
+    records.add(createDataRecord(record, 43, "b"));
+    records.add(createDataRecord(record, 61, "c"));
+    records.add(createDataRecord(record, 89, "d"));
+    records.add(createDataRecord(record, 100, "e"));
+    records.add(createDataRecord(record, 121, "f"));
+    records.add(createDataRecord(record, 122, "g"));
 
     this.dataFile =
         FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), Row.of(0), records);
@@ -104,6 +103,13 @@ public abstract class DeleteReadTests {
   public void cleanup() throws IOException {
     dropTable("test");
     dropTable("test2");
+  }
+
+  private Record createDataRecord(GenericRecord template, int id, String data) {
+    return template.copy(
+        "id", id,
+        "data", data,
+        "bin", ByteBuffer.allocate(4).putInt(id).flip());
   }
 
   private void initDateTable() throws IOException {
@@ -199,15 +205,15 @@ public abstract class DeleteReadTests {
     Schema deleteRowSchema = table.schema().select("bin");
     Record dataDelete = GenericRecord.create(deleteRowSchema);
     List<Record> dataDeletes =
-            Lists.newArrayList(
-                    dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(29).flip()), // id = 29
-                    dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(89).flip()), // id = 89
-                    dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(122).flip()) // id = 122
+        Lists.newArrayList(
+            dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(29).flip()), // id = 29
+            dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(89).flip()), // id = 89
+            dataDelete.copy("bin", ByteBuffer.allocate(4).putInt(122).flip()) // id = 122
             );
 
     DeleteFile eqDeletes =
-            FileHelpers.writeDeleteFile(
-                    table, Files.localOutput(temp.newFile()), Row.of(0), dataDeletes, deleteRowSchema);
+        FileHelpers.writeDeleteFile(
+            table, Files.localOutput(temp.newFile()), Row.of(0), dataDeletes, deleteRowSchema);
 
     table.newRowDelta().addDeletes(eqDeletes).commit();
 

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
 
@@ -46,12 +47,13 @@ public class TestGenericReaderDeletes extends DeleteReadTests {
 
   @Override
   public StructLikeSet rowSet(String name, Table table, String... columns) throws IOException {
-    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    Types.StructType recordSchema = table.schema().select(columns).asStruct();
+    StructLikeSet set = StructLikeSet.create(recordSchema);
     try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
       Iterables.addAll(
           set,
           CloseableIterable.transform(
-              reader, record -> new InternalRecordWrapper(table.schema().asStruct()).wrap(record)));
+              reader, record -> new InternalRecordWrapper(recordSchema).wrap(record)));
     }
     return set;
   }


### PR DESCRIPTION
The filter holds a set of instances, so it's important that each
instance be truly unique. Copying the record risks shallow copies on
reference fields. It's safer to not reuse containers and skip the
post-read copying.

Without this, Equality Deletes on binary fields will misbehave when
a delete file contains multiple keys. All instances added to the filter
set will share the same ByteBuffer, so only the last record's term
will be used.