### PR TITLE
Spark 3.4: Return empty changed rows when there are no snapshots between start time and end time

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -337,6 +337,10 @@ public class SnapshotUtil {
    *     timestamp
    */
   public static long snapshotIdAsOfTime(Table table, long timestampMillis) {
+    return snapshotIdAsOfTime(table, timestampMillis, false);
+  }
+
+  public static Long snapshotIdAsOfTime(Table table, long timestampMillis, boolean nullable) {
     Long snapshotId = null;
     for (HistoryEntry logEntry : table.history()) {
       if (logEntry.timestampMillis() <= timestampMillis) {
@@ -345,7 +349,7 @@ public class SnapshotUtil {
     }
 
     Preconditions.checkArgument(
-        snapshotId != null,
+        snapshotId != null || nullable,
         "Cannot find a snapshot older than %s",
         DateTimeUtil.formatTimestampMillis(timestampMillis));
     return snapshotId;

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -337,10 +337,17 @@ public class SnapshotUtil {
    *     timestamp
    */
   public static long snapshotIdAsOfTime(Table table, long timestampMillis) {
-    return snapshotIdAsOfTime(table, timestampMillis, false);
+    Long snapshotId = nullableSnapshotIdAsOfTime(table, timestampMillis);
+
+    Preconditions.checkArgument(
+        snapshotId != null,
+        "Cannot find a snapshot older than %s",
+        DateTimeUtil.formatTimestampMillis(timestampMillis));
+
+    return snapshotId;
   }
 
-  public static Long snapshotIdAsOfTime(Table table, long timestampMillis, boolean nullable) {
+  public static Long nullableSnapshotIdAsOfTime(Table table, long timestampMillis) {
     Long snapshotId = null;
     for (HistoryEntry logEntry : table.history()) {
       if (logEntry.timestampMillis() <= timestampMillis) {
@@ -348,10 +355,6 @@ public class SnapshotUtil {
       }
     }
 
-    Preconditions.checkArgument(
-        snapshotId != null || nullable,
-        "Cannot find a snapshot older than %s",
-        DateTimeUtil.formatTimestampMillis(timestampMillis));
     return snapshotId;
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -66,7 +66,8 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
       IncrementalChangelogScan scan,
       SparkReadConf readConf,
       Schema expectedSchema,
-      List<Expression> filters) {
+      List<Expression> filters,
+      boolean emptyScan) {
 
     SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), expectedSchema);
 
@@ -78,6 +79,9 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
     this.filters = filters != null ? filters : Collections.emptyList();
     this.startSnapshotId = readConf.startSnapshotId();
     this.endSnapshotId = readConf.endSnapshotId();
+    if (emptyScan) {
+      this.taskGroups = Collections.emptyList();
+    }
   }
 
   @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -498,6 +498,7 @@ public class SparkScanBuilder
         metricsReporter::scanReport);
   }
 
+  @SuppressWarnings("CyclomaticComplexity")
   public Scan buildChangelogScan() {
     Preconditions.checkArgument(
         readConf.snapshotId() == null
@@ -535,12 +536,20 @@ public class SparkScanBuilder
           SparkReadOptions.END_TIMESTAMP);
     }
 
+    boolean emptyScan = false;
     if (startTimestamp != null) {
       startSnapshotId = getStartSnapshotId(startTimestamp);
+      if (startSnapshotId == null && endTimestamp == null) {
+        emptyScan = true;
+      }
     }
 
     if (endTimestamp != null) {
-      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp);
+      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp, true);
+      if ((startSnapshotId == null && endSnapshotId == null)
+          || (startSnapshotId != null && startSnapshotId.equals(endSnapshotId))) {
+        emptyScan = true;
+      }
     }
 
     Schema expectedSchema = schemaWithMetadataColumns();
@@ -562,18 +571,16 @@ public class SparkScanBuilder
 
     scan = configureSplitPlanning(scan);
 
-    return new SparkChangelogScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
+    return new SparkChangelogScan(
+        spark, table, scan, readConf, expectedSchema, filterExpressions, emptyScan);
   }
 
   private Long getStartSnapshotId(Long startTimestamp) {
     Snapshot oldestSnapshotAfter = SnapshotUtil.oldestAncestorAfter(table, startTimestamp);
-    Preconditions.checkArgument(
-        oldestSnapshotAfter != null,
-        "Cannot find a snapshot older than %s for table %s",
-        startTimestamp,
-        table.name());
 
-    if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
+    if (oldestSnapshotAfter == null) {
+      return null;
+    } else if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
       return oldestSnapshotAfter.snapshotId();
     } else {
       return oldestSnapshotAfter.parentId();

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -545,7 +545,7 @@ public class SparkScanBuilder
     }
 
     if (endTimestamp != null) {
-      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp, true);
+      endSnapshotId = SnapshotUtil.nullableSnapshotIdAsOfTime(table, endTimestamp);
       if ((startSnapshotId == null && endSnapshotId == null)
           || (startSnapshotId != null && startSnapshotId.equals(endSnapshotId))) {
         emptyScan = true;


### PR DESCRIPTION
Currently, when running `create_changelog_view` procedure and there are no snapshots between start time(exclusive) and end time(inclusive), the procedure will fail due to null checks on start snapshot and end snapshot. However, it's possible that there's no updates from upstream for a period of time and the procedure should not fail. This PR attempts to handle it by returning empty results when there are no snapshots between start time and end time.
