### PR TITLE
Docs: Add documentation for Rate limiting in Spark Structured Streaming

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -154,16 +154,18 @@ spark.read
     .table("catalog.db.table")
 ```
 
-| Spark option    | Default               | Description                                                                               |
-| --------------- | --------------------- | ----------------------------------------------------------------------------------------- |
-| snapshot-id     | (latest)              | Snapshot ID of the table snapshot to read                                                 |
-| as-of-timestamp | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time. |
-| split-size      | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size         |
-| lookback        | As per table property | Overrides this table's read.split.planning-lookback                                       |
-| file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
-| vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
-| batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
+| Spark option                        | Default               | Description                                                                                                                                                                                                                                               |
+|-------------------------------------| --------------------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| snapshot-id                         | (latest)              | Snapshot ID of the table snapshot to read                                                                                                                                                                                                                 |
+| as-of-timestamp                     | (latest)              | A timestamp in milliseconds; the snapshot used will be the snapshot current at this time.                                                                                                                                                                 |
+| split-size                          | As per table property | Overrides this table's read.split.target-size and read.split.metadata-target-size                                                                                                                                                                         |
+| lookback                            | As per table property | Overrides this table's read.split.planning-lookback                                                                                                                                                                                                       |
+| file-open-cost                      | As per table property | Overrides this table's read.split.open-file-cost                                                                                                                                                                                                          |
+| vectorization-enabled               | As per table property | Overrides this table's read.parquet.vectorization.enabled                                                                                                                                                                                                 |
+| batch-size                          | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                                                                                                                                                                              |
+| stream-from-timestamp               | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used                                                                                                                                         |
+| streaming-max-files-per-micro-batch | INT_MAX | Maximum number of files per microbatch                                                                                                                                                                                                                    | 
+| streaming-max-rows-per-micro-batch  | INT_MAX | Maximum number of rows per microbatch. Note : smallest granuality supported is 1 file, please make sure number of records per file is always greater than the number of records in the largest file possible, otherwise it can lead to stream being stuck | 
 
 ### Write options
 


### PR DESCRIPTION
### About the change

This pr add's the newly introduced spark read options for supporting rate limit in ss. 

cc @jackye1995  @amogh-jahagirdar  @RussellSpitzer