### PR TITLE
Api:Fix add the same listener to the same listeners queue multiple times

### DIFF
--- a/api/src/main/java/org/apache/iceberg/events/Listeners.java
+++ b/api/src/main/java/org/apache/iceberg/events/Listeners.java
@@ -33,7 +33,9 @@ public class Listeners {
   public static <E> void register(Listener<E> listener, Class<E> eventType) {
     Queue<Listener<?>> list =
         listeners.computeIfAbsent(eventType, k -> new ConcurrentLinkedQueue<>());
-    list.add(listener);
+    if (!list.contains(listener)) {
+      list.add(listener);
+    }
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
this issue: https://github.com/apache/iceberg/issues/8107

When I register create snaoshot event listener to listeners, I found that same listener would be added to the same listeners queue multiple times.