### PR TITLE
Parquet: Revert workaround for resource usage with zstd

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1101,12 +1101,8 @@ public class Parquet {
             conf.unset(property);
           }
           optionsBuilder = HadoopReadOptions.builder(conf);
-          // page size not used by decompressors
-          optionsBuilder.withCodecFactory(new ParquetCodecFactory(conf, 0));
         } else {
           optionsBuilder = ParquetReadOptions.builder();
-          // page size not used by decompressors
-          optionsBuilder.withCodecFactory(new ParquetCodecFactory(new Configuration(), 0));
         }
 
         for (Map.Entry<String, String> entry : properties.entrySet()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetCodecFactory.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetCodecFactory.java
@@ -32,8 +32,12 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 /**
  * This class implements a codec factory that is used when reading from Parquet. It adds a
- * workaround for memory issues encountered when reading from zstd-compressed files.
+ * workaround for memory issues encountered when reading from zstd-compressed files. This is no
+ * longer used, as Parquet 1.13 includes this fix.
+ *
+ * @deprecated will be removed in 1.5.0
  */
+@Deprecated
 public class ParquetCodecFactory extends CodecFactory {
 
   public ParquetCodecFactory(Configuration configuration, int pageSize) {


### PR DESCRIPTION
This PR reverts https://github.com/apache/iceberg/pull/5681, which is no longer needed with the [upgrade](https://github.com/apache/iceberg/pull/7301) of Parquet to 1.13. This marks the now-unused codec factory class as deprecated.

Here is a heap leak analysis of one executor when running a large scan with a build of 1.2.1 (Parquet 1.12) and the workaround removed:
![Screenshot 2023-06-13 at 5 04 54 PM](https://github.com/apache/iceberg/assets/5475421/17ddc23e-1240-41fd-bded-e64162f0d098)

Here is the leak analysis with a build of this PR:
![Screenshot 2023-06-13 at 5 04 26 PM](https://github.com/apache/iceberg/assets/5475421/782893e4-e9cc-4f93-b4a0-622b0ecdc254)

In the first example, the zstd buffer pool is accumulating memory. In the second example, there is no such accumulation.