### PR TITLE
Spark: Fix the ChangelogScan casting issue

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -420,7 +420,7 @@ public class SparkScanBuilder
 
   @Override
   public Statistics estimateStatistics() {
-    return ((SparkScan) build()).estimateStatistics();
+    return ((SupportsReportStatistics) build()).estimateStatistics();
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -658,7 +658,7 @@ public class SparkScanBuilder
 
   @Override
   public Statistics estimateStatistics() {
-    return ((SparkScan) build()).estimateStatistics();
+    return ((SupportsReportStatistics) build()).estimateStatistics();
   }
 
   @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -700,7 +700,7 @@ public class SparkScanBuilder
 
   @Override
   public Statistics estimateStatistics() {
-    return ((SparkScan) build()).estimateStatistics();
+    return ((SupportsReportStatistics) build()).estimateStatistics();
   }
 
   @Override


### PR DESCRIPTION
To fixe a casting issue while using CDC read.
```
cannot be cast to class org.apache.iceberg.spark.source.SparkScan (org.apache.iceberg.spark.source.SparkChangelogScan and org.apache.iceberg.spark.source.SparkScan are in unnamed module of loader 'app')
	at org.apache.iceberg.spark.source.SparkScanBuilder.estimateStatistics(SparkScanBuilder.java:454)
	at org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation.computeStats(DataSourceV2Relation.scala:85)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.default(SizeInBytesOnlyStatsPlanVisitor.scala:55)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.default(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit(LogicalPlanVisitor.scala:48)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit$(LogicalPlanVisitor.scala:25)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.visit(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.$anonfun$stats$1(LogicalPlanStats.scala:37)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats(LogicalPlanStats.scala:33)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats$(LogicalPlanStats.scala:33)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlan.stats(LogicalPlan.scala:30)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.visitRepartitionByExpr(SizeInBytesOnlyStatsPlanVisitor.scala:133)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.visitRepartitionByExpr(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit(LogicalPlanVisitor.scala:39)
	at org.apache.spark.sql.catalyst.plans.logical.LogicalPlanVisitor.visit$(LogicalPlanVisitor.scala:25)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.SizeInBytesOnlyStatsPlanVisitor$.visit(SizeInBytesOnlyStatsPlanVisitor.scala:27)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.$anonfun$stats$1(LogicalPlanStats.scala:37)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats(LogicalPlanStats.scala:33)
	at org.apache.spark.sql.catalyst.plans.logical.statsEstimation.LogicalPlanStats.stats$(LogicalPlanStats.scala:33)
```
cc @aokolnychyi 