### PR TITLE
Revert "Bump Gradle to 8.2"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # checksum was taken from https://gradle.org/release-checksums
-distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -86,7 +86,7 @@ APP_BASE_NAME=${0##*/}
 APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.2.0/gradle/wrapper/gradle-wrapper.jar
+    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.1.1/gradle/wrapper/gradle-wrapper.jar
 fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
Reverts apache/iceberg#7955

With Gradle 8.2 and when running `./gradlew clean build -x test -x integrationTest`, this would fail with the below error:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':iceberg-data:revapiAnalyze' (type 'RevapiAnalyzeTask').
  - Gradle detected a problem with the following location: '/home/nastra/Development/workspace/iceberg/common/build/libs/iceberg-common-1.4.0-SNAPSHOT.jar'.
    
    Reason: Task ':iceberg-data:revapiAnalyze' uses this output of task ':iceberg-common:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':iceberg-common:jar' as an input of ':iceberg-data:revapiAnalyze'.
      2. Declare an explicit dependency on ':iceberg-common:jar' from ':iceberg-data:revapiAnalyze' using Task#dependsOn.
      3. Declare an explicit dependency on ':iceberg-common:jar' from ':iceberg-data:revapiAnalyze' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.2/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```