### PR TITLE
Flink: Backport to 1.15 and 1.16: Add possibility of ordering the splits based on the file sequence number (#7661)

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/assigner/OrderedSplitAssignerFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/assigner/OrderedSplitAssignerFactory.java
@@ -19,19 +19,28 @@
 package org.apache.iceberg.flink.source.assigner;
 
 import java.util.Collection;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 
-/** Create simple assigner that hands out splits without any guarantee in order or locality. */
-public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
-  public SimpleSplitAssignerFactory() {}
+/**
+ * Create default assigner with a comparator that hands out splits where the order of the splits
+ * will be defined by the {@link SerializableComparator}.
+ */
+public class OrderedSplitAssignerFactory implements SplitAssignerFactory {
+  private final SerializableComparator<IcebergSourceSplit> comparator;
+
+  public OrderedSplitAssignerFactory(SerializableComparator<IcebergSourceSplit> comparator) {
+    this.comparator = comparator;
+  }
 
   @Override
   public SplitAssigner createAssigner() {
-    return new DefaultSplitAssigner(null);
+    return new DefaultSplitAssigner(comparator);
   }
 
   @Override
   public SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
-    return new DefaultSplitAssigner(null, assignerState);
+    return new DefaultSplitAssigner(comparator, assignerState);
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
@@ -25,6 +25,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -36,9 +37,10 @@ public class IcebergSourceReader<T>
   public IcebergSourceReader(
       IcebergSourceReaderMetrics metrics,
       ReaderFunction<T> readerFunction,
+      SerializableComparator<IcebergSourceSplit> splitComparator,
       SourceReaderContext context) {
     super(
-        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, context),
+        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, splitComparator, context),
         new IcebergSourceRecordEmitter<>(),
         context.getConfiguration(),
         context);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.List;
 import java.util.Queue;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsBySplits;
@@ -31,7 +32,9 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +43,7 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
 
   private final IcebergSourceReaderMetrics metrics;
   private final ReaderFunction<T> openSplitFunction;
+  private final SerializableComparator<IcebergSourceSplit> splitComparator;
   private final int indexOfSubtask;
   private final Queue<IcebergSourceSplit> splits;
 
@@ -50,9 +54,11 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   IcebergSourceSplitReader(
       IcebergSourceReaderMetrics metrics,
       ReaderFunction<T> openSplitFunction,
+      SerializableComparator<IcebergSourceSplit> splitComparator,
       SourceReaderContext context) {
     this.metrics = metrics;
     this.openSplitFunction = openSplitFunction;
+    this.splitComparator = splitComparator;
     this.indexOfSubtask = context.getIndexOfSubtask();
     this.splits = new ArrayDeque<>();
   }
@@ -93,8 +99,15 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
           String.format("Unsupported split change: %s", splitsChange.getClass()));
     }
 
-    LOG.info("Add {} splits to reader", splitsChange.splits().size());
-    splits.addAll(splitsChange.splits());
+    if (splitComparator != null) {
+      List<IcebergSourceSplit> newSplits = Lists.newArrayList(splitsChange.splits());
+      newSplits.sort(splitComparator);
+      LOG.info("Add {} splits to reader: {}", newSplits.size(), newSplits);
+      splits.addAll(newSplits);
+    } else {
+      LOG.info("Add {} splits to reader", splitsChange.splits().size());
+      splits.addAll(splitsChange.splits());
+    }
     metrics.incrementAssignedSplits(splitsChange.splits().size());
     metrics.incrementAssignedBytes(calculateBytes(splitsChange));
   }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializableComparator.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializableComparator.java
@@ -16,22 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.flink.source.assigner;
+package org.apache.iceberg.flink.source.split;
 
-import java.util.Collection;
-import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import java.io.Serializable;
+import java.util.Comparator;
 
-/** Create simple assigner that hands out splits without any guarantee in order or locality. */
-public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
-  public SimpleSplitAssignerFactory() {}
-
-  @Override
-  public SplitAssigner createAssigner() {
-    return new DefaultSplitAssigner(null);
-  }
-
-  @Override
-  public SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
-    return new DefaultSplitAssigner(null, assignerState);
-  }
-}
+public interface SerializableComparator<T> extends Comparator<T>, Serializable {}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.split;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Provides implementations of {@link org.apache.iceberg.flink.source.split.SerializableComparator}
+ * which could be used for ordering splits. These are used by the {@link
+ * org.apache.iceberg.flink.source.assigner.OrderedSplitAssignerFactory} and the {@link
+ * org.apache.iceberg.flink.source.reader.IcebergSourceReader}
+ */
+public class SplitComparators {
+  private SplitComparators() {}
+
+  /** Comparator which orders the splits based on the file sequence number of the data files */
+  public static SerializableComparator<IcebergSourceSplit> fileSequenceNumber() {
+    return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
+      Preconditions.checkArgument(
+          o1.task().files().size() == 1 && o2.task().files().size() == 1,
+          "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
+
+      Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
+      Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();
+
+      Preconditions.checkNotNull(
+          seq1,
+          "Invalid file sequence number: null. Doesn't support splits written with V1 format: %s",
+          o1);
+      Preconditions.checkNotNull(
+          seq2,
+          "IInvalid file sequence number: null. Doesn't support splits written with V1 format: %s",
+          o2);
+
+      int temp = Long.compare(seq1, seq2);
+      if (temp != 0) {
+        return temp;
+      } else {
+        return o1.splitId().compareTo(o2.splitId());
+      }
+    };
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.assigner;
+
+import java.util.List;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
+import org.apache.iceberg.flink.source.split.SplitComparators;
+import org.apache.iceberg.util.SerializationUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestBase {
+  @Override
+  protected SplitAssigner splitAssigner() {
+    return new OrderedSplitAssignerFactory(SplitComparators.fileSequenceNumber()).createAssigner();
+  }
+
+  /** Test the assigner when multiple files are in a single split */
+  @Test
+  public void testMultipleFilesInAnIcebergSplit() {
+    SplitAssigner assigner = splitAssigner();
+    Assertions.assertThatThrownBy(
+            () ->
+                assigner.onDiscoveredSplits(
+                    SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 4, 2, "2")),
+            "Multiple files in a split is not allowed")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please use 'split-open-file-cost'");
+  }
+
+  /** Test sorted splits */
+  @Test
+  public void testSplitSort() throws Exception {
+    SplitAssigner assigner = splitAssigner();
+    List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 5, 1, "2");
+
+    assigner.onDiscoveredSplits(splits.subList(3, 5));
+    assigner.onDiscoveredSplits(splits.subList(0, 1));
+    assigner.onDiscoveredSplits(splits.subList(1, 3));
+
+    assertGetNext(assigner, 1L);
+    assertGetNext(assigner, 2L);
+    assertGetNext(assigner, 3L);
+    assertGetNext(assigner, 4L);
+    assertGetNext(assigner, 5L);
+
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+  }
+
+  @Test
+  public void testSerializable() {
+    byte[] bytes = SerializationUtil.serializeToBytes(SplitComparators.fileSequenceNumber());
+    SerializableComparator<IcebergSourceSplit> comparator =
+        SerializationUtil.deserializeFromBytes(bytes);
+    Assert.assertNotNull(comparator);
+  }
+
+  protected void assertGetNext(SplitAssigner assigner, Long expectedSequenceNumber) {
+    GetSplitResult result = assigner.getNext(null);
+    ContentFile file = result.split().task().files().iterator().next().file();
+    Assert.assertEquals(expectedSequenceNumber, file.fileSequenceNumber());
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -28,7 +28,7 @@ import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumerator
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
-import org.apache.iceberg.flink.source.assigner.SimpleSplitAssigner;
+import org.apache.iceberg.flink.source.assigner.DefaultSplitAssigner;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
@@ -342,7 +342,7 @@ public class TestContinuousIcebergEnumerator {
     ContinuousIcebergEnumerator enumerator =
         new ContinuousIcebergEnumerator(
             context,
-            new SimpleSplitAssigner(Collections.emptyList()),
+            new DefaultSplitAssigner(null, Collections.emptyList()),
             scanContext,
             splitPlanner,
             null);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -55,11 +56,66 @@ public class TestIcebergSourceReader {
     TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
     TestingMetricGroup metricGroup = new TestingMetricGroup();
     TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
-    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext, null);
     reader.start();
 
     testOneSplitFetcher(reader, readerOutput, metricGroup, 1);
     testOneSplitFetcher(reader, readerOutput, metricGroup, 2);
+  }
+
+  @Test
+  public void testReaderOrder() throws Exception {
+    // Create 2 splits
+    List<List<Record>> recordBatchList1 =
+        ReaderUtil.createRecordBatchList(0L, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task1 =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList1, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+
+    List<List<Record>> recordBatchList2 =
+        ReaderUtil.createRecordBatchList(1L, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task2 =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList2, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+
+    // Sort the splits in one way
+    List<RowData> rowDataList1 =
+        read(
+            Arrays.asList(
+                IcebergSourceSplit.fromCombinedScanTask(task1),
+                IcebergSourceSplit.fromCombinedScanTask(task2)),
+            2);
+
+    // Reverse the splits
+    List<RowData> rowDataList2 =
+        read(
+            Arrays.asList(
+                IcebergSourceSplit.fromCombinedScanTask(task2),
+                IcebergSourceSplit.fromCombinedScanTask(task1)),
+            2);
+
+    // Check that the order of the elements is not changed
+    Assert.assertEquals(rowDataList1.get(0), rowDataList2.get(0));
+    Assert.assertEquals(rowDataList1.get(1), rowDataList2.get(1));
+  }
+
+  private List<RowData> read(List<IcebergSourceSplit> splits, long expected) throws Exception {
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    // Using IdBasedComparator, so we can have a deterministic order of the splits
+    IcebergSourceReader reader = createReader(metricGroup, readerContext, new IdBasedComparator());
+    reader.start();
+
+    reader.addSplits(splits);
+    TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
+    while (readerOutput.getEmittedRecords().size() < expected) {
+      reader.pollNext(readerOutput);
+    }
+
+    reader.pollNext(readerOutput);
+
+    Assert.assertEquals(expected, readerOutput.getEmittedRecords().size());
+    return readerOutput.getEmittedRecords();
   }
 
   private void testOneSplitFetcher(
@@ -96,7 +152,9 @@ public class TestIcebergSourceReader {
   }
 
   private IcebergSourceReader createReader(
-      MetricGroup metricGroup, SourceReaderContext readerContext) {
+      MetricGroup metricGroup,
+      SourceReaderContext readerContext,
+      SerializableComparator<IcebergSourceSplit> splitComparator) {
     IcebergSourceReaderMetrics readerMetrics =
         new IcebergSourceReaderMetrics(metricGroup, "db.tbl");
     RowDataReaderFunction readerFunction =
@@ -109,6 +167,13 @@ public class TestIcebergSourceReader {
             new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
             new PlaintextEncryptionManager(),
             Collections.emptyList());
-    return new IcebergSourceReader<>(readerMetrics, readerFunction, readerContext);
+    return new IcebergSourceReader<>(readerMetrics, readerFunction, splitComparator, readerContext);
+  }
+
+  private static class IdBasedComparator implements SerializableComparator<IcebergSourceSplit> {
+    @Override
+    public int compare(IcebergSourceSplit o1, IcebergSourceSplit o2) {
+      return o1.splitId().compareTo(o2.splitId());
+    }
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/assigner/OrderedSplitAssignerFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/assigner/OrderedSplitAssignerFactory.java
@@ -19,19 +19,28 @@
 package org.apache.iceberg.flink.source.assigner;
 
 import java.util.Collection;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 
-/** Create simple assigner that hands out splits without any guarantee in order or locality. */
-public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
-  public SimpleSplitAssignerFactory() {}
+/**
+ * Create default assigner with a comparator that hands out splits where the order of the splits
+ * will be defined by the {@link SerializableComparator}.
+ */
+public class OrderedSplitAssignerFactory implements SplitAssignerFactory {
+  private final SerializableComparator<IcebergSourceSplit> comparator;
+
+  public OrderedSplitAssignerFactory(SerializableComparator<IcebergSourceSplit> comparator) {
+    this.comparator = comparator;
+  }
 
   @Override
   public SplitAssigner createAssigner() {
-    return new DefaultSplitAssigner(null);
+    return new DefaultSplitAssigner(comparator);
   }
 
   @Override
   public SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
-    return new DefaultSplitAssigner(null, assignerState);
+    return new DefaultSplitAssigner(comparator, assignerState);
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssignerFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssignerFactory.java
@@ -23,14 +23,15 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 
 /** Create simple assigner that hands out splits without any guarantee in order or locality. */
 public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
+  public SimpleSplitAssignerFactory() {}
 
   @Override
-  public SimpleSplitAssigner createAssigner() {
-    return new SimpleSplitAssigner();
+  public SplitAssigner createAssigner() {
+    return new DefaultSplitAssigner(null);
   }
 
   @Override
-  public SimpleSplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
-    return new SimpleSplitAssigner(assignerState);
+  public SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
+    return new DefaultSplitAssigner(null, assignerState);
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
@@ -25,6 +25,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -36,9 +37,10 @@ public class IcebergSourceReader<T>
   public IcebergSourceReader(
       IcebergSourceReaderMetrics metrics,
       ReaderFunction<T> readerFunction,
+      SerializableComparator<IcebergSourceSplit> splitComparator,
       SourceReaderContext context) {
     super(
-        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, context),
+        () -> new IcebergSourceSplitReader<>(metrics, readerFunction, splitComparator, context),
         new IcebergSourceRecordEmitter<>(),
         context.getConfiguration(),
         context);

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.List;
 import java.util.Queue;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.connector.base.source.reader.RecordsBySplits;
@@ -31,7 +32,9 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +43,7 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
 
   private final IcebergSourceReaderMetrics metrics;
   private final ReaderFunction<T> openSplitFunction;
+  private final SerializableComparator<IcebergSourceSplit> splitComparator;
   private final int indexOfSubtask;
   private final Queue<IcebergSourceSplit> splits;
 
@@ -50,9 +54,11 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   IcebergSourceSplitReader(
       IcebergSourceReaderMetrics metrics,
       ReaderFunction<T> openSplitFunction,
+      SerializableComparator<IcebergSourceSplit> splitComparator,
       SourceReaderContext context) {
     this.metrics = metrics;
     this.openSplitFunction = openSplitFunction;
+    this.splitComparator = splitComparator;
     this.indexOfSubtask = context.getIndexOfSubtask();
     this.splits = new ArrayDeque<>();
   }
@@ -93,8 +99,15 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
           String.format("Unsupported split change: %s", splitsChange.getClass()));
     }
 
-    LOG.info("Add {} splits to reader", splitsChange.splits().size());
-    splits.addAll(splitsChange.splits());
+    if (splitComparator != null) {
+      List<IcebergSourceSplit> newSplits = Lists.newArrayList(splitsChange.splits());
+      newSplits.sort(splitComparator);
+      LOG.info("Add {} splits to reader: {}", newSplits.size(), newSplits);
+      splits.addAll(newSplits);
+    } else {
+      LOG.info("Add {} splits to reader", splitsChange.splits().size());
+      splits.addAll(splitsChange.splits());
+    }
     metrics.incrementAssignedSplits(splitsChange.splits().size());
     metrics.incrementAssignedBytes(calculateBytes(splitsChange));
   }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializableComparator.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/split/SerializableComparator.java
@@ -16,22 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.flink.source.assigner;
+package org.apache.iceberg.flink.source.split;
 
-import java.util.Collection;
-import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import java.io.Serializable;
+import java.util.Comparator;
 
-/** Create simple assigner that hands out splits without any guarantee in order or locality. */
-public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
-  public SimpleSplitAssignerFactory() {}
-
-  @Override
-  public SplitAssigner createAssigner() {
-    return new DefaultSplitAssigner(null);
-  }
-
-  @Override
-  public SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
-    return new DefaultSplitAssigner(null, assignerState);
-  }
-}
+public interface SerializableComparator<T> extends Comparator<T>, Serializable {}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitComparators.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.split;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Provides implementations of {@link org.apache.iceberg.flink.source.split.SerializableComparator}
+ * which could be used for ordering splits. These are used by the {@link
+ * org.apache.iceberg.flink.source.assigner.OrderedSplitAssignerFactory} and the {@link
+ * org.apache.iceberg.flink.source.reader.IcebergSourceReader}
+ */
+public class SplitComparators {
+  private SplitComparators() {}
+
+  /** Comparator which orders the splits based on the file sequence number of the data files */
+  public static SerializableComparator<IcebergSourceSplit> fileSequenceNumber() {
+    return (IcebergSourceSplit o1, IcebergSourceSplit o2) -> {
+      Preconditions.checkArgument(
+          o1.task().files().size() == 1 && o2.task().files().size() == 1,
+          "Could not compare combined task. Please use 'split-open-file-cost' to prevent combining multiple files to a split");
+
+      Long seq1 = o1.task().files().iterator().next().file().fileSequenceNumber();
+      Long seq2 = o2.task().files().iterator().next().file().fileSequenceNumber();
+
+      Preconditions.checkNotNull(
+          seq1,
+          "Invalid file sequence number: null. Doesn't support splits written with V1 format: %s",
+          o1);
+      Preconditions.checkNotNull(
+          seq2,
+          "IInvalid file sequence number: null. Doesn't support splits written with V1 format: %s",
+          o2);
+
+      int temp = Long.compare(seq1, seq2);
+      if (temp != 0) {
+        return temp;
+      } else {
+        return o1.splitId().compareTo(o2.splitId());
+      }
+    };
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestFileSequenceNumberBasedSplitAssigner.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.assigner;
+
+import java.util.List;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
+import org.apache.iceberg.flink.source.split.SplitComparators;
+import org.apache.iceberg.util.SerializationUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestFileSequenceNumberBasedSplitAssigner extends SplitAssignerTestBase {
+  @Override
+  protected SplitAssigner splitAssigner() {
+    return new OrderedSplitAssignerFactory(SplitComparators.fileSequenceNumber()).createAssigner();
+  }
+
+  /** Test the assigner when multiple files are in a single split */
+  @Test
+  public void testMultipleFilesInAnIcebergSplit() {
+    SplitAssigner assigner = splitAssigner();
+    Assertions.assertThatThrownBy(
+            () ->
+                assigner.onDiscoveredSplits(
+                    SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 4, 2, "2")),
+            "Multiple files in a split is not allowed")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please use 'split-open-file-cost'");
+  }
+
+  /** Test sorted splits */
+  @Test
+  public void testSplitSort() throws Exception {
+    SplitAssigner assigner = splitAssigner();
+    List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 5, 1, "2");
+
+    assigner.onDiscoveredSplits(splits.subList(3, 5));
+    assigner.onDiscoveredSplits(splits.subList(0, 1));
+    assigner.onDiscoveredSplits(splits.subList(1, 3));
+
+    assertGetNext(assigner, 1L);
+    assertGetNext(assigner, 2L);
+    assertGetNext(assigner, 3L);
+    assertGetNext(assigner, 4L);
+    assertGetNext(assigner, 5L);
+
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+  }
+
+  @Test
+  public void testSerializable() {
+    byte[] bytes = SerializationUtil.serializeToBytes(SplitComparators.fileSequenceNumber());
+    SerializableComparator<IcebergSourceSplit> comparator =
+        SerializationUtil.deserializeFromBytes(bytes);
+    Assert.assertNotNull(comparator);
+  }
+
+  protected void assertGetNext(SplitAssigner assigner, Long expectedSequenceNumber) {
+    GetSplitResult result = assigner.getNext(null);
+    ContentFile file = result.split().task().files().iterator().next().file();
+    Assert.assertEquals(expectedSequenceNumber, file.fileSequenceNumber());
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -28,7 +28,7 @@ import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumerator
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
-import org.apache.iceberg.flink.source.assigner.SimpleSplitAssigner;
+import org.apache.iceberg.flink.source.assigner.DefaultSplitAssigner;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
@@ -342,7 +342,7 @@ public class TestContinuousIcebergEnumerator {
     ContinuousIcebergEnumerator enumerator =
         new ContinuousIcebergEnumerator(
             context,
-            new SimpleSplitAssigner(Collections.emptyList()),
+            new DefaultSplitAssigner(null, Collections.emptyList()),
             scanContext,
             splitPlanner,
             null);

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestIcebergSourceReader.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SerializableComparator;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -55,11 +56,66 @@ public class TestIcebergSourceReader {
     TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
     TestingMetricGroup metricGroup = new TestingMetricGroup();
     TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
-    IcebergSourceReader reader = createReader(metricGroup, readerContext);
+    IcebergSourceReader reader = createReader(metricGroup, readerContext, null);
     reader.start();
 
     testOneSplitFetcher(reader, readerOutput, metricGroup, 1);
     testOneSplitFetcher(reader, readerOutput, metricGroup, 2);
+  }
+
+  @Test
+  public void testReaderOrder() throws Exception {
+    // Create 2 splits
+    List<List<Record>> recordBatchList1 =
+        ReaderUtil.createRecordBatchList(0L, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task1 =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList1, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+
+    List<List<Record>> recordBatchList2 =
+        ReaderUtil.createRecordBatchList(1L, TestFixtures.SCHEMA, 1, 1);
+    CombinedScanTask task2 =
+        ReaderUtil.createCombinedScanTask(
+            recordBatchList2, TEMPORARY_FOLDER, FileFormat.PARQUET, appenderFactory);
+
+    // Sort the splits in one way
+    List<RowData> rowDataList1 =
+        read(
+            Arrays.asList(
+                IcebergSourceSplit.fromCombinedScanTask(task1),
+                IcebergSourceSplit.fromCombinedScanTask(task2)),
+            2);
+
+    // Reverse the splits
+    List<RowData> rowDataList2 =
+        read(
+            Arrays.asList(
+                IcebergSourceSplit.fromCombinedScanTask(task2),
+                IcebergSourceSplit.fromCombinedScanTask(task1)),
+            2);
+
+    // Check that the order of the elements is not changed
+    Assert.assertEquals(rowDataList1.get(0), rowDataList2.get(0));
+    Assert.assertEquals(rowDataList1.get(1), rowDataList2.get(1));
+  }
+
+  private List<RowData> read(List<IcebergSourceSplit> splits, long expected) throws Exception {
+    TestingMetricGroup metricGroup = new TestingMetricGroup();
+    TestingReaderContext readerContext = new TestingReaderContext(new Configuration(), metricGroup);
+    // Using IdBasedComparator, so we can have a deterministic order of the splits
+    IcebergSourceReader reader = createReader(metricGroup, readerContext, new IdBasedComparator());
+    reader.start();
+
+    reader.addSplits(splits);
+    TestingReaderOutput<RowData> readerOutput = new TestingReaderOutput<>();
+    while (readerOutput.getEmittedRecords().size() < expected) {
+      reader.pollNext(readerOutput);
+    }
+
+    reader.pollNext(readerOutput);
+
+    Assert.assertEquals(expected, readerOutput.getEmittedRecords().size());
+    return readerOutput.getEmittedRecords();
   }
 
   private void testOneSplitFetcher(
@@ -96,7 +152,9 @@ public class TestIcebergSourceReader {
   }
 
   private IcebergSourceReader createReader(
-      MetricGroup metricGroup, SourceReaderContext readerContext) {
+      MetricGroup metricGroup,
+      SourceReaderContext readerContext,
+      SerializableComparator<IcebergSourceSplit> splitComparator) {
     IcebergSourceReaderMetrics readerMetrics =
         new IcebergSourceReaderMetrics(metricGroup, "db.tbl");
     RowDataReaderFunction readerFunction =
@@ -109,6 +167,13 @@ public class TestIcebergSourceReader {
             new HadoopFileIO(new org.apache.hadoop.conf.Configuration()),
             new PlaintextEncryptionManager(),
             Collections.emptyList());
-    return new IcebergSourceReader<>(readerMetrics, readerFunction, readerContext);
+    return new IcebergSourceReader<>(readerMetrics, readerFunction, splitComparator, readerContext);
+  }
+
+  private static class IdBasedComparator implements SerializableComparator<IcebergSourceSplit> {
+    @Override
+    public int compare(IcebergSourceSplit o1, IcebergSourceSplit o2) {
+      return o1.splitId().compareTo(o2.splitId());
+    }
   }
 }


### PR DESCRIPTION
Clean backport of #7661 to older Flink versions