### PR TITLE
Spark 3.2 and 3.3: Use Reblance instead of Repartition for distribution in SparkWrite

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDistributionAndOrderingUtils.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDistributionAndOrderingUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.ExtendedV2ExpressionUtils.toCatalyst
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
+import org.apache.spark.sql.catalyst.plans.logical.RebalancePartitions
 import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.connector.distributions.ClusteredDistribution
 import org.apache.spark.sql.connector.distributions.OrderedDistribution
@@ -52,15 +52,10 @@ object ExtendedDistributionAndOrderingUtils {
       }
 
       val queryWithDistribution = if (distribution.nonEmpty) {
-        val finalNumPartitions = if (numPartitions > 0) {
-          numPartitions
-        } else {
-          conf.numShufflePartitions
-        }
         // the conversion to catalyst expressions above produces SortOrder expressions
         // for OrderedDistribution and generic expressions for ClusteredDistribution
-        // this allows RepartitionByExpression to pick either range or hash partitioning
-        RepartitionByExpression(ArraySeq.unsafeWrapArray(distribution), query, finalNumPartitions)
+        // this allows RebalancePartitions to pick either range or hash partitioning
+        RebalancePartitions(ArraySeq.unsafeWrapArray(distribution), query)
       } else if (numPartitions > 0) {
         throw QueryCompilationErrors.numberOfPartitionsNotAllowedWithUnspecifiedDistributionError()
       } else {

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDistributionAndOrderingUtils.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDistributionAndOrderingUtils.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.ExtendedV2ExpressionUtils.toCatalyst
 import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
+import org.apache.spark.sql.catalyst.plans.logical.RebalancePartitions
 import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.connector.distributions.ClusteredDistribution
 import org.apache.spark.sql.connector.distributions.OrderedDistribution
@@ -52,15 +52,10 @@ object ExtendedDistributionAndOrderingUtils {
       }
 
       val queryWithDistribution = if (distribution.nonEmpty) {
-        val finalNumPartitions = if (numPartitions > 0) {
-          numPartitions
-        } else {
-          conf.numShufflePartitions
-        }
         // the conversion to catalyst expressions above produces SortOrder expressions
         // for OrderedDistribution and generic expressions for ClusteredDistribution
-        // this allows RepartitionByExpression to pick either range or hash partitioning
-        RepartitionByExpression(ArraySeq.unsafeWrapArray(distribution), query, finalNumPartitions)
+        // this allows RebalancePartitions to pick either range or hash partitioning
+        RebalancePartitions(ArraySeq.unsafeWrapArray(distribution), query)
       } else if (numPartitions > 0) {
         throw QueryCompilationErrors.numberOfPartitionsNotAllowedWithUnspecifiedDistributionError()
       } else {


### PR DESCRIPTION
- Use Reblance instead of Repartition for distribution in Spark 3.2 and 3.3, to avoid small partitioned files cased with AQE decided partition numbers.


Example for executions plan for insertion to an iceberg table, `explain EXTENDED insert into gfpersonas_platform.t_ptr_label_ice_bowen select * from gfpersonas_platform.t_ptr_label_ice;`.

Before: (With 326 data files written, 3KB+ per file)

```
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
'InsertIntoStatement 'UnresolvedRelation [gfpersonas_platform, t_ptr_label_ice_bowen], [], false, false, false
+- 'Project [*]
   +- 'UnresolvedRelation [gfpersonas_platform, t_ptr_label_ice], [], false

== Analyzed Logical Plan ==
AppendData RelationV2[obj_id#485, lab_val#486, lab_numr#487, busi_date#488] spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, false
+- Project [obj_id#481, lab_val#482, lab_numr#483, busi_date#484]
   +- SubqueryAlias spark_catalog.gfpersonas_platform.t_ptr_label_ice
      +- RelationV2[obj_id#481, lab_val#482, lab_numr#483, busi_date#484] spark_catalog.gfpersonas_platform.t_ptr_label_ice

== Optimized Logical Plan ==
AppendData RelationV2[obj_id#485, lab_val#486, lab_numr#487, busi_date#488] spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, false, IcebergWrite(table=spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, format=PARQUET)
+- Sort [busi_date#484 ASC NULLS FIRST], false
   +- RelationV2[obj_id#481, lab_val#482, lab_numr#483, busi_date#484] spark_catalog.gfpersonas_platform.t_ptr_label_ice

== Physical Plan ==
AppendData org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$3217/1372697900@67a7714c, IcebergWrite(table=spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, format=PARQUET)
+- *(1) Sort [busi_date#484 ASC NULLS FIRST], false, 0
   +- *(1) ColumnarToRow
      +- BatchScan[obj_id#481, lab_val#482, lab_numr#483, busi_date#484] spark_catalog.gfpersonas_platform.t_ptr_label_ice [filters=] RuntimeFilters: []
 |
+----------------------------------------------------+
```

After:  (With 45 data files written, ~22MB per file)
Having `REBALANCE_PARTITIONS_BY_COL` in `Exchange hashpartitioning(lab_numr#44, busi_date#45, 200), REBALANCE_PARTITIONS_BY_COL, `

```
+----------------------------------------------------+
|                        plan                        |
+----------------------------------------------------+
| == Parsed Logical Plan ==
'InsertIntoStatement 'UnresolvedRelation [gfpersonas_platform, t_ptr_label_ice_bowen], [], false, false, false
+- 'Project [*]
   +- 'UnresolvedRelation [gfpersonas_platform, t_ptr_label_ice], [], false

== Analyzed Logical Plan ==
AppendData RelationV2[obj_id#46, lab_val#47, lab_numr#48, busi_date#49] spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, false
+- Project [obj_id#42, lab_val#43, lab_numr#44, busi_date#45]
   +- SubqueryAlias spark_catalog.gfpersonas_platform.t_ptr_label_ice
      +- RelationV2[obj_id#42, lab_val#43, lab_numr#44, busi_date#45] spark_catalog.gfpersonas_platform.t_ptr_label_ice

== Optimized Logical Plan ==
AppendData RelationV2[obj_id#46, lab_val#47, lab_numr#48, busi_date#49] spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, false, IcebergWrite(table=spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, format=PARQUET)
+- Sort [lab_numr#44 ASC NULLS FIRST, busi_date#45 ASC NULLS FIRST], false
   +- RebalancePartitions [lab_numr#44, busi_date#45]
      +- RelationV2[obj_id#42, lab_val#43, lab_numr#44, busi_date#45] spark_catalog.gfpersonas_platform.t_ptr_label_ice

== Physical Plan ==
AppendData org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$3367/659079940@629fd732, IcebergWrite(table=spark_catalog.gfpersonas_platform.t_ptr_label_ice_bowen, format=PARQUET)
+- AdaptiveSparkPlan isFinalPlan=false
   +- Sort [lab_numr#44 ASC NULLS FIRST, busi_date#45 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(lab_numr#44, busi_date#45, 200), REBALANCE_PARTITIONS_BY_COL, [plan_id=49]
         +- BatchScan[obj_id#42, lab_val#43, lab_numr#44, busi_date#45] spark_catalog.gfpersonas_platform.t_ptr_label_ice (branch=null) [filters=, groupedBy=] RuntimeFilters: []
 |
+----------------------------------------------------+
```