### PR TITLE
Flink 1.15/1.16: Key projection should be based on the requested Flink table schema

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -63,7 +63,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
     this.wrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
     this.keyWrapper =
         new RowDataWrapper(FlinkSchemaUtil.convert(deleteSchema), deleteSchema.asStruct());
-    this.keyProjection = RowDataProjection.create(schema, deleteSchema);
+    this.keyProjection =
+        RowDataProjection.create(flinkSchema, schema.asStruct(), deleteSchema.asStruct());
     this.upsert = upsert;
   }
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -23,31 +23,47 @@ import static org.apache.iceberg.flink.SimpleDataUtil.createInsert;
 import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,20 +93,6 @@ public class TestDeltaTaskWriter extends TableTestBase {
     Assert.assertTrue(tableDir.delete()); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
-  }
-
-  private void initTable(boolean partitioned) {
-    if (partitioned) {
-      this.table = create(SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("data").build());
-    } else {
-      this.table = create(SCHEMA, PartitionSpec.unpartitioned());
-    }
-
-    table
-        .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
-        .defaultFormat(format)
-        .commit();
   }
 
   private int idFieldId() {
@@ -170,18 +172,18 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testUnpartitioned() throws IOException {
-    initTable(false);
+    createAndInitTable(false);
     testCdcEvents(false);
   }
 
   @Test
   public void testPartitioned() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     testCdcEvents(true);
   }
 
   private void testWritePureEqDeletes(boolean partitioned) throws IOException {
-    initTable(partitioned);
+    createAndInitTable(partitioned);
     List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -210,7 +212,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
   }
 
   private void testAbort(boolean partitioned) throws IOException {
-    initTable(partitioned);
+    createAndInitTable(partitioned);
     List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -253,7 +255,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testPartitionedTableWithDataAsKey() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -298,7 +300,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testPartitionedTableWithDataAndIdAsKey() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId(), idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -319,6 +321,62 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
     Assert.assertEquals(
         "Should have expected records", expectedRowSet(createRecord(1, "aaa")), actualRowSet("*"));
+  }
+
+  @Test
+  public void testEqualityColumnOnCustomPrecisionTSColumn() throws IOException {
+    Schema tableSchema =
+        new Schema(
+            required(3, "id", Types.IntegerType.get()),
+            required(4, "ts", Types.TimestampType.withZone()));
+    RowType flinkType =
+        new RowType(
+            false,
+            ImmutableList.of(
+                new RowType.RowField("id", new IntType()),
+                new RowType.RowField("ts", new LocalZonedTimestampType(3))));
+
+    this.table = create(tableSchema, PartitionSpec.unpartitioned());
+    initTable(table);
+
+    List<Integer> equalityIds = ImmutableList.of(table.schema().findField("ts").fieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(flinkType, equalityIds);
+    taskWriterFactory.initialize(1, 1);
+
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    RowDataSerializer serializer = new RowDataSerializer(flinkType);
+    OffsetDateTime start = OffsetDateTime.now();
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.INSERT, 1, TimestampData.fromInstant(start.toInstant()))));
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.INSERT, 2, TimestampData.fromInstant(start.plusSeconds(1).toInstant()))));
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.DELETE, 2, TimestampData.fromInstant(start.plusSeconds(1).toInstant()))));
+
+    WriteResult result = writer.complete();
+    // One data file
+    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
+    // One eq delete file + one pos delete file
+    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
+    Assertions.assertThat(
+            Arrays.stream(result.deleteFiles())
+                .map(ContentFile::content)
+                .collect(Collectors.toSet()))
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
+    commitTransaction(result);
+
+    Record expectedRecord = GenericRecord.create(tableSchema);
+    expectedRecord.setField("id", 1);
+    int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
+    expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
+
+    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {
@@ -348,5 +406,35 @@ public class TestDeltaTaskWriter extends TableTestBase {
         table.properties(),
         equalityFieldIds,
         false);
+  }
+
+  private TaskWriterFactory<RowData> createTaskWriterFactory(
+      RowType flinkType, List<Integer> equalityFieldIds) {
+    return new RowDataTaskWriterFactory(
+        SerializableTable.copyOf(table),
+        flinkType,
+        128 * 1024 * 1024,
+        format,
+        table.properties(),
+        equalityFieldIds,
+        true);
+  }
+
+  private void createAndInitTable(boolean partitioned) {
+    if (partitioned) {
+      this.table = create(SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("data").build());
+    } else {
+      this.table = create(SCHEMA, PartitionSpec.unpartitioned());
+    }
+
+    initTable(table);
+  }
+
+  private void initTable(TestTables.TestTable testTable) {
+    testTable
+        .updateProperties()
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
+        .defaultFormat(format)
+        .commit();
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -63,7 +63,8 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
     this.wrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
     this.keyWrapper =
         new RowDataWrapper(FlinkSchemaUtil.convert(deleteSchema), deleteSchema.asStruct());
-    this.keyProjection = RowDataProjection.create(schema, deleteSchema);
+    this.keyProjection =
+        RowDataProjection.create(flinkSchema, schema.asStruct(), deleteSchema.asStruct());
     this.upsert = upsert;
   }
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -23,31 +23,47 @@ import static org.apache.iceberg.flink.SimpleDataUtil.createInsert;
 import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
 import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,20 +93,6 @@ public class TestDeltaTaskWriter extends TableTestBase {
     Assert.assertTrue(tableDir.delete()); // created by table create
 
     this.metadataDir = new File(tableDir, "metadata");
-  }
-
-  private void initTable(boolean partitioned) {
-    if (partitioned) {
-      this.table = create(SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("data").build());
-    } else {
-      this.table = create(SCHEMA, PartitionSpec.unpartitioned());
-    }
-
-    table
-        .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
-        .defaultFormat(format)
-        .commit();
   }
 
   private int idFieldId() {
@@ -170,18 +172,18 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testUnpartitioned() throws IOException {
-    initTable(false);
+    createAndInitTable(false);
     testCdcEvents(false);
   }
 
   @Test
   public void testPartitioned() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     testCdcEvents(true);
   }
 
   private void testWritePureEqDeletes(boolean partitioned) throws IOException {
-    initTable(partitioned);
+    createAndInitTable(partitioned);
     List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -210,7 +212,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
   }
 
   private void testAbort(boolean partitioned) throws IOException {
-    initTable(partitioned);
+    createAndInitTable(partitioned);
     List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -253,7 +255,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testPartitionedTableWithDataAsKey() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -298,7 +300,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
   @Test
   public void testPartitionedTableWithDataAndIdAsKey() throws IOException {
-    initTable(true);
+    createAndInitTable(true);
     List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId(), idFieldId());
     TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
     taskWriterFactory.initialize(1, 1);
@@ -319,6 +321,62 @@ public class TestDeltaTaskWriter extends TableTestBase {
 
     Assert.assertEquals(
         "Should have expected records", expectedRowSet(createRecord(1, "aaa")), actualRowSet("*"));
+  }
+
+  @Test
+  public void testEqualityColumnOnCustomPrecisionTSColumn() throws IOException {
+    Schema tableSchema =
+        new Schema(
+            required(3, "id", Types.IntegerType.get()),
+            required(4, "ts", Types.TimestampType.withZone()));
+    RowType flinkType =
+        new RowType(
+            false,
+            ImmutableList.of(
+                new RowType.RowField("id", new IntType()),
+                new RowType.RowField("ts", new LocalZonedTimestampType(3))));
+
+    this.table = create(tableSchema, PartitionSpec.unpartitioned());
+    initTable(table);
+
+    List<Integer> equalityIds = ImmutableList.of(table.schema().findField("ts").fieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(flinkType, equalityIds);
+    taskWriterFactory.initialize(1, 1);
+
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    RowDataSerializer serializer = new RowDataSerializer(flinkType);
+    OffsetDateTime start = OffsetDateTime.now();
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.INSERT, 1, TimestampData.fromInstant(start.toInstant()))));
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.INSERT, 2, TimestampData.fromInstant(start.plusSeconds(1).toInstant()))));
+    writer.write(
+        serializer.toBinaryRow(
+            GenericRowData.ofKind(
+                RowKind.DELETE, 2, TimestampData.fromInstant(start.plusSeconds(1).toInstant()))));
+
+    WriteResult result = writer.complete();
+    // One data file
+    Assertions.assertThat(result.dataFiles().length).isEqualTo(1);
+    // One eq delete file + one pos delete file
+    Assertions.assertThat(result.deleteFiles().length).isEqualTo(2);
+    Assertions.assertThat(
+            Arrays.stream(result.deleteFiles())
+                .map(ContentFile::content)
+                .collect(Collectors.toSet()))
+        .isEqualTo(Sets.newHashSet(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES));
+    commitTransaction(result);
+
+    Record expectedRecord = GenericRecord.create(tableSchema);
+    expectedRecord.setField("id", 1);
+    int cutPrecisionNano = start.getNano() / 1000000 * 1000000;
+    expectedRecord.setField("ts", start.withNano(cutPrecisionNano));
+
+    Assertions.assertThat(actualRowSet("*")).isEqualTo(expectedRowSet(expectedRecord));
   }
 
   private void commitTransaction(WriteResult result) {
@@ -348,5 +406,35 @@ public class TestDeltaTaskWriter extends TableTestBase {
         table.properties(),
         equalityFieldIds,
         false);
+  }
+
+  private TaskWriterFactory<RowData> createTaskWriterFactory(
+      RowType flinkType, List<Integer> equalityFieldIds) {
+    return new RowDataTaskWriterFactory(
+        SerializableTable.copyOf(table),
+        flinkType,
+        128 * 1024 * 1024,
+        format,
+        table.properties(),
+        equalityFieldIds,
+        true);
+  }
+
+  private void createAndInitTable(boolean partitioned) {
+    if (partitioned) {
+      this.table = create(SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("data").build());
+    } else {
+      this.table = create(SCHEMA, PartitionSpec.unpartitioned());
+    }
+
+    initTable(table);
+  }
+
+  private void initTable(TestTables.TestTable testTable) {
+    testTable
+        .updateProperties()
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
+        .defaultFormat(format)
+        .commit();
   }
 }


### PR DESCRIPTION
This ports #7836 to Flink 1.15/1.16.