### PR TITLE
Core: push down filters when evaluating entries in metadata tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -40,8 +40,13 @@ import org.apache.iceberg.types.Types.StructType;
 /** Base class logic for files metadata tables */
 abstract class BaseFilesTable extends BaseMetadataTable {
 
+  private final int defaultSpecId;
+  private final Map<Integer, PartitionSpec> specs;
+
   BaseFilesTable(Table table, String name) {
     super(table, name);
+    this.defaultSpecId = table.spec().specId();
+    this.specs = transformSpecs(schema(), table.specs());
   }
 
   @Override
@@ -55,6 +60,16 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     return TypeUtil.join(schema, MetricsUtil.readableMetricsSchema(table().schema(), schema));
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return specs.get(defaultSpecId);
+  }
+
+  @Override
+  public Map<Integer, PartitionSpec> specs() {
+    return specs;
   }
 
   private static CloseableIterable<FileScanTask> planFiles(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -131,6 +131,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
+
+    Assert.assertEquals(
+        dataFilesTable.spec(),
+        BaseMetadataTable.transformSpec(dataFilesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        dataFilesTable.specs(),
+        BaseMetadataTable.transformSpecs(dataFilesTable.schema(), table.specs()));
   }
 
   @Test
@@ -222,6 +229,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
+
+    Assert.assertEquals(
+        allDataFilesTable.spec(),
+        BaseMetadataTable.transformSpec(allDataFilesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        allDataFilesTable.specs(),
+        BaseMetadataTable.transformSpecs(allDataFilesTable.schema(), table.specs()));
   }
 
   @Test
@@ -538,6 +552,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Types.NestedField.optional(1001, "data_bucket_16", Types.IntegerType.get()),
             Types.NestedField.optional(1002, "data_trunc_2", Types.StringType.get()));
     Assert.assertEquals("Partition type must match", expectedType, actualType);
+    Assert.assertEquals(
+        dataFilesTable.spec(),
+        BaseMetadataTable.transformSpec(dataFilesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        dataFilesTable.specs(),
+        BaseMetadataTable.transformSpecs(dataFilesTable.schema(), table.specs()));
     Accessor<StructLike> accessor = schema.accessorForField(1000);
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -578,6 +598,12 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                     103, "record_count", Types.LongType.get(), "Number of records in the file"))
             .asStruct();
     Assert.assertEquals(expected, scan.schema().asStruct());
+    Assert.assertEquals(
+        deleteFilesTable.spec(),
+        BaseMetadataTable.transformSpec(deleteFilesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        deleteFilesTable.specs(),
+        BaseMetadataTable.transformSpecs(deleteFilesTable.schema(), table.specs()));
   }
 
   @Test
@@ -665,6 +691,10 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 "Column metrics in readable form"));
 
     Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+    Assert.assertEquals(
+        filesTable.spec(), BaseMetadataTable.transformSpec(filesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        filesTable.specs(), BaseMetadataTable.transformSpecs(filesTable.schema(), table.specs()));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -131,13 +131,6 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
-
-    Assert.assertEquals(
-        dataFilesTable.spec(),
-        BaseMetadataTable.transformSpec(dataFilesTable.schema(), table.spec()));
-    Assert.assertEquals(
-        dataFilesTable.specs(),
-        BaseMetadataTable.transformSpecs(dataFilesTable.schema(), table.specs()));
   }
 
   @Test
@@ -229,13 +222,6 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
-
-    Assert.assertEquals(
-        allDataFilesTable.spec(),
-        BaseMetadataTable.transformSpec(allDataFilesTable.schema(), table.spec()));
-    Assert.assertEquals(
-        allDataFilesTable.specs(),
-        BaseMetadataTable.transformSpecs(allDataFilesTable.schema(), table.specs()));
   }
 
   @Test
@@ -356,6 +342,13 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
 
     TableScan scanWithProjection = partitionsTable.newScan().select("file_count");
     Assert.assertEquals(expected, scanWithProjection.schema().asStruct());
+    Assert.assertEquals(
+        partitionsTable.spec(),
+        BaseMetadataTable.transformSpec(partitionsTable.schema(), table.spec()));
+    Assert.assertEquals(
+        partitionsTable.specs(),
+        BaseMetadataTable.transformSpecs(partitionsTable.schema(), table.specs()));
+
     CloseableIterable<ManifestEntry<?>> entries =
         PartitionsTable.planEntries((StaticTableScan) scanWithProjection);
     if (formatVersion == 2) {
@@ -552,12 +545,6 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
             Types.NestedField.optional(1001, "data_bucket_16", Types.IntegerType.get()),
             Types.NestedField.optional(1002, "data_trunc_2", Types.StringType.get()));
     Assert.assertEquals("Partition type must match", expectedType, actualType);
-    Assert.assertEquals(
-        dataFilesTable.spec(),
-        BaseMetadataTable.transformSpec(dataFilesTable.schema(), table.spec()));
-    Assert.assertEquals(
-        dataFilesTable.specs(),
-        BaseMetadataTable.transformSpecs(dataFilesTable.schema(), table.specs()));
     Accessor<StructLike> accessor = schema.accessorForField(1000);
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
@@ -782,6 +769,11 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
                 "Column metrics in readable form"));
 
     Assert.assertEquals("Dynamic schema for readable_metrics should match", actual, expected);
+    Assert.assertEquals(
+        entriesTable.spec(), BaseMetadataTable.transformSpec(entriesTable.schema(), table.spec()));
+    Assert.assertEquals(
+        entriesTable.specs(),
+        BaseMetadataTable.transformSpecs(entriesTable.schema(), table.specs()));
   }
 
   @Test
@@ -982,7 +974,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @Test
-  public void testAllDataFilesTableScanWithPlanExecutor() throws IOException {
+  public void testAllDataFilesTableScanWithPlanExecutor() {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Table allDataFilesTable = new AllDataFilesTable(table);
@@ -1005,7 +997,7 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @Test
-  public void testAllEntriesTableScanWithPlanExecutor() throws IOException {
+  public void testAllEntriesTableScanWithPlanExecutor() {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 
     Table allEntriesTable = new AllEntriesTable(table);


### PR DESCRIPTION
Add spec and partitionSpecs method override in following metadata tables and enable partition filter evaluation oagainst transformed spec. This change get rid of the warning message described in #7774 and with #6899 it allows partition filter to be completely evaluated on iceberg side without spark post-scan filter.

- .files
- .data_files
- .delete_files
- .all_files
- .all_data_files
- .all_delete_files
- .entries
- .all_entries
- .partitions


## Example
Given query of `spark.sql("SELECT * FROM iceberg.db.table.all_files WHERE partition.data='a'");`


## Before
```
23/07/24 12:08:46 WARN SparkScanBuilder: Failed to check if IsNotNull(partition.data) can be pushed down: Cannot find field 'partition.data' in struct: struct<>
23/07/24 12:08:46 WARN SparkScanBuilder: Failed to check if EqualTo(partition.data,a) can be pushed down: Cannot find field 'partition.data' in struct: struct<>
23/07/24 12:08:46 INFO V2ScanRelationPushDown: 
Pushing operators to spark_catalog.default.table.all_files
Pushed Filters: IsNotNull(partition.data), EqualTo(partition.data,a)
Post-Scan Filters: isnotnull(partition#21.data),(partition#21.data = a)
```

## After
```
23/07/24 12:04:43 INFO SparkScanBuilder: Evaluating completely on Iceberg side: IsNotNull(partition.data)
23/07/24 12:04:43 INFO SparkScanBuilder: Evaluating completely on Iceberg side: EqualTo(partition.data,a)
23/07/24 12:04:43 INFO V2ScanRelationPushDown: 
Pushing operators to spark_catalog.default.table.all_files
Pushed Filters: IsNotNull(partition.data), EqualTo(partition.data,a)
Post-Scan Filters: 
```