### PR TITLE
Core: Remove deprecated AssertHelpers

### DIFF
--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -67,14 +68,15 @@ public abstract class ScanTestBase<
 
   @Test
   public void testTableBothProjectAndSelect() {
-    AssertHelpers.assertThrows(
-        "Cannot set projection schema when columns are selected",
-        IllegalStateException.class,
-        () -> newScan().select(Arrays.asList("id")).project(SCHEMA.select("data")));
-    AssertHelpers.assertThrows(
-        "Cannot select columns when projection schema is set",
-        IllegalStateException.class,
-        () -> newScan().project(SCHEMA.select("data")).select(Arrays.asList("id")));
+    Assertions.assertThatThrownBy(
+            () -> newScan().select(Arrays.asList("id")).project(SCHEMA.select("data")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set projection schema when columns are selected");
+
+    Assertions.assertThatThrownBy(
+            () -> newScan().project(SCHEMA.select("data")).select(Arrays.asList("id")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot select columns when projection schema is set");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/ScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/ScanTestBase.java
@@ -72,7 +72,6 @@ public abstract class ScanTestBase<
             () -> newScan().select(Arrays.asList("id")).project(SCHEMA.select("data")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set projection schema when columns are selected");
-
     Assertions.assertThatThrownBy(
             () -> newScan().project(SCHEMA.select("data")).select(Arrays.asList("id")))
         .isInstanceOf(IllegalStateException.class)

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalAppendScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalAppendScan.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -127,23 +128,21 @@ public class TestBaseIncrementalAppendScan
     // scan should fail because snapshot B is not an ancestor of snapshot D
     IncrementalAppendScan scanShouldFail =
         newScan().fromSnapshotExclusive(snapshotBId).toSnapshot(snapshotDId);
-    AssertHelpers.assertThrows(
-        "Should throw exception",
-        IllegalArgumentException.class,
-        String.format(
-            "Starting snapshot (exclusive) %d is not a parent ancestor of end snapshot %d",
-            snapshotBId, snapshotDId),
-        () -> Iterables.size(scanShouldFail.planFiles()));
+    Assertions.assertThatThrownBy(() -> Iterables.size(scanShouldFail.planFiles()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Starting snapshot (exclusive) %d is not a parent ancestor of end snapshot %d",
+                snapshotBId, snapshotDId));
 
     // scan should fail because snapshot B is not an ancestor of snapshot D
     IncrementalAppendScan scanShouldFailInclusive =
         newScan().fromSnapshotInclusive(snapshotBId).toSnapshot(snapshotDId);
-    AssertHelpers.assertThrows(
-        "Should throw exception",
-        IllegalArgumentException.class,
-        String.format(
-            "Starting snapshot (inclusive) %d is not an ancestor of end snapshot %d",
-            snapshotBId, snapshotDId),
-        () -> Iterables.size(scanShouldFailInclusive.planFiles()));
+    Assertions.assertThatThrownBy(() -> Iterables.size(scanShouldFailInclusive.planFiles()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Starting snapshot (inclusive) %d is not an ancestor of end snapshot %d",
+                snapshotBId, snapshotDId));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -256,11 +257,9 @@ public class TestBaseIncrementalChangelogScan
 
     table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
 
-    AssertHelpers.assertThrows(
-        "Should complain about delete files",
-        UnsupportedOperationException.class,
-        "Delete files are currently not supported",
-        () -> plan(newScan()));
+    Assertions.assertThatThrownBy(() -> plan(newScan()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Delete files are currently not supported in changelog scans");
   }
 
   // plans tasks and reorders them to have deterministic order

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -73,13 +73,14 @@ public class TestCatalogUtil {
     options.put("key", "val");
     Configuration hadoopConf = new Configuration();
     String name = "custom";
-    AssertHelpers.assertThrows(
-        "must have no-arg constructor",
-        IllegalArgumentException.class,
-        "NoSuchMethodException: org.apache.iceberg.TestCatalogUtil$TestCatalogBadConstructor.<init>()",
-        () ->
-            CatalogUtil.loadCatalog(
-                TestCatalogBadConstructor.class.getName(), name, options, hadoopConf));
+    Assertions.assertThatThrownBy(
+            () ->
+                CatalogUtil.loadCatalog(
+                    TestCatalogBadConstructor.class.getName(), name, options, hadoopConf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize Catalog implementation")
+        .hasMessageContaining(
+            "NoSuchMethodException: org.apache.iceberg.TestCatalogUtil$TestCatalogBadConstructor.<init>()");
   }
 
   @Test
@@ -89,13 +90,13 @@ public class TestCatalogUtil {
     Configuration hadoopConf = new Configuration();
     String name = "custom";
 
-    AssertHelpers.assertThrows(
-        "must implement catalog",
-        IllegalArgumentException.class,
-        "does not implement Catalog",
-        () ->
-            CatalogUtil.loadCatalog(
-                TestCatalogNoInterface.class.getName(), name, options, hadoopConf));
+    Assertions.assertThatThrownBy(
+            () ->
+                CatalogUtil.loadCatalog(
+                    TestCatalogNoInterface.class.getName(), name, options, hadoopConf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize Catalog")
+        .hasMessageContaining("does not implement Catalog");
   }
 
   @Test
@@ -106,11 +107,10 @@ public class TestCatalogUtil {
     String name = "custom";
 
     String impl = TestCatalogErrorConstructor.class.getName();
-    AssertHelpers.assertThrows(
-        "must be able to initialize catalog",
-        IllegalArgumentException.class,
-        "NoClassDefFoundError: Error while initializing class",
-        () -> CatalogUtil.loadCatalog(impl, name, options, hadoopConf));
+    Assertions.assertThatThrownBy(() -> CatalogUtil.loadCatalog(impl, name, options, hadoopConf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize Catalog implementation")
+        .hasMessageContaining("NoClassDefFoundError: Error while initializing class");
   }
 
   @Test
@@ -120,11 +120,10 @@ public class TestCatalogUtil {
     Configuration hadoopConf = new Configuration();
     String name = "custom";
     String impl = "CatalogDoesNotExist";
-    AssertHelpers.assertThrows(
-        "catalog must exist",
-        IllegalArgumentException.class,
-        "java.lang.ClassNotFoundException: CatalogDoesNotExist",
-        () -> CatalogUtil.loadCatalog(impl, name, options, hadoopConf));
+    Assertions.assertThatThrownBy(() -> CatalogUtil.loadCatalog(impl, name, options, hadoopConf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize Catalog implementation")
+        .hasMessageContaining("java.lang.ClassNotFoundException: CatalogDoesNotExist");
   }
 
   @Test
@@ -159,20 +158,20 @@ public class TestCatalogUtil {
 
   @Test
   public void loadCustomFileIO_badArg() {
-    AssertHelpers.assertThrows(
-        "cannot find constructor",
-        IllegalArgumentException.class,
-        "missing no-arg constructor",
-        () -> CatalogUtil.loadFileIO(TestFileIOBadArg.class.getName(), Maps.newHashMap(), null));
+    Assertions.assertThatThrownBy(
+            () -> CatalogUtil.loadFileIO(TestFileIOBadArg.class.getName(), Maps.newHashMap(), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize FileIO, missing no-arg constructor");
   }
 
   @Test
   public void loadCustomFileIO_badClass() {
-    AssertHelpers.assertThrows(
-        "cannot cast",
-        IllegalArgumentException.class,
-        "does not implement FileIO",
-        () -> CatalogUtil.loadFileIO(TestFileIONotImpl.class.getName(), Maps.newHashMap(), null));
+    Assertions.assertThatThrownBy(
+            () ->
+                CatalogUtil.loadFileIO(TestFileIONotImpl.class.getName(), Maps.newHashMap(), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot initialize FileIO")
+        .hasMessageContaining("does not implement FileIO");
   }
 
   @Test
@@ -182,12 +181,10 @@ public class TestCatalogUtil {
     options.put(CatalogUtil.ICEBERG_CATALOG_TYPE, "hive");
     Configuration hadoopConf = new Configuration();
     String name = "custom";
-
-    AssertHelpers.assertThrows(
-        "Should complain about both configs being set",
-        IllegalArgumentException.class,
-        "both type and catalog-impl are set",
-        () -> CatalogUtil.buildIcebergCatalog(name, options, hadoopConf));
+    Assertions.assertThatThrownBy(() -> CatalogUtil.buildIcebergCatalog(name, options, hadoopConf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot create catalog custom, both type and catalog-impl are set: type=hive, catalog-impl=CustomCatalog");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -300,11 +301,9 @@ public class TestCreateTransaction extends TableTestBase {
 
     txn.updateProperties().set("test-property", "test-value"); // not committed
 
-    AssertHelpers.assertThrows(
-        "Should reject commit when last operation has not committed",
-        IllegalStateException.class,
-        "Cannot create new DeleteFiles: last operation has not committed",
-        txn::newDelete);
+    Assertions.assertThatThrownBy(txn::newDelete)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot create new DeleteFiles: last operation has not committed");
   }
 
   @Test
@@ -323,11 +322,9 @@ public class TestCreateTransaction extends TableTestBase {
 
     txn.updateProperties().set("test-property", "test-value"); // not committed
 
-    AssertHelpers.assertThrows(
-        "Should reject commit when last operation has not committed",
-        IllegalStateException.class,
-        "Cannot commit transaction: last operation has not committed",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot commit transaction: last operation has not committed");
   }
 
   @Test
@@ -360,11 +357,9 @@ public class TestCreateTransaction extends TableTestBase {
     Assert.assertFalse(
         "Table should not have any snapshots", conflict.snapshots().iterator().hasNext());
 
-    AssertHelpers.assertThrows(
-        "Transaction commit should fail",
-        CommitFailedException.class,
-        "Commit failed: table was updated",
-        txn::commitTransaction);
+    Assertions.assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageStartingWith("Commit failed: table was updated");
 
     Assert.assertEquals(
         "Should clean up metadata",

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeWrapper;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -284,15 +285,14 @@ public class TestDeleteFiles extends TableTestBase {
 
     commit(table, table.newFastAppend().appendFile(dataFile), branch);
 
-    AssertHelpers.assertThrows(
-        "Should reject as not all rows match filter",
-        ValidationException.class,
-        "Cannot delete file where some, but not all, rows match filter",
-        () ->
-            commit(
-                table,
-                table.newDelete().deleteFromRowFilter(Expressions.equal("data", "aa")),
-                branch));
+    Assertions.assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    table.newDelete().deleteFromRowFilter(Expressions.equal("data", "aa")),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot delete file where some, but not all, rows match filter");
   }
 
   @Test
@@ -301,21 +301,19 @@ public class TestDeleteFiles extends TableTestBase {
 
     Expression rowFilter = Expressions.lessThan("iD", 5);
 
-    AssertHelpers.assertThrows(
-        "Should use case sensitive binding by default",
-        ValidationException.class,
-        "Cannot find field 'iD'",
-        () -> commit(table, table.newDelete().deleteFromRowFilter(rowFilter), branch));
+    Assertions.assertThatThrownBy(
+            () -> commit(table, table.newDelete().deleteFromRowFilter(rowFilter), branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot find field 'iD'");
 
-    AssertHelpers.assertThrows(
-        "Should fail with case sensitive binding",
-        ValidationException.class,
-        "Cannot find field 'iD'",
-        () ->
-            commit(
-                table,
-                table.newDelete().deleteFromRowFilter(rowFilter).caseSensitive(true),
-                branch));
+    Assertions.assertThatThrownBy(
+            () ->
+                commit(
+                    table,
+                    table.newDelete().deleteFromRowFilter(rowFilter).caseSensitive(true),
+                    branch))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot find field 'iD'");
 
     Snapshot deleteSnapshot =
         commit(

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -239,11 +239,9 @@ public class TestFastAppend extends TableTestBase {
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
     Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
 
-    AssertHelpers.assertThrows(
-        "Should retry 4 times and throw last failure",
-        CommitFailedException.class,
-        "Injected failure",
-        append::commit);
+    Assertions.assertThatThrownBy(append::commit)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
 
     Assert.assertFalse("Should clean up new manifest", new File(newManifest.path()).exists());
   }
@@ -260,11 +258,9 @@ public class TestFastAppend extends TableTestBase {
     ManifestFile newManifest = pending.allManifests(FILE_IO).get(0);
     Assert.assertTrue("Should create new manifest", new File(newManifest.path()).exists());
 
-    AssertHelpers.assertThrows(
-        "Should retry 4 times and throw last failure",
-        CommitFailedException.class,
-        "Injected failure",
-        append::commit);
+    Assertions.assertThatThrownBy(append::commit)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
 
     Assert.assertFalse("Should clean up new manifest", new File(newManifest.path()).exists());
   }
@@ -376,8 +372,9 @@ public class TestFastAppend extends TableTestBase {
     AppendFiles append = table.newAppend();
     append.appendManifest(manifest);
 
-    AssertHelpers.assertThrows(
-        "Should reject commit", CommitFailedException.class, "Injected failure", append::commit);
+    Assertions.assertThatThrownBy(append::commit)
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
 
     Assert.assertTrue("Append manifest should not be deleted", new File(manifest.path()).exists());
   }
@@ -391,19 +388,17 @@ public class TestFastAppend extends TableTestBase {
 
     ManifestFile manifestWithExistingFiles =
         writeManifest("manifest-file-1.avro", manifestEntry(Status.EXISTING, null, FILE_A));
-    AssertHelpers.assertThrows(
-        "Should reject commit",
-        IllegalArgumentException.class,
-        "Cannot append manifest with existing files",
-        () -> table.newFastAppend().appendManifest(manifestWithExistingFiles).commit());
+    Assertions.assertThatThrownBy(
+            () -> table.newFastAppend().appendManifest(manifestWithExistingFiles).commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot append manifest with existing files");
 
     ManifestFile manifestWithDeletedFiles =
         writeManifest("manifest-file-2.avro", manifestEntry(Status.DELETED, null, FILE_A));
-    AssertHelpers.assertThrows(
-        "Should reject commit",
-        IllegalArgumentException.class,
-        "Cannot append manifest with deleted files",
-        () -> table.newFastAppend().appendManifest(manifestWithDeletedFiles).commit());
+    Assertions.assertThatThrownBy(
+            () -> table.newFastAppend().appendManifest(manifestWithDeletedFiles).commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot append manifest with deleted files");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestFormatVersions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,11 +49,9 @@ public class TestFormatVersions extends TableTestBase {
 
     Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
 
-    AssertHelpers.assertThrows(
-        "Should reject a version downgrade",
-        IllegalArgumentException.class,
-        "Cannot downgrade",
-        () -> ops.current().upgradeToFormatVersion(1));
+    Assertions.assertThatThrownBy(() -> ops.current().upgradeToFormatVersion(1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot downgrade v2 table to v1");
 
     Assert.assertEquals("Should report v2", 2, ops.current().formatVersion());
   }
@@ -61,14 +60,14 @@ public class TestFormatVersions extends TableTestBase {
   public void testFormatVersionUpgradeNotSupported() {
     TableOperations ops = table.ops();
     TableMetadata base = ops.current();
-    AssertHelpers.assertThrows(
-        "Should reject an unsupported version upgrade",
-        IllegalArgumentException.class,
-        "Cannot upgrade table to unsupported format version",
-        () ->
-            ops.commit(
-                base,
-                base.upgradeToFormatVersion(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION + 1)));
+
+    Assertions.assertThatThrownBy(
+            () ->
+                ops.commit(
+                    base,
+                    base.upgradeToFormatVersion(TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION + 1)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot upgrade table to unsupported format version: v3 (supported: v2)");
 
     Assert.assertEquals("Should report v1", 1, ops.current().formatVersion());
   }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -172,13 +173,16 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, nonExistentImpl)
         .commit();
 
-    AssertHelpers.assertThrows(
-        "Non-existent implementation should fail on finding constructor",
-        IllegalArgumentException.class,
-        String.format(
-            "Unable to find a constructor for implementation %s of %s. ",
-            nonExistentImpl, LocationProvider.class),
-        () -> table.locationProvider());
+    Assertions.assertThatThrownBy(() -> table.locationProvider())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            String.format(
+                "Unable to find a constructor for implementation %s of %s. ",
+                nonExistentImpl, LocationProvider.class))
+        .hasMessageEndingWith(
+            "Make sure the implementation is in classpath, and that it either "
+                + "has a public no-arg constructor or a two-arg constructor "
+                + "taking in the string base table location and its property string map.");
   }
 
   @Test
@@ -193,13 +197,12 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, invalidImpl)
         .commit();
 
-    AssertHelpers.assertThrows(
-        "Class with missing interface implementation should fail on instantiation.",
-        IllegalArgumentException.class,
-        String.format(
-            "Provided implementation for dynamic instantiation should implement %s",
-            LocationProvider.class),
-        () -> table.locationProvider());
+    Assertions.assertThatThrownBy(() -> table.locationProvider())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format(
+                "Provided implementation for dynamic instantiation should implement %s.",
+                LocationProvider.class));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -217,13 +217,12 @@ public class TestLocationProvider extends TableTestBase {
         .set(TableProperties.WRITE_LOCATION_PROVIDER_IMPL, invalidImpl)
         .commit();
 
-    AssertHelpers.assertThrows(
-        "Implementation with invalid arg types should fail on finding constructor",
-        IllegalArgumentException.class,
-        String.format(
-            "Unable to find a constructor for implementation %s of %s. ",
-            invalidImpl, LocationProvider.class),
-        () -> table.locationProvider());
+    Assertions.assertThatThrownBy(() -> table.locationProvider())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            String.format(
+                "Unable to find a constructor for implementation %s of %s. ",
+                invalidImpl, LocationProvider.class));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -76,11 +77,9 @@ public class TestManifestReader extends TableTestBase {
   @Test
   public void testInvalidUsage() throws IOException {
     ManifestFile manifest = writeManifest(FILE_A, FILE_B);
-    AssertHelpers.assertThrows(
-        "Should not be possible to read manifest without explicit snapshot ids and inheritable metadata",
-        IllegalArgumentException.class,
-        "Cannot read from ManifestFile with null (unassigned) snapshot ID",
-        () -> ManifestFiles.read(manifest, FILE_IO));
+    Assertions.assertThatThrownBy(() -> ManifestFiles.read(manifest, FILE_IO))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read from ManifestFile with null (unassigned) snapshot ID");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -275,9 +275,8 @@ public class TestManifestReaderStats extends TableTestBase {
 
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    AssertHelpers.assertThrows(
-        "Should throw NPE when accessing non-populated record count field",
-        NullPointerException.class,
-        dataFile::recordCount);
+    Assertions.assertThatThrownBy(dataFile::recordCount)
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(null);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -275,8 +275,6 @@ public class TestManifestReaderStats extends TableTestBase {
 
   private void assertNullRecordCount(DataFile dataFile) {
     // record count is a primitive type, accessing null record count will throw NPE
-    Assertions.assertThatThrownBy(dataFile::recordCount)
-        .isInstanceOf(NullPointerException.class)
-        .hasMessage(null);
+    Assertions.assertThatThrownBy(dataFile::recordCount).isInstanceOf(NullPointerException.class);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -111,11 +112,9 @@ public class TestManifestWriterVersions {
 
   @Test
   public void testV1WriteDelete() {
-    AssertHelpers.assertThrows(
-        "Should fail to write a delete manifest for v1",
-        IllegalArgumentException.class,
-        "Cannot write delete files in a v1 table",
-        () -> writeDeleteManifest(1));
+    Assertions.assertThatThrownBy(() -> writeDeleteManifest(1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot write delete files in a v1 table");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -56,11 +56,9 @@ public class TestMetadataUpdateParser {
         ImmutableList.of("{\"action\":null,\"format-version\":2}", "{\"format-version\":2}");
 
     for (String json : invalidJson) {
-      AssertHelpers.assertThrows(
-          "MetadataUpdate without a recognized action should fail to deserialize",
-          IllegalArgumentException.class,
-          "Cannot parse metadata update. Missing field: action",
-          () -> MetadataUpdateParser.fromJson(json));
+      Assertions.assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Cannot parse metadata update. Missing field: action");
     }
   }
 
@@ -702,11 +700,9 @@ public class TestMetadataUpdateParser {
     props.put("prop2", null);
     String propsMap = "{\"prop1\":\"val1\",\"prop2\":null}";
     String json = String.format("{\"action\":\"%s\",\"updated\":%s}", action, propsMap);
-    AssertHelpers.assertThrows(
-        "Parsing updates from SetProperties with a property set to null should throw",
-        IllegalArgumentException.class,
-        "Cannot parse to a string value: prop2: null",
-        () -> MetadataUpdateParser.fromJson(json));
+    Assertions.assertThatThrownBy(() -> MetadataUpdateParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse to a string value: prop2: null");
   }
 
   @Test


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094
Remove `AssertHelpers` in `iceberg-core` module.