### PR TITLE
Remove the direct dependency on Apache Commons. Issue - #7658

### DIFF
--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockLocalStore.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockLocalStore.java
@@ -33,10 +33,11 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
+import java.util.stream.Stream;
 import org.apache.directory.api.util.Hex;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -101,7 +102,7 @@ public class AliyunOSSMockLocalStore {
 
   void createBucket(String bucketName) throws IOException {
     File newBucket = new File(root, bucketName);
-    FileUtils.forceMkdir(newBucket);
+    Files.createDirectory(newBucket.toPath());
   }
 
   Bucket getBucket(String bucketName) {
@@ -122,7 +123,9 @@ public class AliyunOSSMockLocalStore {
           409, OSSErrorCode.BUCKET_NOT_EMPTY, "The bucket you tried to delete is not empty. ");
     }
 
-    FileUtils.deleteDirectory(dir);
+    try (Stream<Path> walk = Files.walk(dir.toPath())) {
+      walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+    }
   }
 
   ObjectMetadata putObject(

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockRule.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockRule.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.aliyun.oss.AliyunOSSTestRule;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -114,7 +113,8 @@ public class AliyunOSSMockRule implements AliyunOSSTestRule {
       if (Strings.isNullOrEmpty(rootDir)) {
         File dir =
             new File(
-                FileUtils.getTempDirectory(), "oss-mock-file-store-" + System.currentTimeMillis());
+                System.getProperty("java.io.tmpdir"),
+                "oss-mock-file-store-" + System.currentTimeMillis());
         rootDir = dir.getAbsolutePath();
         props.put(AliyunOSSMockApp.PROP_ROOT_DIR, rootDir);
       }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -28,8 +28,11 @@ import com.esotericsoftware.kryo.serializers.ClosureSerializer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
 import java.lang.invoke.SerializedLambda;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -41,6 +44,7 @@ import org.apache.iceberg.expressions.BoundSetPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 import org.assertj.core.api.Assertions;
 import org.objenesis.strategy.StdInstantiatorStrategy;
@@ -166,6 +170,99 @@ public class TestHelpers {
                       "Should be the same schema. Schema 1: %s, schema 2: %s", schema1, schema2))
               .isTrue();
         });
+  }
+
+  /**
+   * Deserializes a single {@link Object} from an array of bytes.
+   *
+   * <p>If the call site incorrectly types the return value, a {@link ClassCastException} is thrown
+   * from the call site. Without Generics in this declaration, the call site must type cast and can
+   * cause the same ClassCastException. Note that in both cases, the ClassCastException is in the
+   * call site, not in this method.
+   *
+   * <p>This code is borrowed from `org.apache.commons:commons-lang3`
+   *
+   * @param <T> the object type to be deserialized
+   * @param objectData the serialized object, must not be null
+   * @return the deserialized object
+   * @throws NullPointerException if {@code objectData} is {@code null}
+   * @throws IOException (runtime) if the serialization fails
+   */
+  public static <T> T deserialize(final byte[] objectData)
+      throws IOException, ClassNotFoundException {
+    Preconditions.checkNotNull(objectData, "objectData");
+    return deserialize(new ByteArrayInputStream(objectData));
+  }
+
+  /**
+   * Deserializes an {@link Object} from the specified stream.
+   *
+   * <p>The stream will be closed once the object is written. This avoids the need for a finally
+   * clause, and maybe also exception handling, in the application code.
+   *
+   * <p>The stream passed in is not buffered internally within this method. This is the
+   * responsibility of your application if desired.
+   *
+   * <p>If the call site incorrectly types the return value, a {@link ClassCastException} is thrown
+   * from the call site. Without Generics in this declaration, the call site must type cast and can
+   * cause the same ClassCastException. Note that in both cases, the ClassCastException is in the
+   * call site, not in this method.
+   *
+   * <p>This code is borrowed from `org.apache.commons:commons-lang3`
+   *
+   * @param <T> the object type to be deserialized
+   * @param inputStream the serialized object input stream, must not be null
+   * @return the deserialized object
+   * @throws NullPointerException if {@code inputStream} is {@code null}
+   * @throws IOException (runtime) if the serialization fails
+   * @throws ClassNotFoundException if Class is not found
+   */
+  public static <T> T deserialize(final InputStream inputStream)
+      throws IOException, ClassNotFoundException {
+    Preconditions.checkNotNull(inputStream, "inputStream");
+    try (ObjectInputStream in = new ObjectInputStream(inputStream)) {
+      @SuppressWarnings("unchecked")
+      final T obj = (T) in.readObject();
+      return obj;
+    }
+  }
+  /**
+   * Serializes an {@link Object} to a byte array for storage/serialization.
+   *
+   * <p>This code is borrowed from `org.apache.commons:commons-lang3`
+   *
+   * @param obj the object to serialize to bytes
+   * @return a byte[] with the converted Serializable
+   * @throws IOException (runtime) if the serialization fails
+   */
+  public static byte[] serialize(final Serializable obj) throws IOException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+    serialize(obj, baos);
+    return baos.toByteArray();
+  }
+
+  /**
+   * Serializes an {@link Object} to the specified stream.
+   *
+   * <p>The stream will be closed once the object is written. This avoids the need for a finally
+   * clause, and maybe also exception handling, in the application code.
+   *
+   * <p>The stream passed in is not buffered internally within this method. This is the
+   * responsibility of your application if desired.
+   *
+   * <p>This code is borrowed from `org.apache.commons:commons-lang3`
+   *
+   * @param obj the object to serialize to bytes, may be null
+   * @param outputStream the stream to write to, must not be null
+   * @throws NullPointerException if {@code outputStream} is {@code null}
+   * @throws IOException (runtime) if the serialization fails
+   */
+  public static void serialize(final Serializable obj, final OutputStream outputStream)
+      throws IOException {
+    Preconditions.checkNotNull(outputStream, "outputStream");
+    try (ObjectOutputStream out = new ObjectOutputStream(outputStream)) {
+      out.writeObject(obj);
+    }
   }
 
   public static class KryoHelpers {

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIOIntegration.java
@@ -33,7 +33,7 @@ import java.util.Random;
 import java.util.UUID;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import org.apache.commons.lang3.SerializationUtils;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
@@ -354,8 +354,8 @@ public class TestS3FileIOIntegration {
   public void testClientFactorySerialization() throws Exception {
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     write(fileIO);
-    byte[] data = SerializationUtils.serialize(fileIO);
-    S3FileIO fileIO2 = SerializationUtils.deserialize(data);
+    byte[] data = TestHelpers.serialize(fileIO);
+    S3FileIO fileIO2 = TestHelpers.deserialize(data);
     validateRead(fileIO2);
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3InputStream.java
@@ -22,7 +22,7 @@ import com.adobe.testing.s3mock.junit5.S3MockExtension;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
-import org.apache.commons.io.IOUtils;
+import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.RangeReadable;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.assertj.core.api.Assertions;
@@ -94,7 +94,7 @@ public class TestS3InputStream {
     byte[] actual = new byte[size];
 
     if (buffered) {
-      IOUtils.readFully(in, actual);
+      IOUtil.readFully(in, actual, 0, size);
     } else {
       int read = 0;
       while (read < size) {
@@ -168,7 +168,8 @@ public class TestS3InputStream {
 
     try (SeekableInputStream in = new S3InputStream(s3, uri)) {
       in.seek(expected.length / 2);
-      byte[] actual = IOUtils.readFully(in, expected.length / 2);
+      byte[] actual = new byte[expected.length / 2];
+      IOUtil.readFully(in, actual, 0, expected.length / 2);
       Assertions.assertThat(actual)
           .isEqualTo(Arrays.copyOfRange(expected, expected.length / 2, expected.length));
     }

--- a/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/ObjectData.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/mock/ecs/ObjectData.java
@@ -20,9 +20,10 @@ package org.apache.iceberg.dell.mock.ecs;
 
 import com.emc.object.Range;
 import com.emc.object.s3.S3ObjectMetadata;
-import com.emc.object.shadow.org.apache.commons.codec.digest.DigestUtils;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -31,6 +32,12 @@ import java.util.Map;
 public class ObjectData {
   public final byte[] content;
   public final Map<String, String> userMetadata;
+  private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+
+  private ObjectData(byte[] content, Map<String, String> userMetadata) {
+    this.content = content;
+    this.userMetadata = userMetadata;
+  }
 
   public static ObjectData create(byte[] content, S3ObjectMetadata metadata) {
     Map<String, String> userMetadata = new LinkedHashMap<>();
@@ -39,11 +46,6 @@ public class ObjectData {
     }
 
     return new ObjectData(content, userMetadata);
-  }
-
-  private ObjectData(byte[] content, Map<String, String> userMetadata) {
-    this.content = content;
-    this.userMetadata = userMetadata;
   }
 
   public int length() {
@@ -70,9 +72,27 @@ public class ObjectData {
 
   public S3ObjectMetadata createFullMetadata() {
     S3ObjectMetadata metadata = new S3ObjectMetadata();
-    metadata.setETag(DigestUtils.md5Hex(content));
+    MessageDigest md = null;
+    try {
+      md = MessageDigest.getInstance("MD5");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+    md.update(content);
+    byte[] digest = md.digest();
+    metadata.setETag(bytesToHex(digest));
     metadata.setContentLength((long) content.length);
     metadata.setUserMetadata(userMetadata);
     return metadata;
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    char[] hexChars = new char[bytes.length * 2];
+    for (int j = 0; j < bytes.length; j++) {
+      int accum = bytes[j] & 0xFF;
+      hexChars[j * 2] = HEX_ARRAY[accum >>> 4];
+      hexChars[j * 2 + 1] = HEX_ARRAY[accum & 0x0F];
+    }
+    return new String(hexChars);
   }
 }

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -25,14 +25,15 @@ import io.delta.standalone.actions.AddFile;
 import io.delta.standalone.actions.RemoveFile;
 import io.delta.standalone.exceptions.DeltaStandaloneException;
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.apache.commons.codec.DecoderException;
-import org.apache.commons.codec.net.URLCodec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -451,13 +452,13 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
   private static String getFullFilePath(String path, String tableRoot) {
     URI dataFileUri = URI.create(path);
     try {
-      String decodedPath = new URLCodec().decode(path);
+      String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8.name());
       if (dataFileUri.isAbsolute()) {
         return decodedPath;
       } else {
         return tableRoot + File.separator + decodedPath;
       }
-    } catch (DecoderException e) {
+    } catch (UnsupportedEncodingException e) {
       throw new IllegalArgumentException(String.format("Cannot decode path %s", path), e);
     }
   }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSFileIOTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSFileIOTest.java
@@ -27,12 +27,13 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.stream.StreamSupport;
-import org.apache.commons.io.IOUtils;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -62,14 +63,14 @@ public class GCSFileIOTest {
 
     OutputFile out = io.newOutputFile(location);
     try (OutputStream os = out.createOrOverwrite()) {
-      IOUtils.write(expected, os);
+      IOUtil.writeFully(os, ByteBuffer.wrap(expected));
     }
 
     assertThat(in.exists()).isTrue();
     byte[] actual = new byte[1024 * 1024];
 
     try (InputStream is = in.newStream()) {
-      IOUtils.readFully(is, actual);
+      IOUtil.readFully(is, actual, 0, actual.length);
     }
 
     assertThat(expected).isEqualTo(actual);

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
@@ -29,8 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
-import org.apache.commons.io.IOUtils;
 import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
@@ -104,7 +104,7 @@ public class GCSInputStreamTest {
     byte[] actual = new byte[size];
 
     if (buffered) {
-      IOUtils.readFully(in, actual);
+      IOUtil.readFully(in, actual, 0, actual.length);
     } else {
       int read = 0;
       while (read < size) {
@@ -137,7 +137,7 @@ public class GCSInputStreamTest {
       in.seek(data.length / 2);
       byte[] actual = new byte[data.length / 2];
 
-      IOUtils.readFully(in, actual, 0, data.length / 2);
+      IOUtil.readFully(in, actual, 0, data.length / 2);
 
       byte[] expected = Arrays.copyOfRange(data, data.length / 2, data.length);
       assertThat(actual).isEqualTo(expected);

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/CompatibilityHiveVectorUtils.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/CompatibilityHiveVectorUtils.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.mr.hive.vector;
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
@@ -67,7 +66,7 @@ public class CompatibilityHiveVectorUtils {
       LOG.debug("Initializing for input {}", inputName);
     }
     String prefixes = job.get(DagUtils.TEZ_MERGE_WORK_FILE_PREFIXES);
-    if (prefixes != null && !StringUtils.isBlank(prefixes)) {
+    if (prefixes != null && !prefixes.trim().isEmpty()) {
       // Currently SMB is broken, so we cannot check if it's  compatible with IO elevator.
       // So, we don't use the below code that would get the correct MapWork. See HIVE-16985.
       return null;

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.mr.hive.vector;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.IOConstants;
@@ -101,7 +100,7 @@ public class HiveVectorizedReader {
         }
       }
 
-      partitionColIndices = ArrayUtils.toPrimitive(partitionColIndicesList.toArray(new Integer[0]));
+      partitionColIndices = partitionColIndicesList.stream().mapToInt(Integer::intValue).toArray();
       partitionValues = partitionValuesList.toArray(new Object[0]);
 
       ColumnProjectionUtils.setReadColumns(job, readColumnIds);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -25,16 +25,18 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
-import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HasTableOperations;
@@ -107,7 +109,9 @@ public class TestNessieTable extends BaseTestIceberg {
   public void afterEach() throws Exception {
     // drop the table data
     if (tableLocation != null) {
-      FileUtils.deleteDirectory(new File(tableLocation));
+      try (Stream<Path> walk = Files.walk(Paths.get(tableLocation))) {
+        walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+      }
       catalog.dropTable(TABLE_IDENTIFIER, false);
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvro.java
@@ -31,7 +31,6 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.specific.SpecificData;
-import org.apache.commons.math3.util.Pair;
 import org.apache.iceberg.avro.AvroSchemaVisitor;
 import org.apache.iceberg.avro.UUIDConversion;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
@@ -366,6 +365,28 @@ class ParquetAvro {
       }
 
       return copy;
+    }
+  }
+
+  private static class Pair<K, V> {
+    private final K first;
+    private final V second;
+
+    Pair(final K first, final V second) {
+      this.first = first;
+      this.second = second;
+    }
+
+    public static <K, V> Pair<K, V> of(K first, V second) {
+      return new Pair<>(first, second);
+    }
+
+    public K getFirst() {
+      return first;
+    }
+
+    public V getSecond() {
+      return second;
     }
   }
 }


### PR DESCRIPTION
The followed approach is to use native Java 8 code when the alternative was clear or replicate/borrow when not following iceberg-core approach..

Flink and Spark projects declare Apache Commons as direct dependency and therefore on those subprojects the dependency is not removed.

Closes #7658