### PR TITLE
Python: let load_namespace_properties consistent where database is created outside of pyiceberg

### DIFF
--- a/python/pyiceberg/catalog/glue.py
+++ b/python/pyiceberg/catalog/glue.py
@@ -444,10 +444,8 @@ class GlueCatalog(Catalog):
             raise NoSuchNamespaceError(f"Invalid input for namespace {database_name}") from e
 
         database = database_response[PROP_GLUE_DATABASE]
-        if PROP_GLUE_DATABASE_PARAMETERS not in database:
-            return {}
 
-        properties = dict(database[PROP_GLUE_DATABASE_PARAMETERS])
+        properties = dict(database.get(PROP_GLUE_DATABASE_PARAMETERS, {}))
         if database_location := database.get(PROP_GLUE_DATABASE_LOCATION):
             properties[LOCATION] = database_location
         if database_description := database.get(PROP_GLUE_DATABASE_DESCRIPTION):


### PR DESCRIPTION
pyiceberg creates 'Parameter' properties on glue catalog database entity and reads namespace properties from 'Parameters' except Location and Comment.

Previous logic ignores Location and Comment if there is no 'Parameters' property in glue database entity. But if glue database is created outside of pyiceberg (for example, create database from AWS web UI of aws cli), 'Parameters' property is not set.

So let load_namespace_properties fallback to empty dict when 'Parameters' property does not exist to load namespace properties consistently.