### PR TITLE
Build: Fix revapi task dependency issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,9 @@ subprojects {
         rootTask.finalizedBy showDeprecationRulesOnRevApiFailure
       }
     }
+    tasks.named("revapiAnalyze").configure {
+      dependsOn(":iceberg-common:jar")
+    }
   }
 
   configurations {


### PR DESCRIPTION
Gradle 8.2 detects this task dependency issue, which means that the build is non-deterministic:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':iceberg-data:revapiAnalyze' (type 'RevapiAnalyzeTask').
  - Gradle detected a problem with the following location: '/home/nastra/Development/workspace/iceberg/common/build/libs/iceberg-common-1.4.0-SNAPSHOT.jar'.

    Reason: Task ':iceberg-data:revapiAnalyze' uses this output of task ':iceberg-common:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':iceberg-common:jar' as an input of ':iceberg-data:revapiAnalyze'.
      2. Declare an explicit dependency on ':iceberg-common:jar' from ':iceberg-data:revapiAnalyze' using Task#dependsOn.
      3. Declare an explicit dependency on ':iceberg-common:jar' from ':iceberg-data:revapiAnalyze' using Task#mustRunAfter.

    For more information, please refer to https://docs.gradle.org/8.2/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```