### PR TITLE
Core: Register JSON Parser for UpdateTableRequest

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -91,8 +91,9 @@ public class RESTSerializers {
         .addDeserializer(
             ImmutableReportMetricsRequest.class, new ReportMetricsRequestDeserializer<>())
         .addSerializer(CommitTransactionRequest.class, new CommitTransactionRequestSerializer())
-        .addDeserializer(
-            CommitTransactionRequest.class, new CommitTransactionRequestDeserializer());
+        .addDeserializer(CommitTransactionRequest.class, new CommitTransactionRequestDeserializer())
+        .addSerializer(UpdateTableRequest.class, new UpdateTableRequestSerializer())
+        .addDeserializer(UpdateTableRequest.class, new UpdateTableRequestDeserializer());
     mapper.registerModule(module);
   }
 


### PR DESCRIPTION
We introduced an explicit JSON parser as part of #7750 for `UpdateTableRequest` so that we don't rely on JSON parsing via Reflection. However, registering it got lost during a rebase. This PR adds it back