### PR TITLE
Spark 3.3: Remove unnecessary metadata columns reading when merge using Iceberg table

### DIFF
--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.analysis.AlignRowLevelCommandAssignments
 import org.apache.spark.sql.catalyst.analysis.CheckMergeIntoTableConditions
 import org.apache.spark.sql.catalyst.analysis.MergeIntoIcebergTableResolutionCheck
 import org.apache.spark.sql.catalyst.analysis.ProcedureArgumentCoercion
+import org.apache.spark.sql.catalyst.analysis.RemoveUnusedMetadataColumns
 import org.apache.spark.sql.catalyst.analysis.ResolveMergeIntoTableReferences
 import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
 import org.apache.spark.sql.catalyst.analysis.RewriteDeleteFromIcebergTable
@@ -55,6 +56,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule { _ => RewriteDeleteFromIcebergTable }
     extensions.injectResolutionRule { _ => RewriteUpdateTable }
     extensions.injectResolutionRule { _ => RewriteMergeIntoTable }
+    extensions.injectResolutionRule { _ => RemoveUnusedMetadataColumns }
     extensions.injectCheckRule { _ => MergeIntoIcebergTableResolutionCheck }
     extensions.injectCheckRule { _ => AlignedRowLevelIcebergCommandCheck }
 

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RemoveUnusedMetadataColumns.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RemoveUnusedMetadataColumns.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+/**
+ * A rule to add a projection on top of the source table of MergeRows to remove unnecessary
+ * metadata columns reading.
+ */
+object RemoveUnusedMetadataColumns extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case mergeRows: MergeRows if mergeRows.resolved =>
+      mergeRows.child match {
+        case join @ Join(left, right, _, _, _) if isIcebergSourcePlan(left, conf.resolver) =>
+          val projected = projectWithoutMetadata(left)
+          mergeRows.withNewChildren(Seq(join.withNewChildren(Seq(projected, right))))
+
+        case join @ Join(left, right, _, _, _) if isIcebergSourcePlan(right, conf.resolver) =>
+          val projected = projectWithoutMetadata(right)
+          mergeRows.withNewChildren(Seq(join.withNewChildren(Seq(left, projected))))
+
+        case _ => mergeRows
+      }
+  }
+
+  private def projectWithoutMetadata(plan: LogicalPlan): LogicalPlan = {
+
+    import org.apache.spark.sql.catalyst.util.MetadataColumnHelper
+
+    val outputWithoutMetadata = plan.output.filterNot(col => col.isMetadataCol)
+    if (outputWithoutMetadata.nonEmpty && outputWithoutMetadata.size != plan.output.size) {
+      Project(outputWithoutMetadata, plan)
+    } else {
+      plan
+    }
+  }
+
+  private def isIcebergSourcePlan(plan: LogicalPlan, resolve: Resolver): Boolean = {
+    plan.output.exists(col => resolve(col.name, RewriteMergeIntoTable.ROW_FROM_SOURCE)) &&
+      onlyHasIcebergRelation(plan)
+  }
+
+  private def onlyHasIcebergRelation(plan: LogicalPlan): Boolean = {
+    val icebergRelations = plan.collect {
+      case node: LeafNode =>
+        node
+    }
+
+    icebergRelations.forall {
+      case r: DataSourceV2Relation if r.table.isInstanceOf[SparkTable] =>
+        true
+      case _ => false
+    }
+  }
+}

--- a/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.3/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -78,7 +78,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
  */
 object RewriteMergeIntoTable extends RewriteRowLevelIcebergCommand with PredicateHelper {
 
-  private final val ROW_FROM_SOURCE = "__row_from_source"
+  private[spark] final val ROW_FROM_SOURCE = "__row_from_source"
   private final val ROW_FROM_TARGET = "__row_from_target"
   private final val ROW_ID = "__row_id"
 


### PR DESCRIPTION
There are many unnecessary metadata columns reading when merging using the Iceberg table. The problem should be caused by Spark 3.3 [AddMetadataColumns](https://github.com/apache/spark/blob/e9b525e205402ac458db682802771544ced86758/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala#L915) rule which has been fixed in Spark 3.4. 
In this PR, we add a rule to remove the unnecessary metadata column reading to fix the problem in Spark 3.3.

Before this PR:
<img width="969" alt="image" src="https://github.com/apache/iceberg/assets/12733256/63055ba0-7ad0-4aa0-8d3f-b395e611f70b">

After this PR:
<img width="913" alt="image" src="https://github.com/apache/iceberg/assets/12733256/2f03b1ec-4dcb-4e6c-a9d2-6dc2e95ca441">
