### PR TITLE
Build: Let Rev API compare against 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ subprojects {
     revapi {
       oldGroup = project.group
       oldName = project.name
-      oldVersion = "1.2.0"
+      oldVersion = "1.3.0"
     }
 
     tasks.register('showDeprecationRulesOnRevApiFailure') {


### PR DESCRIPTION
Missed after the release step I guess. 
It is already covered in the docs.
https://iceberg.apache.org/how-to-release/#update-revapi

