### PR TITLE
Core: Avoid concurrent commits causing commit failures

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -75,7 +75,12 @@ public class RewriteDataFilesCommitManager {
       rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }
 
-    rewrite.commit();
+    synchronized (this) {
+      // synchronized to avoid committing conflict by multiple threads when enabled
+      // partial-progress. And it should be cheaper when not enabled partial-progress
+      // because it commits in a single thread
+      rewrite.commit();
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesCommitManager.java
@@ -64,7 +64,12 @@ public class RewritePositionDeletesCommitManager {
       }
     }
 
-    rewriteFiles.commit();
+    synchronized (this) {
+      // synchronized to avoid committing conflict by multiple threads when enabled
+      // partial-progress. And it should be cheaper when not enabled partial-progress
+      // because it commits in a single thread
+      rewriteFiles.commit();
+    }
   }
 
   /**

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.actions;
 
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -495,8 +494,6 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   public void testPartialProgressEnabled() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
-
-    table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
     List<Object[]> originalData = currentData();
     long dataSizeBefore = testDataSize(table);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.actions;
 
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.spark.sql.functions.current_date;
@@ -531,8 +530,6 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   public void testPartialProgressEnabled() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
-
-    table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
     List<Object[]> originalData = currentData();
     long dataSizeBefore = testDataSize(table);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.actions;
 
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.spark.sql.functions.current_date;
@@ -532,8 +531,6 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   public void testPartialProgressEnabled() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
-
-    table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
     List<Object[]> originalData = currentData();
     long dataSizeBefore = testDataSize(table);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.actions;
 
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.spark.sql.functions.current_date;
@@ -541,8 +540,6 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
   public void testPartialProgressEnabled() {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
-
-    table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
     List<Object[]> originalData = currentData();
     long dataSizeBefore = testDataSize(table);


### PR DESCRIPTION
In #6539, we change the committing from a single thread to multiple threads (the rewrite thread pool) when enabled partial progress. However, the concurrent commit increases the probability of the commit failing when rewriting data/delete files. And those rewritten files will be deleted. In this PR, we use a lock to avoid concurrent committing to address the mentioned problem.