### PR TITLE
GCP: fix single byte read in GCSInputStream

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -117,7 +117,7 @@ class GCSInputStream extends SeekableInputStream {
     readBytes.increment();
     readOperations.increment();
 
-    return singleByteBuffer.array()[0];
+    return singleByteBuffer.array()[0] & 0xFF;
   }
 
   @Override

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
@@ -78,6 +78,22 @@ public class GCSInputStreamTest {
     }
   }
 
+  @Test
+  public void testReadSingle() throws Exception {
+    BlobId uri = BlobId.fromGsUtilUri("gs://bucket/path/to/read.dat");
+    int i0 = 1;
+    int i1 = 255;
+    byte[] data = {(byte) i0, (byte) i1};
+
+    writeGCSData(uri, data);
+
+    try (SeekableInputStream in =
+        new GCSInputStream(storage, uri, gcpProperties, MetricsContext.nullMetrics())) {
+      assertThat(in.read()).isEqualTo(i0);
+      assertThat(in.read()).isEqualTo(i1);
+    }
+  }
+
   private void readAndCheck(
       SeekableInputStream in, long rangeStart, int size, byte[] original, boolean buffered)
       throws IOException {


### PR DESCRIPTION
This PR fixes the conversion of a byte to an int when reading a single byte from GCSInputStream. Decoding integers in Parquet was throwing an exception because of this, in [this method](https://github.com/apache/parquet-mr/blob/1bdb3c6caf1bc45d66719ce6f77d25461216d697/parquet-common/src/main/java/org/apache/parquet/bytes/BytesUtils.java#L88).