### PR TITLE
Core: add missing start and length for FileScanTaskParser. 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -81,6 +81,11 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
     }
 
     @Override
+    public Schema schema() {
+      return fileScanTask.schema();
+    }
+
+    @Override
     public PartitionSpec spec() {
       return fileScanTask.spec();
     }

--- a/core/src/main/java/org/apache/iceberg/FileScanTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/FileScanTaskParser.java
@@ -33,6 +33,8 @@ public class FileScanTaskParser {
   private static final String SCHEMA = "schema";
   private static final String SPEC = "spec";
   private static final String DATA_FILE = "data-file";
+  private static final String START = "start";
+  private static final String LENGTH = "length";
   private static final String DELETE_FILES = "delete-files";
   private static final String RESIDUAL = "residual-filter";
 
@@ -60,6 +62,9 @@ public class FileScanTaskParser {
       generator.writeFieldName(DATA_FILE);
       ContentFileParser.toJson(fileScanTask.file(), spec, generator);
     }
+
+    generator.writeNumberField(START, fileScanTask.start());
+    generator.writeNumberField(LENGTH, fileScanTask.length());
 
     if (fileScanTask.deletes() != null) {
       generator.writeArrayFieldStart(DELETE_FILES);
@@ -98,6 +103,9 @@ public class FileScanTaskParser {
       dataFile = (DataFile) ContentFileParser.fromJson(jsonNode.get(DATA_FILE), spec);
     }
 
+    long start = JsonUtil.getLong(START, jsonNode);
+    long length = JsonUtil.getLong(LENGTH, jsonNode);
+
     DeleteFile[] deleteFiles = null;
     if (jsonNode.has(DELETE_FILES)) {
       JsonNode deletesArray = jsonNode.get(DELETE_FILES);
@@ -121,6 +129,8 @@ public class FileScanTaskParser {
     }
 
     ResidualEvaluator residualEvaluator = ResidualEvaluator.of(spec, filter, caseSensitive);
-    return new BaseFileScanTask(dataFile, deleteFiles, schemaString, specString, residualEvaluator);
+    BaseFileScanTask baseFileScanTask =
+        new BaseFileScanTask(dataFile, deleteFiles, schemaString, specString, residualEvaluator);
+    return new BaseFileScanTask.SplitScanTask(start, length, baseFileScanTask);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
@@ -74,6 +74,7 @@ public class TestFileScanTaskParser {
         + "\"data-file\":{\"spec-id\":0,\"content\":\"DATA\",\"file-path\":\"/path/to/data-a.parquet\","
         + "\"file-format\":\"PARQUET\",\"partition\":{\"1000\":0},"
         + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
+        + "\"start\":0,\"length\":10,"
         + "\"delete-files\":[{\"spec-id\":0,\"content\":\"POSITION_DELETES\","
         + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"PARQUET\","
         + "\"partition\":{\"1000\":0},\"file-size-in-bytes\":10,\"record-count\":1},"


### PR DESCRIPTION
Also added `schema()` override for BaseFileScanTask$SplitScanTask inner class.