### PR TITLE
Upgrade scala-collection-compat

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -24,8 +24,8 @@ org.glassfish.jaxb:jaxb-runtime = 2.3.3
 software.amazon.awssdk:* = 2.17.257
 org.projectnessie:* = 0.44.0
 com.google.cloud:libraries-bom = 24.1.0
-org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
-org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
+org.scala-lang.modules:scala-collection-compat_2.12 = 2.11.0
+org.scala-lang.modules:scala-collection-compat_2.13 = 2.11.0
 com.emc.ecs:object-client-bundle = 3.3.2
 org.immutables:value = 2.9.2
 


### PR DESCRIPTION
We are bumping into an issue downstream where StringOps is not present and with Spark we can only shade our version.