### PR TITLE
Python: Let produce last-updated-ms field in metadata at microsecond level

### DIFF
--- a/python/pyiceberg/table/metadata.py
+++ b/python/pyiceberg/table/metadata.py
@@ -40,7 +40,7 @@ from pyiceberg.table.sorting import (
     assign_fresh_sort_order_ids,
 )
 from pyiceberg.typedef import EMPTY_DICT, IcebergBaseModel, Properties
-from pyiceberg.utils.datetime import datetime_to_micros
+from pyiceberg.utils.datetime import datetime_to_millis
 
 CURRENT_SNAPSHOT_ID = "current_snapshot_id"
 CURRENT_SCHEMA_ID = "current_schema_id"
@@ -124,7 +124,9 @@ class TableMetadataCommonFields(IcebergBaseModel):
     Implementations must throw an exception if a table’s UUID does not match
     the expected UUID after refreshing metadata."""
 
-    last_updated_ms: int = Field(alias="last-updated-ms", default_factory=lambda: datetime_to_micros(datetime.datetime.now()))
+    last_updated_ms: int = Field(
+        alias="last-updated-ms", default_factory=lambda: datetime_to_millis(datetime.datetime.now().astimezone())
+    )
     """Timestamp in milliseconds from the unix epoch when the table
     was last updated. Each table metadata file should update this
     field just before writing."""

--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -91,6 +91,25 @@ def timestamp_to_micros(timestamp_str: str) -> int:
     raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
 
 
+def datetime_to_millis(dt: datetime) -> int:
+    """Converts a datetime to milliseconds from 1970-01-01T00:00:00.000000."""
+    if dt.tzinfo:
+        delta = dt - EPOCH_TIMESTAMPTZ
+    else:
+        delta = dt - EPOCH_TIMESTAMP
+    return (delta.days * 86400 + delta.seconds) * 1_000 + delta.microseconds // 1_000
+
+
+def timestamp_to_millis(timestamp_str: str) -> int:
+    """Converts an ISO-9601 formatted timestamp without zone to microseconds from 1970-01-01T00:00:00.000000."""
+    if ISO_TIMESTAMP.fullmatch(timestamp_str):
+        return datetime_to_millis(datetime.fromisoformat(timestamp_str))
+    if ISO_TIMESTAMPTZ.fullmatch(timestamp_str):
+        # When we can match a timestamp without a zone, we can give a more specific error
+        raise ValueError(f"Zone offset provided, but not expected: {timestamp_str}")
+    raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
+
+
 def timestamptz_to_micros(timestamptz_str: str) -> int:
     """Converts an ISO-8601 formatted timestamp with zone to microseconds from 1970-01-01T00:00:00.000000+00:00."""
     if ISO_TIMESTAMPTZ.fullmatch(timestamptz_str):

--- a/python/pyiceberg/utils/datetime.py
+++ b/python/pyiceberg/utils/datetime.py
@@ -100,16 +100,6 @@ def datetime_to_millis(dt: datetime) -> int:
     return (delta.days * 86400 + delta.seconds) * 1_000 + delta.microseconds // 1_000
 
 
-def timestamp_to_millis(timestamp_str: str) -> int:
-    """Converts an ISO-9601 formatted timestamp without zone to microseconds from 1970-01-01T00:00:00.000000."""
-    if ISO_TIMESTAMP.fullmatch(timestamp_str):
-        return datetime_to_millis(datetime.fromisoformat(timestamp_str))
-    if ISO_TIMESTAMPTZ.fullmatch(timestamp_str):
-        # When we can match a timestamp without a zone, we can give a more specific error
-        raise ValueError(f"Zone offset provided, but not expected: {timestamp_str}")
-    raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
-
-
 def timestamptz_to_micros(timestamptz_str: str) -> int:
     """Converts an ISO-8601 formatted timestamp with zone to microseconds from 1970-01-01T00:00:00.000000+00:00."""
     if ISO_TIMESTAMPTZ.fullmatch(timestamptz_str):

--- a/python/tests/utils/test_datetime.py
+++ b/python/tests/utils/test_datetime.py
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 from datetime import datetime, tzinfo
 
 import pytest

--- a/python/tests/utils/test_datetime.py
+++ b/python/tests/utils/test_datetime.py
@@ -1,40 +1,40 @@
-import pytest
-
-from pyiceberg.utils.datetime import datetime_to_millis
 from datetime import datetime, tzinfo
+
+import pytest
 from pytz import timezone
 
+from pyiceberg.utils.datetime import datetime_to_millis
 
 timezones = [
-    timezone('Etc/GMT'),
-    timezone('Etc/GMT+0'),
-    timezone('Etc/GMT+1'),
-    timezone('Etc/GMT+10'),
-    timezone('Etc/GMT+11'),
-    timezone('Etc/GMT+12'),
-    timezone('Etc/GMT+2'),
-    timezone('Etc/GMT+3'),
-    timezone('Etc/GMT+4'),
-    timezone('Etc/GMT+5'),
-    timezone('Etc/GMT+6'),
-    timezone('Etc/GMT+7'),
-    timezone('Etc/GMT+8'),
-    timezone('Etc/GMT+9'),
-    timezone('Etc/GMT-0'),
-    timezone('Etc/GMT-1'),
-    timezone('Etc/GMT-10'),
-    timezone('Etc/GMT-11'),
-    timezone('Etc/GMT-12'),
-    timezone('Etc/GMT-13'),
-    timezone('Etc/GMT-14'),
-    timezone('Etc/GMT-2'),
-    timezone('Etc/GMT-3'),
-    timezone('Etc/GMT-4'),
-    timezone('Etc/GMT-5'),
-    timezone('Etc/GMT-6'),
-    timezone('Etc/GMT-7'),
-    timezone('Etc/GMT-8'),
-    timezone('Etc/GMT-9'),
+    timezone("Etc/GMT"),
+    timezone("Etc/GMT+0"),
+    timezone("Etc/GMT+1"),
+    timezone("Etc/GMT+10"),
+    timezone("Etc/GMT+11"),
+    timezone("Etc/GMT+12"),
+    timezone("Etc/GMT+2"),
+    timezone("Etc/GMT+3"),
+    timezone("Etc/GMT+4"),
+    timezone("Etc/GMT+5"),
+    timezone("Etc/GMT+6"),
+    timezone("Etc/GMT+7"),
+    timezone("Etc/GMT+8"),
+    timezone("Etc/GMT+9"),
+    timezone("Etc/GMT-0"),
+    timezone("Etc/GMT-1"),
+    timezone("Etc/GMT-10"),
+    timezone("Etc/GMT-11"),
+    timezone("Etc/GMT-12"),
+    timezone("Etc/GMT-13"),
+    timezone("Etc/GMT-14"),
+    timezone("Etc/GMT-2"),
+    timezone("Etc/GMT-3"),
+    timezone("Etc/GMT-4"),
+    timezone("Etc/GMT-5"),
+    timezone("Etc/GMT-6"),
+    timezone("Etc/GMT-7"),
+    timezone("Etc/GMT-8"),
+    timezone("Etc/GMT-9"),
 ]
 
 

--- a/python/tests/utils/test_datetime.py
+++ b/python/tests/utils/test_datetime.py
@@ -1,0 +1,53 @@
+import pytest
+
+from pyiceberg.utils.datetime import datetime_to_millis
+from datetime import datetime, tzinfo
+from pytz import timezone
+
+
+timezones = [
+    timezone('Etc/GMT'),
+    timezone('Etc/GMT+0'),
+    timezone('Etc/GMT+1'),
+    timezone('Etc/GMT+10'),
+    timezone('Etc/GMT+11'),
+    timezone('Etc/GMT+12'),
+    timezone('Etc/GMT+2'),
+    timezone('Etc/GMT+3'),
+    timezone('Etc/GMT+4'),
+    timezone('Etc/GMT+5'),
+    timezone('Etc/GMT+6'),
+    timezone('Etc/GMT+7'),
+    timezone('Etc/GMT+8'),
+    timezone('Etc/GMT+9'),
+    timezone('Etc/GMT-0'),
+    timezone('Etc/GMT-1'),
+    timezone('Etc/GMT-10'),
+    timezone('Etc/GMT-11'),
+    timezone('Etc/GMT-12'),
+    timezone('Etc/GMT-13'),
+    timezone('Etc/GMT-14'),
+    timezone('Etc/GMT-2'),
+    timezone('Etc/GMT-3'),
+    timezone('Etc/GMT-4'),
+    timezone('Etc/GMT-5'),
+    timezone('Etc/GMT-6'),
+    timezone('Etc/GMT-7'),
+    timezone('Etc/GMT-8'),
+    timezone('Etc/GMT-9'),
+]
+
+
+def test_datetime_to_millis() -> None:
+    dt = datetime(2023, 7, 10, 10, 10, 10, 123456)
+    expected = int(dt.timestamp() * 1_000)
+    datetime_millis = datetime_to_millis(dt)
+    assert datetime_millis == expected
+
+
+@pytest.mark.parametrize("tz", timezones)
+def test_datetime_tz_to_millis(tz: tzinfo) -> None:
+    dt = datetime(2023, 7, 10, 10, 10, 10, 123456, tzinfo=tz)
+    expected = int(dt.timestamp() * 1_000)
+    datetime_millis = datetime_to_millis(dt)
+    assert datetime_millis == expected


### PR DESCRIPTION
close #8025 

Use millisecond in TableMetadata in last-update-ms in construction.