### PR TITLE
Dell: Migrate TestRules to JUnit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,6 +337,7 @@ project(':iceberg-api') {
 project(':iceberg-common') {
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    implementation 'org.junit.jupiter:junit-jupiter'
   }
 }
 

--- a/common/src/main/java/org/apache/iceberg/common/testutils/CustomExtension.java
+++ b/common/src/main/java/org/apache/iceberg/common/testutils/CustomExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.common.testutils;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * An extension that is invoked before/after all/each tests, depending on whether it is wrapped in a
+ * {@link PerTestCallbackWrapper} or {@link PerClassCallbackWrapper}.
+ *
+ * <p>{@code before} method will be called in {@code beforeEach} or {@code beforeAll}. {@code after}
+ * will be called in {@code afterEach} or {@code afterAll}.
+ *
+ * <p>Usage example:
+ *
+ * <pre><code>
+ * public class Test{
+ *      {@literal @}RegisterExtension
+ *      static PerClassCallbackWrapper classCallbackWrapper = new PerClassCallbackWrapper(customExtension);
+ *      {@literal @}RegisterExtension
+ *      PerTestCallbackWrapper testCallbackWrapper = new PerTestCallbackWrapper(customExtension);
+ * }
+ * }</code></pre>
+ */
+public interface CustomExtension {
+  default void before(ExtensionContext context) throws Exception {}
+
+  default void after(ExtensionContext context) throws Exception {}
+}

--- a/common/src/main/java/org/apache/iceberg/common/testutils/PerClassCallbackWrapper.java
+++ b/common/src/main/java/org/apache/iceberg/common/testutils/PerClassCallbackWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.common.testutils;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This class is used to wrap a specific {@link CustomExtension} to junit5 extension with
+ * class-level callbacks {@link BeforeAllCallback} and {@link AfterAllCallback}. It can be used as a
+ * substitute for @ClassRule in junit4.
+ */
+public class PerClassCallbackWrapper<C extends CustomExtension>
+    implements BeforeAllCallback, AfterAllCallback {
+  private final C extension;
+
+  public PerClassCallbackWrapper(C extension) {
+    this.extension = extension;
+  }
+
+  public C getExtension() {
+    return extension;
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) throws Exception {
+    extension.after(context);
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) throws Exception {
+    extension.before(context);
+  }
+}

--- a/common/src/main/java/org/apache/iceberg/common/testutils/PerTestCallbackWrapper.java
+++ b/common/src/main/java/org/apache/iceberg/common/testutils/PerTestCallbackWrapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.common.testutils;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * This class is used to wrap a specific {@link CustomExtension} to junit5 extension with test-level
+ * callbacks {@link BeforeEachCallback} and {@link AfterEachCallback}. It can be used as a
+ * substitute for @Rule in junit4.
+ */
+public class PerTestCallbackWrapper<C extends CustomExtension>
+    implements BeforeEachCallback, AfterEachCallback {
+  private final C extension;
+
+  public PerTestCallbackWrapper(C extension) {
+    this.extension = extension;
+  }
+
+  public C getExtension() {
+    return extension;
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    extension.after(context);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    extension.before(context);
+  }
+}

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -23,38 +23,53 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.common.testutils.PerClassCallbackWrapper;
+import org.apache.iceberg.dell.mock.ecs.EcsS3MockExtension;
 import org.apache.iceberg.metrics.MetricsContext;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class TestEcsSeekableInputStream {
+class TestEcsSeekableInputStream {
 
-  @ClassRule public static EcsS3MockRule rule = EcsS3MockRule.create();
+  @RegisterExtension
+  static PerClassCallbackWrapper<EcsS3MockExtension> extensionWrapper =
+      new PerClassCallbackWrapper<>(EcsS3MockExtension.create());
 
   @Test
-  public void testSeekPosRead() throws IOException {
-    String objectName = rule.randomObjectName();
-    rule.client()
-        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+  void testSeekPosRead() throws IOException {
+    String objectName = extensionWrapper.getExtension().randomObjectName();
+    extensionWrapper
+        .getExtension()
+        .client()
+        .putObject(
+            new PutObjectRequest(
+                extensionWrapper.getExtension().bucket(), objectName, "0123456789".getBytes()));
 
     try (EcsSeekableInputStream input =
         new EcsSeekableInputStream(
-            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+            extensionWrapper.getExtension().client(),
+            new EcsURI(extensionWrapper.getExtension().bucket(), objectName),
+            MetricsContext.nullMetrics())) {
       input.seek(2);
       assertThat(input.read()).as("Expect 2 when seek to 2").isEqualTo('2');
     }
   }
 
   @Test
-  public void testMultipleSeekPosRead() throws IOException {
-    String objectName = rule.randomObjectName();
-    rule.client()
-        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+  void testMultipleSeekPosRead() throws IOException {
+    String objectName = extensionWrapper.getExtension().randomObjectName();
+    extensionWrapper
+        .getExtension()
+        .client()
+        .putObject(
+            new PutObjectRequest(
+                extensionWrapper.getExtension().bucket(), objectName, "0123456789".getBytes()));
 
     try (EcsSeekableInputStream input =
         new EcsSeekableInputStream(
-            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+            extensionWrapper.getExtension().client(),
+            new EcsURI(extensionWrapper.getExtension().bucket(), objectName),
+            MetricsContext.nullMetrics())) {
       input.seek(999);
       input.seek(3);
       assertThat(input.read()).as("Expect 3 when seek to 3 finally").isEqualTo('3');
@@ -62,27 +77,39 @@ public class TestEcsSeekableInputStream {
   }
 
   @Test
-  public void testReadOneByte() throws IOException {
-    String objectName = rule.randomObjectName();
-    rule.client()
-        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+  void testReadOneByte() throws IOException {
+    String objectName = extensionWrapper.getExtension().randomObjectName();
+    extensionWrapper
+        .getExtension()
+        .client()
+        .putObject(
+            new PutObjectRequest(
+                extensionWrapper.getExtension().bucket(), objectName, "0123456789".getBytes()));
 
     try (EcsSeekableInputStream input =
         new EcsSeekableInputStream(
-            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+            extensionWrapper.getExtension().client(),
+            new EcsURI(extensionWrapper.getExtension().bucket(), objectName),
+            MetricsContext.nullMetrics())) {
       assertThat(input.read()).as("The first byte should be 0 ").isEqualTo('0');
     }
   }
 
   @Test
-  public void testReadBytes() throws IOException {
-    String objectName = rule.randomObjectName();
-    rule.client()
-        .putObject(new PutObjectRequest(rule.bucket(), objectName, "0123456789".getBytes()));
+  void testReadBytes() throws IOException {
+    String objectName = extensionWrapper.getExtension().randomObjectName();
+    extensionWrapper
+        .getExtension()
+        .client()
+        .putObject(
+            new PutObjectRequest(
+                extensionWrapper.getExtension().bucket(), objectName, "0123456789".getBytes()));
 
     try (EcsSeekableInputStream input =
         new EcsSeekableInputStream(
-            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+            extensionWrapper.getExtension().client(),
+            new EcsURI(extensionWrapper.getExtension().bucket(), objectName),
+            MetricsContext.nullMetrics())) {
       byte[] buffer = new byte[3];
       assertThat(input.read(buffer)).as("The first read should be 3 bytes").isEqualTo(3);
       assertThat(new String(buffer, StandardCharsets.UTF_8))

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
@@ -24,10 +24,10 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class TestEcsURI {
+class TestEcsURI {
 
   @Test
-  public void testConstructor() {
+  void testConstructor() {
     assertURI("bucket", "", new EcsURI("ecs://bucket"));
     assertURI("bucket", "", new EcsURI("ecs://bucket/"));
     assertURI("bucket", "", new EcsURI("ecs://bucket//"));
@@ -38,7 +38,7 @@ public class TestEcsURI {
   }
 
   @Test
-  public void testConstructorWithBucketAndName() {
+  void testConstructorWithBucketAndName() {
     assertURI("bucket", "", new EcsURI("bucket", ""));
     assertURI("bucket", "", new EcsURI("bucket", "/"));
     assertURI("bucket", "", new EcsURI("bucket", "//"));
@@ -54,7 +54,7 @@ public class TestEcsURI {
   }
 
   @Test
-  public void testInvalidLocation() {
+  void testInvalidLocation() {
     Assertions.assertThatThrownBy(() -> new EcsURI("http://bucket/a"))
         .isInstanceOf(ValidationException.class)
         .hasMessage("Invalid ecs location: http://bucket/a");

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestPropertiesSerDesUtil.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestPropertiesSerDesUtil.java
@@ -24,10 +24,10 @@ import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
-public class TestPropertiesSerDesUtil {
+class TestPropertiesSerDesUtil {
 
   @Test
-  public void testPropertiesSerDes() {
+  void testPropertiesSerDes() {
     Map<String, String> properties = ImmutableMap.of("a", "a", "b", "b");
     byte[] byteValue = PropertiesSerDesUtil.toBytes(properties);
     Map<String, String> result =

--- a/dell/src/test/java/org/apache/iceberg/dell/mock/MockDellClientFactory.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/mock/MockDellClientFactory.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.dell.mock;
 import com.emc.object.s3.S3Client;
 import java.util.Map;
 import org.apache.iceberg.dell.DellClientFactory;
-import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.dell.mock.ecs.EcsS3MockExtension;
 
-/** Provide client which initialized by {@link EcsS3MockRule} */
+/** Provide client which initialized by {@link EcsS3MockExtension} */
 public class MockDellClientFactory implements DellClientFactory {
 
   public static final String ID_KEY = "mock.dell.client.factory.id";
@@ -33,7 +33,7 @@ public class MockDellClientFactory implements DellClientFactory {
 
   @Override
   public S3Client ecsS3() {
-    return EcsS3MockRule.rule(id).client();
+    return EcsS3MockExtension.extension(id).client();
   }
 
   @Override


### PR DESCRIPTION
Migrate test class using Junit4 `@Rule` or `@ClassRule` in dell package to Junit5. 

This fixed #7888.
<del>
Note: This pull request based on #7872 as that migrate assertions to `AssertJ`. I will rebase this after #7872 has been merged. 
Only c4873db and c1c02a7 need review. 
</del>
