### PR TITLE
Core, AWS: Support Lambda-based HTTP client for REST catalog

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvoker.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvoker.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.BaseRESTClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+/**
+ * A client to fulfill REST catalog request and response using AWS Lambda's Invoke API.
+ *
+ * <p>This is useful for situations where an HTTP connection cannot be established against a REST
+ * endpoint. For example, when the endpoint is in an isolated private subnet, a Lambda can be placed
+ * within the subnet as a proxy for communication. See {@link LambdaRESTRequest} and {@link
+ * LambdaRESTResponse} for request-response contract
+ */
+public class LambdaRESTInvoker extends BaseRESTClient {
+
+  private LambdaClient lambda;
+  private String functionArn;
+  private Map<String, String> baseHeaders;
+
+  public LambdaRESTInvoker() {}
+
+  @VisibleForTesting
+  LambdaRESTInvoker(
+      String baseUri,
+      ObjectMapper objectMapper,
+      Map<String, String> baseHeaders,
+      LambdaClient lambda,
+      String functionArn) {
+    super.initialize(baseUri, objectMapper, baseHeaders, ImmutableMap.of());
+    this.baseHeaders = baseHeaders;
+    this.lambda = lambda;
+    this.functionArn = functionArn;
+  }
+
+  @Override
+  protected <T> T execute(
+      Method method,
+      String path,
+      Map<String, String> queryParams,
+      Object requestBody,
+      Class<T> responseType,
+      Map<String, String> inputHeaders,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    validateInputPath(path);
+    URI uri = buildUri(path, queryParams);
+
+    Map<String, String> headers;
+    String entity = null;
+    if (requestBody instanceof Map) {
+      headers = requestHeaders(inputHeaders, ContentType.APPLICATION_FORM_URLENCODED.getMimeType());
+      entity = RESTUtil.encodeFormData((Map<?, ?>) requestBody);
+    } else if (requestBody != null) {
+      headers = requestHeaders(inputHeaders, ContentType.APPLICATION_JSON.getMimeType());
+      entity = super.toJsonString(requestBody);
+    } else {
+      headers = requestHeaders(inputHeaders, ContentType.APPLICATION_JSON.getMimeType());
+    }
+
+    LambdaRESTRequest request =
+        ImmutableLambdaRESTRequest.builder()
+            .method(method.name())
+            .uri(uri)
+            .headers(headers)
+            .entity(entity)
+            .build();
+
+    InvokeResponse lambdaResponse;
+    try {
+      lambdaResponse =
+          lambda.invoke(
+              InvokeRequest.builder()
+                  .functionName(functionArn)
+                  .payload(SdkBytes.fromUtf8String(LambdaRESTRequestParser.toJson(request)))
+                  .build());
+    } catch (AwsServiceException e) {
+      throw new RESTException(e, "Error occurred while processing %s request", method);
+    }
+
+    LambdaRESTResponse response =
+        LambdaRESTResponseParser.fromJsonStream(lambdaResponse.payload().asInputStream());
+    responseHeaders.accept(response.headers());
+
+    if (response.code() == HttpStatus.SC_NO_CONTENT
+        || (responseType == null && isSuccessful(response.code()))) {
+      return null;
+    }
+
+    if (!isSuccessful(response.code())) {
+      throwFailure(response.code(), response.entity(), response.reason(), errorHandler);
+    }
+
+    if (response.entity() == null) {
+      throw new RESTException(
+          "Invalid (null) response body for request (expected %s): method=%s, path=%s, status=%d",
+          responseType.getSimpleName(), method.name(), path, response.code());
+    }
+
+    return parseResponse(response.entity(), responseType, response.code());
+  }
+
+  @Override
+  public void close() throws IOException {
+    lambda.close();
+  }
+
+  @Override
+  public void initialize(
+      String baseUri,
+      ObjectMapper objectMapper,
+      Map<String, String> headers,
+      Map<String, String> properties) {
+    super.initialize(baseUri, objectMapper, headers, properties);
+    LambdaRESTInvokerProperties lambdaRESTInvokerProperties =
+        new LambdaRESTInvokerProperties(properties);
+    this.functionArn = lambdaRESTInvokerProperties.functionArn();
+    this.lambda = LambdaRESTInvokerAwsClientFactories.from(properties).lambda();
+    this.baseHeaders = headers;
+    LOG.info("Initialized invoker with function {} and headers {}", functionArn, baseHeaders);
+    // TODO: support sigv4 signer
+  }
+
+  private Map<String, String> requestHeaders(
+      Map<String, String> inputHeaders, String bodyMimeType) {
+    return ImmutableMap.<String, String>builder()
+        .putAll(baseHeaders)
+        .putAll(inputHeaders)
+        .put(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType())
+        .put(HttpHeaders.CONTENT_TYPE, bodyMimeType)
+        .buildKeepingLast();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvoker.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvoker.java
@@ -152,7 +152,6 @@ public class LambdaRESTInvoker extends BaseRESTClient {
     this.functionArn = lambdaRESTInvokerProperties.functionArn();
     this.lambda = LambdaRESTInvokerAwsClientFactories.from(properties).lambda();
     this.baseHeaders = headers;
-    LOG.info("Initialized invoker with function {} and headers {}", functionArn, baseHeaders);
     // TODO: support sigv4 signer
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerAwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerAwsClientFactories.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.util.Map;
+import org.apache.iceberg.aws.AwsClientProperties;
+import org.apache.iceberg.aws.HttpClientProperties;
+import org.apache.iceberg.common.DynConstructors;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+public class LambdaRESTInvokerAwsClientFactories {
+
+  private LambdaRESTInvokerAwsClientFactories() {}
+
+  public static LambdaRESTInvokerAwsClientFactory from(Map<String, String> properties) {
+    String factoryImpl = properties.get(LambdaRESTInvokerProperties.CLIENT_FACTORY);
+    if (factoryImpl == null) {
+      LambdaRESTInvokerAwsClientFactory factory = new DefaultLambdaRESTInvokerAwsClientFactory();
+      factory.initialize(properties);
+      return factory;
+    }
+
+    DynConstructors.Ctor<LambdaRESTInvokerAwsClientFactory> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(LambdaRESTInvokerAwsClientFactory.class)
+              .loader(LambdaRESTInvokerAwsClientFactories.class.getClassLoader())
+              .hiddenImpl(factoryImpl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize LambdaRESTInvokerAwsClientFactory, missing no-arg constructor: %s",
+              factoryImpl),
+          e);
+    }
+
+    LambdaRESTInvokerAwsClientFactory factory;
+    try {
+      factory = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot construct instance of: %s, does not implement LambdaHttpClientAwsClientFactory.",
+              factoryImpl),
+          e);
+    }
+
+    factory.initialize(properties);
+    return factory;
+  }
+
+  static class DefaultLambdaRESTInvokerAwsClientFactory
+      implements LambdaRESTInvokerAwsClientFactory {
+
+    private HttpClientProperties httpClientProperties;
+    private AwsClientProperties awsClientProperties;
+
+    DefaultLambdaRESTInvokerAwsClientFactory() {}
+
+    @Override
+    public LambdaClient lambda() {
+      return LambdaClient.builder()
+          .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+          .applyMutation(awsClientProperties::applyClientRegionConfiguration)
+          .build();
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.httpClientProperties = new HttpClientProperties(properties);
+      this.awsClientProperties = new AwsClientProperties(properties);
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerAwsClientFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.util.Map;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+public interface LambdaRESTInvokerAwsClientFactory {
+
+  LambdaClient lambda();
+
+  void initialize(Map<String, String> properties);
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTInvokerProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.util.Map;
+
+public class LambdaRESTInvokerProperties {
+
+  public static final String CLIENT_FACTORY = "lambda-rest-invoker.client-factory-impl";
+
+  public static final String FUNCTION_ARN = "lambda-rest-invoker.function-arn";
+
+  private String functionArn;
+
+  public LambdaRESTInvokerProperties(Map<String, String> properties) {
+    this.functionArn = properties.get(FUNCTION_ARN);
+  }
+
+  public String functionArn() {
+    return functionArn;
+  }
+
+  public void setFunctionArn(String functionArn) {
+    this.functionArn = functionArn;
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTRequest.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTRequest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.net.URI;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface LambdaRESTRequest {
+
+  String method();
+
+  URI uri();
+
+  Map<String, String> headers();
+
+  @Nullable
+  String entity();
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTRequestParser.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTRequestParser.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class LambdaRESTRequestParser {
+
+  private static final String METHOD = "method";
+  private static final String URI = "uri";
+  private static final String HEADERS = "headers";
+  private static final String ENTITY = "entity";
+
+  private LambdaRESTRequestParser() {}
+
+  public static String toJson(LambdaRESTRequest request) {
+    return toJson(request, false);
+  }
+
+  public static String toJson(LambdaRESTRequest request, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(request, gen), pretty);
+  }
+
+  public static InputStream toJsonStream(LambdaRESTRequest request) {
+    return JsonUtil.generateStream(gen -> toJson(request, gen), false);
+  }
+
+  public static InputStream toJsonStream(LambdaRESTRequest request, boolean pretty) {
+    return JsonUtil.generateStream(gen -> toJson(request, gen), pretty);
+  }
+
+  public static void toJson(LambdaRESTRequest request, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != request, "Invalid Lambda REST request: null");
+
+    gen.writeStartObject();
+    gen.writeStringField(METHOD, request.method());
+    gen.writeStringField(URI, request.uri().toString());
+    JsonUtil.writeStringMap(HEADERS, request.headers(), gen);
+
+    if (request.entity() != null) {
+      gen.writeStringField(ENTITY, request.entity());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static LambdaRESTRequest fromJson(String json) {
+    return JsonUtil.parse(json, LambdaRESTRequestParser::fromJson);
+  }
+
+  public static LambdaRESTRequest fromJsonStream(InputStream json) {
+    return JsonUtil.parseStream(json, LambdaRESTRequestParser::fromJson);
+  }
+
+  public static LambdaRESTRequest fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse Lambda REST request from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse Lambda REST request from non-object: %s", json);
+
+    String method = JsonUtil.getString(METHOD, json);
+    java.net.URI uri = java.net.URI.create(JsonUtil.getString(URI, json));
+    Map<String, String> headers = JsonUtil.getStringMap(HEADERS, json);
+    String entity = JsonUtil.getStringOrNull(ENTITY, json);
+    return ImmutableLambdaRESTRequest.builder()
+        .method(method)
+        .uri(uri)
+        .headers(headers)
+        .entity(entity)
+        .build();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTResponse.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface LambdaRESTResponse {
+
+  int code();
+
+  Map<String, String> headers();
+
+  @Nullable
+  String entity();
+
+  @Nullable
+  String reason();
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTResponseParser.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lambda/rest/LambdaRESTResponseParser.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class LambdaRESTResponseParser {
+
+  private static final String CODE = "code";
+  private static final String HEADERS = "headers";
+  private static final String ENTITY = "entity";
+  private static final String REASON = "reason";
+
+  private LambdaRESTResponseParser() {}
+
+  public static String toJson(LambdaRESTResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(LambdaRESTResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static InputStream toJsonStream(LambdaRESTResponse response) {
+    return JsonUtil.generateStream(gen -> toJson(response, gen), false);
+  }
+
+  public static InputStream toJsonStream(LambdaRESTResponse response, boolean pretty) {
+    return JsonUtil.generateStream(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void writeToStream(OutputStream stream, LambdaRESTResponse response) {
+    JsonUtil.writeToStream(stream, gen -> toJson(response, gen), false);
+  }
+
+  public static void writeToStream(
+      OutputStream stream, LambdaRESTResponse response, boolean pretty) {
+    JsonUtil.writeToStream(stream, gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(LambdaRESTResponse response, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid Lambda REST response: null");
+
+    gen.writeStartObject();
+    gen.writeNumberField(CODE, response.code());
+    JsonUtil.writeStringMap(HEADERS, response.headers(), gen);
+
+    if (response.entity() != null) {
+      gen.writeStringField(ENTITY, response.entity());
+    }
+
+    if (response.reason() != null) {
+      gen.writeStringField(REASON, response.reason());
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static LambdaRESTResponse fromJson(String json) {
+    return JsonUtil.parse(json, LambdaRESTResponseParser::fromJson);
+  }
+
+  public static LambdaRESTResponse fromJsonStream(InputStream json) {
+    return JsonUtil.parseStream(json, LambdaRESTResponseParser::fromJson);
+  }
+
+  public static LambdaRESTResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse Lambda REST response from null object");
+    Preconditions.checkArgument(
+        json.isObject(), "Cannot parse Lambda REST response from non-object: %s", json);
+
+    int code = JsonUtil.getInt(CODE, json);
+    Map<String, String> headers = JsonUtil.getStringMap(HEADERS, json);
+    String entity = JsonUtil.getStringOrNull(ENTITY, json);
+    String reason = JsonUtil.getStringOrNull(REASON, json);
+    return ImmutableLambdaRESTResponse.builder()
+        .code(code)
+        .headers(headers)
+        .entity(entity)
+        .reason(reason)
+        .build();
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4Signer.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4Signer.java
@@ -24,7 +24,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.rest.HTTPClient;
+import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.ConfigResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
@@ -42,7 +42,7 @@ import software.amazon.awssdk.auth.signer.internal.SignerConstant;
 
 public class TestRESTSigV4Signer {
   private static ClientAndServer mockServer;
-  private static HTTPClient client;
+  private static RESTClient client;
 
   @BeforeAll
   public static void beforeClass() {
@@ -60,7 +60,7 @@ public class TestRESTSigV4Signer {
             AwsProperties.REST_SECRET_ACCESS_KEY,
             "secret");
     client =
-        HTTPClient.builder(properties)
+        RESTClient.buildFrom(properties)
             .uri("http://localhost:" + mockServer.getLocalPort())
             .withHeader(HttpHeaders.AUTHORIZATION, "Bearer existing_token")
             .build();

--- a/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTInvokerAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTInvokerAwsClientFactories.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+public class TestLambdaRESTInvokerAwsClientFactories {
+
+  @Test
+  public void testLoadDefaultFactory() {
+    LambdaRESTInvokerAwsClientFactory factory =
+        LambdaRESTInvokerAwsClientFactories.from(ImmutableMap.of());
+    Assertions.assertThat(factory)
+        .isInstanceOf(
+            LambdaRESTInvokerAwsClientFactories.DefaultLambdaRESTInvokerAwsClientFactory.class);
+  }
+
+  @Test
+  public void testLoadCustomFactory() {
+    LambdaRESTInvokerAwsClientFactory factory =
+        LambdaRESTInvokerAwsClientFactories.from(
+            ImmutableMap.of(
+                LambdaRESTInvokerProperties.CLIENT_FACTORY, CustomFactory.class.getName()));
+    Assertions.assertThat(factory).isInstanceOf(CustomFactory.class);
+    Assertions.assertThat(factory.lambda()).isNull();
+  }
+
+  @Test
+  public void testLoadCustomFactoryBadConstructor() {
+    Assertions.assertThatThrownBy(
+            () ->
+                LambdaRESTInvokerAwsClientFactories.from(
+                    ImmutableMap.of(
+                        LambdaRESTInvokerProperties.CLIENT_FACTORY,
+                        BadConstructorFactory.class.getName())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot initialize LambdaRESTInvokerAwsClientFactory, missing no-arg constructor: "
+                + BadConstructorFactory.class.getName());
+  }
+
+  @Test
+  public void testLoadCustomFactoryNotSubclass() {
+    Assertions.assertThatThrownBy(
+            () ->
+                LambdaRESTInvokerAwsClientFactories.from(
+                    ImmutableMap.of(
+                        LambdaRESTInvokerProperties.CLIENT_FACTORY,
+                        NotSubclassFactory.class.getName())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot construct instance of: "
+                + NotSubclassFactory.class.getName()
+                + ", does not implement LambdaHttpClientAwsClientFactory.");
+  }
+
+  public static class CustomFactory implements LambdaRESTInvokerAwsClientFactory {
+    @Override
+    public LambdaClient lambda() {
+      return null;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+  }
+
+  public static class BadConstructorFactory implements LambdaRESTInvokerAwsClientFactory {
+
+    private final String arg;
+
+    public BadConstructorFactory(String arg) {
+      this.arg = arg;
+    }
+
+    @Override
+    public LambdaClient lambda() {
+      return null;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+  }
+
+  public static class NotSubclassFactory {}
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTRequestParser.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTRequestParser.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.InputStream;
+import java.net.URI;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestLambdaRESTRequestParser {
+
+  @Test
+  public void testNullRequest() {
+    Assertions.assertThatThrownBy(() -> LambdaRESTRequestParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse Lambda REST request from null object");
+
+    Assertions.assertThatThrownBy(() -> LambdaRESTRequestParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid Lambda REST request: null");
+  }
+
+  @Test
+  public void testMissingFields() {
+    Assertions.assertThatThrownBy(() -> LambdaRESTRequestParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: method");
+
+    Assertions.assertThatThrownBy(() -> LambdaRESTRequestParser.fromJson("{\"method\":\"GET\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: uri");
+
+    Assertions.assertThatThrownBy(
+            () -> LambdaRESTRequestParser.fromJson("{\"method\":\"GET\", \"uri\":\"test.com\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing map: headers");
+  }
+
+  @Test
+  public void testRoundTripSerdeWithoutEntity() {
+    ImmutableLambdaRESTRequest request =
+        ImmutableLambdaRESTRequest.builder()
+            .method("GET")
+            .uri(URI.create("test.com"))
+            .headers(ImmutableMap.of("key", "val"))
+            .build();
+
+    String json = LambdaRESTRequestParser.toJson(request, true);
+    Assertions.assertThat(LambdaRESTRequestParser.fromJson(json)).isEqualTo(request);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"method\" : \"GET\",\n"
+                + "  \"uri\" : \"test.com\",\n"
+                + "  \"headers\" : {\n"
+                + "    \"key\" : \"val\"\n"
+                + "  }\n"
+                + "}");
+  }
+
+  @Test
+  public void testRoundTripSerde() {
+    ImmutableLambdaRESTRequest request =
+        ImmutableLambdaRESTRequest.builder()
+            .method("POST")
+            .uri(URI.create("test.com"))
+            .headers(ImmutableMap.of("key", "val"))
+            .entity("string")
+            .build();
+
+    String json = LambdaRESTRequestParser.toJson(request, true);
+    Assertions.assertThat(LambdaRESTRequestParser.fromJson(json)).isEqualTo(request);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"method\" : \"POST\",\n"
+                + "  \"uri\" : \"test.com\",\n"
+                + "  \"headers\" : {\n"
+                + "    \"key\" : \"val\"\n"
+                + "  },\n"
+                + "  \"entity\" : \"string\"\n"
+                + "}");
+  }
+
+  @Test
+  public void testRoundTripSerdeJsonStream() {
+    ImmutableLambdaRESTRequest request =
+        ImmutableLambdaRESTRequest.builder()
+            .method("POST")
+            .uri(URI.create("test.com"))
+            .headers(ImmutableMap.of("key", "val"))
+            .entity("string")
+            .build();
+
+    InputStream json = LambdaRESTRequestParser.toJsonStream(request, true);
+    Assertions.assertThat(LambdaRESTRequestParser.fromJsonStream(json)).isEqualTo(request);
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTResponseParser.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lambda/rest/TestLambdaRESTResponseParser.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lambda.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.InputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestLambdaRESTResponseParser {
+
+  @Test
+  public void testNullRequest() {
+    Assertions.assertThatThrownBy(() -> LambdaRESTResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse Lambda REST response from null object");
+
+    Assertions.assertThatThrownBy(() -> LambdaRESTResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid Lambda REST response: null");
+  }
+
+  @Test
+  public void testMissingFields() {
+    Assertions.assertThatThrownBy(() -> LambdaRESTResponseParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing int: code");
+    Assertions.assertThatThrownBy(() -> LambdaRESTResponseParser.fromJson("{\"code\":1}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing map: headers");
+  }
+
+  @Test
+  public void testRoundTripSerdeWithoutEntity() {
+    ImmutableLambdaRESTResponse response =
+        ImmutableLambdaRESTResponse.builder()
+            .code(1)
+            .headers(ImmutableMap.of("key", "val"))
+            .reason("string")
+            .build();
+
+    String json = LambdaRESTResponseParser.toJson(response, true);
+    Assertions.assertThat(LambdaRESTResponseParser.fromJson(json)).isEqualTo(response);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"code\" : 1,\n"
+                + "  \"headers\" : {\n"
+                + "    \"key\" : \"val\"\n"
+                + "  },\n"
+                + "  \"reason\" : \"string\"\n"
+                + "}");
+  }
+
+  @Test
+  public void testRoundTripSerdeWithoutReason() {
+    ImmutableLambdaRESTResponse response =
+        ImmutableLambdaRESTResponse.builder()
+            .code(1)
+            .headers(ImmutableMap.of("key", "val"))
+            .entity("string")
+            .build();
+
+    String json = LambdaRESTResponseParser.toJson(response, true);
+    Assertions.assertThat(LambdaRESTResponseParser.fromJson(json)).isEqualTo(response);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"code\" : 1,\n"
+                + "  \"headers\" : {\n"
+                + "    \"key\" : \"val\"\n"
+                + "  },\n"
+                + "  \"entity\" : \"string\"\n"
+                + "}");
+  }
+
+  @Test
+  public void testRoundTripSerde() {
+    ImmutableLambdaRESTResponse response =
+        ImmutableLambdaRESTResponse.builder()
+            .code(1)
+            .headers(ImmutableMap.of("key", "val"))
+            .entity("string")
+            .reason("string2")
+            .build();
+
+    String json = LambdaRESTResponseParser.toJson(response, true);
+    Assertions.assertThat(LambdaRESTResponseParser.fromJson(json)).isEqualTo(response);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"code\" : 1,\n"
+                + "  \"headers\" : {\n"
+                + "    \"key\" : \"val\"\n"
+                + "  },\n"
+                + "  \"entity\" : \"string\",\n"
+                + "  \"reason\" : \"string2\"\n"
+                + "}");
+  }
+
+  @Test
+  public void testRoundTripSerdeJsonStream() {
+    ImmutableLambdaRESTResponse response =
+        ImmutableLambdaRESTResponse.builder()
+            .code(1)
+            .headers(ImmutableMap.of("key", "val"))
+            .entity("string")
+            .reason("string2")
+            .build();
+
+    InputStream json = LambdaRESTResponseParser.toJsonStream(response, true);
+    Assertions.assertThat(LambdaRESTResponseParser.fromJsonStream(json)).isEqualTo(response);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -473,6 +473,7 @@ project(':iceberg-aws') {
     compileOnly 'software.amazon.awssdk:sts'
     compileOnly 'software.amazon.awssdk:dynamodb'
     compileOnly 'software.amazon.awssdk:lakeformation'
+    compileOnly 'software.amazon.awssdk:lambda'
 
     compileOnly("org.apache.hadoop:hadoop-common") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/core/src/main/java/org/apache/iceberg/rest/BaseRESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/BaseRESTClient.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.hc.core5.net.URIBuilder;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** An HttpClient for usage with the REST catalog. */
+public abstract class BaseRESTClient implements RESTClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseRESTClient.class);
+
+  private String uri;
+  private ObjectMapper mapper;
+
+  protected BaseRESTClient() {}
+
+  @Override
+  public void initialize(
+      String baseUri,
+      ObjectMapper objectMapper,
+      Map<String, String> baseHeaders,
+      Map<String, String> properties) {
+    this.uri = baseUri;
+    this.mapper = objectMapper;
+  }
+
+  /**
+   * Method to execute an HTTP request and process the corresponding response.
+   *
+   * @param method - HTTP method, such as GET, POST, HEAD, etc.
+   * @param queryParams - A map of query parameters
+   * @param path - URL path to send the request to
+   * @param requestBody - Content to place in the request body
+   * @param responseType - Class of the Response type. Needs to have serializer registered with
+   *     ObjectMapper
+   * @param errorHandler - Error handler delegated for HTTP responses which handles server error
+   *     responses
+   * @param <T> - Class type of the response for deserialization. Must be registered with the
+   *     ObjectMapper.
+   * @return The response entity, parsed and converted to its type T
+   */
+  private <T> T execute(
+      Method method,
+      String path,
+      Map<String, String> queryParams,
+      Object requestBody,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(
+        method, path, queryParams, requestBody, responseType, headers, errorHandler, h -> {});
+  }
+
+  /**
+   * Method to execute an HTTP request and process the corresponding response.
+   *
+   * @param method - HTTP method, such as GET, POST, HEAD, etc.
+   * @param queryParams - A map of query parameters
+   * @param path - URL path to send the request to
+   * @param requestBody - Content to place in the request body
+   * @param responseType - Class of the Response type. Needs to have serializer registered with
+   *     ObjectMapper
+   * @param errorHandler - Error handler delegated for HTTP responses which handles server error
+   *     responses
+   * @param responseHeaders The consumer of the response headers
+   * @param <T> - Class type of the response for deserialization. Must be registered with the
+   *     ObjectMapper.
+   * @return The response entity, parsed and converted to its type T
+   */
+  protected abstract <T> T execute(
+      Method method,
+      String path,
+      Map<String, String> queryParams,
+      Object requestBody,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders);
+
+  @Override
+  public void head(String path, Map<String, String> headers, Consumer<ErrorResponse> errorHandler) {
+    execute(Method.HEAD, path, null, null, null, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T get(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.GET, path, queryParams, null, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.POST, path, null, body, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T post(
+      String path,
+      RESTRequest body,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler,
+      Consumer<Map<String, String>> responseHeaders) {
+    return execute(
+        Method.POST, path, null, body, responseType, headers, errorHandler, responseHeaders);
+  }
+
+  @Override
+  public <T extends RESTResponse> T delete(
+      String path,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.DELETE, path, null, null, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T delete(
+      String path,
+      Map<String, String> queryParams,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.DELETE, path, queryParams, null, responseType, headers, errorHandler);
+  }
+
+  @Override
+  public <T extends RESTResponse> T postForm(
+      String path,
+      Map<String, String> formData,
+      Class<T> responseType,
+      Map<String, String> headers,
+      Consumer<ErrorResponse> errorHandler) {
+    return execute(Method.POST, path, null, formData, responseType, headers, errorHandler);
+  }
+
+  // Per the spec, the only currently defined / used "success" responses are 200 and 202.
+  protected static boolean isSuccessful(int code) {
+    return code == HttpStatus.SC_OK
+        || code == HttpStatus.SC_ACCEPTED
+        || code == HttpStatus.SC_NO_CONTENT;
+  }
+
+  protected static ErrorResponse buildDefaultErrorResponse(int code, String responseReason) {
+    String message =
+        responseReason != null && !responseReason.isEmpty()
+            ? responseReason
+            : EnglishReasonPhraseCatalog.INSTANCE.getReason(code, null /* ignored */);
+    String type = "RESTException";
+    return ErrorResponse.builder().responseCode(code).withMessage(message).withType(type).build();
+  }
+
+  // Process a failed response through the provided errorHandler, and throw a RESTException if the
+  // provided error handler doesn't already throw.
+  protected static void throwFailure(
+      int code, String responseBody, String reason, Consumer<ErrorResponse> errorHandler) {
+    ErrorResponse errorResponse = null;
+
+    if (responseBody != null) {
+      try {
+        if (errorHandler instanceof ErrorHandler) {
+          errorResponse = ((ErrorHandler) errorHandler).parseResponse(code, responseBody);
+        } else {
+          LOG.warn(
+              "Unknown error handler {}, response body won't be parsed",
+              errorHandler.getClass().getName());
+          errorResponse =
+              ErrorResponse.builder().responseCode(code).withMessage(responseBody).build();
+        }
+
+      } catch (UncheckedIOException | IllegalArgumentException e) {
+        // It's possible to receive a non-successful response that isn't a properly defined
+        // ErrorResponse
+        // without any bugs in the server implementation. So we ignore this exception and build an
+        // error
+        // response for the user.
+        //
+        // For example, the connection could time out before every reaching the server, in which
+        // case we'll
+        // likely get a 5xx with the load balancers default 5xx response.
+        LOG.error("Failed to parse an error response. Will create one instead.", e);
+      }
+    }
+
+    if (errorResponse == null) {
+      errorResponse = buildDefaultErrorResponse(code, reason);
+    }
+
+    errorHandler.accept(errorResponse);
+
+    // Throw an exception in case the provided error handler does not throw.
+    throw new RESTException("Unhandled error: %s", errorResponse);
+  }
+
+  protected URI buildUri(String path, Map<String, String> params) {
+    String baseUri = String.format("%s/%s", uri, path);
+    try {
+      URIBuilder builder = new URIBuilder(baseUri);
+      if (params != null) {
+        params.forEach(builder::addParameter);
+      }
+      return builder.build();
+    } catch (URISyntaxException e) {
+      throw new RESTException(
+          "Failed to create request URI from base %s, params %s", baseUri, params);
+    }
+  }
+
+  protected <T> T parseResponse(String responseBody, Class<T> responseType, int code) {
+    try {
+      return mapper.readValue(responseBody, responseType);
+    } catch (JsonProcessingException e) {
+      throw new RESTException(
+          e,
+          "Received a success response code of %d, but failed to parse response body into %s",
+          code,
+          responseType.getSimpleName());
+    }
+  }
+
+  protected String toJsonString(Object requestBody) {
+    try {
+      return mapper.writeValueAsString(requestBody);
+    } catch (JsonProcessingException e) {
+      throw new RESTException(e, "Failed to write request body: %s", requestBody);
+    }
+  }
+
+  protected void validateInputPath(String path) {
+    if (path.startsWith("/")) {
+      throw new RESTException(
+          "Received a malformed path for a REST request: %s. Paths should not start with /", path);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -50,7 +50,7 @@ public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Ob
   public RESTCatalog() {
     this(
         SessionCatalog.SessionContext.createEmpty(),
-        config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build());
+        config -> RESTClient.buildFrom(config).uri(config.get(CatalogProperties.URI)).build());
   }
 
   public RESTCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Closeable;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -158,4 +159,14 @@ public interface RESTClient extends Closeable {
       Class<T> responseType,
       Map<String, String> headers,
       Consumer<ErrorResponse> errorHandler);
+
+  default void initialize(
+      String uri,
+      ObjectMapper objectMapper,
+      Map<String, String> baseHeaders,
+      Map<String, String> properties) {}
+
+  static RESTClientBuilder buildFrom(Map<String, String> properties) {
+    return new RESTClientBuilder(properties);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClientBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClientBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class RESTClientBuilder {
+
+  private final Map<String, String> properties;
+  private final Map<String, String> baseHeaders = Maps.newHashMap();
+  private String uri;
+  private ObjectMapper mapper = RESTObjectMapper.mapper();
+
+  RESTClientBuilder(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  public RESTClientBuilder uri(String baseUri) {
+    Preconditions.checkNotNull(baseUri, "Invalid uri for http client: null");
+    this.uri = RESTUtil.stripTrailingSlash(baseUri);
+    return this;
+  }
+
+  public RESTClientBuilder withHeader(String key, String value) {
+    baseHeaders.put(key, value);
+    return this;
+  }
+
+  public RESTClientBuilder withHeaders(Map<String, String> headers) {
+    baseHeaders.putAll(headers);
+    return this;
+  }
+
+  public RESTClientBuilder withObjectMapper(ObjectMapper objectMapper) {
+    this.mapper = objectMapper;
+    return this;
+  }
+
+  public RESTClient build() {
+    withHeader(RESTClientProperties.CLIENT_VERSION_HEADER, IcebergBuild.fullVersion());
+    withHeader(
+        RESTClientProperties.CLIENT_GIT_COMMIT_SHORT_HEADER, IcebergBuild.gitCommitShortId());
+
+    RESTClient client;
+    if (!properties.containsKey(RESTClientProperties.REST_CLIENT_IMPL)) {
+      client = new HTTPClient();
+    } else {
+      String impl = properties.get(RESTClientProperties.REST_CLIENT_IMPL);
+      DynConstructors.Ctor<BaseRESTClient> ctor;
+      try {
+        ctor =
+            DynConstructors.builder(RESTClient.class)
+                .loader(RESTClientBuilder.class.getClassLoader())
+                .hiddenImpl(impl)
+                .buildChecked();
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException(
+            String.format("Cannot find no-arg constructor for: %s", impl), e);
+      }
+
+      try {
+        client = ctor.newInstance();
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot initialize new instance of: %s, not a subclass of RESTClient", impl),
+            e);
+      }
+    }
+
+    client.initialize(uri, mapper, baseHeaders, properties);
+    return client;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTClientProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClientProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+public class RESTClientProperties {
+
+  private RESTClientProperties() {}
+
+  public static final String REST_CLIENT_IMPL = "rest.client-impl";
+  public static final String CLIENT_VERSION_HEADER = "X-Client-Version";
+  public static final String CLIENT_GIT_COMMIT_SHORT_HEADER = "X-Client-Git-Commit-Short";
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -25,14 +25,14 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
-class RESTObjectMapper {
+public class RESTObjectMapper {
   private static final JsonFactory FACTORY = new JsonFactory();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
   private static volatile boolean isInitialized = false;
 
   private RESTObjectMapper() {}
 
-  static ObjectMapper mapper() {
+  public static ObjectMapper mapper() {
     if (!isInitialized) {
       synchronized (RESTObjectMapper.class) {
         if (!isInitialized) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -132,7 +132,9 @@ public class RESTSessionCatalog extends BaseSessionCatalog
   }
 
   public RESTSessionCatalog() {
-    this(config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build(), null);
+    this(
+        config -> RESTClient.buildFrom(config).uri(config.get(CatalogProperties.URI)).build(),
+        null);
   }
 
   public RESTSessionCatalog(

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -176,7 +176,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     this.restCatalog =
         new RESTCatalog(
             context,
-            (config) -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build());
+            (config) ->
+                RESTClient.buildFrom(config).uri(config.get(CatalogProperties.URI)).build());
     restCatalog.setConf(conf);
     restCatalog.initialize(
         "prod",
@@ -1352,7 +1353,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 "user",
                 ImmutableMap.of("credential", "user:12345"),
                 ImmutableMap.of()),
-            (config) -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build());
+            (config) ->
+                RESTClient.buildFrom(config).uri(config.get(CatalogProperties.URI)).build());
     restCatalog.setConf(new Configuration());
     restCatalog.initialize(
         "prod",

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTClientBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTClientBuilder.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.hc.core5.http.Method;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestRESTClientBuilder {
+
+  @Test
+  public void testBuildHttpClient() {
+    RESTClient client = RESTClient.buildFrom(ImmutableMap.of()).build();
+    Assertions.assertThat(client).isInstanceOf(HTTPClient.class);
+  }
+
+  @Test
+  public void testBuildAlternativeClient() {
+    RESTClient client =
+        RESTClient.buildFrom(
+                ImmutableMap.of(RESTClientProperties.REST_CLIENT_IMPL, TestClient.class.getName()))
+            .build();
+    Assertions.assertThat(client).isInstanceOf(TestClient.class);
+  }
+
+  @Test
+  public void testBuildClientBadConstructor() {
+    Assertions.assertThatThrownBy(
+            () ->
+                RESTClient.buildFrom(
+                        ImmutableMap.of(
+                            RESTClientProperties.REST_CLIENT_IMPL,
+                            BadConstructorClient.class.getName()))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find no-arg constructor for: " + BadConstructorClient.class.getName());
+  }
+
+  @Test
+  public void testBuildClientNotSubclass() {
+    Assertions.assertThatThrownBy(
+            () ->
+                RESTClient.buildFrom(
+                        ImmutableMap.of(
+                            RESTClientProperties.REST_CLIENT_IMPL,
+                            NotSubclassClient.class.getName()))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot initialize new instance of: "
+                + NotSubclassClient.class.getName()
+                + ", not a subclass of RESTClient");
+  }
+
+  static class TestClient extends BaseRESTClient {
+    @Override
+    protected <T> T execute(
+        Method method,
+        String path,
+        Map<String, String> queryParams,
+        Object requestBody,
+        Class<T> responseType,
+        Map<String, String> headers,
+        Consumer<ErrorResponse> errorHandler,
+        Consumer<Map<String, String>> responseHeaders) {
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException {}
+  }
+
+  static class BadConstructorClient extends BaseRESTClient {
+
+    private final String arg;
+
+    BadConstructorClient(String arg) {
+      this.arg = arg;
+    }
+
+    @Override
+    protected <T> T execute(
+        Method method,
+        String path,
+        Map<String, String> queryParams,
+        Object requestBody,
+        Class<T> responseType,
+        Map<String, String> headers,
+        Consumer<ErrorResponse> errorHandler,
+        Consumer<Map<String, String>> responseHeaders) {
+      return null;
+    }
+
+    @Override
+    public void close() throws IOException {}
+  }
+
+  static class NotSubclassClient {}
+}


### PR DESCRIPTION
This PR refactors the existing implementation for vending `HTTPClient`, which is an implementation of the `RESTClient`, by allowing an alternative implementation `LambdaRESTInvoker` to fulfill REST catalog request and response using AWS Lambda's Invoke API.

This is useful for situations where an HTTP connection cannot be established against a REST endpoint, for serverless compute engines like Athena Trino/Spark, Glue ETL Spark, Kinesis Flink, etc. A Lambda can be placed within the subnet as a proxy.

@rdblue @danielcweeks @nastra @amogh-jahagirdar 