### PR TITLE
Core: Generate Builder for UpdateTableRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,7 @@ project(':iceberg-core') {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     annotationProcessor "org.immutables:value"
     compileOnly "org.immutables:value"
+    compileOnly "org.immutables:builder"
 
     implementation("org.apache.avro:avro") {
       exclude group: 'org.tukaani' // xz compression is not supported

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.requests;
 
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
@@ -31,7 +32,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RESTRequest;
+import org.immutables.builder.Builder.Constructor;
+import org.immutables.value.Value;
 
+@Value.Style(newBuilder = "newBuilder")
 public class UpdateTableRequest implements RESTRequest {
 
   private TableIdentifier identifier;
@@ -42,13 +46,19 @@ public class UpdateTableRequest implements RESTRequest {
     // needed for Jackson deserialization
   }
 
+  /**
+   * @deprecated will be removed in 1.5.0; use {@link UpdateTableRequestBuilder#newBuilder()}
+   *     instead.
+   */
+  @Deprecated
   public UpdateTableRequest(List<UpdateRequirement> requirements, List<MetadataUpdate> updates) {
     this.requirements = requirements;
     this.updates = updates;
   }
 
+  @Constructor
   UpdateTableRequest(
-      TableIdentifier identifier,
+      @Nullable TableIdentifier identifier,
       List<UpdateRequirement> requirements,
       List<MetadataUpdate> updates) {
     this(requirements, updates);
@@ -73,6 +83,7 @@ public class UpdateTableRequest implements RESTRequest {
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .add("identifier", identifier)
         .add("requirements", requirements)
         .add("updates", updates)
         .toString();

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCommitTransactionRequestParser.java
@@ -81,22 +81,24 @@ public class TestCommitTransactionRequestParser {
   public void roundTripSerde() {
     String uuid = "2cc52516-5e73-41f2-b139-545d41a4e151";
     UpdateTableRequest commitTableRequestOne =
-        new UpdateTableRequest(
-            TableIdentifier.of("ns1", "table1"),
-            ImmutableList.of(
+        UpdateTableRequestBuilder.newBuilder()
+            .identifier(TableIdentifier.of("ns1", "table1"))
+            .addRequirements(
                 new UpdateRequirement.AssertTableUUID(uuid),
-                new UpdateRequirement.AssertTableDoesNotExist()),
-            ImmutableList.of(
-                new MetadataUpdate.AssignUUID(uuid), new MetadataUpdate.SetCurrentSchema(23)));
+                new UpdateRequirement.AssertTableDoesNotExist())
+            .addUpdates(
+                new MetadataUpdate.AssignUUID(uuid), new MetadataUpdate.SetCurrentSchema(23))
+            .build();
 
     UpdateTableRequest commitTableRequestTwo =
-        new UpdateTableRequest(
-            TableIdentifier.of("ns1", "table2"),
-            ImmutableList.of(
+        UpdateTableRequestBuilder.newBuilder()
+            .identifier(TableIdentifier.of("ns1", "table2"))
+            .addRequirements(
                 new UpdateRequirement.AssertDefaultSpecID(4),
-                new UpdateRequirement.AssertCurrentSchemaID(24)),
-            ImmutableList.of(
-                new MetadataUpdate.RemoveSnapshot(101L), new MetadataUpdate.SetCurrentSchema(25)));
+                new UpdateRequirement.AssertCurrentSchemaID(24))
+            .addUpdates(
+                new MetadataUpdate.RemoveSnapshot(101L), new MetadataUpdate.SetCurrentSchema(25))
+            .build();
 
     CommitTransactionRequest request =
         new CommitTransactionRequest(
@@ -160,8 +162,9 @@ public class TestCommitTransactionRequestParser {
     CommitTransactionRequest commitTxRequest =
         new CommitTransactionRequest(
             ImmutableList.of(
-                new UpdateTableRequest(
-                    TableIdentifier.of("ns1", "table1"), ImmutableList.of(), ImmutableList.of())));
+                UpdateTableRequestBuilder.newBuilder()
+                    .identifier(TableIdentifier.of("ns1", "table1"))
+                    .build()));
 
     String json =
         "{\"table-changes\":[{\"identifier\":{\"namespace\":[\"ns1\"],\"name\":\"table1\"},\"requirements\":[],\"updates\":[]}]}";

--- a/versions.props
+++ b/versions.props
@@ -27,7 +27,7 @@ com.google.cloud:libraries-bom = 24.1.0
 org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
-org.immutables:value = 2.9.2
+org.immutables:* = 2.9.2
 net.snowflake:snowflake-jdbc = 3.13.30
 io.delta:delta-standalone_* = 0.6.0
 


### PR DESCRIPTION
I've mainly opened this PR as a discussion point to have an alternative to writing manual builders for classes that we can't or don't want to switch to `@Value.Immutable`. 

The [Immutables](https://immutables.github.io/) lib can also be used to generate a [Builder](https://immutables.github.io/factory.html#pojo-constructors) without having to annotate a class with `@Value.Immutable`. It's worth mentioning that this is mainly for use cases where we don't require additional processing logic in the builders.
