### PR TITLE
Core, API: Add non-nullable constraint checks to support making optional columns…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -49,6 +49,26 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema allowIncompatibleChanges();
 
   /**
+   * Validate only live data in compatibility checks.
+   *
+   * <p>All data referenced from all living snapshots will be validated by default when performing
+   * compatibility checks, because deleted data may still be read by schemas in future snapshots.
+   * For example, changelog reads will use the current schema to read deleted data. However, If the
+   * table does not have such a query mode that needs to read deleted data, only liva data in the
+   * current snapshot needs to be validated.
+   *
+   * <p>This option allows validating only live data when performing compatibility checks. This
+   * should be used when the caller determines that it does not need to query deleted data using the
+   * current schema.
+   *
+   * @return this for method chaining
+   */
+  default UpdateSchema validateLiveDataOnly() {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + "doesn't implement validateLiveDataOnly");
+  }
+
+  /**
    * Add a new top-level column.
    *
    * <p>Because "." may be interpreted as a column path separator or may be used in field names, it

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -579,28 +579,6 @@ public class TestSchemaUpdate {
   }
 
   @Test
-  public void testAddRequiredColumn() {
-    Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
-    Schema expected =
-        new Schema(
-            required(1, "id", Types.IntegerType.get()),
-            required(2, "data", Types.StringType.get()));
-
-    Assertions.assertThatThrownBy(
-            () -> new SchemaUpdate(schema, 1).addRequiredColumn("data", Types.StringType.get()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Incompatible change: cannot add required column: data");
-
-    Schema result =
-        new SchemaUpdate(schema, 1)
-            .allowIncompatibleChanges()
-            .addRequiredColumn("data", Types.StringType.get())
-            .apply();
-
-    Assert.assertEquals("Should add required column", expected.asStruct(), result.asStruct());
-  }
-
-  @Test
   public void testAddRequiredColumnCaseInsensitive() {
     Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
 
@@ -624,25 +602,6 @@ public class TestSchemaUpdate {
 
     Assert.assertEquals(
         "Should update column to be optional", expected.asStruct(), result.asStruct());
-  }
-
-  @Test
-  public void testRequireColumn() {
-    Schema schema = new Schema(optional(1, "id", Types.IntegerType.get()));
-    Schema expected = new Schema(required(1, "id", Types.IntegerType.get()));
-
-    Assertions.assertThatThrownBy(() -> new SchemaUpdate(schema, 1).requireColumn("id"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot change column nullability: id: optional -> required");
-
-    // required to required is not an incompatible change
-    new SchemaUpdate(expected, 1).requireColumn("id").apply();
-
-    Schema result =
-        new SchemaUpdate(schema, 1).allowIncompatibleChanges().requireColumn("id").apply();
-
-    Assert.assertEquals(
-        "Should update column to be required", expected.asStruct(), result.asStruct());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestUpdateSchemaConstraintChecks.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateSchemaConstraintChecks.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestUpdateSchemaConstraintChecks {
+
+  private static final Schema SCHEMA =
+      new Schema(
+          optional(1, "no_nulls", Types.IntegerType.get()),
+          optional(2, "some_nulls", Types.LongType.get()),
+          optional(3, "no_stats", Types.StringType.get()),
+          optional(
+              4,
+              "struct",
+              Types.StructType.of(
+                  optional(5, "list", Types.ListType.ofOptional(6, Types.StringType.get())))));
+
+  private static final String EXCEPTION_MSG_FORMAT =
+      "Cannot set a column to required: %s, as it cannot be determined from "
+          + "existing metadata metrics that it must not contain null values";
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private TestTables.TestTable table;
+
+  @Before
+  public void before() throws IOException {
+    table = TestTables.create(temp.newFolder(), "test", SCHEMA, PartitionSpec.unpartitioned(), 2);
+  }
+
+  @After
+  public void after() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testFreshTableRequireColumn() {
+    makeRequiredAndValidate("no_nulls", "some_nulls", "no_stats", "struct", "struct.list");
+  }
+
+  @Test
+  public void testRequireColumnOnlyDataFiles() {
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 3L));
+
+    makeRequiredAndValidate("no_nulls");
+
+    makeRequiredAndCapture("some_nulls");
+    makeRequiredAndCapture("no_stats");
+    makeRequiredAndCapture("struct");
+  }
+
+  @Test
+  public void testRequireColumnWithEqualityDeletes() {
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 0L, 3, 0L));
+    addEqualityDeleteToTable(10L, ImmutableMap.of(1, 0L, 2, 3L), 1, 2, 3);
+
+    makeRequiredAndValidate("no_nulls");
+
+    makeRequiredAndCapture("some_nulls");
+    makeRequiredAndCapture("no_stats");
+  }
+
+  @Test
+  public void testRequireColumnWithDeletedDataFileHasNulls() {
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 3L));
+
+    table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
+    assertThat(table.newScan().planFiles()).isEmpty();
+
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 0L));
+
+    makeRequiredAndValidate("no_nulls");
+
+    makeRequiredAndCapture("some_nulls");
+  }
+
+  @Test
+  public void testRequireColumnDeletedDeleteFileHasNulls() {
+    addEqualityDeleteToTable(10L, ImmutableMap.of(1, 0L, 2, 3L), 1, 2);
+
+    table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
+    Iterable<DeleteFile> deleteFiles = table.currentSnapshot().removedDeleteFiles(table.ops().io());
+    assertThat(deleteFiles).hasOnlyElementsOfType(DeleteFile.class);
+
+    addEqualityDeleteToTable(10L, ImmutableMap.of(1, 0L, 2, 0L), 1, 2);
+
+    makeRequiredAndValidate("no_nulls");
+
+    makeRequiredAndCapture("some_nulls");
+  }
+
+  @Test
+  public void testFreshTableAddRequiredColumns() {
+    table
+        .updateSchema()
+        .addRequiredColumn(
+            "point",
+            Types.StructType.of(
+                required(9, "x", Types.LongType.get()), required(10, "y", Types.LongType.get())))
+        .commit();
+
+    assertColumnsRequired("point", "point.x", "point.y");
+  }
+
+  @Test
+  public void testOnlyValidateLiveData() {
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 3L));
+
+    table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
+    assertThat(table.newScan().planFiles()).isEmpty();
+
+    table
+        .updateSchema()
+        .validateLiveDataOnly()
+        .addRequiredColumn("added", Types.DoubleType.get())
+        .commit();
+    assertColumnsRequired("added");
+
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 0L));
+
+    makeRequiredAndValidate(true, false, "some_nulls");
+  }
+
+  @Test
+  public void testAllowIncompatibleChanges() {
+    addDataFileToTable(10L, ImmutableMap.of(1, 0L, 2, 3L));
+
+    makeRequiredAndCapture("some_nulls");
+    makeRequiredAndValidate(false, true, "some_nulls");
+
+    Assertions.assertThatThrownBy(
+            () -> table.updateSchema().addRequiredColumn("added", Types.DoubleType.get()).commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(String.format(EXCEPTION_MSG_FORMAT, "added"));
+
+    table
+        .updateSchema()
+        .allowIncompatibleChanges()
+        .addRequiredColumn("added", Types.DoubleType.get())
+        .commit();
+    assertColumnsRequired("added");
+  }
+
+  private void makeRequiredAndCapture(String column) {
+    Assertions.assertThatThrownBy(() -> applyUpdate(false, false, column))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(String.format(EXCEPTION_MSG_FORMAT, column));
+  }
+
+  private void makeRequiredAndValidate(String... columns) {
+    makeRequiredAndValidate(false, false, columns);
+  }
+
+  private void makeRequiredAndValidate(
+      boolean onlyValidateLiveData, boolean allowIncompatibleChanges, String... columns) {
+
+    applyUpdate(onlyValidateLiveData, allowIncompatibleChanges, columns);
+
+    assertColumnsRequired(columns);
+  }
+
+  private void applyUpdate(
+      boolean onlyValidateLiveData, boolean allowIncompatibleChanges, String... columns) {
+    UpdateSchema updateSchema = table.updateSchema();
+    if (onlyValidateLiveData) {
+      updateSchema.validateLiveDataOnly();
+    }
+
+    if (allowIncompatibleChanges) {
+      updateSchema.allowIncompatibleChanges();
+    }
+
+    for (String column : columns) {
+      updateSchema.requireColumn(column);
+    }
+
+    updateSchema.commit();
+  }
+
+  private void assertColumnsRequired(String... columns) {
+    for (String column : columns) {
+      assertThat(table.schema().findField(column).isRequired())
+          .overridingErrorMessage(
+              String.format("Expect column to be required but is optional: %s", column))
+          .isTrue();
+    }
+  }
+
+  private void addDataFileToTable(Long rowCount, Map<Integer, Long> nullCounts) {
+    Metrics metrics = new Metrics(10L, null, null, nullCounts, null);
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(10)
+            .withMetrics(metrics)
+            .build();
+
+    table.newAppend().appendFile(dataFile).commit();
+  }
+
+  private void addEqualityDeleteToTable(
+      Long rowCount, Map<Integer, Long> nullCounts, int... eqFieldIds) {
+    Metrics metrics = new Metrics(rowCount, null, null, nullCounts, null);
+    DeleteFile eqDelete =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes(eqFieldIds)
+            .withPath(UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(100)
+            .withMetrics(metrics)
+            .build();
+
+    table.newRowDelta().addDeletes(eqDelete).commit();
+  }
+}


### PR DESCRIPTION
… required.

This adds support for adding new required columns and making optional columns required to `SchemaUpdate` (without calling `allowIncompatibleChanges`). This is inspired by this [comment](https://github.com/apache/iceberg/pull/5007#issuecomment-1154241027).

When applying schema changes to the table, it will check table's metadata to see if there are any null values and allow the change after verifying that compatibility is sure not broken, otherwise throws a validation exception.
 By default this will check all files referenced(including files marked as `deleted`) by all live snapshots in the table，because deleted files may also be read using the  new schema (e.g. CDC read), this also provides a method `validateLiveDataOnly` to allow validate live data only when performing compatibility checks, which can be used when the user confirms that the deleted data does not need to be queried.

@szehon-ho @rdblue Can you please help review this ? Thansks.