### PR TITLE
Spark 3.3, 3.4: Migrate TestRewritePositionDeleteFiles to assertJ

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -132,14 +131,6 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     createTable("timestamp");
     Timestamp baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00");
     insertData(i -> Timestamp.valueOf(baseTimestamp.toLocalDateTime().plusDays(i)));
-    testDanglingDelete();
-  }
-
-  @Test
-  public void testTimestampNtz() throws Exception {
-    createTable("timestamp_ntz");
-    LocalDateTime baseTimestamp = Timestamp.valueOf("2023-01-01 15:30:00").toLocalDateTime();
-    insertData(baseTimestamp::plusDays);
     testDanglingDelete();
   }
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.spark.sql.functions.expr;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -68,7 +69,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -192,15 +192,15 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     testDanglingDelete(2);
   }
 
-  private <T> void testDanglingDelete() throws Exception {
+  private void testDanglingDelete() throws Exception {
     testDanglingDelete(NUM_DATA_FILES);
   }
 
-  private <T> void testDanglingDelete(int numDataFiles) throws Exception {
+  private void testDanglingDelete(int numDataFiles) throws Exception {
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
 
     List<DataFile> dataFiles = dataFiles(table);
-    Assert.assertEquals(numDataFiles, dataFiles.size());
+    assertThat(numDataFiles).isEqualTo(dataFiles.size());
 
     SparkActions.get(spark)
         .rewriteDataFiles(table)
@@ -210,7 +210,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     // write dangling delete files for 'old data files'
     writePosDeletesForFiles(table, dataFiles);
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(numDataFiles * DELETE_FILES_PER_PARTITION, deleteFiles.size());
+    assertThat(numDataFiles * DELETE_FILES_PER_PARTITION).isEqualTo(deleteFiles.size());
 
     List<Object[]> expectedRecords = records(tableName);
 
@@ -221,7 +221,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have removed all dangling delete files", 0, newDeleteFiles.size());
+    assertThat(newDeleteFiles.size()).as("Remaining dangling deletes").isEqualTo(0);
     checkResult(result, deleteFiles, Lists.newArrayList(), numDataFiles);
 
     List<Object[]> actualRecords = records(tableName);
@@ -241,12 +241,11 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
         tableName, partitionType, partitionCol);
   }
 
-  private <T> void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
+  private void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
     insertData(partitionValueFunction, NUM_DATA_FILES);
   }
 
-  private <T> void insertData(Function<Integer, ?> partitionValue, int numDataFiles)
-      throws Exception {
+  private void insertData(Function<Integer, ?> partitionValue, int numDataFiles) throws Exception {
     for (int i = 0; i < numDataFiles; i++) {
       Dataset<Row> df =
           spark
@@ -278,11 +277,9 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<DataFile> partitionFiles = filesByPartitionEntry.getValue();
 
       int deletesForPartition = partitionFiles.size() * DELETE_FILE_SIZE;
-      Assert.assertEquals(
-          "Number of delete files per partition should be "
-              + "evenly divisible by requested deletes per data file times number of data files in this partition",
-          0,
-          deletesForPartition % DELETE_FILE_SIZE);
+      assertThat(deletesForPartition % DELETE_FILE_SIZE)
+          .as("Number of delete files per partition modulo number of data files in this partition")
+          .isEqualTo(0);
       int deleteFileSize = deletesForPartition / DELETE_FILES_PER_PARTITION;
 
       int counter = 0;
@@ -361,48 +358,43 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<DeleteFile> rewrittenDeletes,
       List<DeleteFile> newDeletes,
       int expectedGroups) {
-    Assert.assertEquals(
-        "Expected rewritten delete file count does not match",
-        rewrittenDeletes.size(),
-        result.rewrittenDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected new delete file count does not match",
-        newDeletes.size(),
-        result.addedDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected rewritten delete byte count does not match",
-        size(rewrittenDeletes),
-        result.rewrittenBytesCount());
-    Assert.assertEquals(
-        "Expected new delete byte count does not match",
-        size(newDeletes),
-        result.addedBytesCount());
+    assertThat(result.rewrittenDeleteFilesCount())
+        .as("Rewritten delete files")
+        .isEqualTo(rewrittenDeletes.size());
+    assertThat(result.addedDeleteFilesCount())
+        .as("Added delete files")
+        .isEqualTo(newDeletes.size());
+    assertThat(result.rewrittenBytesCount())
+        .as("Rewritten delete bytes")
+        .isEqualTo(size(rewrittenDeletes));
+    assertThat(result.addedBytesCount()).as("New Delete byte count").isEqualTo(size(newDeletes));
 
-    Assert.assertEquals(
-        "Expected rewrite group count does not match",
-        expectedGroups,
-        result.rewriteResults().size());
-    Assert.assertEquals(
-        "Expected rewritten delete file count in all groups to match",
-        rewrittenDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete file count in all groups to match",
-        newDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected rewritten delete bytes in all groups to match",
-        size(rewrittenDeletes),
-        result.rewriteResults().stream()
-            .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete bytes in all groups to match",
-        size(newDeletes),
-        result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+    assertThat(result.rewriteResults().size())
+        .as("Rewritten group count")
+        .isEqualTo(expectedGroups);
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
+                .sum())
+        .as("Rewritten delete file count in all groups")
+        .isEqualTo(rewrittenDeletes.size());
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
+                .sum())
+        .as("Added delete file count in all groups")
+        .isEqualTo(newDeletes.size());
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
+                .sum())
+        .as("Rewritten delete bytes in all groups")
+        .isEqualTo(size(rewrittenDeletes));
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::addedBytesCount)
+                .sum())
+        .as("Added delete bytes in all groups")
+        .isEqualTo(size(newDeletes));
   }
 }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -209,7 +209,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
 
     List<DataFile> dataFiles = dataFiles(table);
-    assertThat(numDataFiles).isEqualTo(dataFiles.size());
+    assertThat(dataFiles).hasSize(numDataFiles);
 
     SparkActions.get(spark)
         .rewriteDataFiles(table)
@@ -219,7 +219,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     // write dangling delete files for 'old data files'
     writePosDeletesForFiles(table, dataFiles);
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    assertThat(numDataFiles * DELETE_FILES_PER_PARTITION).isEqualTo(deleteFiles.size());
+    assertThat(deleteFiles).hasSize(numDataFiles * DELETE_FILES_PER_PARTITION);
 
     List<Object[]> expectedRecords = records(tableName);
 
@@ -230,7 +230,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    assertThat(newDeleteFiles.size()).as("Remaining dangling deletes").isEqualTo(0);
+    assertThat(newDeleteFiles).as("Remaining dangling deletes").isEmpty();
     checkResult(result, deleteFiles, Lists.newArrayList(), numDataFiles);
 
     List<Object[]> actualRecords = records(tableName);
@@ -378,9 +378,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
         .isEqualTo(size(rewrittenDeletes));
     assertThat(result.addedBytesCount()).as("New Delete byte count").isEqualTo(size(newDeletes));
 
-    assertThat(result.rewriteResults().size())
-        .as("Rewritten group count")
-        .isEqualTo(expectedGroups);
+    assertThat(result.rewriteResults()).as("Rewritten group count").hasSize(expectedGroups);
     assertThat(
             result.rewriteResults().stream()
                 .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFiles.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.spark.sql.functions.expr;
 import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -69,7 +70,6 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.StructType;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -201,15 +201,15 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     testDanglingDelete(2);
   }
 
-  private <T> void testDanglingDelete() throws Exception {
+  private void testDanglingDelete() throws Exception {
     testDanglingDelete(NUM_DATA_FILES);
   }
 
-  private <T> void testDanglingDelete(int numDataFiles) throws Exception {
+  private void testDanglingDelete(int numDataFiles) throws Exception {
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
 
     List<DataFile> dataFiles = dataFiles(table);
-    Assert.assertEquals(numDataFiles, dataFiles.size());
+    assertThat(numDataFiles).isEqualTo(dataFiles.size());
 
     SparkActions.get(spark)
         .rewriteDataFiles(table)
@@ -219,7 +219,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
     // write dangling delete files for 'old data files'
     writePosDeletesForFiles(table, dataFiles);
     List<DeleteFile> deleteFiles = deleteFiles(table);
-    Assert.assertEquals(numDataFiles * DELETE_FILES_PER_PARTITION, deleteFiles.size());
+    assertThat(numDataFiles * DELETE_FILES_PER_PARTITION).isEqualTo(deleteFiles.size());
 
     List<Object[]> expectedRecords = records(tableName);
 
@@ -230,7 +230,7 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
             .execute();
 
     List<DeleteFile> newDeleteFiles = deleteFiles(table);
-    Assert.assertEquals("Should have removed all dangling delete files", 0, newDeleteFiles.size());
+    assertThat(newDeleteFiles.size()).as("Remaining dangling deletes").isEqualTo(0);
     checkResult(result, deleteFiles, Lists.newArrayList(), numDataFiles);
 
     List<Object[]> actualRecords = records(tableName);
@@ -250,12 +250,11 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
         tableName, partitionType, partitionCol);
   }
 
-  private <T> void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
+  private void insertData(Function<Integer, ?> partitionValueFunction) throws Exception {
     insertData(partitionValueFunction, NUM_DATA_FILES);
   }
 
-  private <T> void insertData(Function<Integer, ?> partitionValue, int numDataFiles)
-      throws Exception {
+  private void insertData(Function<Integer, ?> partitionValue, int numDataFiles) throws Exception {
     for (int i = 0; i < numDataFiles; i++) {
       Dataset<Row> df =
           spark
@@ -287,11 +286,9 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<DataFile> partitionFiles = filesByPartitionEntry.getValue();
 
       int deletesForPartition = partitionFiles.size() * DELETE_FILE_SIZE;
-      Assert.assertEquals(
-          "Number of delete files per partition should be "
-              + "evenly divisible by requested deletes per data file times number of data files in this partition",
-          0,
-          deletesForPartition % DELETE_FILE_SIZE);
+      assertThat(deletesForPartition % DELETE_FILE_SIZE)
+          .as("Number of delete files per partition modulo number of data files in this partition")
+          .isEqualTo(0);
       int deleteFileSize = deletesForPartition / DELETE_FILES_PER_PARTITION;
 
       int counter = 0;
@@ -370,48 +367,43 @@ public class TestRewritePositionDeleteFiles extends SparkExtensionsTestBase {
       List<DeleteFile> rewrittenDeletes,
       List<DeleteFile> newDeletes,
       int expectedGroups) {
-    Assert.assertEquals(
-        "Expected rewritten delete file count does not match",
-        rewrittenDeletes.size(),
-        result.rewrittenDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected new delete file count does not match",
-        newDeletes.size(),
-        result.addedDeleteFilesCount());
-    Assert.assertEquals(
-        "Expected rewritten delete byte count does not match",
-        size(rewrittenDeletes),
-        result.rewrittenBytesCount());
-    Assert.assertEquals(
-        "Expected new delete byte count does not match",
-        size(newDeletes),
-        result.addedBytesCount());
+    assertThat(result.rewrittenDeleteFilesCount())
+        .as("Rewritten delete files")
+        .isEqualTo(rewrittenDeletes.size());
+    assertThat(result.addedDeleteFilesCount())
+        .as("Added delete files")
+        .isEqualTo(newDeletes.size());
+    assertThat(result.rewrittenBytesCount())
+        .as("Rewritten delete bytes")
+        .isEqualTo(size(rewrittenDeletes));
+    assertThat(result.addedBytesCount()).as("New Delete byte count").isEqualTo(size(newDeletes));
 
-    Assert.assertEquals(
-        "Expected rewrite group count does not match",
-        expectedGroups,
-        result.rewriteResults().size());
-    Assert.assertEquals(
-        "Expected rewritten delete file count in all groups to match",
-        rewrittenDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete file count in all groups to match",
-        newDeletes.size(),
-        result.rewriteResults().stream()
-            .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected rewritten delete bytes in all groups to match",
-        size(rewrittenDeletes),
-        result.rewriteResults().stream()
-            .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
-            .sum());
-    Assert.assertEquals(
-        "Expected added delete bytes in all groups to match",
-        size(newDeletes),
-        result.rewriteResults().stream().mapToLong(FileGroupRewriteResult::addedBytesCount).sum());
+    assertThat(result.rewriteResults().size())
+        .as("Rewritten group count")
+        .isEqualTo(expectedGroups);
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::rewrittenDeleteFilesCount)
+                .sum())
+        .as("Rewritten delete file count in all groups")
+        .isEqualTo(rewrittenDeletes.size());
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToInt(FileGroupRewriteResult::addedDeleteFilesCount)
+                .sum())
+        .as("Added delete file count in all groups")
+        .isEqualTo(newDeletes.size());
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::rewrittenBytesCount)
+                .sum())
+        .as("Rewritten delete bytes in all groups")
+        .isEqualTo(size(rewrittenDeletes));
+    assertThat(
+            result.rewriteResults().stream()
+                .mapToLong(FileGroupRewriteResult::addedBytesCount)
+                .sum())
+        .as("Added delete bytes in all groups")
+        .isEqualTo(size(newDeletes));
   }
 }


### PR DESCRIPTION
Follow up from comment https://github.com/apache/iceberg/pull/8059#discussion_r1263692477