### PR TITLE
Revert: Core: Make `TableMetadataParser.fromJson` public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -299,7 +299,7 @@ public class TableMetadataParser {
     return JsonUtil.parse(json, node -> TableMetadataParser.fromJson(metadataLocation, node));
   }
 
-  public static TableMetadata fromJson(InputFile file, JsonNode node) {
+  static TableMetadata fromJson(InputFile file, JsonNode node) {
     return fromJson(file.location(), node);
   }
 
@@ -308,7 +308,7 @@ public class TableMetadataParser {
   }
 
   @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
-  public static TableMetadata fromJson(String metadataLocation, JsonNode node) {
+  static TableMetadata fromJson(String metadataLocation, JsonNode node) {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse metadata from a non-object: %s", node);
 


### PR DESCRIPTION
This reverts commit 8a8508de70f54335e5f551ff39e5954da7274b5c.

@rdblue raised the issue of exposing Jackson in the public API. Which I think is a valid one, and we should avoid.