### PR TITLE
[1.3.x] Core: Include all reachable snapshots with v1 format and REF snapshot mode

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -499,11 +499,6 @@ public class TableMetadata implements Serializable {
       List<Snapshot> loadedSnapshots = Lists.newArrayList(snapshotsSupplier.get());
       loadedSnapshots.removeIf(s -> s.sequenceNumber() > lastSequenceNumber);
 
-      // Format version 1 does not have accurate sequence numbering, so remove based on timestamp
-      if (this.formatVersion == 1) {
-        loadedSnapshots.removeIf(s -> s.timestampMillis() > currentSnapshot().timestampMillis());
-      }
-
       this.snapshots = ImmutableList.copyOf(loadedSnapshots);
       this.snapshotsById = indexAndValidateSnapshots(snapshots, lastSequenceNumber);
       validateCurrentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.assertj.core.api.Assumptions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -131,6 +132,10 @@ public class TestSnapshotLoading extends TableTestBase {
 
   @Test
   public void testFutureSnapshotsAreRemoved() {
+    Assumptions.assumeThat(formatVersion)
+        .as("Future snapshots are only removed for V2 tables")
+        .isGreaterThan(1);
+
     table.newFastAppend().appendFile(FILE_C).commit();
 
     TableMetadata futureTableMetadata =


### PR DESCRIPTION
This backports https://github.com/apache/iceberg/pull/7621 to 1.3.x