### PR TITLE
Build: Ignore generated directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ derby.log
 python/.mypy_cache/
 python/htmlcov
 python/coverage.xml
+
+# generated files
+api/src/main/generated/
+core/src/main/generated/
+hive-metastore/src/main/generated/


### PR DESCRIPTION
Ignore the generated directory. We could get the following when running UTs locally which should be ignored.
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	api/src/main/generated/
	core/src/main/generated/
	hive-metastore/src/main/generated/
```