### PR TITLE
Spark: Remove deprecated AssertHelpers

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTableSchema.java
@@ -19,9 +19,9 @@
 package org.apache.iceberg.spark.extensions;
 
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -77,17 +77,14 @@ public class TestAlterTableSchema extends SparkExtensionsTestBase {
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertTrue(
         "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
-    AssertHelpers.assertThrows(
-        "should not allow setting unknown fields",
-        IllegalArgumentException.class,
-        "not found in current schema or added columns",
-        () -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS unknown", tableName));
+    Assertions.assertThatThrownBy(
+            () -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS unknown", tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith("not found in current schema or added columns");
 
-    AssertHelpers.assertThrows(
-        "should not allow setting optional fields",
-        IllegalArgumentException.class,
-        "not a required field",
-        () -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS id2", tableName));
+    Assertions.assertThatThrownBy(() -> sql("ALTER TABLE %s SET IDENTIFIER FIELDS id2", tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith("not a required field");
   }
 
   @Test
@@ -140,23 +137,22 @@ public class TestAlterTableSchema extends SparkExtensionsTestBase {
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertTrue(
         "Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
-    AssertHelpers.assertThrows(
-        "should not allow dropping unknown fields",
-        IllegalArgumentException.class,
-        "field unknown not found",
-        () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS unknown", tableName));
+    Assertions.assertThatThrownBy(
+            () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS unknown", tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot complete drop identifier fields operation: field unknown not found");
 
     sql("ALTER TABLE %s SET IDENTIFIER FIELDS id", tableName);
-    AssertHelpers.assertThrows(
-        "should not allow dropping a field that is not an identifier",
-        IllegalArgumentException.class,
-        "data is not an identifier field",
-        () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS data", tableName));
+    Assertions.assertThatThrownBy(
+            () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS data", tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot complete drop identifier fields operation: data is not an identifier field");
 
-    AssertHelpers.assertThrows(
-        "should not allow dropping a nested field that is not an identifier",
-        IllegalArgumentException.class,
-        "location.lon is not an identifier field",
-        () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS location.lon", tableName));
+    Assertions.assertThatThrownBy(
+            () -> sql("ALTER TABLE %s DROP IDENTIFIER FIELDS location.lon", tableName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot complete drop identifier fields operation: location.lon is not an identifier field");
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAncestorsOfProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAncestorsOfProcedure.java
@@ -20,10 +20,10 @@ package org.apache.iceberg.spark.extensions;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.AnalysisException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
 
@@ -147,22 +147,17 @@ public class TestAncestorsOfProcedure extends SparkExtensionsTestBase {
 
   @Test
   public void testInvalidAncestorOfCases() {
-    AssertHelpers.assertThrows(
-        "Should reject calls without all required args",
-        AnalysisException.class,
-        "Missing required parameters",
-        () -> sql("CALL %s.system.ancestors_of()", catalogName));
+    Assertions.assertThatThrownBy(() -> sql("CALL %s.system.ancestors_of()", catalogName))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessage("Missing required parameters: [table]");
 
-    AssertHelpers.assertThrows(
-        "Should reject calls with empty table identifier",
-        IllegalArgumentException.class,
-        "Cannot handle an empty identifier for parameter 'table'",
-        () -> sql("CALL %s.system.ancestors_of('')", catalogName));
+    Assertions.assertThatThrownBy(() -> sql("CALL %s.system.ancestors_of('')", catalogName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot handle an empty identifier for parameter 'table'");
 
-    AssertHelpers.assertThrows(
-        "Should reject calls with invalid arg types",
-        AnalysisException.class,
-        "Wrong arg type for snapshot_id: cannot cast",
-        () -> sql("CALL %s.system.ancestors_of('%s', 1.1)", catalogName, tableIdent));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.system.ancestors_of('%s', 1.1)", catalogName, tableIdent))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("Wrong arg type for snapshot_id: cannot cast");
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.SparkSession;
@@ -38,6 +37,7 @@ import org.apache.spark.sql.catalyst.plans.logical.NamedArgument;
 import org.apache.spark.sql.catalyst.plans.logical.PositionalArgument;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -144,11 +144,9 @@ public class TestCallStatementParser {
 
   @Test
   public void testCallParseError() {
-    AssertHelpers.assertThrows(
-        "Should fail with a sensible parse error",
-        IcebergParseException.class,
-        "missing '(' at 'radish'",
-        () -> parser.parsePlan("CALL cat.system radish kebab"));
+    Assertions.assertThatThrownBy(() -> parser.parsePlan("CALL cat.system radish kebab"))
+        .isInstanceOf(IcebergParseException.class)
+        .hasMessageContaining("missing '(' at 'radish'");
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -22,7 +22,6 @@ import static org.apache.iceberg.TableProperties.WRITE_AUDIT_PUBLISH_ENABLED;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -32,6 +31,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
 
@@ -161,43 +161,36 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
   public void testCherrypickInvalidSnapshot() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
-    AssertHelpers.assertThrows(
-        "Should reject invalid snapshot id",
-        ValidationException.class,
-        "Cannot cherry-pick unknown snapshot ID",
-        () -> sql("CALL %s.system.cherrypick_snapshot('%s', -1L)", catalogName, tableIdent));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.system.cherrypick_snapshot('%s', -1L)", catalogName, tableIdent))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot cherry-pick unknown snapshot ID: -1");
   }
 
   @Test
   public void testInvalidCherrypickSnapshotCases() {
-    AssertHelpers.assertThrows(
-        "Should not allow mixed args",
-        AnalysisException.class,
-        "Named and positional arguments cannot be mixed",
-        () -> sql("CALL %s.system.cherrypick_snapshot('n', table => 't', 1L)", catalogName));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.system.cherrypick_snapshot('n', table => 't', 1L)", catalogName))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessage("Named and positional arguments cannot be mixed");
 
-    AssertHelpers.assertThrows(
-        "Should not resolve procedures in arbitrary namespaces",
-        NoSuchProcedureException.class,
-        "not found",
-        () -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.custom.cherrypick_snapshot('n', 't', 1L)", catalogName))
+        .isInstanceOf(NoSuchProcedureException.class)
+        .hasMessage("Procedure custom.cherrypick_snapshot not found");
 
-    AssertHelpers.assertThrows(
-        "Should reject calls without all required args",
-        AnalysisException.class,
-        "Missing required parameters",
-        () -> sql("CALL %s.system.cherrypick_snapshot('t')", catalogName));
+    Assertions.assertThatThrownBy(() -> sql("CALL %s.system.cherrypick_snapshot('t')", catalogName))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessage("Missing required parameters: [snapshot_id]");
 
-    AssertHelpers.assertThrows(
-        "Should reject calls with empty table identifier",
-        IllegalArgumentException.class,
-        "Cannot handle an empty identifier",
-        () -> sql("CALL %s.system.cherrypick_snapshot('', 1L)", catalogName));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.system.cherrypick_snapshot('', 1L)", catalogName))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot handle an empty identifier for argument table");
 
-    AssertHelpers.assertThrows(
-        "Should reject calls with invalid arg types",
-        AnalysisException.class,
-        "Wrong arg type for snapshot_id: cannot cast",
-        () -> sql("CALL %s.system.cherrypick_snapshot('t', 2.2)", catalogName));
+    Assertions.assertThatThrownBy(
+            () -> sql("CALL %s.system.cherrypick_snapshot('t', 2.2)", catalogName))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("Wrong arg type for snapshot_id: cannot cast");
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
@@ -28,7 +28,6 @@ import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.functions;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
@@ -70,18 +69,13 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(
                         SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                    .overwrite(functions.col("id").equalTo(1));
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwrite(functions.col("id").equalTo(1)))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting files that can contain records matching ref(name=\"id\") == 1:");
@@ -113,17 +107,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                    .overwrite(functions.col("id").equalTo(1));
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwrite(functions.col("id").equalTo(1)))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:");
@@ -151,18 +140,13 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(
                         SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                    .overwrite(functions.col("id").equalTo(1));
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwrite(functions.col("id").equalTo(1)))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting deleted files that can contain records matching ref(name=\"id\") == 1:");
@@ -188,17 +172,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
 
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(
                         SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                    .overwrite(functions.col("id").equalTo(1));
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwrite(functions.col("id").equalTo(1)))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting files that can contain records matching ref(name=\"id\") == 1:");
@@ -230,17 +209,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                    .overwrite(functions.col("id").equalTo(1));
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwrite(functions.col("id").equalTo(1)))
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:");
@@ -283,18 +257,13 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(
                         SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                    .overwritePartitions();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwritePartitions())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting files that can contain records matching partitions [id=1]");
@@ -324,17 +293,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                    .overwritePartitions();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwritePartitions())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found new conflicting delete files that can apply to records matching [id=1]");
@@ -363,17 +327,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
 
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
                     .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                    .overwritePartitions();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwritePartitions())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting deleted files that can apply to records matching [id=1]");
@@ -415,17 +374,12 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from null snapshot is equivalent to validating from beginning
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 conflictingDf
                     .writeTo(tableName)
                     .option(
                         SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                    .overwritePartitions();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .overwritePartitions())
         .isInstanceOf(ValidationException.class)
         .hasMessageStartingWith(
             "Found conflicting files that can contain records matching partitions [id=1]");

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestConflictValidation.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.spark.extensions;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -31,6 +30,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.functions;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,21 +69,22 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
 
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting new data files should throw exception",
-        ValidationException.class,
-        "Found conflicting files that can contain records matching ref(name=\"id\") == 1:",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                .overwrite(functions.col("id").equalTo(1));
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(
+                        SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
+                    .overwrite(functions.col("id").equalTo(1));
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting files that can contain records matching ref(name=\"id\") == 1:");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -111,21 +112,21 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting new delete files should throw exception",
-        ValidationException.class,
-        "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                .overwrite(functions.col("id").equalTo(1));
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
+                    .overwrite(functions.col("id").equalTo(1));
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -149,21 +150,22 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting deleted data files should throw exception",
-        ValidationException.class,
-        "Found conflicting deleted files that can contain records matching ref(name=\"id\") == 1:",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                .overwrite(functions.col("id").equalTo(1));
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(
+                        SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
+                    .overwrite(functions.col("id").equalTo(1));
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting deleted files that can contain records matching ref(name=\"id\") == 1:");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -184,20 +186,22 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
 
     // Validating from no snapshot id defaults to beginning snapshot id and finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting new data files should throw exception",
-        ValidationException.class,
-        "Found conflicting files that can contain records matching ref(name=\"id\") == 1:",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                .overwrite(functions.col("id").equalTo(1));
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(
+                        SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
+                    .overwrite(functions.col("id").equalTo(1));
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting files that can contain records matching ref(name=\"id\") == 1:");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -225,21 +229,21 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     // Validating from previous snapshot finds conflicts
     List<SimpleRecord> conflictingRecords = Lists.newArrayList(new SimpleRecord(1, "a"));
     Dataset<Row> conflictingDf = spark.createDataFrame(conflictingRecords, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting new delete files should throw exception",
-        ValidationException.class,
-        "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                .overwrite(functions.col("id").equalTo(1));
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
+                    .overwrite(functions.col("id").equalTo(1));
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found new conflicting delete files that can apply to records matching ref(name=\"id\") == 1:");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -278,21 +282,22 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
 
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting deleted data files should throw exception",
-        ValidationException.class,
-        "Found conflicting files that can contain records matching partitions [id=1]",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                .overwritePartitions();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(
+                        SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
+                    .overwritePartitions();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting files that can contain records matching partitions [id=1]");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -318,21 +323,21 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
 
     // Validating from previous snapshot finds conflicts
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting deleted data files should throw exception",
-        ValidationException.class,
-        "Found new conflicting delete files that can apply to records matching [id=1]",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                .overwritePartitions();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
+                    .overwritePartitions();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found new conflicting delete files that can apply to records matching [id=1]");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -357,21 +362,21 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
     spark.createDataFrame(records, SimpleRecord.class).coalesce(1).writeTo(tableName).append();
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
 
-    AssertHelpers.assertThrows(
-        "Conflicting deleted data files should throw exception",
-        ValidationException.class,
-        "Found conflicting deleted files that can apply to records matching [id=1]",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
-                .overwritePartitions();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.VALIDATE_FROM_SNAPSHOT_ID, String.valueOf(snapshotId))
+                    .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SNAPSHOT.toString())
+                    .overwritePartitions();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting deleted files that can apply to records matching [id=1]");
 
     // Validating from latest snapshot should succeed
     table.refresh();
@@ -409,20 +414,21 @@ public class TestConflictValidation extends SparkExtensionsTestBase {
 
     // Validating from null snapshot is equivalent to validating from beginning
     Dataset<Row> conflictingDf = spark.createDataFrame(records, SimpleRecord.class);
-    AssertHelpers.assertThrows(
-        "Conflicting deleted data files should throw exception",
-        ValidationException.class,
-        "Found conflicting files that can contain records matching partitions [id=1]",
-        () -> {
-          try {
-            conflictingDf
-                .writeTo(tableName)
-                .option(SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
-                .overwritePartitions();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                conflictingDf
+                    .writeTo(tableName)
+                    .option(
+                        SparkWriteOptions.ISOLATION_LEVEL, IsolationLevel.SERIALIZABLE.toString())
+                    .overwritePartitions();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith(
+            "Found conflicting files that can contain records matching partitions [id=1]");
 
     // Validating from latest snapshot should succeed
     table.refresh();

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -43,7 +43,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.ManifestFile;
@@ -522,11 +521,10 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("INSERT INTO TABLE %s VALUES (1, 'hr'), (2, 'hardware')", tableName);
     createBranchIfNeeded();
 
-    AssertHelpers.assertThrows(
-        "Should complain about non-deterministic expressions",
-        AnalysisException.class,
-        "nondeterministic expressions are only allowed",
-        () -> sql("DELETE FROM %s WHERE id = 1 AND rand() > 0.5", commitTarget()));
+    Assertions.assertThatThrownBy(
+            () -> sql("DELETE FROM %s WHERE id = 1 AND rand() > 0.5", commitTarget()))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageStartingWith("nondeterministic expressions are only allowed");
   }
 
   @Test
@@ -813,11 +811,9 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     sql("CREATE TABLE parquet_table (c1 INT, c2 INT) USING parquet");
 
-    AssertHelpers.assertThrows(
-        "Delete is supported only for Iceberg tables",
-        AnalysisException.class,
-        "does not support DELETE",
-        () -> sql("DELETE FROM parquet_table WHERE c1 = -100"));
+    Assertions.assertThatThrownBy(() -> sql("DELETE FROM parquet_table WHERE c1 = -100"))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageContaining("does not support DELETE");
   }
 
   @Test

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadDelete.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.RowLevelOperationMode;
 import org.apache.iceberg.Table;
@@ -37,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.spark.source.TestSparkCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
@@ -123,11 +123,10 @@ public class TestMergeOnReadDelete extends TestDelete {
     TestSparkCatalog.setTable(ident, sparkTable);
 
     // Although an exception is thrown here, write and commit have succeeded
-    AssertHelpers.assertThrows(
-        "Should throw a Commit State Unknown Exception",
-        CommitStateUnknownException.class,
-        "Datacenter on Fire",
-        () -> sql("DELETE FROM %s WHERE id = 2", "dummy_catalog.default.table"));
+    Assertions.assertThatThrownBy(
+            () -> sql("DELETE FROM %s WHERE id = 2", "dummy_catalog.default.table"))
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("Datacenter on Fire");
 
     // Since write and commit succeeded, the rows should be readable
     assertEquals(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.extensions;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -39,6 +38,7 @@ import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -105,23 +105,22 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
             new SimpleRecord(4, "b"));
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
 
-    AssertHelpers.assertThrows(
-        "Write must fail",
-        SparkException.class,
-        "Encountered records that belong to already closed files",
-        () -> {
-          try {
-            // incoming records are not ordered by partitions so the job must fail
-            inputDF
-                .coalesce(1)
-                .sortWithinPartitions("id")
-                .writeTo(tableName)
-                .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
-                .append();
-          } catch (NoSuchTableException e) {
-            throw new RuntimeException(e);
-          }
-        });
+    Assertions.assertThatThrownBy(
+            () -> {
+              try {
+                // incoming records are not ordered by partitions so the job must fail
+                inputDF
+                    .coalesce(1)
+                    .sortWithinPartitions("id")
+                    .writeTo(tableName)
+                    .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+                    .append();
+              } catch (NoSuchTableException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .isInstanceOf(SparkException.class)
+        .hasMessageContaining("Encountered records that belong to already closed files");
 
     assertEquals("Should be no records", sql("SELECT * FROM %s", tableName), ImmutableList.of());
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Rule;
@@ -106,19 +105,14 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
 
     Assertions.assertThatThrownBy(
-            () -> {
-              try {
+            () ->
                 // incoming records are not ordered by partitions so the job must fail
                 inputDF
                     .coalesce(1)
                     .sortWithinPartitions("id")
                     .writeTo(tableName)
                     .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
-                    .append();
-              } catch (NoSuchTableException e) {
-                throw new RuntimeException(e);
-              }
-            })
+                    .append())
         .isInstanceOf(SparkException.class)
         .hasMessageContaining("Encountered records that belong to already closed files");
 


### PR DESCRIPTION
- SubTask of https://github.com/apache/iceberg/issues/7094

Remove `AssertHelpers` in `iceberg-spark` module.