### PR TITLE
Docs: add support for spark TimestampNtz type to docs

### DIFF
--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -397,25 +397,26 @@ so you may want to understand the type conversion in Iceberg in prior to design 
 
 This type conversion table describes how Spark types are converted to the Iceberg types. The conversion applies on both creating Iceberg table and writing to Iceberg table via Spark.
 
-| Spark           | Iceberg                 | Notes |
-|-----------------|-------------------------|-------|
-| boolean         | boolean                 |       |
-| short           | integer                 |       |
-| byte            | integer                 |       |
-| integer         | integer                 |       |
-| long            | long                    |       |
-| float           | float                   |       |
-| double          | double                  |       |
-| date            | date                    |       |
-| timestamp       | timestamp with timezone |       |
-| char            | string                  |       |
-| varchar         | string                  |       |
-| string          | string                  |       |
-| binary          | binary                  |       |
-| decimal         | decimal                 |       |
-| struct          | struct                  |       |
-| array           | list                    |       |
-| map             | map                     |       |
+| Spark           | Iceberg                    | Notes |
+|-----------------|----------------------------|-------|
+| boolean         | boolean                    |       |
+| short           | integer                    |       |
+| byte            | integer                    |       |
+| integer         | integer                    |       |
+| long            | long                       |       |
+| float           | float                      |       |
+| double          | double                     |       |
+| date            | date                       |       |
+| timestamp       | timestamp with timezone    |       |
+| timestampNtz    | timestamp without timezone |       |
+| char            | string                     |       |
+| varchar         | string                     |       |
+| string          | string                     |       |
+| binary          | binary                     |       |
+| decimal         | decimal                    |       |
+| struct          | struct                     |       |
+| array           | list                       |       |
+| map             | map                        |       |
 
 {{< hint info >}}
 The table is based on representing conversion during creating table. In fact, broader supports are applied on write. Here're some points on write:
@@ -438,7 +439,7 @@ This type conversion table describes how Iceberg types are converted to the Spar
 | date                       | date                    |               |
 | time                       |                         | Not supported |
 | timestamp with timezone    | timestamp               |               |
-| timestamp without timezone |                         | Not supported |
+| timestamp without timezone | timestampNtz            |               |
 | string                     | string                  |               |
 | uuid                       | string                  |               |
 | fixed                      | binary                  |               |

--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -408,7 +408,7 @@ This type conversion table describes how Spark types are converted to the Iceber
 | double          | double                     |       |
 | date            | date                       |       |
 | timestamp       | timestamp with timezone    |       |
-| timestampNtz    | timestamp without timezone |       |
+| timestamp_ntz    | timestamp without timezone |       |
 | char            | string                     |       |
 | varchar         | string                     |       |
 | string          | string                     |       |

--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -439,7 +439,7 @@ This type conversion table describes how Iceberg types are converted to the Spar
 | date                       | date                    |               |
 | time                       |                         | Not supported |
 | timestamp with timezone    | timestamp               |               |
-| timestamp without timezone | timestampNtz            |               |
+| timestamp without timezone | timestamp_ntz            |               |
 | string                     | string                  |               |
 | uuid                       | string                  |               |
 | fixed                      | binary                  |               |


### PR DESCRIPTION
The new `TimestampNtz` Spark type (added in spark 3.4.0) is now [supported by Iceberg](https://github.com/apache/iceberg/pull/7553), this just updates the type conversion tables in the iceberg docs to reflect this.