### PR TITLE
Core: Remove deprecated AssertHelpers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -190,7 +190,7 @@ public class ScanSummary {
               "Cannot satisfy time filters: time range may include expired snapshots");
         }
 
-        // filter down to the the set of manifest files that were added after the start of the
+        // filter down to the set of manifest files that were added after the start of the
         // time range. manifests after the end of the time range must be included because
         // compaction may create a manifest after the time range that includes files added in the
         // range.

--- a/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsTruncation.java
@@ -27,6 +27,7 @@ import static org.apache.iceberg.util.UnicodeUtil.truncateStringMin;
 import java.nio.ByteBuffer;
 import java.util.Comparator;
 import org.apache.iceberg.expressions.Literal;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -58,11 +59,9 @@ public class TestMetricsTruncation {
     Assert.assertTrue(
         "Truncating should not modify the input buffer",
         original.remaining() == 4 && original.position() == 0);
-    AssertHelpers.assertThrows(
-        "Should not allow a negative truncation length",
-        IllegalArgumentException.class,
-        "length should be non-negative",
-        () -> truncateBinary(original, -1));
+    Assertions.assertThatThrownBy(() -> truncateBinary(original, -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Truncate length should be non-negative");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -170,11 +171,9 @@ public class TestOverwrite extends TableTestBase {
             .newOverwrite()
             .overwriteByRowFilter(and(equal("date", "2018-06-09"), lessThan("id", 9)));
 
-    AssertHelpers.assertThrows(
-        "Should reject commit with file not matching delete expression",
-        ValidationException.class,
-        "Cannot delete file where some, but not all, rows match filter",
-        () -> commit(table, overwrite, branch));
+    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot delete file where some, but not all, rows match filter");
 
     Assert.assertEquals(
         "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());
@@ -264,11 +263,9 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09, NOT in 2018-06-08
             .validateAddedFilesMatchOverwriteFilter();
 
-    AssertHelpers.assertThrows(
-        "Should reject commit with file not matching delete expression",
-        ValidationException.class,
-        "Cannot append file with rows that do not match filter",
-        () -> commit(table, overwrite, branch));
+    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     Assert.assertEquals(
         "Should not create a new snapshot", baseId, latestSnapshot(table, branch).snapshotId());
@@ -287,11 +284,9 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09 matches, but IDs are outside range
             .validateAddedFilesMatchOverwriteFilter();
 
-    AssertHelpers.assertThrows(
-        "Should reject commit with file not matching delete expression",
-        ValidationException.class,
-        "Cannot append file with rows that do not match filter",
-        () -> commit(table, overwrite, branch));
+    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     Assert.assertEquals(
         "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());
@@ -310,11 +305,9 @@ public class TestOverwrite extends TableTestBase {
             .addFile(FILE_10_TO_14) // in 2018-06-09 matches and IDs are inside range
             .validateAddedFilesMatchOverwriteFilter();
 
-    AssertHelpers.assertThrows(
-        "Should reject commit with file not matching delete expression",
-        ValidationException.class,
-        "Cannot append file with rows that do not match filter",
-        () -> commit(table, overwrite, branch));
+    Assertions.assertThatThrownBy(() -> commit(table, overwrite, branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     Assert.assertEquals(
         "Should not create a new snapshot", baseId, latestSnapshot(base, branch).snapshotId());

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -167,11 +168,9 @@ public class TestPartitioning {
 
     Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
 
-    AssertHelpers.assertThrows(
-        "Should complain about incompatible specs",
-        ValidationException.class,
-        "Conflicting partition fields",
-        () -> Partitioning.partitionType(table));
+    Assertions.assertThatThrownBy(() -> Partitioning.partitionType(table))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Conflicting partition fields");
   }
 
   @Test
@@ -380,11 +379,10 @@ public class TestPartitioning {
 
     Assert.assertEquals("Should have 2 specs", 2, table.specs().size());
 
-    AssertHelpers.assertThrows(
-        "Should complain about incompatible specs",
-        ValidationException.class,
-        "Conflicting partition fields",
-        () -> Partitioning.groupingKeyType(table.schema(), table.specs().values()));
+    Assertions.assertThatThrownBy(
+            () -> Partitioning.groupingKeyType(table.schema(), table.specs().values()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Conflicting partition fields");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestScanSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanSummary.java
@@ -29,6 +29,7 @@ import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.Pair;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -89,11 +90,9 @@ public class TestScanSummary extends TableTestBase {
             .filter(greaterThanOrEqual("dateCreated", t0))
             .filter(lessThan("dateCreated", t2));
 
-    AssertHelpers.assertThrows(
-        "Should fail summary because range may include expired snapshots",
-        IllegalArgumentException.class,
-        "may include expired snapshots",
-        () -> new ScanSummary.Builder(scan).build());
+    Assertions.assertThatThrownBy(() -> new ScanSummary.Builder(scan).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot satisfy time filters: time range may include expired snapshots");
   }
 
   @Test
@@ -147,13 +146,12 @@ public class TestScanSummary extends TableTestBase {
             ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", upper))));
 
     // >= lower and < lower is an empty range
-    AssertHelpers.assertThrows(
-        "Should reject empty ranges",
-        IllegalArgumentException.class,
-        "No timestamps can match filters",
-        () ->
-            timestampRange(
-                ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", lower))));
+    Assertions.assertThatThrownBy(
+            () ->
+                timestampRange(
+                    ImmutableList.of(greaterThanOrEqual("ts_ms", lower), lessThan("ts_ms", lower))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("No timestamps can match filters");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -170,16 +171,16 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
         .set("write.metadata.metrics.column.id", "full")
         .commit();
 
-    AssertHelpers.assertThrows(
-        "Creating metrics for non-existent column fails",
-        ValidationException.class,
-        null,
-        () ->
-            table
-                .updateProperties()
-                .set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson)
-                .set("write.metadata.metrics.column.ids", "full")
-                .commit());
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .updateProperties()
+                    .set(TableProperties.DEFAULT_NAME_MAPPING, mappingJson)
+                    .set("write.metadata.metrics.column.ids", "full")
+                    .commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Invalid metrics config, could not find column ids from table prop write.metadata.metrics.column.ids in schema table");
 
     // Re-naming a column with metrics succeeds;
     table.updateSchema().renameColumn("id", "bloop").commit();

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class TestSequenceNumberForV2Table extends TableTestBase {
@@ -104,11 +105,9 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     table.ops().failCommits(1);
 
-    AssertHelpers.assertThrows(
-        "Should reject commit",
-        CommitFailedException.class,
-        "Injected failure",
-        () -> table.newFastAppend().appendFile(FILE_B).commit());
+    Assertions.assertThatThrownBy(() -> table.newFastAppend().appendFile(FILE_B).commit())
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
 
     table.updateProperties().set(TableProperties.COMMIT_NUM_RETRIES, "5").commit();
 
@@ -352,11 +351,9 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     Transaction txn = table.newTransaction();
     txn.newAppend().appendFile(FILE_C).commit();
 
-    AssertHelpers.assertThrows(
-        "Transaction commit should fail",
-        CommitFailedException.class,
-        "Injected failure",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
 
     V2Assert.assertEquals(
         "Last sequence number should be 1", 1, readMetadata().lastSequenceNumber());

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -100,16 +100,14 @@ public class TestSortOrder {
         SortOrder.unsorted(),
         SortOrder.builderFor(SCHEMA).withOrderId(0).build());
 
-    AssertHelpers.assertThrows(
-        "Should not allow sort orders ID 0",
-        IllegalArgumentException.class,
-        "order ID 0 is reserved for unsorted order",
-        () -> SortOrder.builderFor(SCHEMA).asc("data").withOrderId(0).build());
-    AssertHelpers.assertThrows(
-        "Should not allow unsorted orders with arbitrary IDs",
-        IllegalArgumentException.class,
-        "order ID must be 0",
-        () -> SortOrder.builderFor(SCHEMA).withOrderId(1).build());
+    Assertions.assertThatThrownBy(
+            () -> SortOrder.builderFor(SCHEMA).asc("data").withOrderId(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Sort order ID 0 is reserved for unsorted order");
+
+    Assertions.assertThatThrownBy(() -> SortOrder.builderFor(SCHEMA).withOrderId(1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unsorted order ID must be 0");
   }
 
   @Test
@@ -335,11 +333,9 @@ public class TestSortOrder {
     TestTables.TestTable table =
         TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
 
-    AssertHelpers.assertThrows(
-        "Should reject deletion of sort columns",
-        ValidationException.class,
-        "Cannot find source column",
-        () -> table.updateSchema().deleteColumn("s.id").commit());
+    Assertions.assertThatThrownBy(() -> table.updateSchema().deleteColumn("s.id").commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot find source column for sort field");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -177,32 +178,29 @@ public class TestSplitPlanning extends TableTestBase {
 
   @Test
   public void testSplitPlanningWithNegativeValues() {
-    AssertHelpers.assertThrows(
-        "User provided split size should be validated",
-        IllegalArgumentException.class,
-        "Split size must be > 0: -10",
-        () -> {
-          table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(-10)).planTasks();
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(-10)).planTasks())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Split size must be > 0: -10");
 
-    AssertHelpers.assertThrows(
-        "User provided split planning lookback should be validated",
-        IllegalArgumentException.class,
-        "Split planning lookback must be > 0: -10",
-        () -> {
-          table.newScan().option(TableProperties.SPLIT_LOOKBACK, String.valueOf(-10)).planTasks();
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .newScan()
+                    .option(TableProperties.SPLIT_LOOKBACK, String.valueOf(-10))
+                    .planTasks())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Split planning lookback must be > 0: -10");
 
-    AssertHelpers.assertThrows(
-        "User provided split open file cost should be validated",
-        IllegalArgumentException.class,
-        "File open cost must be >= 0: -10",
-        () -> {
-          table
-              .newScan()
-              .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(-10))
-              .planTasks();
-        });
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .newScan()
+                    .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(-10))
+                    .planTasks())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("File open cost must be >= 0: -10");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -216,11 +216,9 @@ public class TestTransaction extends TableTestBase {
         "Base metadata should not change when commit is created", base, readMetadata());
     Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
 
-    AssertHelpers.assertThrows(
-        "Should reject commit when last operation has not committed",
-        IllegalStateException.class,
-        "Cannot create new DeleteFiles: last operation has not committed",
-        txn::newDelete);
+    Assertions.assertThatThrownBy(txn::newDelete)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot create new DeleteFiles: last operation has not committed");
   }
 
   @Test
@@ -241,11 +239,9 @@ public class TestTransaction extends TableTestBase {
         "Base metadata should not change when commit is created", base, readMetadata());
     Assert.assertEquals("Table should be on version 0 after txn create", 0, (int) version());
 
-    AssertHelpers.assertThrows(
-        "Should reject commit when last operation has not committed",
-        IllegalStateException.class,
-        "Cannot commit transaction: last operation has not committed",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot commit transaction: last operation has not committed");
   }
 
   @Test
@@ -272,11 +268,9 @@ public class TestTransaction extends TableTestBase {
     // cause the transaction commit to fail
     table.ops().failCommits(1);
 
-    AssertHelpers.assertThrows(
-        "Transaction commit should fail",
-        CommitFailedException.class,
-        "Injected failure",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
   }
 
   @Test
@@ -445,11 +439,9 @@ public class TestTransaction extends TableTestBase {
         schemaId);
 
     // commit the transaction for adding "new-column"
-    AssertHelpers.assertThrows(
-        "Should fail due to conflicting transaction even after retry",
-        CommitFailedException.class,
-        "Table metadata refresh is required",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Table metadata refresh is required");
   }
 
   @Test
@@ -664,17 +656,16 @@ public class TestTransaction extends TableTestBase {
 
   @Test
   public void testTransactionNoCustomDeleteFunc() {
-    AssertHelpers.assertThrows(
-        "Should fail setting a custom delete function with a transaction",
-        IllegalArgumentException.class,
-        "Cannot set delete callback more than once",
-        () ->
-            table
-                .newTransaction()
-                .newAppend()
-                .appendFile(FILE_A)
-                .appendFile(FILE_B)
-                .deleteWith(file -> {}));
+    Assertions.assertThatThrownBy(
+            () ->
+                table
+                    .newTransaction()
+                    .newAppend()
+                    .appendFile(FILE_A)
+                    .appendFile(FILE_B)
+                    .deleteWith(file -> {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot set delete callback more than once");
   }
 
   @Test
@@ -758,11 +749,9 @@ public class TestTransaction extends TableTestBase {
     Transaction transaction = table.newTransaction();
     transaction.newAppend().appendFile(FILE_A).commit();
 
-    AssertHelpers.assertThrows(
-        "Transaction commit should fail with CommitStateUnknownException",
-        CommitStateUnknownException.class,
-        "datacenter on fire",
-        () -> transaction.commitTransaction());
+    Assertions.assertThatThrownBy(transaction::commitTransaction)
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("datacenter on fire");
 
     // Make sure metadata files still exist
     Snapshot current = table.currentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -28,7 +28,6 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumWriter;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappedField;
@@ -41,6 +40,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -202,12 +202,11 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
             new Schema(Types.NestedField.optional(18, "y", Types.IntegerType.get())));
 
     Schema readSchema = writeSchema;
-    AssertHelpers.assertThrows(
-        "Missing required field in nameMapping",
-        IllegalArgumentException.class,
-        "Missing required field: x",
-        // In this case, pruneColumns result is an empty record
-        () -> writeAndRead(writeSchema, readSchema, record, nameMapping));
+    Assertions.assertThatThrownBy(
+            // In this case, pruneColumns result is an empty record
+            () -> writeAndRead(writeSchema, readSchema, record, nameMapping))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required field: x");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -714,7 +714,6 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("nested_empty_req_proj", writeSchema, emptyStruct, record);
     assertEmptyAvroField(projected, "id");
-
     Record outerResult = (Record) projected.get("outer");
     Assert.assertEquals("Outer should be in the 0th position", outerResult, projected.get(0));
     Assert.assertNotNull("Should contain the outer record", outerResult);

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -21,8 +21,9 @@ package org.apache.iceberg.avro;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.GenericData.Record;
-import org.apache.iceberg.AssertHelpers;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -140,14 +141,14 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("basic_projection_id", writeSchema, idOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "data");
+    assertEmptyAvroField(projected, "data");
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
 
     Schema dataOnly = new Schema(Types.NestedField.optional(1, "data", Types.StringType.get()));
 
     projected = writeAndRead("basic_projection_data", writeSchema, dataOnly, record);
 
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     int cmp = Comparators.charSequences().compare("test", (CharSequence) projected.get("data"));
     Assert.assertEquals("Should contain the correct data value", 0, cmp);
   }
@@ -198,7 +199,7 @@ public abstract class TestReadProjection {
     Schema idOnly = new Schema(Types.NestedField.required(0, "id", Types.LongType.get()));
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "location");
+    assertEmptyAvroField(projected, "location");
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
 
     Schema latOnly =
@@ -210,9 +211,9 @@ public abstract class TestReadProjection {
 
     projected = writeAndRead("latitude_only", writeSchema, latOnly, record);
     Record projectedLocation = (Record) projected.get("location");
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project location", projected.get("location"));
-    AssertHelpers.assertEmptyAvroField(projectedLocation, "long");
+    assertEmptyAvroField(projectedLocation, "long");
     Assert.assertEquals(
         "Should project latitude", 52.995143f, (float) projectedLocation.get("lat"), 0.000001f);
 
@@ -225,16 +226,16 @@ public abstract class TestReadProjection {
 
     projected = writeAndRead("longitude_only", writeSchema, longOnly, record);
     projectedLocation = (Record) projected.get("location");
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project location", projected.get("location"));
-    AssertHelpers.assertEmptyAvroField(projectedLocation, "lat");
+    assertEmptyAvroField(projectedLocation, "lat");
     Assert.assertEquals(
         "Should project longitude", -1.539054f, (float) projectedLocation.get("long"), 0.000001f);
 
     Schema locationOnly = writeSchema.select("location");
     projected = writeAndRead("location_only", writeSchema, locationOnly, record);
     projectedLocation = (Record) projected.get("location");
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project location", projected.get("location"));
     Assert.assertEquals(
         "Should project latitude", 52.995143f, (float) projectedLocation.get("lat"), 0.000001f);
@@ -262,23 +263,23 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    AssertHelpers.assertEmptyAvroField(projected, "properties");
+    assertEmptyAvroField(projected, "properties");
 
     Schema keyOnly = writeSchema.select("properties.key");
     projected = writeAndRead("key_only", writeSchema, keyOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals(
         "Should project entire map", properties, toStringMap((Map) projected.get("properties")));
 
     Schema valueOnly = writeSchema.select("properties.value");
     projected = writeAndRead("value_only", writeSchema, valueOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals(
         "Should project entire map", properties, toStringMap((Map) projected.get("properties")));
 
     Schema mapOnly = writeSchema.select("properties");
     projected = writeAndRead("map_only", writeSchema, mapOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals(
         "Should project entire map", properties, toStringMap((Map) projected.get("properties")));
   }
@@ -329,17 +330,17 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    AssertHelpers.assertEmptyAvroField(projected, "locations");
+    assertEmptyAvroField(projected, "locations");
 
     projected = writeAndRead("all_locations", writeSchema, writeSchema.select("locations"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals(
         "Should project locations map",
         record.get("locations"),
         toStringMap((Map) projected.get("locations")));
 
     projected = writeAndRead("lat_only", writeSchema, writeSchema.select("locations.lat"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Map<String, ?> locations = toStringMap((Map) projected.get("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals(
@@ -348,28 +349,28 @@ public abstract class TestReadProjection {
     Assert.assertNotNull("L1 should not be null", projectedL1);
     Assert.assertEquals(
         "L1 should contain lat", 53.992811f, (float) projectedL1.get("lat"), 0.000001);
-    AssertHelpers.assertEmptyAvroField(projectedL1, "long");
+    assertEmptyAvroField(projectedL1, "long");
     Record projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
     Assert.assertEquals(
         "L2 should contain lat", 52.995143f, (float) projectedL2.get("lat"), 0.000001);
-    AssertHelpers.assertEmptyAvroField(projectedL2, "y");
+    assertEmptyAvroField(projectedL2, "y");
 
     projected =
         writeAndRead("long_only", writeSchema, writeSchema.select("locations.long"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     locations = toStringMap((Map) projected.get("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals(
         "Should contain L1 and L2", Sets.newHashSet("L1", "L2"), locations.keySet());
     projectedL1 = (Record) locations.get("L1");
     Assert.assertNotNull("L1 should not be null", projectedL1);
-    AssertHelpers.assertEmptyAvroField(projectedL1, "lat");
+    assertEmptyAvroField(projectedL1, "lat");
     Assert.assertEquals(
         "L1 should contain long", -1.542616f, (float) projectedL1.get("long"), 0.000001);
     projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
-    AssertHelpers.assertEmptyAvroField(projectedL2, "lat");
+    assertEmptyAvroField(projectedL2, "lat");
     Assert.assertEquals(
         "L2 should contain long", -1.539054f, (float) projectedL2.get("long"), 0.000001);
 
@@ -386,7 +387,7 @@ public abstract class TestReadProjection {
                         Types.NestedField.required(1, "latitude", Types.FloatType.get())))));
 
     projected = writeAndRead("latitude_renamed", writeSchema, latitiudeRenamed, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     locations = toStringMap((Map) projected.get("locations"));
     Assert.assertNotNull("Should project locations map", locations);
     Assert.assertEquals(
@@ -395,14 +396,14 @@ public abstract class TestReadProjection {
     Assert.assertNotNull("L1 should not be null", projectedL1);
     Assert.assertEquals(
         "L1 should contain latitude", 53.992811f, (float) projectedL1.get("latitude"), 0.000001);
-    AssertHelpers.assertEmptyAvroField(projectedL1, "lat");
-    AssertHelpers.assertEmptyAvroField(projectedL1, "long");
+    assertEmptyAvroField(projectedL1, "lat");
+    assertEmptyAvroField(projectedL1, "long");
     projectedL2 = (Record) locations.get("L2");
     Assert.assertNotNull("L2 should not be null", projectedL2);
     Assert.assertEquals(
         "L2 should contain latitude", 52.995143f, (float) projectedL2.get("latitude"), 0.000001);
-    AssertHelpers.assertEmptyAvroField(projectedL2, "lat");
-    AssertHelpers.assertEmptyAvroField(projectedL2, "long");
+    assertEmptyAvroField(projectedL2, "lat");
+    assertEmptyAvroField(projectedL2, "long");
   }
 
   @Test
@@ -423,16 +424,16 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    AssertHelpers.assertEmptyAvroField(projected, "values");
+    assertEmptyAvroField(projected, "values");
 
     Schema elementOnly = writeSchema.select("values.element");
     projected = writeAndRead("element_only", writeSchema, elementOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals("Should project entire list", values, projected.get("values"));
 
     Schema listOnly = writeSchema.select("values");
     projected = writeAndRead("list_only", writeSchema, listOnly, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals("Should project entire list", values, projected.get("values"));
   }
 
@@ -469,35 +470,35 @@ public abstract class TestReadProjection {
 
     Record projected = writeAndRead("id_only", writeSchema, idOnly, record);
     Assert.assertEquals("Should contain the correct id value", 34L, (long) projected.get("id"));
-    AssertHelpers.assertEmptyAvroField(projected, "points");
+    assertEmptyAvroField(projected, "points");
 
     projected = writeAndRead("all_points", writeSchema, writeSchema.select("points"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertEquals(
         "Should project points list", record.get("points"), projected.get("points"));
 
     projected = writeAndRead("x_only", writeSchema, writeSchema.select("points.x"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project points list", projected.get("points"));
     List<Record> points = (List<Record>) projected.get("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     Record projectedP1 = points.get(0);
     Assert.assertEquals("Should project x", 1, (int) projectedP1.get("x"));
-    AssertHelpers.assertEmptyAvroField(projectedP1, "y");
+    assertEmptyAvroField(projectedP1, "y");
     Record projectedP2 = points.get(1);
     Assert.assertEquals("Should project x", 3, (int) projectedP2.get("x"));
-    AssertHelpers.assertEmptyAvroField(projectedP2, "y");
+    assertEmptyAvroField(projectedP2, "y");
 
     projected = writeAndRead("y_only", writeSchema, writeSchema.select("points.y"), record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project points list", projected.get("points"));
     points = (List<Record>) projected.get("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     projectedP1 = points.get(0);
-    AssertHelpers.assertEmptyAvroField(projectedP1, "x");
+    assertEmptyAvroField(projectedP1, "x");
     Assert.assertEquals("Should project y", 2, (int) projectedP1.get("y"));
     projectedP2 = points.get(1);
-    AssertHelpers.assertEmptyAvroField(projectedP2, "x");
+    assertEmptyAvroField(projectedP2, "x");
     Assert.assertEquals("Should project null y", null, projectedP2.get("y"));
 
     Schema yRenamed =
@@ -511,17 +512,17 @@ public abstract class TestReadProjection {
                         Types.NestedField.optional(18, "z", Types.IntegerType.get())))));
 
     projected = writeAndRead("y_renamed", writeSchema, yRenamed, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Assert.assertNotNull("Should project points list", projected.get("points"));
     points = (List<Record>) projected.get("points");
     Assert.assertEquals("Should read 2 points", 2, points.size());
     projectedP1 = points.get(0);
-    AssertHelpers.assertEmptyAvroField(projectedP1, "x");
-    AssertHelpers.assertEmptyAvroField(projectedP1, "y");
+    assertEmptyAvroField(projectedP1, "x");
+    assertEmptyAvroField(projectedP1, "y");
     Assert.assertEquals("Should project z", 2, (int) projectedP1.get("z"));
     projectedP2 = points.get(1);
-    AssertHelpers.assertEmptyAvroField(projectedP2, "x");
-    AssertHelpers.assertEmptyAvroField(projectedP2, "y");
+    assertEmptyAvroField(projectedP2, "x");
+    assertEmptyAvroField(projectedP2, "y");
     Assert.assertNull("Should project null z", projectedP2.get("z"));
   }
 
@@ -549,13 +550,13 @@ public abstract class TestReadProjection {
         new Schema(Types.NestedField.required(3, "location", Types.StructType.of()));
 
     Record projected = writeAndRead("empty_proj", writeSchema, emptyStruct, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Record result = (Record) projected.get("location");
 
     Assert.assertEquals("location should be in the 0th position", result, projected.get(0));
     Assert.assertNotNull("Should contain an empty record", result);
-    AssertHelpers.assertEmptyAvroField(result, "lat");
-    AssertHelpers.assertEmptyAvroField(result, "long");
+    assertEmptyAvroField(result, "lat");
+    assertEmptyAvroField(result, "long");
   }
 
   @Test
@@ -581,12 +582,12 @@ public abstract class TestReadProjection {
         new Schema(Types.NestedField.required(3, "location", Types.StructType.of()));
 
     Record projected = writeAndRead("empty_req_proj", writeSchema, emptyStruct, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Record result = (Record) projected.get("location");
     Assert.assertEquals("location should be in the 0th position", result, projected.get(0));
     Assert.assertNotNull("Should contain an empty record", result);
-    AssertHelpers.assertEmptyAvroField(result, "lat");
-    AssertHelpers.assertEmptyAvroField(result, "long");
+    assertEmptyAvroField(result, "lat");
+    assertEmptyAvroField(result, "long");
   }
 
   @Test
@@ -623,8 +624,8 @@ public abstract class TestReadProjection {
     Record result = (Record) projected.get("location");
     Assert.assertEquals("location should be in the 1st position", result, projected.get(1));
     Assert.assertNotNull("Should contain an empty record", result);
-    AssertHelpers.assertEmptyAvroField(result, "lat");
-    AssertHelpers.assertEmptyAvroField(result, "long");
+    assertEmptyAvroField(result, "lat");
+    assertEmptyAvroField(result, "long");
     Assert.assertNotNull("Should project empty", result.getSchema().getField("empty"));
     Assert.assertNotNull("Empty should not be null", result.get("empty"));
     Assert.assertEquals(
@@ -667,15 +668,15 @@ public abstract class TestReadProjection {
                     Types.NestedField.required(2, "inner", Types.StructType.of()))));
 
     Record projected = writeAndRead("nested_empty_proj", writeSchema, emptyStruct, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
     Record outerResult = (Record) projected.get("outer");
     Assert.assertEquals("Outer should be in the 0th position", outerResult, projected.get(0));
     Assert.assertNotNull("Should contain the outer record", outerResult);
-    AssertHelpers.assertEmptyAvroField(outerResult, "lat");
+    assertEmptyAvroField(outerResult, "lat");
     Record innerResult = (Record) outerResult.get("inner");
     Assert.assertEquals("Inner should be in the 0th position", innerResult, outerResult.get(0));
     Assert.assertNotNull("Should contain the inner record", innerResult);
-    AssertHelpers.assertEmptyAvroField(innerResult, "lon");
+    assertEmptyAvroField(innerResult, "lon");
   }
 
   @Test
@@ -712,14 +713,21 @@ public abstract class TestReadProjection {
                     Types.NestedField.required(2, "inner", Types.StructType.of()))));
 
     Record projected = writeAndRead("nested_empty_req_proj", writeSchema, emptyStruct, record);
-    AssertHelpers.assertEmptyAvroField(projected, "id");
+    assertEmptyAvroField(projected, "id");
+
     Record outerResult = (Record) projected.get("outer");
     Assert.assertEquals("Outer should be in the 0th position", outerResult, projected.get(0));
     Assert.assertNotNull("Should contain the outer record", outerResult);
-    AssertHelpers.assertEmptyAvroField(outerResult, "lat");
+    assertEmptyAvroField(outerResult, "lat");
     Record innerResult = (Record) outerResult.get("inner");
     Assert.assertEquals("Inner should be in the 0th position", innerResult, outerResult.get(0));
     Assert.assertNotNull("Should contain the inner record", innerResult);
-    AssertHelpers.assertEmptyAvroField(innerResult, "lon");
+    assertEmptyAvroField(innerResult, "lon");
+  }
+
+  private void assertEmptyAvroField(GenericRecord record, String field) {
+    Assertions.assertThatThrownBy(() -> record.get(field))
+        .isInstanceOf(AvroRuntimeException.class)
+        .hasMessage("Not a valid schema field: " + field);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/encryption/TestKeyMetadataParser.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestKeyMetadataParser.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.encryption;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import org.apache.iceberg.AssertHelpers;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,10 +41,8 @@ public class TestKeyMetadataParser {
   @Test
   public void testUnsupportedVersion() {
     ByteBuffer badBuffer = ByteBuffer.wrap(new byte[] {0x02});
-    AssertHelpers.assertThrows(
-        "Should throw when attempting to parse a buffer with wrong key metadata version",
-        UnsupportedOperationException.class,
-        "Cannot resolve schema for version",
-        () -> KeyMetadata.parse(badBuffer));
+    Assertions.assertThatThrownBy(() -> KeyMetadata.parse(badBuffer))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot resolve schema for version: 2");
   }
 }


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in `iceberg-core-avro` module.