### PR TITLE
Hive: Fix assertion

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -112,7 +112,7 @@ public class TestHiveMetastore {
                     FileSystem fs = Util.getFs(localDirPath, new Configuration());
                     String errMsg = "Failed to delete " + localDirPath;
                     try {
-                      assertThat(fs.delete(localDirPath, true)).isEqualTo(errMsg);
+                      assertThat(fs.delete(localDirPath, true)).as(errMsg).isTrue();
                     } catch (IOException e) {
                       throw new RuntimeException(errMsg, e);
                     }


### PR DESCRIPTION
Tests would fail with the below error because the assertion check is wrong and I missed this during review of #8058 
```
expected: "Failed to delete /tmp/hive8945016726872271834"
 but was: true
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at org.apache.iceberg.hive.TestHiveMetastore.lambda$static$0(TestHiveMetastore.java:115)
        at java.lang.Thread.run(Thread.java:750)
```