### PR TITLE
Flink: Key projection should be based on the requested Flink table schema

### DIFF
--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -63,7 +63,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
     this.wrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
     this.keyWrapper =
         new RowDataWrapper(FlinkSchemaUtil.convert(deleteSchema), deleteSchema.asStruct());
-    this.keyProjection = RowDataProjection.create(schema, deleteSchema);
+    this.keyProjection =
+        RowDataProjection.create(flinkSchema, schema.asStruct(), deleteSchema.asStruct());
     this.upsert = upsert;
   }
 

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -360,12 +361,14 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
     WriteResult result = writer.complete();
     // One data file
-    Assert.assertEquals(1, result.dataFiles().length);
+    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
     // One eq delete file + one pos delete file
-    Assert.assertEquals(2, result.deleteFiles().length);
-    Assert.assertEquals(
-        Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES),
-        Arrays.stream(result.deleteFiles()).map(ContentFile::content).collect(Collectors.toSet()));
+    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
+    Assertions.assertThat(
+            Arrays.stream(result.deleteFiles())
+                .map(ContentFile::content)
+                .collect(Collectors.toSet()))
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
     commitTransaction(result);
 
     Record expectedRecord = GenericRecord.create(tableSchema);
@@ -373,8 +376,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
     expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
 
-    Assert.assertEquals(
-        "Should have expected records", expectedRowSet(expectedRecord), actualRowSet("*"));
+    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {


### PR DESCRIPTION
Flink data type could have some customized precision, such as `LocalZonedTimestampType(3)`. However, the precision could be lost after converting from  Flink type to Iceberg type back and forth. For example:
```
Flink LocalZonedTimestampType(3) -> Iceberg TimestampType
Iceberg TimestampType -> Flink LocalZonedTimestampType(6)
``` 
So when projecting on the row data to get the equality key, we should create the `RowDataProjection` based on the requested flink table schema