### PR TITLE
Nessie: Minor Refactoring of NessieTableOperations

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -26,10 +26,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -38,9 +35,7 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Suppliers;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
@@ -90,8 +85,12 @@ public class NessieIcebergClient implements AutoCloseable {
     return api;
   }
 
-  public UpdateableReference getRef() {
+  UpdateableReference getRef() {
     return reference.get();
+  }
+
+  public Reference getReference() {
+    return reference.get().getReference();
   }
 
   public void refresh() throws NessieNotFoundException {
@@ -527,50 +526,5 @@ public class NessieIcebergClient implements AutoCloseable {
     if (null != api) {
       api.close();
     }
-  }
-
-  public TableMetadata loadTableMetadataWithNessieSpecificProperties(
-      String metadataLocation, IcebergTable table, FileIO fileIO, String identifier) {
-    // Update the TableMetadata with the Content of NessieTableState.
-    TableMetadata deserialized = TableMetadataParser.read(fileIO, metadataLocation);
-    Map<String, String> newProperties = Maps.newHashMap(deserialized.properties());
-    newProperties.put(NessieTableOperations.NESSIE_COMMIT_ID_PROPERTY, getRef().getHash());
-    // To prevent accidental deletion of files that are still referenced by other branches/tags,
-    // setting GC_ENABLED to false. So that all Iceberg's gc operations like expire_snapshots,
-    // remove_orphan_files, drop_table with purge will fail with an error.
-    // Nessie CLI will provide a reference aware GC functionality for the expired/unreferenced
-    // files.
-    newProperties.put(TableProperties.GC_ENABLED, "false");
-
-    boolean metadataCleanupEnabled =
-        newProperties
-            .getOrDefault(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false")
-            .equalsIgnoreCase("true");
-    if (metadataCleanupEnabled) {
-      newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
-      LOG.warn(
-          "Automatic table metadata files cleanup was requested, but disabled because "
-              + "the Nessie catalog can use historical metadata files from other references. "
-              + "Use the 'nessie-gc' tool for history-aware GC");
-    }
-
-    TableMetadata.Builder builder =
-        TableMetadata.buildFrom(deserialized)
-            .setPreviousFileLocation(null)
-            .setCurrentSchema(table.getSchemaId())
-            .setDefaultSortOrder(table.getSortOrderId())
-            .setDefaultPartitionSpec(table.getSpecId())
-            .withMetadataLocation(metadataLocation)
-            .setProperties(newProperties);
-    if (table.getSnapshotId() != -1) {
-      builder.setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH);
-    }
-    LOG.info(
-        "loadTableMetadata for '{}' from location '{}' at '{}'",
-        identifier,
-        metadataLocation,
-        reference);
-
-    return builder.discardChanges().build();
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -21,10 +21,7 @@ package org.apache.iceberg.nessie;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
-import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -32,7 +29,6 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
@@ -81,47 +77,6 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     return key.toString();
   }
 
-  private TableMetadata loadTableMetadata(String metadataLocation, Reference reference) {
-    // Update the TableMetadata with the Content of NessieTableState.
-    TableMetadata deserialized = TableMetadataParser.read(io(), metadataLocation);
-    Map<String, String> newProperties = Maps.newHashMap(deserialized.properties());
-    newProperties.put(NESSIE_COMMIT_ID_PROPERTY, reference.getHash());
-    // To prevent accidental deletion of files that are still referenced by other branches/tags,
-    // setting GC_ENABLED to false. So that all Iceberg's gc operations like expire_snapshots,
-    // remove_orphan_files, drop_table with purge will fail with an error.
-    // Nessie CLI will provide a reference aware GC functionality for the expired/unreferenced
-    // files.
-    newProperties.put(TableProperties.GC_ENABLED, "false");
-
-    boolean metadataCleanupEnabled =
-        newProperties
-            .getOrDefault(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false")
-            .equalsIgnoreCase("true");
-    if (metadataCleanupEnabled) {
-      newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
-      LOG.warn(
-          "Automatic table metadata files cleanup was requested, but disabled because "
-              + "the Nessie catalog can use historical metadata files from other references. "
-              + "Use the 'nessie-gc' tool for history-aware GC");
-    }
-
-    TableMetadata.Builder builder =
-        TableMetadata.buildFrom(deserialized)
-            .setPreviousFileLocation(null)
-            .setCurrentSchema(table.getSchemaId())
-            .setDefaultSortOrder(table.getSortOrderId())
-            .setDefaultPartitionSpec(table.getSpecId())
-            .withMetadataLocation(metadataLocation)
-            .setProperties(newProperties);
-    if (table.getSnapshotId() != -1) {
-      builder.setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH);
-    }
-    LOG.info(
-        "loadTableMetadata for '{}' from location '{}' at '{}'", key, metadataLocation, reference);
-
-    return builder.discardChanges().build();
-  }
-
   @Override
   protected void doRefresh() {
     try {
@@ -159,7 +114,13 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
         throw new NoSuchTableException(ex, "No such table '%s'", key);
       }
     }
-    refreshFromMetadataLocation(metadataLocation, null, 2, l -> loadTableMetadata(l, reference));
+    refreshFromMetadataLocation(
+        metadataLocation,
+        null,
+        2,
+        location ->
+            client.loadTableMetadataWithNessieSpecificProperties(
+                location, table, fileIO, key.toString()));
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -119,8 +120,12 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
         null,
         2,
         location ->
-            NessieUtil.loadTableMetadataWithNessieSpecificProperties(
-                location, table, fileIO, key.toString(), reference));
+            NessieUtil.updateTableMetadataWithNessieSpecificProperties(
+                TableMetadataParser.read(fileIO, location),
+                location,
+                table,
+                key.toString(),
+                reference));
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -119,8 +119,8 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
         null,
         2,
         location ->
-            client.loadTableMetadataWithNessieSpecificProperties(
-                location, table, fileIO, key.toString()));
+            NessieUtil.loadTableMetadataWithNessieSpecificProperties(
+                location, table, fileIO, key.toString(), reference));
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -24,15 +24,27 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
+import org.projectnessie.model.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class NessieUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(NessieUtil.class);
 
   public static final String NESSIE_CONFIG_PREFIX = "nessie.";
   static final String APPLICATION_TYPE = "application-type";
@@ -90,5 +102,54 @@ public final class NessieUtil {
   private static String commitAuthor(Map<String, String> catalogOptions) {
     return Optional.ofNullable(catalogOptions.get(CatalogProperties.USER))
         .orElseGet(() -> System.getProperty("user.name"));
+  }
+
+  public static TableMetadata loadTableMetadataWithNessieSpecificProperties(
+      String metadataLocation,
+      IcebergTable table,
+      FileIO fileIO,
+      String identifier,
+      Reference reference) {
+    // Update the TableMetadata with the Content of NessieTableState.
+    TableMetadata deserialized = TableMetadataParser.read(fileIO, metadataLocation);
+    Map<String, String> newProperties = Maps.newHashMap(deserialized.properties());
+    newProperties.put(NessieTableOperations.NESSIE_COMMIT_ID_PROPERTY, reference.getHash());
+    // To prevent accidental deletion of files that are still referenced by other branches/tags,
+    // setting GC_ENABLED to false. So that all Iceberg's gc operations like expire_snapshots,
+    // remove_orphan_files, drop_table with purge will fail with an error.
+    // Nessie CLI will provide a reference aware GC functionality for the expired/unreferenced
+    // files.
+    newProperties.put(TableProperties.GC_ENABLED, "false");
+
+    boolean metadataCleanupEnabled =
+        newProperties
+            .getOrDefault(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false")
+            .equalsIgnoreCase("true");
+    if (metadataCleanupEnabled) {
+      newProperties.put(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "false");
+      LOG.warn(
+          "Automatic table metadata files cleanup was requested, but disabled because "
+              + "the Nessie catalog can use historical metadata files from other references. "
+              + "Use the 'nessie-gc' tool for history-aware GC");
+    }
+
+    TableMetadata.Builder builder =
+        TableMetadata.buildFrom(deserialized)
+            .setPreviousFileLocation(null)
+            .setCurrentSchema(table.getSchemaId())
+            .setDefaultSortOrder(table.getSortOrderId())
+            .setDefaultPartitionSpec(table.getSpecId())
+            .withMetadataLocation(metadataLocation)
+            .setProperties(newProperties);
+    if (table.getSnapshotId() != -1) {
+      builder.setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH);
+    }
+    LOG.info(
+        "loadTableMetadata for '{}' from location '{}' at '{}'",
+        identifier,
+        metadataLocation,
+        reference);
+
+    return builder.discardChanges().build();
   }
 }


### PR DESCRIPTION
Move `NessieTableOperations#loadTableMetadata` -> `NessieUtil#updateTableMetadataWithNessieSpecificProperties `

This is needed for reusing the common code at Trino-Iceberg side for fixing the https://github.com/trinodb/trino/issues/17813

Tentative Trino side changes looks like https://github.com/ajantha-bhat/trino/commit/959445c807204e4c55b008d7b0963e97c8d726d6 once this PR changes are released. 