### PR TITLE
Spark 3.3: Evaluate ExpressionUtil.selectsPartitions for partitioned table only

### DIFF
--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.IncrementalChangelogScan;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
@@ -164,7 +165,9 @@ public class SparkScanBuilder
           pushableFilters.add(filter);
         }
 
-        if (expr == null || !ExpressionUtil.selectsPartitions(expr, table, caseSensitive)) {
+        if (expr == null
+            || unpartitioned()
+            || !ExpressionUtil.selectsPartitions(expr, table, caseSensitive)) {
           postScanFilters.add(filter);
         } else {
           LOG.info("Evaluating completely on Iceberg side: {}", filter);
@@ -180,6 +183,10 @@ public class SparkScanBuilder
     this.pushedFilters = pushableFilters.toArray(new Filter[0]);
 
     return postScanFilters.toArray(new Filter[0]);
+  }
+
+  private boolean unpartitioned() {
+    return table.specs().values().stream().noneMatch(PartitionSpec::isPartitioned);
   }
 
   @Override


### PR DESCRIPTION
Backport #8142 to Spark 3.3