### PR TITLE
Core: Make metrics reporter serializable (alternative impl)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java
@@ -18,11 +18,12 @@
  */
 package org.apache.iceberg.metrics;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /** This interface defines the basic API for reporting metrics for operations to a Table. */
 @FunctionalInterface
-public interface MetricsReporter {
+public interface MetricsReporter extends Serializable {
 
   /**
    * A custom MetricsReporter implementation must have a no-arg constructor, which will be called

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -25,6 +25,8 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.ClosureSerializer;
+import com.esotericsoftware.kryo.serializers.JavaSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -278,6 +280,7 @@ public class TestHelpers {
 
       // required for serializing and deserializing $$Lambda$ Anonymous Classes
       kryo.register(SerializedLambda.class);
+      kryo.register(ObjectMapper.class, new JavaSerializer());
       kryo.register(ClosureSerializer.Closure.class, new ClosureSerializer());
 
       ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -263,4 +263,8 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   Object writeReplace() {
     return SerializableTable.copyOf(this);
   }
+
+  public MetricsReporter metricsReporter() {
+    return reporter;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -770,6 +770,10 @@ public class BaseTransaction implements Transaction {
       return current.refs();
     }
 
+    public MetricsReporter metricsReporter() {
+      return BaseTransaction.this.reporter;
+    }
+
     @Override
     public String toString() {
       return name();

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SerializableSupplier;
@@ -62,6 +63,7 @@ public class SerializableTable implements Table, Serializable {
   private final EncryptionManager encryption;
   private final LocationProvider locationProvider;
   private final Map<String, SnapshotRef> refs;
+  private final MetricsReporter metricsReporter;
 
   private transient volatile Table lazyTable = null;
   private transient volatile Schema lazySchema = null;
@@ -83,6 +85,8 @@ public class SerializableTable implements Table, Serializable {
     this.encryption = table.encryption();
     this.locationProvider = table.locationProvider();
     this.refs = SerializableMap.copyOf(table.refs());
+    this.metricsReporter =
+        table instanceof BaseTable ? ((BaseTable) table).metricsReporter() : null;
   }
 
   /**
@@ -136,7 +140,7 @@ public class SerializableTable implements Table, Serializable {
   }
 
   protected Table newTable(TableOperations ops, String tableName) {
-    return new BaseTable(ops, tableName);
+    return new BaseTable(ops, tableName, metricsReporter());
   }
 
   @Override
@@ -245,6 +249,10 @@ public class SerializableTable implements Table, Serializable {
   @Override
   public Map<String, SnapshotRef> refs() {
     return refs;
+  }
+
+  public MetricsReporter metricsReporter() {
+    return metricsReporter;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/MetricsReporters.java
@@ -18,10 +18,10 @@
  */
 package org.apache.iceberg.metrics;
 
-import java.util.Collections;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.SerializableSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,14 +52,14 @@ public class MetricsReporters {
       reporters.add(second);
     }
 
-    return new CompositeMetricsReporter(reporters);
+    return new CompositeMetricsReporter(SerializableSet.copyOf(reporters));
   }
 
   @VisibleForTesting
   static class CompositeMetricsReporter implements MetricsReporter {
-    private final Set<MetricsReporter> reporters;
+    private final SerializableSet<MetricsReporter> reporters;
 
-    private CompositeMetricsReporter(Set<MetricsReporter> reporters) {
+    private CompositeMetricsReporter(SerializableSet<MetricsReporter> reporters) {
       this.reporters = reporters;
     }
 
@@ -79,7 +79,7 @@ public class MetricsReporters {
     }
 
     Set<MetricsReporter> reporters() {
-      return Collections.unmodifiableSet(reporters);
+      return reporters.immutableSet();
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import java.io.IOException;
+import java.io.Serializable;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.MetadataUpdateParser;
 import org.apache.iceberg.PartitionSpecParser;
@@ -107,7 +108,8 @@ public class RESTSerializers {
 
   /** @deprecated will be removed in 1.5.0, use {@link UpdateReqDeserializer} instead. */
   @Deprecated
-  public static class UpdateRequirementDeserializer extends JsonDeserializer<UpdateRequirement> {
+  public static class UpdateRequirementDeserializer extends JsonDeserializer<UpdateRequirement>
+      implements Serializable {
     @Override
     public UpdateRequirement deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
@@ -118,7 +120,8 @@ public class RESTSerializers {
 
   /** @deprecated will be removed in 1.5.0, use {@link UpdateReqSerializer} instead. */
   @Deprecated
-  public static class UpdateRequirementSerializer extends JsonSerializer<UpdateRequirement> {
+  public static class UpdateRequirementSerializer extends JsonSerializer<UpdateRequirement>
+      implements Serializable {
     @Override
     public void serialize(
         UpdateRequirement value, JsonGenerator gen, SerializerProvider serializers)
@@ -127,8 +130,8 @@ public class RESTSerializers {
     }
   }
 
-  static class UpdateReqDeserializer
-      extends JsonDeserializer<org.apache.iceberg.UpdateRequirement> {
+  static class UpdateReqDeserializer extends JsonDeserializer<org.apache.iceberg.UpdateRequirement>
+      implements Serializable {
     @Override
     public org.apache.iceberg.UpdateRequirement deserialize(
         JsonParser p, DeserializationContext ctxt) throws IOException {
@@ -137,7 +140,8 @@ public class RESTSerializers {
     }
   }
 
-  static class UpdateReqSerializer extends JsonSerializer<org.apache.iceberg.UpdateRequirement> {
+  static class UpdateReqSerializer extends JsonSerializer<org.apache.iceberg.UpdateRequirement>
+      implements Serializable {
     @Override
     public void serialize(
         org.apache.iceberg.UpdateRequirement value,
@@ -148,7 +152,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class TableMetadataDeserializer extends JsonDeserializer<TableMetadata> {
+  public static class TableMetadataDeserializer extends JsonDeserializer<TableMetadata>
+      implements Serializable {
     @Override
     public TableMetadata deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -157,7 +162,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class TableMetadataSerializer extends JsonSerializer<TableMetadata> {
+  public static class TableMetadataSerializer extends JsonSerializer<TableMetadata>
+      implements Serializable {
     @Override
     public void serialize(TableMetadata metadata, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -165,7 +171,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class MetadataUpdateDeserializer extends JsonDeserializer<MetadataUpdate> {
+  public static class MetadataUpdateDeserializer extends JsonDeserializer<MetadataUpdate>
+      implements Serializable {
     @Override
     public MetadataUpdate deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
@@ -174,7 +181,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class MetadataUpdateSerializer extends JsonSerializer<MetadataUpdate> {
+  public static class MetadataUpdateSerializer extends JsonSerializer<MetadataUpdate>
+      implements Serializable {
     @Override
     public void serialize(MetadataUpdate value, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -182,7 +190,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class ErrorResponseDeserializer extends JsonDeserializer<ErrorResponse> {
+  public static class ErrorResponseDeserializer extends JsonDeserializer<ErrorResponse>
+      implements Serializable {
     @Override
     public ErrorResponse deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -191,7 +200,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class ErrorResponseSerializer extends JsonSerializer<ErrorResponse> {
+  public static class ErrorResponseSerializer extends JsonSerializer<ErrorResponse>
+      implements Serializable {
     @Override
     public void serialize(
         ErrorResponse errorResponse, JsonGenerator gen, SerializerProvider serializers)
@@ -200,7 +210,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class NamespaceDeserializer extends JsonDeserializer<Namespace> {
+  public static class NamespaceDeserializer extends JsonDeserializer<Namespace>
+      implements Serializable {
     @Override
     public Namespace deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
       String[] levels = JsonUtil.getStringArray(p.getCodec().readTree(p));
@@ -208,7 +219,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class NamespaceSerializer extends JsonSerializer<Namespace> {
+  public static class NamespaceSerializer extends JsonSerializer<Namespace>
+      implements Serializable {
     @Override
     public void serialize(Namespace namespace, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -217,7 +229,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class TableIdentifierDeserializer extends JsonDeserializer<TableIdentifier> {
+  public static class TableIdentifierDeserializer extends JsonDeserializer<TableIdentifier>
+      implements Serializable {
     @Override
     public TableIdentifier deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -226,7 +239,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class TableIdentifierSerializer extends JsonSerializer<TableIdentifier> {
+  public static class TableIdentifierSerializer extends JsonSerializer<TableIdentifier>
+      implements Serializable {
     @Override
     public void serialize(
         TableIdentifier identifier, JsonGenerator gen, SerializerProvider serializers)
@@ -235,7 +249,7 @@ public class RESTSerializers {
     }
   }
 
-  public static class SchemaDeserializer extends JsonDeserializer<Schema> {
+  public static class SchemaDeserializer extends JsonDeserializer<Schema> implements Serializable {
     @Override
     public Schema deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
@@ -243,7 +257,7 @@ public class RESTSerializers {
     }
   }
 
-  public static class SchemaSerializer extends JsonSerializer<Schema> {
+  public static class SchemaSerializer extends JsonSerializer<Schema> implements Serializable {
     @Override
     public void serialize(Schema schema, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -251,7 +265,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class UnboundPartitionSpecSerializer extends JsonSerializer<UnboundPartitionSpec> {
+  public static class UnboundPartitionSpecSerializer extends JsonSerializer<UnboundPartitionSpec>
+      implements Serializable {
     @Override
     public void serialize(
         UnboundPartitionSpec spec, JsonGenerator gen, SerializerProvider serializers)
@@ -261,7 +276,7 @@ public class RESTSerializers {
   }
 
   public static class UnboundPartitionSpecDeserializer
-      extends JsonDeserializer<UnboundPartitionSpec> {
+      extends JsonDeserializer<UnboundPartitionSpec> implements Serializable {
     @Override
     public UnboundPartitionSpec deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -270,7 +285,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class UnboundSortOrderSerializer extends JsonSerializer<UnboundSortOrder> {
+  public static class UnboundSortOrderSerializer extends JsonSerializer<UnboundSortOrder>
+      implements Serializable {
     @Override
     public void serialize(
         UnboundSortOrder sortOrder, JsonGenerator gen, SerializerProvider serializers)
@@ -279,7 +295,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class UnboundSortOrderDeserializer extends JsonDeserializer<UnboundSortOrder> {
+  public static class UnboundSortOrderDeserializer extends JsonDeserializer<UnboundSortOrder>
+      implements Serializable {
     @Override
     public UnboundSortOrder deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -288,7 +305,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class OAuthTokenResponseSerializer extends JsonSerializer<OAuthTokenResponse> {
+  public static class OAuthTokenResponseSerializer extends JsonSerializer<OAuthTokenResponse>
+      implements Serializable {
     @Override
     public void serialize(
         OAuthTokenResponse tokenResponse, JsonGenerator gen, SerializerProvider serializers)
@@ -297,7 +315,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class OAuthTokenResponseDeserializer extends JsonDeserializer<OAuthTokenResponse> {
+  public static class OAuthTokenResponseDeserializer extends JsonDeserializer<OAuthTokenResponse>
+      implements Serializable {
     @Override
     public OAuthTokenResponse deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -307,7 +326,7 @@ public class RESTSerializers {
   }
 
   public static class ReportMetricsRequestSerializer<T extends ReportMetricsRequest>
-      extends JsonSerializer<T> {
+      extends JsonSerializer<T> implements Serializable {
     @Override
     public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -316,7 +335,7 @@ public class RESTSerializers {
   }
 
   public static class ReportMetricsRequestDeserializer<T extends ReportMetricsRequest>
-      extends JsonDeserializer<T> {
+      extends JsonDeserializer<T> implements Serializable {
     @Override
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
@@ -325,7 +344,7 @@ public class RESTSerializers {
   }
 
   public static class CommitTransactionRequestSerializer
-      extends JsonSerializer<CommitTransactionRequest> {
+      extends JsonSerializer<CommitTransactionRequest> implements Serializable {
     @Override
     public void serialize(
         CommitTransactionRequest request, JsonGenerator gen, SerializerProvider serializers)
@@ -335,7 +354,7 @@ public class RESTSerializers {
   }
 
   public static class CommitTransactionRequestDeserializer
-      extends JsonDeserializer<CommitTransactionRequest> {
+      extends JsonDeserializer<CommitTransactionRequest> implements Serializable {
     @Override
     public CommitTransactionRequest deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -344,7 +363,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class UpdateTableRequestSerializer extends JsonSerializer<UpdateTableRequest> {
+  public static class UpdateTableRequestSerializer extends JsonSerializer<UpdateTableRequest>
+      implements Serializable {
     @Override
     public void serialize(
         UpdateTableRequest request, JsonGenerator gen, SerializerProvider serializers)
@@ -353,7 +373,8 @@ public class RESTSerializers {
     }
   }
 
-  public static class UpdateTableRequestDeserializer extends JsonDeserializer<UpdateTableRequest> {
+  public static class UpdateTableRequestDeserializer extends JsonDeserializer<UpdateTableRequest>
+      implements Serializable {
     @Override
     public UpdateTableRequest deserialize(JsonParser p, DeserializationContext context)
         throws IOException {
@@ -363,7 +384,7 @@ public class RESTSerializers {
   }
 
   public static class RegisterTableRequestSerializer<T extends RegisterTableRequest>
-      extends JsonSerializer<T> {
+      extends JsonSerializer<T> implements Serializable {
     @Override
     public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
@@ -372,7 +393,7 @@ public class RESTSerializers {
   }
 
   public static class RegisterTableRequestDeserializer<T extends RegisterTableRequest>
-      extends JsonDeserializer<T> {
+      extends JsonDeserializer<T> implements Serializable {
     @Override
     public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -86,6 +86,7 @@ import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.SerializableSupplier;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -384,7 +385,7 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   private MetricsReporter metricsReporter(
-      String metricsEndpoint, Supplier<Map<String, String>> headers) {
+      String metricsEndpoint, SerializableSupplier<Map<String, String>> headers) {
     if (reportingViaRestEnabled) {
       RESTMetricsReporter restMetricsReporter =
           new RESTMetricsReporter(client, metricsEndpoint, headers);

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.rest.ResourcePaths;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -354,7 +355,7 @@ public class OAuth2Util {
     private static int tokenRefreshNumRetries = 5;
     private static final long MAX_REFRESH_WINDOW_MILLIS = 300_000; // 5 minutes
     private static final long MIN_REFRESH_WAIT_MILLIS = 10;
-    private volatile Map<String, String> headers;
+    private volatile SerializableMap<String, String> headers;
     private volatile String token;
     private volatile String tokenType;
     private volatile Long expiresAtMillis;
@@ -368,7 +369,7 @@ public class OAuth2Util {
         String tokenType,
         String credential,
         String scope) {
-      this.headers = RESTUtil.merge(baseHeaders, authHeaders(token));
+      this.headers = SerializableMap.copyOf(RESTUtil.merge(baseHeaders, authHeaders(token)));
       this.token = token;
       this.tokenType = tokenType;
       this.expiresAtMillis = OAuth2Util.expiresAtMillis(token);
@@ -377,7 +378,7 @@ public class OAuth2Util {
     }
 
     public Map<String, String> headers() {
-      return headers;
+      return headers.immutableMap();
     }
 
     public String token() {
@@ -454,7 +455,7 @@ public class OAuth2Util {
         this.token = response.token();
         this.tokenType = response.issuedTokenType();
         this.expiresAtMillis = OAuth2Util.expiresAtMillis(token);
-        this.headers = RESTUtil.merge(headers, authHeaders(token));
+        this.headers = SerializableMap.copyOf(RESTUtil.merge(headers, authHeaders(token)));
 
         if (response.expiresInSeconds() != null) {
           return Pair.of(response.expiresInSeconds(), TimeUnit.SECONDS);

--- a/core/src/main/java/org/apache/iceberg/util/SerializableSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializableSet.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+public class SerializableSet<E> implements Set<E>, Serializable {
+  private final Set<E> copiedSet;
+  private transient volatile Set<E> immutableSet;
+
+  SerializableSet() {
+    this.copiedSet = Sets.newHashSet();
+  }
+
+  private SerializableSet(Set<E> set) {
+    this.copiedSet = Sets.newHashSet();
+    this.copiedSet.addAll(set);
+  }
+
+  public static <E> SerializableSet<E> copyOf(Set<E> set) {
+    return set == null ? null : new SerializableSet<>(set);
+  }
+
+  public Set<E> immutableSet() {
+    if (null == immutableSet) {
+      synchronized (this) {
+        if (null == immutableSet) {
+          immutableSet = Collections.unmodifiableSet(copiedSet);
+        }
+      }
+    }
+
+    return immutableSet;
+  }
+
+  @Override
+  public int size() {
+    return copiedSet.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return copiedSet.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return copiedSet.contains(o);
+  }
+
+  @Override
+  public Iterator<E> iterator() {
+    return copiedSet.iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return copiedSet.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return copiedSet.toArray(a);
+  }
+
+  @Override
+  public boolean add(E e) {
+    return copiedSet.add(e);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return copiedSet.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return copiedSet.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends E> c) {
+    return copiedSet.addAll(c);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return copiedSet.retainAll(c);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return copiedSet.removeAll(c);
+  }
+
+  @Override
+  public void clear() {
+    copiedSet.clear();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return copiedSet.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return copiedSet.hashCode();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestSerializableTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestSerializableTable.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.metrics.InMemoryMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestSerializableTable {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(2, "data", Types.StringType.get()),
+          required(3, "date", Types.StringType.get()),
+          optional(4, "double", Types.DoubleType.get()));
+
+  private static final PartitionSpec SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("date").build();
+
+  private static final SortOrder SORT_ORDER = SortOrder.builderFor(SCHEMA).asc("id").build();
+
+  @TempDir private File temp;
+
+  @AfterAll
+  public static void clean() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void serializableTableWithMetricsReporter() throws IOException, ClassNotFoundException {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            CatalogProperties.METRICS_REPORTER_IMPL,
+            InMemoryMetricsReporter.class.getName(),
+            "key1",
+            "value1");
+    MetricsReporter reporter = CatalogUtil.loadMetricsReporter(properties);
+    Table table = TestTables.create(temp, "tbl_A", SCHEMA, SPEC, SORT_ORDER, 2, reporter);
+
+    Table serializableTable = TestHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    assertThat(serializableTable)
+        .isInstanceOf(SerializableTable.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(SerializableTable.class))
+        .extracting(SerializableTable::metricsReporter)
+        .isNotNull()
+        .isInstanceOf(InMemoryMetricsReporter.class);
+
+    serializableTable = TestHelpers.KryoHelpers.roundTripSerialize(SerializableTable.copyOf(table));
+    assertThat(serializableTable)
+        .isInstanceOf(SerializableTable.class)
+        .asInstanceOf(InstanceOfAssertFactories.type(SerializableTable.class))
+        .extracting(SerializableTable::metricsReporter)
+        .isNotNull()
+        .isInstanceOf(InMemoryMetricsReporter.class);
+  }
+}


### PR DESCRIPTION
This is an alternative implementation to #7370. This PR avoids breaking the API and rather makes the `HTTPClient` serializable, where the underlying `CloseableHttpClient` and `ObjectMapper` are both loaded dynamically