### PR TITLE
Core: Handle optional fields

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1325,6 +1325,16 @@ public class TestTableMetadata {
   }
 
   @Test
+  public void testParseMinimal() throws Exception {
+    String data = readTableMetadataInputFile("TableMetadataV2ValidMinimal.json");
+    TableMetadata parsed = TableMetadataParser.fromJson(data);
+    Assert.assertEquals(Lists.newArrayList(), parsed.snapshots());
+    Assert.assertEquals(Lists.newArrayList(), parsed.snapshotLog());
+    Assert.assertEquals(ImmutableMap.of(), parsed.properties());
+    Assert.assertEquals(Lists.newArrayList(), parsed.previousFiles());
+  }
+
+  @Test
   public void testUpdateSchemaIdentifierFields() {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1328,10 +1328,10 @@ public class TestTableMetadata {
   public void testParseMinimal() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataV2ValidMinimal.json");
     TableMetadata parsed = TableMetadataParser.fromJson(data);
-    Assert.assertEquals(Lists.newArrayList(), parsed.snapshots());
-    Assert.assertEquals(Lists.newArrayList(), parsed.snapshotLog());
-    Assert.assertEquals(ImmutableMap.of(), parsed.properties());
-    Assert.assertEquals(Lists.newArrayList(), parsed.previousFiles());
+    Assertions.assertThat(parsed.snapshots()).isEmpty();
+    Assertions.assertThat(parsed.snapshotLog()).isEmpty();
+    Assertions.assertThat(parsed.properties()).isEmpty();
+    Assertions.assertThat(parsed.previousFiles()).isEmpty();
   }
 
   @Test

--- a/core/src/test/resources/TableMetadataV2ValidMinimal.json
+++ b/core/src/test/resources/TableMetadataV2ValidMinimal.json
@@ -1,0 +1,71 @@
+{
+  "format-version": 2,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 3,
+  "sort-orders": [
+    {
+      "order-id": 3,
+      "fields": [
+        {
+          "transform": "identity",
+          "source-id": 2,
+          "direction": "asc",
+          "null-order": "nulls-first"
+        },
+        {
+          "transform": "bucket[4]",
+          "source-id": 3,
+          "direction": "desc",
+          "null-order": "nulls-last"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In the Java code, we expect:

- current-snapshot-id
- properties
- snapshots

to be there, but they are actually optional. Related https://github.com/apache/iceberg/pull/8049

<img width="831" alt="image" src="https://github.com/apache/iceberg/assets/1134248/545ba2b2-9181-46da-911c-7f5210973521">

Java still writes `-1` for the `current-snapshot-id` when there is no snapshot, but I think it is important to fix the readers first.
