### PR TITLE
API: Implement bound expression sanitization

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -46,9 +46,13 @@ public class TestExpressionUtil {
           Types.NestedField.required(5, "date", Types.DateType.get()),
           Types.NestedField.required(6, "time", Types.DateType.get()),
           Types.NestedField.optional(7, "data", Types.StringType.get()),
-          Types.NestedField.optional(8, "measurement", Types.DoubleType.get()));
+          Types.NestedField.optional(8, "measurement", Types.DoubleType.get()),
+          Types.NestedField.optional(9, "test", Types.IntegerType.get()));
 
   private static final Types.StructType STRUCT = SCHEMA.asStruct();
+
+  private static final Types.StructType FLOAT_TEST =
+      Types.StructType.of(Types.NestedField.optional(1, "test", Types.FloatType.get()));
 
   @Test
   public void testUnchangedUnaryPredicates() {
@@ -59,6 +63,7 @@ public class TestExpressionUtil {
             Expressions.isNaN("test"),
             Expressions.notNaN("test"))) {
       assertEquals(unary, ExpressionUtil.sanitize(unary));
+      assertEquals(unary, ExpressionUtil.sanitize(FLOAT_TEST, unary, true));
     }
   }
 
@@ -68,7 +73,15 @@ public class TestExpressionUtil {
         Expressions.in("test", "(2-digit-int)", "(3-digit-int)"),
         ExpressionUtil.sanitize(Expressions.in("test", 34, 345)));
 
+    assertEquals(
+        Expressions.in("test", "(2-digit-int)", "(3-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.in("test", 34, 345), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.in("test", 34, 345)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test IN ((2-digit-int), (3-digit-int))");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.in("test", 34, 345), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test IN ((2-digit-int), (3-digit-int))");
   }
@@ -126,6 +139,10 @@ public class TestExpressionUtil {
     assertThat(ExpressionUtil.toSanitizedString(Expressions.notIn("test", 34, 345)))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test NOT IN ((2-digit-int), (3-digit-int))");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.notIn("test", 34, 345), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test NOT IN ((2-digit-int), (3-digit-int))");
   }
 
   @Test
@@ -161,7 +178,15 @@ public class TestExpressionUtil {
         Expressions.lessThan("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.lessThan("test", 34)));
 
+    assertEquals(
+        Expressions.lessThan("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.lessThan("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.lessThan("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test < (2-digit-int)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.lessThan("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test < (2-digit-int)");
   }
@@ -172,7 +197,16 @@ public class TestExpressionUtil {
         Expressions.lessThanOrEqual("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.lessThanOrEqual("test", 34)));
 
+    assertEquals(
+        Expressions.lessThanOrEqual("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.lessThanOrEqual("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.lessThanOrEqual("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test <= (2-digit-int)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.lessThanOrEqual("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test <= (2-digit-int)");
   }
@@ -183,7 +217,15 @@ public class TestExpressionUtil {
         Expressions.greaterThan("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.greaterThan("test", 34)));
 
+    assertEquals(
+        Expressions.greaterThan("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.greaterThan("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.greaterThan("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test > (2-digit-int)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.greaterThan("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test > (2-digit-int)");
   }
@@ -194,7 +236,17 @@ public class TestExpressionUtil {
         Expressions.greaterThanOrEqual("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.greaterThanOrEqual("test", 34)));
 
+    assertEquals(
+        Expressions.greaterThanOrEqual("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.greaterThanOrEqual("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.greaterThanOrEqual("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test >= (2-digit-int)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(
+                STRUCT, Expressions.greaterThanOrEqual("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test >= (2-digit-int)");
   }
@@ -205,7 +257,15 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.equal("test", 34)));
 
+    assertEquals(
+        Expressions.equal("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test = (2-digit-int)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (2-digit-int)");
   }
@@ -216,7 +276,15 @@ public class TestExpressionUtil {
         Expressions.notEqual("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.notEqual("test", 34)));
 
+    assertEquals(
+        Expressions.notEqual("test", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.notEqual("test", 34), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.notEqual("test", 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test != (2-digit-int)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.notEqual("test", 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test != (2-digit-int)");
   }
@@ -227,9 +295,18 @@ public class TestExpressionUtil {
         Expressions.startsWith("test", "(hash-34d05fb7)"),
         ExpressionUtil.sanitize(Expressions.startsWith("test", "aaa")));
 
+    assertEquals(
+        Expressions.startsWith("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.startsWith("data", "aaa"), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.startsWith("test", "aaa")))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test STARTS WITH (hash-34d05fb7)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.startsWith("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data STARTS WITH (hash-34d05fb7)");
   }
 
   @Test
@@ -238,9 +315,19 @@ public class TestExpressionUtil {
         Expressions.notStartsWith("test", "(hash-34d05fb7)"),
         ExpressionUtil.sanitize(Expressions.notStartsWith("test", "aaa")));
 
+    assertEquals(
+        Expressions.notStartsWith("data", "(hash-34d05fb7)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.notStartsWith("data", "aaa"), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.notStartsWith("test", "aaa")))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test NOT STARTS WITH (hash-34d05fb7)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(
+                STRUCT, Expressions.notStartsWith("data", "aaa"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("data NOT STARTS WITH (hash-34d05fb7)");
   }
 
   @Test
@@ -249,9 +336,20 @@ public class TestExpressionUtil {
         Expressions.equal(Expressions.truncate("test", 2), "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.equal(Expressions.truncate("test", 2), 34)));
 
+    assertEquals(
+        Expressions.equal(Expressions.truncate("test", 2), "(2-digit-int)"),
+        ExpressionUtil.sanitize(
+            STRUCT, Expressions.equal(Expressions.truncate("test", 2), 34), true));
+
     assertThat(
             ExpressionUtil.toSanitizedString(
                 Expressions.equal(Expressions.truncate("test", 2), 34)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("truncate[2](test) = (2-digit-int)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(
+                STRUCT, Expressions.equal(Expressions.truncate("test", 2), 34), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("truncate[2](test) = (2-digit-int)");
   }
@@ -262,9 +360,17 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(2-digit-int)"),
         ExpressionUtil.sanitize(Expressions.equal("test", 34L)));
 
+    assertEquals(
+        Expressions.equal("id", "(2-digit-int)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("id", 34L), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", 34L)))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (2-digit-int)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("id", 34L), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("id = (2-digit-int)");
   }
 
   @Test
@@ -273,7 +379,15 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(2-digit-float)"),
         ExpressionUtil.sanitize(Expressions.equal("test", 34.12F)));
 
+    assertEquals(
+        Expressions.equal("test", "(2-digit-float)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("test", 34.12F), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", 34.12F)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("test = (2-digit-float)");
+
+    assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("test", 34.12F), true))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (2-digit-float)");
   }
@@ -284,9 +398,17 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(2-digit-float)"),
         ExpressionUtil.sanitize(Expressions.equal("test", 34.12D)));
 
+    assertEquals(
+        Expressions.equal("measurement", "(2-digit-float)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("measurement", 34.12D), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", 34.12D)))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (2-digit-float)");
+
+    assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("measurement", 34.12D)))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("measurement = (2-digit-float)");
   }
 
   @Test
@@ -295,9 +417,18 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(date)"),
         ExpressionUtil.sanitize(Expressions.equal("test", "2022-04-29")));
 
+    assertEquals(
+        Expressions.equal("date", "(date)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("date", "2022-04-29"), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", "2022-04-29")))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (date)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("date", "2022-04-29"), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("date = (date)");
   }
 
   @Test
@@ -309,9 +440,18 @@ public class TestExpressionUtil {
         Expressions.equal("test", "(time)"),
         ExpressionUtil.sanitize(Expressions.equal("test", currentTime)));
 
+    assertEquals(
+        Expressions.equal("time", "(time)"),
+        ExpressionUtil.sanitize(STRUCT, Expressions.equal("time", currentTime), true));
+
     assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", currentTime)))
         .as("Sanitized string should be identical except for descriptive literal")
         .isEqualTo("test = (time)");
+
+    assertThat(
+            ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("time", currentTime), true))
+        .as("Sanitized string should be identical except for descriptive literal")
+        .isEqualTo("time = (time)");
   }
 
   @Test
@@ -326,9 +466,17 @@ public class TestExpressionUtil {
           Expressions.equal("test", "(timestamp)"),
           ExpressionUtil.sanitize(Expressions.equal("test", timestamp)));
 
+      assertEquals(
+          Expressions.equal("ts", "(timestamp)"),
+          ExpressionUtil.sanitize(STRUCT, Expressions.equal("ts", timestamp), true));
+
       assertThat(ExpressionUtil.toSanitizedString(Expressions.equal("test", timestamp)))
           .as("Sanitized string should be identical except for descriptive literal")
           .isEqualTo("test = (timestamp)");
+
+      assertThat(ExpressionUtil.toSanitizedString(STRUCT, Expressions.equal("ts", timestamp), true))
+          .as("Sanitized string should be identical except for descriptive literal")
+          .isEqualTo("ts = (timestamp)");
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -140,7 +140,9 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
                   .projectedFieldNames(projectedFieldNames)
                   .tableName(table().name())
                   .snapshotId(snapshot.snapshotId())
-                  .filter(ExpressionUtil.sanitize(filter()))
+                  .filter(
+                      ExpressionUtil.sanitize(
+                          schema().asStruct(), filter(), context().caseSensitive()))
                   .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
                   .metadata(metadata)
                   .build();


### PR DESCRIPTION
This implements sanitization for bound expressions and adds an option to bind an expression when sanitizing. The purpose is to get better sanitization for dates and timestamps, which may show up as longs when pushed down from Spark.