### PR TITLE
Spark 3.4: Support NOT_EQ for V2 filters

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -252,19 +252,19 @@ public class SparkV2Filters {
   }
 
   private static Pair<UnboundTerm<Object>, Object> predicateChildren(Predicate predicate) {
-    Object value;
-    UnboundTerm<Object> term;
     if (isRef(leftChild(predicate)) && isLiteral(rightChild(predicate))) {
-      term = ref(SparkUtil.toColumnName(leftChild(predicate)));
-      value = convertLiteral(rightChild(predicate));
+      UnboundTerm<Object> term = ref(SparkUtil.toColumnName(leftChild(predicate)));
+      Object value = convertLiteral(rightChild(predicate));
+      return Pair.of(term, value);
+
     } else if (isRef(rightChild(predicate)) && isLiteral(leftChild(predicate))) {
-      term = ref(SparkUtil.toColumnName(rightChild(predicate)));
-      value = convertLiteral(leftChild(predicate));
+      UnboundTerm<Object> term = ref(SparkUtil.toColumnName(rightChild(predicate)));
+      Object value = convertLiteral(leftChild(predicate));
+      return Pair.of(term, value);
+
     } else {
       return null;
     }
-
-    return Pair.of(term, value);
   }
 
   @SuppressWarnings("unchecked")
@@ -314,9 +314,7 @@ public class SparkV2Filters {
   private static UnboundPredicate<Object> handleEqual(UnboundTerm<Object> term, Object value) {
     if (value == null) {
       return isNull(term);
-    }
-
-    if (NaNUtil.isNaN(value)) {
+    } else if (NaNUtil.isNaN(value)) {
       return isNaN(term);
     } else {
       return equal(term, value);
@@ -326,9 +324,7 @@ public class SparkV2Filters {
   private static UnboundPredicate<Object> handleNotEqual(UnboundTerm<Object> term, Object value) {
     if (value == null) {
       return notNull(term);
-    }
-
-    if (NaNUtil.isNaN(value)) {
+    } else if (NaNUtil.isNaN(value)) {
       return notNaN(term);
     } else {
       return notEqual(term, value);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -251,9 +251,9 @@ public class SparkV2Filters {
     return null;
   }
 
-  private static <T> Pair<UnboundTerm<T>, T> predicateChildren(Predicate predicate) {
-    T value;
-    UnboundTerm<T> term;
+  private static Pair<UnboundTerm<Object>, Object> predicateChildren(Predicate predicate) {
+    Object value;
+    UnboundTerm<Object> term;
     if (isRef(leftChild(predicate)) && isLiteral(rightChild(predicate))) {
       term = ref(SparkUtil.toColumnName(leftChild(predicate)));
       value = convertLiteral(rightChild(predicate));
@@ -304,15 +304,14 @@ public class SparkV2Filters {
     return expr instanceof Literal;
   }
 
-  @SuppressWarnings("unchecked")
-  private static <T> T convertLiteral(Literal<?> literal) {
+  private static Object convertLiteral(Literal<?> literal) {
     if (literal.value() instanceof UTF8String) {
-      return (T) ((UTF8String) literal.value()).toString();
+      return ((UTF8String) literal.value()).toString();
     }
-    return (T) literal.value();
+    return literal.value();
   }
 
-  private static <T> UnboundPredicate<T> handleEqual(Pair<UnboundTerm<T>, T> children) {
+  private static UnboundPredicate<Object> handleEqual(Pair<UnboundTerm<Object>, Object> children) {
     if (children.second() == null) {
       return isNull(children.first());
     }
@@ -324,7 +323,8 @@ public class SparkV2Filters {
     }
   }
 
-  private static <T> UnboundPredicate<T> handleNotEqual(Pair<UnboundTerm<T>, T> children) {
+  private static UnboundPredicate<Object> handleNotEqual(
+      Pair<UnboundTerm<Object>, Object> children) {
     if (children.second() == null) {
       return notNull(children.first());
     }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -173,7 +173,7 @@ public class SparkV2Filters {
                 predicate);
           }
 
-          return handleEqual(eqChildren);
+          return handleEqual(eqChildren.first(), eqChildren.second());
 
         case NOT_EQ:
           Pair<UnboundTerm<Object>, Object> notEqChildren = predicateChildren(predicate);
@@ -181,7 +181,7 @@ public class SparkV2Filters {
             return null;
           }
 
-          return handleNotEqual(notEqChildren);
+          return handleNotEqual(notEqChildren.first(), notEqChildren.second());
 
         case IN:
           if (isSupportedInPredicate(predicate)) {
@@ -311,28 +311,27 @@ public class SparkV2Filters {
     return literal.value();
   }
 
-  private static UnboundPredicate<Object> handleEqual(Pair<UnboundTerm<Object>, Object> children) {
-    if (children.second() == null) {
-      return isNull(children.first());
+  private static UnboundPredicate<Object> handleEqual(UnboundTerm<Object> term, Object value) {
+    if (value == null) {
+      return isNull(term);
     }
 
-    if (NaNUtil.isNaN(children.second())) {
-      return isNaN(children.first());
+    if (NaNUtil.isNaN(value)) {
+      return isNaN(term);
     } else {
-      return equal(children.first(), children.second());
+      return equal(term, value);
     }
   }
 
-  private static UnboundPredicate<Object> handleNotEqual(
-      Pair<UnboundTerm<Object>, Object> children) {
-    if (children.second() == null) {
-      return notNull(children.first());
+  private static UnboundPredicate<Object> handleNotEqual(UnboundTerm<Object> term, Object value) {
+    if (value == null) {
+      return notNull(term);
     }
 
-    if (NaNUtil.isNaN(children.second())) {
-      return notNaN(children.first());
+    if (NaNUtil.isNaN(value)) {
+      return notNaN(term);
     } else {
-      return notEqual(children.first(), children.second());
+      return notEqual(term, value);
     }
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -181,6 +181,12 @@ public class SparkV2Filters {
             return null;
           }
 
+          // comparison with null in normal equality is always null. this is probably a mistake.
+          Preconditions.checkNotNull(
+              notEqChildren.second(),
+              "Expression is always false (notEq is not null-safe): %s",
+              predicate);
+
           return handleNotEqual(notEqChildren.first(), notEqChildren.second());
 
         case IN:
@@ -322,9 +328,7 @@ public class SparkV2Filters {
   }
 
   private static UnboundPredicate<Object> handleNotEqual(UnboundTerm<Object> term, Object value) {
-    if (value == null) {
-      return notNull(term);
-    } else if (NaNUtil.isNaN(value)) {
+    if (NaNUtil.isNaN(value)) {
       return notNaN(term);
     } else {
       return notEqual(term, value);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 
 public class TestSparkV2Filters {
 
+  @SuppressWarnings("checkstyle:MethodLength")
   @Test
   public void testV2Filters() {
     Map<String, String> attrMap = Maps.newHashMap();
@@ -127,6 +128,18 @@ public class TestSparkV2Filters {
           Expression expectedEq2 = Expressions.equal(unquoted, 1);
           Expression actualEq2 = SparkV2Filters.convert(eq2);
           Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+
+          Predicate notEq1 = new Predicate("<>", attrAndValue);
+          Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
+          Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
+          Assert.assertEquals(
+              "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
+
+          Predicate notEq2 = new Predicate("<>", valueAndAttr);
+          Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
+          Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
+          Assert.assertEquals(
+              "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
 
           Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
           Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -34,11 +34,13 @@ import org.apache.spark.sql.connector.expressions.filter.Or;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSparkV2Filters {
 
+  @SuppressWarnings("checkstyle:MethodLength")
   @Test
   public void testV2Filters() {
     Map<String, String> attrMap = Maps.newHashMap();
@@ -48,150 +50,252 @@ public class TestSparkV2Filters {
     attrMap.put("`d`.b.`dd```", "d.b.dd`");
     attrMap.put("a.`aa```.c", "a.aa`.c");
 
-    attrMap.forEach(this::testV2Filter);
+    attrMap.forEach(
+        (quoted, unquoted) -> {
+          NamedReference namedReference = FieldReference.apply(quoted);
+          org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
+              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
+
+          LiteralValue value = new LiteralValue(1, DataTypes.IntegerType);
+          org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+          org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+              new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
+
+          Predicate isNull = new Predicate("IS_NULL", attrOnly);
+          Expression expectedIsNull = Expressions.isNull(unquoted);
+          Expression actualIsNull = SparkV2Filters.convert(isNull);
+          Assert.assertEquals(
+              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+
+          Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
+          Expression expectedIsNotNull = Expressions.notNull(unquoted);
+          Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
+          Assert.assertEquals(
+              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+
+          Predicate lt1 = new Predicate("<", attrAndValue);
+          Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
+          Expression actualLt1 = SparkV2Filters.convert(lt1);
+          Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
+
+          Predicate lt2 = new Predicate("<", valueAndAttr);
+          Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
+          Expression actualLt2 = SparkV2Filters.convert(lt2);
+          Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
+
+          Predicate ltEq1 = new Predicate("<=", attrAndValue);
+          Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
+          Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
+          Assert.assertEquals(
+              "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
+
+          Predicate ltEq2 = new Predicate("<=", valueAndAttr);
+          Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
+          Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
+          Assert.assertEquals(
+              "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
+
+          Predicate gt1 = new Predicate(">", attrAndValue);
+          Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
+          Expression actualGt1 = SparkV2Filters.convert(gt1);
+          Assert.assertEquals(
+              "GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
+
+          Predicate gt2 = new Predicate(">", valueAndAttr);
+          Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
+          Expression actualGt2 = SparkV2Filters.convert(gt2);
+          Assert.assertEquals(
+              "GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
+
+          Predicate gtEq1 = new Predicate(">=", attrAndValue);
+          Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
+          Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
+          Assert.assertEquals(
+              "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
+
+          Predicate gtEq2 = new Predicate(">=", valueAndAttr);
+          Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
+          Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
+          Assert.assertEquals(
+              "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
+
+          Predicate eq1 = new Predicate("=", attrAndValue);
+          Expression expectedEq1 = Expressions.equal(unquoted, 1);
+          Expression actualEq1 = SparkV2Filters.convert(eq1);
+          Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+
+          Predicate eq2 = new Predicate("=", valueAndAttr);
+          Expression expectedEq2 = Expressions.equal(unquoted, 1);
+          Expression actualEq2 = SparkV2Filters.convert(eq2);
+          Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+
+          Predicate notEq1 = new Predicate("<>", attrAndValue);
+          Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
+          Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
+          Assert.assertEquals(
+              "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
+
+          Predicate notEq2 = new Predicate("<>", valueAndAttr);
+          Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
+          Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
+          Assert.assertEquals(
+              "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
+
+          Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
+          Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
+          Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
+          Assert.assertEquals(
+              "EqualNullSafe must match",
+              expectedEqNullSafe1.toString(),
+              actualEqNullSafe1.toString());
+
+          Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
+          Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
+          Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
+          Assert.assertEquals(
+              "EqualNullSafe must match",
+              expectedEqNullSafe2.toString(),
+              actualEqNullSafe2.toString());
+
+          LiteralValue str =
+              new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
+          org.apache.spark.sql.connector.expressions.Expression[] attrAndStr =
+              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, str};
+          Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
+          Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
+          Expression actualStartsWith = SparkV2Filters.convert(startsWith);
+          Assert.assertEquals(
+              "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
+
+          Predicate in = new Predicate("IN", attrAndValue);
+          Expression expectedIn = Expressions.in(unquoted, 1);
+          Expression actualIn = SparkV2Filters.convert(in);
+          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+
+          Predicate and = new And(lt1, eq1);
+          Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
+          Expression actualAnd = SparkV2Filters.convert(and);
+          Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+
+          org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
+              new org.apache.spark.sql.connector.expressions.Expression[] {
+                namedReference, namedReference
+              };
+          Predicate invalid = new Predicate("<", attrAndAttr);
+          Predicate andWithInvalidLeft = new And(invalid, eq1);
+          Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
+          Assert.assertEquals("And must match", convertedAnd, null);
+
+          Predicate or = new Or(lt1, eq1);
+          Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
+          Expression actualOr = SparkV2Filters.convert(or);
+          Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+
+          Predicate orWithInvalidLeft = new Or(invalid, eq1);
+          Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
+          Assert.assertEquals("Or must match", convertedOr, null);
+
+          Predicate not = new Not(lt1);
+          Expression expectedNot = Expressions.not(expectedLt1);
+          Expression actualNot = SparkV2Filters.convert(not);
+          Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
+        });
   }
 
-  private void testV2Filter(String quoted, String unquoted) {
-    NamedReference namedReference = FieldReference.apply(quoted);
-    org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
-        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
+  @Test
+  public void testEqualToNull() {
+    String col = "col";
+    NamedReference namedReference = FieldReference.apply(col);
+    LiteralValue value = new LiteralValue(null, DataTypes.IntegerType);
 
-    LiteralValue value = new LiteralValue(1, DataTypes.IntegerType);
     org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
         new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
     org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
         new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
-    Predicate isNull = new Predicate("IS_NULL", attrOnly);
-    Expression expectedIsNull = Expressions.isNull(unquoted);
-    Expression actualIsNull = SparkV2Filters.convert(isNull);
-    Assert.assertEquals("IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
-
-    Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
-    Expression expectedIsNotNull = Expressions.notNull(unquoted);
-    Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-    Assert.assertEquals(
-        "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
-
-    Predicate lt1 = new Predicate("<", attrAndValue);
-    Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
-    Expression actualLt1 = SparkV2Filters.convert(lt1);
-    Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
-
-    Predicate lt2 = new Predicate("<", valueAndAttr);
-    Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
-    Expression actualLt2 = SparkV2Filters.convert(lt2);
-    Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
-
-    Predicate ltEq1 = new Predicate("<=", attrAndValue);
-    Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
-    Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
-    Assert.assertEquals(
-        "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
-
-    Predicate ltEq2 = new Predicate("<=", valueAndAttr);
-    Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
-    Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
-    Assert.assertEquals(
-        "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
-
-    Predicate gt1 = new Predicate(">", attrAndValue);
-    Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
-    Expression actualGt1 = SparkV2Filters.convert(gt1);
-    Assert.assertEquals("GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
-
-    Predicate gt2 = new Predicate(">", valueAndAttr);
-    Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
-    Expression actualGt2 = SparkV2Filters.convert(gt2);
-    Assert.assertEquals("GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
-
-    Predicate gtEq1 = new Predicate(">=", attrAndValue);
-    Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
-    Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
-    Assert.assertEquals(
-        "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
-
-    Predicate gtEq2 = new Predicate(">=", valueAndAttr);
-    Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
-    Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
-    Assert.assertEquals(
-        "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
-
     Predicate eq1 = new Predicate("=", attrAndValue);
-    Expression expectedEq1 = Expressions.equal(unquoted, 1);
-    Expression actualEq1 = SparkV2Filters.convert(eq1);
-    Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(eq1))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression is always false");
 
     Predicate eq2 = new Predicate("=", valueAndAttr);
-    Expression expectedEq2 = Expressions.equal(unquoted, 1);
-    Expression actualEq2 = SparkV2Filters.convert(eq2);
-    Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
-
-    Predicate notEq1 = new Predicate("<>", attrAndValue);
-    Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
-    Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
-    Assert.assertEquals(
-        "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
-
-    Predicate notEq2 = new Predicate("<>", valueAndAttr);
-    Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
-    Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
-    Assert.assertEquals(
-        "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(eq2))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression is always false");
 
     Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
-    Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
+    Expression expectedEqNullSafe = Expressions.isNull(col);
     Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-    Assert.assertEquals(
-        "EqualNullSafe must match", expectedEqNullSafe1.toString(), actualEqNullSafe1.toString());
+    Assertions.assertThat(actualEqNullSafe1.toString()).isEqualTo(expectedEqNullSafe.toString());
 
     Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
-    Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
     Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-    Assert.assertEquals(
-        "EqualNullSafe must match", expectedEqNullSafe2.toString(), actualEqNullSafe2.toString());
+    Assertions.assertThat(actualEqNullSafe2.toString()).isEqualTo(expectedEqNullSafe.toString());
+  }
 
-    LiteralValue str = new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
-    org.apache.spark.sql.connector.expressions.Expression[] attrAndStr =
-        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, str};
-    Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
-    Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
-    Expression actualStartsWith = SparkV2Filters.convert(startsWith);
-    Assert.assertEquals(
-        "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
+  @Test
+  public void testEqualToNaN() {
+    String col = "col";
+    NamedReference namedReference = FieldReference.apply(col);
+    LiteralValue value = new LiteralValue(Float.NaN, DataTypes.FloatType);
 
-    Predicate in = new Predicate("IN", attrAndValue);
-    Expression expectedIn = Expressions.in(unquoted, 1);
-    Expression actualIn = SparkV2Filters.convert(in);
-    Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+    org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
-    Predicate and = new And(lt1, eq1);
-    Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
-    Expression actualAnd = SparkV2Filters.convert(and);
-    Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+    Predicate eqNaN1 = new Predicate("=", attrAndValue);
+    Expression expectedEqNaN = Expressions.isNaN(col);
+    Expression actualEqNaN1 = SparkV2Filters.convert(eqNaN1);
+    Assertions.assertThat(actualEqNaN1.toString()).isEqualTo(expectedEqNaN.toString());
 
-    org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
-        new org.apache.spark.sql.connector.expressions.Expression[] {
-          namedReference, namedReference
-        };
-    Predicate invalid = new Predicate("<", attrAndAttr);
-    Predicate andWithInvalidLeft = new And(invalid, eq1);
-    Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-    Assert.assertEquals("And must match", convertedAnd, null);
+    Predicate eqNaN2 = new Predicate("=", valueAndAttr);
+    Expression actualEqNaN2 = SparkV2Filters.convert(eqNaN2);
+    Assertions.assertThat(actualEqNaN2.toString()).isEqualTo(expectedEqNaN.toString());
+  }
 
-    Predicate or = new Or(lt1, eq1);
-    Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
-    Expression actualOr = SparkV2Filters.convert(or);
-    Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+  @Test
+  public void testNotEqualToNull() {
+    String col = "col";
+    NamedReference namedReference = FieldReference.apply(col);
+    LiteralValue value = new LiteralValue(null, DataTypes.IntegerType);
 
-    Predicate orWithInvalidLeft = new Or(invalid, eq1);
-    Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-    Assert.assertEquals("Or must match", convertedOr, null);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+    org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
-    Predicate not = new Not(lt1);
-    Expression expectedNot = Expressions.not(expectedLt1);
-    Expression actualNot = SparkV2Filters.convert(not);
-    Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
+    Predicate notEq1 = new Predicate("<>", attrAndValue);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notEq1))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression is always false");
+
+    Predicate notEq2 = new Predicate("<>", valueAndAttr);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notEq2))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression is always false");
+  }
+
+  @Test
+  public void testNotEqualToNaN() {
+    String col = "col";
+    NamedReference namedReference = FieldReference.apply(col);
+    LiteralValue value = new LiteralValue(Float.NaN, DataTypes.FloatType);
+
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+    org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
+
+    Predicate notEqNaN1 = new Predicate("<>", attrAndValue);
+    Expression expectedNotEqNaN = Expressions.notNaN(col);
+    Expression actualNotEqNaN1 = SparkV2Filters.convert(notEqNaN1);
+    Assertions.assertThat(actualNotEqNaN1.toString()).isEqualTo(expectedNotEqNaN.toString());
+
+    Predicate notEqNaN2 = new Predicate("<>", valueAndAttr);
+    Expression actualNotEqNaN2 = SparkV2Filters.convert(notEqNaN2);
+    Assertions.assertThat(actualNotEqNaN2.toString()).isEqualTo(expectedNotEqNaN.toString());
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -39,7 +39,6 @@ import org.junit.Test;
 
 public class TestSparkV2Filters {
 
-  @SuppressWarnings("checkstyle:MethodLength")
   @Test
   public void testV2Filters() {
     Map<String, String> attrMap = Maps.newHashMap();
@@ -49,157 +48,150 @@ public class TestSparkV2Filters {
     attrMap.put("`d`.b.`dd```", "d.b.dd`");
     attrMap.put("a.`aa```.c", "a.aa`.c");
 
-    attrMap.forEach(
-        (quoted, unquoted) -> {
-          NamedReference namedReference = FieldReference.apply(quoted);
-          org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
-              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
+    attrMap.forEach(this::testV2Filter);
+  }
 
-          LiteralValue value = new LiteralValue(1, DataTypes.IntegerType);
-          org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
-              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
-          org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
-              new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
+  private void testV2Filter(String quoted, String unquoted) {
+    NamedReference namedReference = FieldReference.apply(quoted);
+    org.apache.spark.sql.connector.expressions.Expression[] attrOnly =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference};
 
-          Predicate isNull = new Predicate("IS_NULL", attrOnly);
-          Expression expectedIsNull = Expressions.isNull(unquoted);
-          Expression actualIsNull = SparkV2Filters.convert(isNull);
-          Assert.assertEquals(
-              "IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
+    LiteralValue value = new LiteralValue(1, DataTypes.IntegerType);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndValue =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, value};
+    org.apache.spark.sql.connector.expressions.Expression[] valueAndAttr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {value, namedReference};
 
-          Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
-          Expression expectedIsNotNull = Expressions.notNull(unquoted);
-          Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
-          Assert.assertEquals(
-              "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
+    Predicate isNull = new Predicate("IS_NULL", attrOnly);
+    Expression expectedIsNull = Expressions.isNull(unquoted);
+    Expression actualIsNull = SparkV2Filters.convert(isNull);
+    Assert.assertEquals("IsNull must match", expectedIsNull.toString(), actualIsNull.toString());
 
-          Predicate lt1 = new Predicate("<", attrAndValue);
-          Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
-          Expression actualLt1 = SparkV2Filters.convert(lt1);
-          Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
+    Predicate isNotNull = new Predicate("IS_NOT_NULL", attrOnly);
+    Expression expectedIsNotNull = Expressions.notNull(unquoted);
+    Expression actualIsNotNull = SparkV2Filters.convert(isNotNull);
+    Assert.assertEquals(
+        "IsNotNull must match", expectedIsNotNull.toString(), actualIsNotNull.toString());
 
-          Predicate lt2 = new Predicate("<", valueAndAttr);
-          Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
-          Expression actualLt2 = SparkV2Filters.convert(lt2);
-          Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
+    Predicate lt1 = new Predicate("<", attrAndValue);
+    Expression expectedLt1 = Expressions.lessThan(unquoted, 1);
+    Expression actualLt1 = SparkV2Filters.convert(lt1);
+    Assert.assertEquals("LessThan must match", expectedLt1.toString(), actualLt1.toString());
 
-          Predicate ltEq1 = new Predicate("<=", attrAndValue);
-          Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
-          Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
+    Predicate lt2 = new Predicate("<", valueAndAttr);
+    Expression expectedLt2 = Expressions.greaterThan(unquoted, 1);
+    Expression actualLt2 = SparkV2Filters.convert(lt2);
+    Assert.assertEquals("LessThan must match", expectedLt2.toString(), actualLt2.toString());
 
-          Predicate ltEq2 = new Predicate("<=", valueAndAttr);
-          Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
-          Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
-          Assert.assertEquals(
-              "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
+    Predicate ltEq1 = new Predicate("<=", attrAndValue);
+    Expression expectedLtEq1 = Expressions.lessThanOrEqual(unquoted, 1);
+    Expression actualLtEq1 = SparkV2Filters.convert(ltEq1);
+    Assert.assertEquals(
+        "LessThanOrEqual must match", expectedLtEq1.toString(), actualLtEq1.toString());
 
-          Predicate gt1 = new Predicate(">", attrAndValue);
-          Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
-          Expression actualGt1 = SparkV2Filters.convert(gt1);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
+    Predicate ltEq2 = new Predicate("<=", valueAndAttr);
+    Expression expectedLtEq2 = Expressions.greaterThanOrEqual(unquoted, 1);
+    Expression actualLtEq2 = SparkV2Filters.convert(ltEq2);
+    Assert.assertEquals(
+        "LessThanOrEqual must match", expectedLtEq2.toString(), actualLtEq2.toString());
 
-          Predicate gt2 = new Predicate(">", valueAndAttr);
-          Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
-          Expression actualGt2 = SparkV2Filters.convert(gt2);
-          Assert.assertEquals(
-              "GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
+    Predicate gt1 = new Predicate(">", attrAndValue);
+    Expression expectedGt1 = Expressions.greaterThan(unquoted, 1);
+    Expression actualGt1 = SparkV2Filters.convert(gt1);
+    Assert.assertEquals("GreaterThan must match", expectedGt1.toString(), actualGt1.toString());
 
-          Predicate gtEq1 = new Predicate(">=", attrAndValue);
-          Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
-          Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
+    Predicate gt2 = new Predicate(">", valueAndAttr);
+    Expression expectedGt2 = Expressions.lessThan(unquoted, 1);
+    Expression actualGt2 = SparkV2Filters.convert(gt2);
+    Assert.assertEquals("GreaterThan must match", expectedGt2.toString(), actualGt2.toString());
 
-          Predicate gtEq2 = new Predicate(">=", valueAndAttr);
-          Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
-          Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
-          Assert.assertEquals(
-              "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
+    Predicate gtEq1 = new Predicate(">=", attrAndValue);
+    Expression expectedGtEq1 = Expressions.greaterThanOrEqual(unquoted, 1);
+    Expression actualGtEq1 = SparkV2Filters.convert(gtEq1);
+    Assert.assertEquals(
+        "GreaterThanOrEqual must match", expectedGtEq1.toString(), actualGtEq1.toString());
 
-          Predicate eq1 = new Predicate("=", attrAndValue);
-          Expression expectedEq1 = Expressions.equal(unquoted, 1);
-          Expression actualEq1 = SparkV2Filters.convert(eq1);
-          Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
+    Predicate gtEq2 = new Predicate(">=", valueAndAttr);
+    Expression expectedGtEq2 = Expressions.lessThanOrEqual(unquoted, 1);
+    Expression actualGtEq2 = SparkV2Filters.convert(gtEq2);
+    Assert.assertEquals(
+        "GreaterThanOrEqual must match", expectedGtEq2.toString(), actualGtEq2.toString());
 
-          Predicate eq2 = new Predicate("=", valueAndAttr);
-          Expression expectedEq2 = Expressions.equal(unquoted, 1);
-          Expression actualEq2 = SparkV2Filters.convert(eq2);
-          Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
+    Predicate eq1 = new Predicate("=", attrAndValue);
+    Expression expectedEq1 = Expressions.equal(unquoted, 1);
+    Expression actualEq1 = SparkV2Filters.convert(eq1);
+    Assert.assertEquals("EqualTo must match", expectedEq1.toString(), actualEq1.toString());
 
-          Predicate notEq1 = new Predicate("<>", attrAndValue);
-          Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
-          Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
+    Predicate eq2 = new Predicate("=", valueAndAttr);
+    Expression expectedEq2 = Expressions.equal(unquoted, 1);
+    Expression actualEq2 = SparkV2Filters.convert(eq2);
+    Assert.assertEquals("EqualTo must match", expectedEq2.toString(), actualEq2.toString());
 
-          Predicate notEq2 = new Predicate("<>", valueAndAttr);
-          Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
-          Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
-          Assert.assertEquals(
-              "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
+    Predicate notEq1 = new Predicate("<>", attrAndValue);
+    Expression expectedNotEq1 = Expressions.notEqual(unquoted, 1);
+    Expression actualNotEq1 = SparkV2Filters.convert(notEq1);
+    Assert.assertEquals(
+        "NotEqualTo must match", expectedNotEq1.toString(), actualNotEq1.toString());
 
-          Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
-          Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
-          Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe1.toString(),
-              actualEqNullSafe1.toString());
+    Predicate notEq2 = new Predicate("<>", valueAndAttr);
+    Expression expectedNotEq2 = Expressions.notEqual(unquoted, 1);
+    Expression actualNotEq2 = SparkV2Filters.convert(notEq2);
+    Assert.assertEquals(
+        "NotEqualTo must match", expectedNotEq2.toString(), actualNotEq2.toString());
 
-          Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
-          Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
-          Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
-          Assert.assertEquals(
-              "EqualNullSafe must match",
-              expectedEqNullSafe2.toString(),
-              actualEqNullSafe2.toString());
+    Predicate eqNullSafe1 = new Predicate("<=>", attrAndValue);
+    Expression expectedEqNullSafe1 = Expressions.equal(unquoted, 1);
+    Expression actualEqNullSafe1 = SparkV2Filters.convert(eqNullSafe1);
+    Assert.assertEquals(
+        "EqualNullSafe must match", expectedEqNullSafe1.toString(), actualEqNullSafe1.toString());
 
-          LiteralValue str =
-              new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
-          org.apache.spark.sql.connector.expressions.Expression[] attrAndStr =
-              new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, str};
-          Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
-          Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
-          Expression actualStartsWith = SparkV2Filters.convert(startsWith);
-          Assert.assertEquals(
-              "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
+    Predicate eqNullSafe2 = new Predicate("<=>", valueAndAttr);
+    Expression expectedEqNullSafe2 = Expressions.equal(unquoted, 1);
+    Expression actualEqNullSafe2 = SparkV2Filters.convert(eqNullSafe2);
+    Assert.assertEquals(
+        "EqualNullSafe must match", expectedEqNullSafe2.toString(), actualEqNullSafe2.toString());
 
-          Predicate in = new Predicate("IN", attrAndValue);
-          Expression expectedIn = Expressions.in(unquoted, 1);
-          Expression actualIn = SparkV2Filters.convert(in);
-          Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
+    LiteralValue str = new LiteralValue(UTF8String.fromString("iceberg"), DataTypes.StringType);
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndStr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {namedReference, str};
+    Predicate startsWith = new Predicate("STARTS_WITH", attrAndStr);
+    Expression expectedStartsWith = Expressions.startsWith(unquoted, "iceberg");
+    Expression actualStartsWith = SparkV2Filters.convert(startsWith);
+    Assert.assertEquals(
+        "StartsWith must match", expectedStartsWith.toString(), actualStartsWith.toString());
 
-          Predicate and = new And(lt1, eq1);
-          Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
-          Expression actualAnd = SparkV2Filters.convert(and);
-          Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
+    Predicate in = new Predicate("IN", attrAndValue);
+    Expression expectedIn = Expressions.in(unquoted, 1);
+    Expression actualIn = SparkV2Filters.convert(in);
+    Assert.assertEquals("In must match", expectedIn.toString(), actualIn.toString());
 
-          org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
-              new org.apache.spark.sql.connector.expressions.Expression[] {
-                namedReference, namedReference
-              };
-          Predicate invalid = new Predicate("<", attrAndAttr);
-          Predicate andWithInvalidLeft = new And(invalid, eq1);
-          Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
-          Assert.assertEquals("And must match", convertedAnd, null);
+    Predicate and = new And(lt1, eq1);
+    Expression expectedAnd = Expressions.and(expectedLt1, expectedEq1);
+    Expression actualAnd = SparkV2Filters.convert(and);
+    Assert.assertEquals("And must match", expectedAnd.toString(), actualAnd.toString());
 
-          Predicate or = new Or(lt1, eq1);
-          Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
-          Expression actualOr = SparkV2Filters.convert(or);
-          Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
+    org.apache.spark.sql.connector.expressions.Expression[] attrAndAttr =
+        new org.apache.spark.sql.connector.expressions.Expression[] {
+          namedReference, namedReference
+        };
+    Predicate invalid = new Predicate("<", attrAndAttr);
+    Predicate andWithInvalidLeft = new And(invalid, eq1);
+    Expression convertedAnd = SparkV2Filters.convert(andWithInvalidLeft);
+    Assert.assertEquals("And must match", convertedAnd, null);
 
-          Predicate orWithInvalidLeft = new Or(invalid, eq1);
-          Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
-          Assert.assertEquals("Or must match", convertedOr, null);
+    Predicate or = new Or(lt1, eq1);
+    Expression expectedOr = Expressions.or(expectedLt1, expectedEq1);
+    Expression actualOr = SparkV2Filters.convert(or);
+    Assert.assertEquals("Or must match", expectedOr.toString(), actualOr.toString());
 
-          Predicate not = new Not(lt1);
-          Expression expectedNot = Expressions.not(expectedLt1);
-          Expression actualNot = SparkV2Filters.convert(not);
-          Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
-        });
+    Predicate orWithInvalidLeft = new Or(invalid, eq1);
+    Expression convertedOr = SparkV2Filters.convert(orWithInvalidLeft);
+    Assert.assertEquals("Or must match", convertedOr, null);
+
+    Predicate not = new Not(lt1);
+    Expression expectedNot = Expressions.not(expectedLt1);
+    Expression actualNot = SparkV2Filters.convert(not);
+    Assert.assertEquals("Not must match", expectedNot.toString(), actualNot.toString());
   }
 
   @Test


### PR DESCRIPTION
This splits the changes for `NOT_EQ` from #7886