### PR TITLE
Python: allow projection of Iceberg fields to pyarrow table schema with names

### DIFF
--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -860,7 +860,7 @@ class DataScan(TableScan):
             for data_entry in data_entries
         ]
 
-    def to_arrow(self) -> pa.Table:
+    def to_arrow(self, *, match_with_field_name: bool = False, ignore_unprojectable_fields: bool = False) -> pa.Table:
         from pyiceberg.io.pyarrow import project_table
 
         return project_table(
@@ -870,23 +870,25 @@ class DataScan(TableScan):
             self.projection(),
             case_sensitive=self.case_sensitive,
             limit=self.limit,
+            match_with_field_name=match_with_field_name,
+            ignore_unprojectable_fields=ignore_unprojectable_fields,
         )
 
-    def to_pandas(self, **kwargs: Any) -> pd.DataFrame:
-        return self.to_arrow().to_pandas(**kwargs)
+    def to_pandas(self, *, match_with_field_name: bool = False, ignore_unprojectable_fields: bool = False, **kwargs: Any) -> pd.DataFrame:
+        return self.to_arrow(match_with_field_name=match_with_field_name, ignore_unprojectable_fields=ignore_unprojectable_fields).to_pandas(**kwargs)
 
-    def to_duckdb(self, table_name: str, connection: Optional[DuckDBPyConnection] = None) -> DuckDBPyConnection:
+    def to_duckdb(self, table_name: str, connection: Optional[DuckDBPyConnection] = None, *, match_with_field_name: bool = False) -> DuckDBPyConnection:
         import duckdb
 
         con = connection or duckdb.connect(database=":memory:")
-        con.register(table_name, self.to_arrow())
+        con.register(table_name, self.to_arrow(match_with_field_name=match_with_field_name, ignore_unprojectable_fields=ignore_unprojectable_fields))
 
         return con
 
-    def to_ray(self) -> ray.data.dataset.Dataset:
+    def to_ray(self, *, match_with_field_name: bool = False, ignore_unprojectable_fields: bool = False) -> ray.data.dataset.Dataset:
         import ray
 
-        return ray.data.from_arrow(self.to_arrow())
+        return ray.data.from_arrow(self.to_arrow(match_with_field_name=match_with_field_name, ignore_unprojectable_fields=ignore_unprojectable_fields))
 
 
 class UpdateSchema:


### PR DESCRIPTION
Fixes #7451.

## Design note

In this PR, thw following two new keyword arguments are introduced to `Table.to_pyarrow`, `Table.to_pandas', and likewise.

* `matched_with_field_name` (bool)
    * Setting this to `True` instructs it to map fields between the data file (pyarrow) schema and Iceberg schema by names, when the mapping by field ids is not feasible.  Setting this to `False` willl keep it adhering to the normal behavior.
* `ignore_unprojectable_fields` (bool)
    * Setting this to `True` instructs it to ignore fields that are present in the data file (pyarrow) schema, but absent in the Iceberg schema.
 