### PR TITLE
Spark: Evaluate ExpressionUtil.selectsPartitions for partitioned table only

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -169,7 +169,7 @@ public class SparkScanBuilder
         }
 
         if (expr == null
-            || unPartitioned()
+            || unpartitioned()
             || !ExpressionUtil.selectsPartitions(expr, table, caseSensitive)) {
           postScanFilters.add(filter);
         } else {
@@ -188,7 +188,7 @@ public class SparkScanBuilder
     return postScanFilters.toArray(new Filter[0]);
   }
 
-  private boolean unPartitioned() {
+  private boolean unpartitioned() {
     return table.specs().values().stream().noneMatch(PartitionSpec::isPartitioned);
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.IncrementalChangelogScan;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
@@ -167,7 +168,9 @@ public class SparkScanBuilder
           pushableFilters.add(filter);
         }
 
-        if (expr == null || !ExpressionUtil.selectsPartitions(expr, table, caseSensitive)) {
+        if (expr == null
+            || unPartitioned()
+            || !ExpressionUtil.selectsPartitions(expr, table, caseSensitive)) {
           postScanFilters.add(filter);
         } else {
           LOG.info("Evaluating completely on Iceberg side: {}", filter);
@@ -183,6 +186,10 @@ public class SparkScanBuilder
     this.pushedFilters = pushableFilters.toArray(new Filter[0]);
 
     return postScanFilters.toArray(new Filter[0]);
+  }
+
+  private boolean unPartitioned() {
+    return table.specs().values().stream().noneMatch(PartitionSpec::isPartitioned);
   }
 
   @Override


### PR DESCRIPTION
The `ExpressionUtil.selectsPartitions` is aimed to determine whether the expression can be fully applied to the whole partitions. However, it is not necessary for an unpartitioned table. Especially for metadata tables which are always unpartitioned. For example, we get unexpected warnings for the following scan:
```
scala> spark.sql("select file_path, partition, record_count from iceberg.db.table.files where partition.partition_time = 2023012410").show()

23/07/24 14:20:47 WARN SparkScanBuilder: Failed to check if IsNotNull(partition.partition_time) can be pushed down: Cannot find field 'partition.partition_time' in struct: struct<>
23/07/24 14:20:47 WARN SparkScanBuilder: Failed to check if EqualTo(partition.partition_time,2023012410) can be pushed down: Cannot find field 'partition.partition_time' in struct: struct<>

```