### PR TITLE
Remove `com.palantir.baseline-exact-dependencies` plugin

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -38,7 +38,6 @@ subprojects {
   }
   apply plugin: 'com.palantir.baseline-class-uniqueness'
   apply plugin: 'com.palantir.baseline-reproducibility'
-  apply plugin: 'com.palantir.baseline-exact-dependencies'
   apply plugin: 'com.palantir.baseline-release-compatibility'
   apply plugin: 'com.diffplug.spotless'
 


### PR DESCRIPTION
The plugin description says: _Ensures projects explicitly declare all the dependencies they rely on, no more and no less_. However, I doubt that the plugin really works, because it there are transitive dependencies being used - and the negative side ("no more") doesn't seem to work at all.

BTW: The plugin causes issues in Nessie's integration test suite. The error indicates that the plugin does some things "wrong" wrt configuation and dependency management.

It forces "too eager" configuration, which produce errors that look like this:
```
* What went wrong:
Could not determine the dependencies of task ':nessie:nessie-iceberg:nessie-gc-iceberg:compileJava'.
> Could not resolve all dependencies for configuration ':nessie:nessie-iceberg:nessie-gc-iceberg:compileClasspath'.
   > Cannot change dependencies of dependency configuration ':iceberg:iceberg-core:testImplementation' after it has been included in dependency resolution.
```