### PR TITLE
AWS: Add retry on UncheckedIOException and max retries for S3FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -53,6 +53,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
                 s3FileIOProperties.applyCredentialConfigurations(
                     awsClientProperties, s3ClientBuilder))
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
+        .applyMutation(s3FileIOProperties::applyRetryConfiguration)
         .build();
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -113,6 +113,12 @@ public class TestS3FileIOProperties {
 
     Assertions.assertThat(Collections.emptyMap())
         .isEqualTo(s3FileIOProperties.bucketToAccessPointMapping());
+
+    Assertions.assertThat(S3FileIOProperties.RETRY_ON_UNCHECKED_IO_EXCEPTION_DEFAULT)
+        .isEqualTo(s3FileIOProperties.isRetryOnUncheckedIoExceptionEnabled());
+
+    Assertions.assertThat(S3FileIOProperties.MAX_RETRIES_DEFAULT)
+        .isEqualTo(s3FileIOProperties.getMaxRetries());
   }
 
   @Test
@@ -472,5 +478,17 @@ public class TestS3FileIOProperties {
 
     s3FileIOProperties.applyEndpointConfigurations(mockS3ClientBuilder);
     Mockito.verify(mockS3ClientBuilder).endpointOverride(Mockito.any(URI.class));
+  }
+
+  @Test
+  public void testRetryConfiguration() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.RETRY_ON_UNCHECKED_IO_EXCEPTION, "true");
+    properties.put(S3FileIOProperties.MAX_RETRIES, "999");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+
+    s3FileIOProperties.applyRetryConfiguration(mockS3ClientBuilder);
+    Mockito.verify(mockS3ClientBuilder).overrideConfiguration(Mockito.any(Consumer.class));
   }
 }


### PR DESCRIPTION
This adds two options for the S3 client used by S3FileIO

- s3.retry-on-unchecked-io-exception - This will configure the client to retry on an UncheckedIOException.  At Netflix we have seen this happen during metadata commits which cause an entire job to fail.
- s3.max-retries - The maximum number of retries