### PR TITLE
Spark 3.4: Force Jackson version to 2.14.2

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -31,9 +31,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:2.13.4"
-        force 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
-        force 'com.fasterxml.jackson.core:jackson-core:2.13.4'
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:2.14.2"
+        force 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
+        force 'com.fasterxml.jackson.core:jackson-core:2.14.2'
       }
     }
   }


### PR DESCRIPTION
Spark 3.4.1 uses Jackson 2.14.2 according to
https://github.com/apache/spark/blob/v3.4.1/pom.xml#L186-L187, so we should enforce the same version.