### PR TITLE
Revert "Bump Gradle to 8.2 (#7955)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,9 +164,6 @@ subprojects {
         rootTask.finalizedBy showDeprecationRulesOnRevApiFailure
       }
     }
-    tasks.named("revapiAnalyze").configure {
-      dependsOn(":iceberg-common:jar")
-    }
   }
 
   configurations {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 # checksum was taken from https://gradle.org/release-checksums
-distributionSha256Sum=38f66cd6eef217b4c35855bb11ea4e9fbc53594ccccb5fb82dfd317ef8c2c5a3
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionSha256Sum=e111cb9948407e26351227dabce49822fb88c37ee72f1d1582a69c68af2e702f
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -86,7 +86,7 @@ APP_BASE_NAME=${0##*/}
 APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.2.0/gradle/wrapper/gradle-wrapper.jar
+    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v8.1.1/gradle/wrapper/gradle-wrapper.jar
 fi
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
This reverts commit d2e570a57658a9e2dc20193120338183590a1651 and e62e0add11f5deab9cbd81c7fa122c8047e2f497.

https://github.com/apache/iceberg/pull/7992 introduced API-breaking changes, where I would have expected RevAPI to fail. However, all RevAPI checks passed. I think the best is probably to revert the Gradle version bump for now, so that we don't silently introduce API-breaking changes to the codebase.