### PR TITLE
Build: Run RevAPI on all configured projects

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -52,7 +52,7 @@ jobs:
           java-version: 11
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
-      - run: ./gradlew :iceberg-api:revapi --rerun-tasks
+      - run: ./gradlew revapi --rerun-tasks
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
This also probably explains why the PR checks on #7955 all passed, but RevAPI started to complain once #7955 got merged to `master`

![image](https://github.com/apache/iceberg/assets/271029/b9eade4e-9b78-4ce7-acb6-af0e5f87ef73)
