### PR TITLE
ORC: Fix to avoid test failure on Hadoop 2.7.3

### DIFF
--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataWriter.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.UnsupportedFileSystemException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
@@ -140,12 +139,13 @@ public class TestOrcDataWriter {
     // When files other than HadoopInputFile and HadoopOutputFile are supplied the location
     // is used to determine the corresponding FileSystem class based on the scheme in case of
     // local files that would be the LocalFileSystem. To prevent this we use the Proxy classes to
-    // use a scheme `dummy` that is not handled.
+    // use a scheme `dummy` that is not handled. Note that Hadoop 2.7.3 throws IOException
+    // while latest Hadoop versions throw UnsupportedFileSystemException (extends IOException)
     ProxyOutputFile outFile = new ProxyOutputFile(Files.localOutput(temp.newFile()));
     Assertions.assertThatThrownBy(
             () -> new Path(outFile.location()).getFileSystem(new Configuration()))
-        .isInstanceOf(UnsupportedFileSystemException.class)
-        .hasMessageStartingWith("No FileSystem for scheme \"dummy\"");
+        .isInstanceOf(IOException.class)
+        .hasMessageStartingWith("No FileSystem for scheme");
 
     // Given that FileIO is now handled there is no determination of FileSystem based on scheme
     // but instead operations are handled by the InputFileSystem and OutputFileSystem that wrap


### PR DESCRIPTION
This PR aims to fix test failures due to the heterogeneous Hadoop exception types across multiple versions.

**HADOOP VERSION IN GRADLE**
Apache Iceberg builds with Apache Hadoop `2.7.3`

https://github.com/apache/iceberg/blob/6b23d2555d542b83396ce488e253813276d0c25d/versions.props#L4

**Apache Hadoop 2.7.3 Exception**

https://github.com/apache/hadoop/blob/baa91f7c6bc9cb92be5982de4719c1c8af91ccff/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L2660
```
throw new IOException("No FileSystem for scheme: " + scheme);
```

**Apache Hadoop 2.9.0+ Exception**

https://github.com/apache/hadoop/blame/1c15987ee38b96cf2ef4ff383f3f86e082c50fab/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java#L3575
```
throw new UnsupportedFileSystemException("No FileSystem for scheme "
```