### PR TITLE
[spark 3.4] skip empty file during table migration, table snapshotting or adding files

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.extensions;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.Table;
@@ -220,5 +221,27 @@ public class TestSnapshotTableProcedure extends SparkExtensionsTestBase {
     Assertions.assertThatThrownBy(() -> sql("CALL %s.system.snapshot('src', '')", catalogName))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot handle an empty identifier for argument table");
+  }
+
+  @Test
+  public void testSnapshotWithEmptyFile() throws IOException {
+    File tempFolder = temp.newFolder();
+    String location = tempFolder.toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'",
+        sourceName, location);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", sourceName);
+    int fileCount = tempFolder.listFiles().length;
+    sql("INSERT INTO TABLE %s SELECT * FROM VALUES (1, 'a') limit 0", sourceName);
+    int newFileCount = tempFolder.listFiles().length;
+    Assert.assertEquals(
+        "There should be exactly 2 new file generated after writing empty data to the table (1 SUCCESS file, 1 empty file)",
+        2,
+        newFileCount - fileCount);
+
+    Object result =
+        scalarSql("CALL %s.system.snapshot('%s', '%s')", catalogName, sourceName, tableName);
+
+    Assert.assertEquals("Should have added one file", 1L, result);
   }
 }


### PR DESCRIPTION
This PR tries to fix https://github.com/apache/iceberg/issues/7949