### PR TITLE
Python: improve Avro parsing by caching struct types.

### DIFF
--- a/python/pyiceberg/avro/reader.py
+++ b/python/pyiceberg/avro/reader.py
@@ -266,6 +266,7 @@ class OptionReader(Reader):
 
 
 class StructReader(Reader):
+    __slots__ = ("field_readers", "create_struct", "struct", "create_with_keyword")
     field_readers: Tuple[Tuple[Optional[int], Reader], ...]
     create_struct: Callable[..., StructProtocol]
     struct: StructType
@@ -280,18 +281,22 @@ class StructReader(Reader):
         self.create_struct = create_struct
         self.struct = struct
 
-    def read(self, decoder: BinaryDecoder) -> StructProtocol:
         try:
             # Try initializing the struct, first with the struct keyword argument
-            struct = self.create_struct(struct=self.struct)
+            created_struct = self.create_struct(struct=self.struct)
+            self._create_with_keyword = True
         except TypeError as e:
             if "'struct' is an invalid keyword argument for" in str(e):
-                struct = self.create_struct()
+                created_struct = self.create_struct()
+                self._create_with_keyword = False
             else:
                 raise ValueError(f"Unable to initialize struct: {self.create_struct}") from e
 
-        if not isinstance(struct, StructProtocol):
+        if not isinstance(created_struct, StructProtocol):
             raise ValueError(f"Incompatible with StructProtocol: {self.create_struct}")
+
+    def read(self, decoder: BinaryDecoder) -> StructProtocol:
+        struct = self.create_struct(struct=self.struct) if self._create_with_keyword else self.create_struct()
 
         for pos, field in self.field_readers:
             if pos is not None:

--- a/python/pyiceberg/manifest.py
+++ b/python/pyiceberg/manifest.py
@@ -212,8 +212,11 @@ MANIFEST_ENTRY_SCHEMA = Schema(
     NestedField(2, "data_file", DATA_FILE_TYPE, required=True),
 )
 
+MANIFEST_ENTRY_SCHEMA_STRUCT = MANIFEST_ENTRY_SCHEMA.as_struct()
+
 
 class ManifestEntry(Record):
+    __slots__ = ("status", "snapshot_id", "data_sequence_number", "file_sequence_number", "data_file")
     status: ManifestEntryStatus
     snapshot_id: Optional[int]
     data_sequence_number: Optional[int]
@@ -221,7 +224,7 @@ class ManifestEntry(Record):
     data_file: DataFile
 
     def __init__(self, *data: Any, **named_data: Any) -> None:
-        super().__init__(*data, **{"struct": MANIFEST_ENTRY_SCHEMA.as_struct(), **named_data})
+        super().__init__(*data, **{"struct": MANIFEST_ENTRY_SCHEMA_STRUCT, **named_data})
 
 
 PARTITION_FIELD_SUMMARY_TYPE = StructType(
@@ -260,6 +263,8 @@ MANIFEST_FILE_SCHEMA: Schema = Schema(
     NestedField(519, "key_metadata", BinaryType(), required=False),
 )
 
+MANIFEST_FILE_SCHEMA_STRUCT = MANIFEST_FILE_SCHEMA.as_struct()
+
 POSITIONAL_DELETE_SCHEMA = Schema(
     NestedField(2147483546, "file_path", StringType()), NestedField(2147483545, "pos", IntegerType())
 )
@@ -283,7 +288,7 @@ class ManifestFile(Record):
     key_metadata: Optional[bytes]
 
     def __init__(self, *data: Any, **named_data: Any) -> None:
-        super().__init__(*data, **{"struct": MANIFEST_FILE_SCHEMA.as_struct(), **named_data})
+        super().__init__(*data, **{"struct": MANIFEST_FILE_SCHEMA_STRUCT, **named_data})
 
     def has_added_files(self) -> bool:
         return self.added_files_count is None or self.added_files_count > 0

--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -127,12 +127,20 @@ class IcebergBaseModel(BaseModel):
         )
 
 
+CACHED_STRUCT_TO_POSITION: Dict[StructType, Dict[int, str]] = {}
+
+
 class Record(StructProtocol):
     _position_to_field_name: Dict[int, str]
 
     def __init__(self, *data: Any, struct: Optional[StructType] = None, **named_data: Any) -> None:
         if struct is not None:
-            self._position_to_field_name = {idx: field.name for idx, field in enumerate(struct.fields)}
+            if struct in CACHED_STRUCT_TO_POSITION:
+                self._position_to_field_name = CACHED_STRUCT_TO_POSITION[struct]
+            else:
+                self._position_to_field_name = CACHED_STRUCT_TO_POSITION[struct] = {
+                    idx: field.name for idx, field in enumerate(struct.fields)
+                }
         elif named_data:
             # Order of named_data is preserved (PEP 468) so this can be used to generate the position dict
             self._position_to_field_name = dict(enumerate(named_data.keys()))

--- a/python/tests/avro/test_file.py
+++ b/python/tests/avro/test_file.py
@@ -14,6 +14,7 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
+import inspect
 from enum import Enum
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -90,7 +91,7 @@ def todict(obj: Any) -> Any:
     elif hasattr(obj, "__iter__") and not isinstance(obj, str) and not isinstance(obj, bytes):
         return [todict(v) for v in obj]
     elif hasattr(obj, "__dict__"):
-        return {key: todict(value) for key, value in obj.__dict__.items() if not callable(value) and not key.startswith("_")}
+        return {key: todict(value) for key, value in inspect.getmembers(obj) if not callable(value) and not key.startswith("_")}
     else:
         return obj
 


### PR DESCRIPTION
Cache the struct types for ManifestEntry and ManifestFile schemas.

Cache the _position_to_field_name lookup in Records if a struct type is passed.

Improve StructReader to use slots and avoid isinstance() lookups on each time the structure is read, by performing the check in __init__().

Improve StructReader to determine the arguments to create_struct() once in init and reuse the result each time the structure is read, avoid a try block.