### PR TITLE
Spark: Consolidate duplicated test methods to TestHelpers

### DIFF
--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -40,10 +40,13 @@ import java.util.stream.Stream;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.vectorized.IcebergArrowColumnVector;
@@ -795,5 +798,10 @@ public class TestHelpers {
 
   public static Types.StructType nonDerivedSchema(Dataset<Row> metadataTable) {
     return SparkSchemaUtil.convert(TestHelpers.selectNonDerived(metadataTable).schema()).asStruct();
+  }
+
+  public static List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -801,7 +801,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -801,7 +801,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -38,7 +38,6 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
-import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -1486,7 +1485,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             AvroSchemaUtil.convert(
                 partitionsTable.schema().findType("partition").asStructType(), "partition"));
 
-    List<DataFile> dataFiles = dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     assertDataFilePartitions(dataFiles, Arrays.asList(1, 2, 2));
 
     List<GenericData.Record> expected = Lists.newArrayList();
@@ -2056,11 +2055,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   private long totalSizeInBytes(Iterable<DataFile> dataFiles) {
     return Lists.newArrayList(dataFiles).stream().mapToLong(DataFile::fileSizeInBytes).sum();
-  }
-
-  private List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   private void assertDataFilePartitions(

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -145,11 +144,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table);
+    List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", tableName);
 
-    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table);
+    List<DataFile> dataFilesAfter = TestHelpers.dataFiles(table);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -145,11 +145,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.dataFiles(table);
+    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", tableName);
 
-    Set<DataFile> dataFilesAfter = TestHelpers.dataFiles(table);
+    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -94,6 +94,7 @@ import org.apache.iceberg.spark.FileScanTaskSetManager;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction.RewriteExecutionContext;
+import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
@@ -253,9 +254,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 8);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();
@@ -299,9 +298,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 1);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -793,7 +793,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -789,6 +790,11 @@ public class TestHelpers {
     }
 
     return dataFiles;
+  }
+
+  public static List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   public static Set<DeleteFile> deleteFiles(Table table) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -793,7 +793,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -781,7 +781,7 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> dataFiles(Table table) {
+  public static Set<DataFile> uniqueDataFiles(Table table) {
     Set<DataFile> dataFiles = Sets.newHashSet();
 
     for (FileScanTask task : table.newScan().planFiles()) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -782,18 +783,17 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> uniqueDataFiles(Table table) {
-    Set<DataFile> dataFiles = Sets.newHashSet();
-
-    for (FileScanTask task : table.newScan().planFiles()) {
-      dataFiles.add(task.file());
-    }
-
-    return dataFiles;
+  public static List<DataFile> dataFiles(Table table) {
+    return dataFiles(table, null);
   }
 
-  public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+  public static List<DataFile> dataFiles(Table table, String branch) {
+    TableScan scan = table.newScan();
+    if (branch != null) {
+      scan.useRef(branch);
+    }
+
+    CloseableIterable<FileScanTask> tasks = scan.includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -37,7 +37,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
@@ -1491,7 +1490,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             AvroSchemaUtil.convert(
                 partitionsTable.schema().findType("partition").asStructType(), "partition"));
 
-    List<DataFile> dataFiles = dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     assertDataFilePartitions(dataFiles, Arrays.asList(1, 2, 2));
 
     List<GenericData.Record> expected = Lists.newArrayList();
@@ -2193,11 +2192,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   private long totalSizeInBytes(Iterable<DataFile> dataFiles) {
     return Lists.newArrayList(dataFiles).stream().mapToLong(DataFile::fileSizeInBytes).sum();
-  }
-
-  private List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   private void assertDataFilePartitions(

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -152,11 +151,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table, branch);
+    List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, branch);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", commitTarget());
 
-    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table, branch);
+    List<DataFile> dataFilesAfter = TestHelpers.dataFiles(table, branch);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -152,11 +152,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, branch);
+    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table, branch);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", commitTarget());
 
-    Set<DataFile> dataFilesAfter = TestHelpers.dataFiles(table, branch);
+    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table, branch);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -94,6 +94,7 @@ import org.apache.iceberg.spark.ScanTaskSetManager;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction.RewriteExecutionContext;
+import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
@@ -254,9 +255,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 8);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();
@@ -300,9 +299,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 1);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -136,7 +136,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -170,7 +170,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteAll() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -206,7 +206,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteToSmallerTarget() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -243,7 +243,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRemoveDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(
         table,
         2,
@@ -288,7 +288,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testSomePartitionsDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -340,7 +340,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
     Assert.assertEquals(2, unpartitionedDataFiles.size());
 
@@ -355,7 +355,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles =
-        except(TestHelpers.dataFiles(table, true), unpartitionedDataFiles);
+        except(TestHelpers.dataFiles(table), unpartitionedDataFiles);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
     Assert.assertEquals(2, partitionedDataFiles.size());
 
@@ -392,7 +392,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
     Assert.assertEquals(2, dataFilesUnpartitioned.size());
 
@@ -403,7 +403,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     writeRecords(table, 2, SCALE);
     List<DataFile> dataFilesPartitioned =
-        except(TestHelpers.dataFiles(table, true), dataFilesUnpartitioned);
+        except(TestHelpers.dataFiles(table), dataFilesUnpartitioned);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
     Assert.assertEquals(2, dataFilesPartitioned.size());
 
@@ -440,7 +440,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -452,7 +452,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     int newColId = table.schema().findField("c4").fieldId();
     List<DataFile> newSchemaDataFiles =
-        TestHelpers.dataFiles(table, true).stream()
+        TestHelpers.dataFiles(table).stream()
             .filter(f -> f.upperBounds().containsKey(newColId))
             .collect(Collectors.toList());
     writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -136,7 +136,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -170,7 +170,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteAll() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -206,7 +206,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteToSmallerTarget() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -243,7 +243,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRemoveDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(
         table,
         2,
@@ -288,7 +288,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testSomePartitionsDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -340,7 +340,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
     Assert.assertEquals(2, unpartitionedDataFiles.size());
 
@@ -355,7 +355,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles =
-        except(TestHelpers.dataFiles(table), unpartitionedDataFiles);
+        except(TestHelpers.dataFiles(table, true), unpartitionedDataFiles);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
     Assert.assertEquals(2, partitionedDataFiles.size());
 
@@ -392,7 +392,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table);
+    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
     Assert.assertEquals(2, dataFilesUnpartitioned.size());
 
@@ -403,7 +403,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     writeRecords(table, 2, SCALE);
     List<DataFile> dataFilesPartitioned =
-        except(TestHelpers.dataFiles(table), dataFilesUnpartitioned);
+        except(TestHelpers.dataFiles(table, true), dataFilesUnpartitioned);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
     Assert.assertEquals(2, dataFilesPartitioned.size());
 
@@ -440,7 +440,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -452,7 +452,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     int newColId = table.schema().findField("c4").fieldId();
     List<DataFile> newSchemaDataFiles =
-        TestHelpers.dataFiles(table).stream()
+        TestHelpers.dataFiles(table, true).stream()
             .filter(f -> f.upperBounds().containsKey(newColId))
             .collect(Collectors.toList());
     writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -798,6 +799,11 @@ public class TestHelpers {
     }
 
     return dataFiles;
+  }
+
+  public static List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   public static Set<DeleteFile> deleteFiles(Table table) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -782,11 +782,11 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> dataFiles(Table table) {
-    return dataFiles(table, null);
+  public static Set<DataFile> uniqueDataFiles(Table table) {
+    return uniqueDataFiles(table, null);
   }
 
-  public static Set<DataFile> dataFiles(Table table, String branch) {
+  public static Set<DataFile> uniqueDataFiles(Table table, String branch) {
     Set<DataFile> dataFiles = Sets.newHashSet();
     TableScan scan = table.newScan();
     if (branch != null) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -783,26 +783,17 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> uniqueDataFiles(Table table) {
-    return uniqueDataFiles(table, null);
+  public static List<DataFile> dataFiles(Table table) {
+    return dataFiles(table, null);
   }
 
-  public static Set<DataFile> uniqueDataFiles(Table table, String branch) {
-    Set<DataFile> dataFiles = Sets.newHashSet();
+  public static List<DataFile> dataFiles(Table table, String branch) {
     TableScan scan = table.newScan();
     if (branch != null) {
       scan.useRef(branch);
     }
 
-    for (FileScanTask task : scan.planFiles()) {
-      dataFiles.add(task.file());
-    }
-
-    return dataFiles;
-  }
-
-  public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    CloseableIterable<FileScanTask> tasks = scan.includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -802,7 +802,13 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return dataFiles(table, false);
+  }
+
+  public static List<DataFile> dataFiles(Table table, boolean includeColumnStats) {
+    TableScan tableScan =
+        includeColumnStats ? table.newScan().includeColumnStats() : table.newScan();
+    CloseableIterable<FileScanTask> tasks = tableScan.planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -802,13 +802,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    return dataFiles(table, false);
-  }
-
-  public static List<DataFile> dataFiles(Table table, boolean includeColumnStats) {
-    TableScan tableScan =
-        includeColumnStats ? table.newScan().includeColumnStats() : table.newScan();
-    CloseableIterable<FileScanTask> tasks = tableScan.planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -40,7 +40,6 @@ import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
@@ -1489,7 +1488,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             .orderBy("partition.id")
             .collectAsList();
 
-    List<DataFile> dataFiles = dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     assertDataFilePartitions(dataFiles, Arrays.asList(1, 2, 2));
 
     GenericRecordBuilder builder =
@@ -2260,11 +2259,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   private long totalSizeInBytes(Iterable<DataFile> dataFiles) {
     return Lists.newArrayList(dataFiles).stream().mapToLong(DataFile::fileSizeInBytes).sum();
-  }
-
-  private List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   private void assertDataFilePartitions(

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -289,11 +288,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table, branch);
+    List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, branch);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", commitTarget());
 
-    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table, branch);
+    List<DataFile> dataFilesAfter = TestHelpers.dataFiles(table, branch);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -289,11 +289,11 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // Metadata Delete
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
-    Set<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, branch);
+    Set<DataFile> dataFilesBefore = TestHelpers.uniqueDataFiles(table, branch);
 
     sql("DELETE FROM %s AS t WHERE t.id = 1", commitTarget());
 
-    Set<DataFile> dataFilesAfter = TestHelpers.dataFiles(table, branch);
+    Set<DataFile> dataFilesAfter = TestHelpers.uniqueDataFiles(table, branch);
     Assert.assertTrue(
         "Data file should have been removed", dataFilesBefore.size() > dataFilesAfter.size());
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -94,6 +94,7 @@ import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction.RewriteExecutionContext;
+import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
@@ -263,9 +264,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 8);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();
@@ -309,9 +308,7 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
     shouldHaveFiles(table, 1);
     table.refresh();
 
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    List<DataFile> dataFiles =
-        Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     int total = (int) dataFiles.stream().mapToLong(ContentFile::recordCount).sum();
 
     RowDelta rowDelta = table.newRowDelta();

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -136,7 +136,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -170,7 +170,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteAll() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -206,7 +206,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteToSmallerTarget() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -243,7 +243,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRemoveDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(
         table,
         2,
@@ -288,7 +288,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testSomePartitionsDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -340,7 +340,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
     Assert.assertEquals(2, unpartitionedDataFiles.size());
 
@@ -355,7 +355,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles =
-        except(TestHelpers.dataFiles(table, true), unpartitionedDataFiles);
+        except(TestHelpers.dataFiles(table), unpartitionedDataFiles);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
     Assert.assertEquals(2, partitionedDataFiles.size());
 
@@ -392,7 +392,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
     Assert.assertEquals(2, dataFilesUnpartitioned.size());
 
@@ -403,7 +403,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     writeRecords(table, 2, SCALE);
     List<DataFile> dataFilesPartitioned =
-        except(TestHelpers.dataFiles(table, true), dataFilesUnpartitioned);
+        except(TestHelpers.dataFiles(table), dataFilesUnpartitioned);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
     Assert.assertEquals(2, dataFilesPartitioned.size());
 
@@ -440,7 +440,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -452,7 +452,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     int newColId = table.schema().findField("c4").fieldId();
     List<DataFile> newSchemaDataFiles =
-        TestHelpers.dataFiles(table, true).stream()
+        TestHelpers.dataFiles(table).stream()
             .filter(f -> f.upperBounds().containsKey(newColId))
             .collect(Collectors.toList());
     writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -136,7 +136,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testUnpartitioned() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -170,7 +170,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteAll() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -206,7 +206,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRewriteToSmallerTarget() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -243,7 +243,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testRemoveDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(
         table,
         2,
@@ -288,7 +288,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   public void testSomePartitionsDanglingDeletes() throws Exception {
     Table table = createTablePartitioned(4, 2, SCALE);
 
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(4, dataFiles.size());
 
@@ -340,7 +340,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionAdd() throws Exception {
     Table table = createTableUnpartitioned(2, SCALE);
-    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> unpartitionedDataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, unpartitionedDataFiles);
     Assert.assertEquals(2, unpartitionedDataFiles.size());
 
@@ -355,7 +355,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
     table.updateSpec().addField("c1").commit();
     writeRecords(table, 2, SCALE, 2);
     List<DataFile> partitionedDataFiles =
-        except(TestHelpers.dataFiles(table), unpartitionedDataFiles);
+        except(TestHelpers.dataFiles(table, true), unpartitionedDataFiles);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, partitionedDataFiles);
     Assert.assertEquals(2, partitionedDataFiles.size());
 
@@ -392,7 +392,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testPartitionEvolutionRemove() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table);
+    List<DataFile> dataFilesUnpartitioned = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesUnpartitioned);
     Assert.assertEquals(2, dataFilesUnpartitioned.size());
 
@@ -403,7 +403,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     writeRecords(table, 2, SCALE);
     List<DataFile> dataFilesPartitioned =
-        except(TestHelpers.dataFiles(table), dataFilesUnpartitioned);
+        except(TestHelpers.dataFiles(table, true), dataFilesUnpartitioned);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFilesPartitioned);
     Assert.assertEquals(2, dataFilesPartitioned.size());
 
@@ -440,7 +440,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
   @Test
   public void testSchemaEvolution() throws Exception {
     Table table = createTablePartitioned(2, 2, SCALE);
-    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table, true);
     writePosDeletesForFiles(table, 2, DELETES_SCALE, dataFiles);
     Assert.assertEquals(2, dataFiles.size());
 
@@ -452,7 +452,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
 
     int newColId = table.schema().findField("c4").fieldId();
     List<DataFile> newSchemaDataFiles =
-        TestHelpers.dataFiles(table).stream()
+        TestHelpers.dataFiles(table, true).stream()
             .filter(f -> f.upperBounds().containsKey(newColId))
             .collect(Collectors.toList());
     writePosDeletesForFiles(table, 2, DELETES_SCALE, newSchemaDataFiles);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -818,7 +818,13 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return dataFiles(table, false);
+  }
+
+  public static List<DataFile> dataFiles(Table table, boolean includeColumnStats) {
+    TableScan tableScan =
+        includeColumnStats ? table.newScan().includeColumnStats() : table.newScan();
+    CloseableIterable<FileScanTask> tasks = tableScan.planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -798,11 +798,11 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> dataFiles(Table table) {
-    return dataFiles(table, null);
+  public static Set<DataFile> uniqueDataFiles(Table table) {
+    return uniqueDataFiles(table, null);
   }
 
-  public static Set<DataFile> dataFiles(Table table, String branch) {
+  public static Set<DataFile> uniqueDataFiles(Table table, String branch) {
     Set<DataFile> dataFiles = Sets.newHashSet();
     TableScan scan = table.newScan();
     if (branch != null) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -818,13 +818,7 @@ public class TestHelpers {
   }
 
   public static List<DataFile> dataFiles(Table table) {
-    return dataFiles(table, false);
-  }
-
-  public static List<DataFile> dataFiles(Table table, boolean includeColumnStats) {
-    TableScan tableScan =
-        includeColumnStats ? table.newScan().includeColumnStats() : table.newScan();
-    CloseableIterable<FileScanTask> tasks = tableScan.planFiles();
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -799,26 +799,17 @@ public class TestHelpers {
     return table.currentSnapshot().deleteManifests(table.io());
   }
 
-  public static Set<DataFile> uniqueDataFiles(Table table) {
-    return uniqueDataFiles(table, null);
+  public static List<DataFile> dataFiles(Table table) {
+    return dataFiles(table, null);
   }
 
-  public static Set<DataFile> uniqueDataFiles(Table table, String branch) {
-    Set<DataFile> dataFiles = Sets.newHashSet();
+  public static List<DataFile> dataFiles(Table table, String branch) {
     TableScan scan = table.newScan();
     if (branch != null) {
       scan.useRef(branch);
     }
 
-    for (FileScanTask task : scan.planFiles()) {
-      dataFiles.add(task.file());
-    }
-
-    return dataFiles;
-  }
-
-  public static List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    CloseableIterable<FileScanTask> tasks = scan.includeColumnStats().planFiles();
     return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -814,6 +815,11 @@ public class TestHelpers {
     }
 
     return dataFiles;
+  }
+
+  public static List<DataFile> dataFiles(Table table) {
+    CloseableIterable<FileScanTask> tasks = table.newScan().includeColumnStats().planFiles();
+    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   public static Set<DeleteFile> deleteFiles(Table table) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -39,7 +39,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
@@ -1493,7 +1492,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
             AvroSchemaUtil.convert(
                 partitionsTable.schema().findType("partition").asStructType(), "partition"));
 
-    List<DataFile> dataFiles = dataFiles(table);
+    List<DataFile> dataFiles = TestHelpers.dataFiles(table);
     assertDataFilePartitions(dataFiles, Arrays.asList(1, 2, 2));
 
     List<GenericData.Record> expected = Lists.newArrayList();
@@ -2257,11 +2256,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   private long totalSizeInBytes(Iterable<DataFile> dataFiles) {
     return Lists.newArrayList(dataFiles).stream().mapToLong(DataFile::fileSizeInBytes).sum();
-  }
-
-  private List<DataFile> dataFiles(Table table) {
-    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
-    return Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
   }
 
   private void assertDataFilePartitions(


### PR DESCRIPTION
### Note
 - Retrieving data files of a table has been implemented multiple times so moved to `TestHelpers`.
 - This is a follow-up PR based on our discussion in https://github.com/apache/iceberg/pull/7920