### PR TITLE
Doc: update Flink get started instruction for 1.16+ due to regression of loading external jar

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -84,7 +84,7 @@ Start the Flink SQL client. There is a separate `flink-runtime` module in the Ic
 export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`   
 
 # Below works for 1.15 or less
-./bin/sql-client.sh embedded -j <flink-runtime-directory>/iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar shell
+./bin/sql-client.sh embedded -j <flink-runtime-directory>/iceberg-flink-runtime-1.15-{{% icebergVersion %}}.jar shell
 
 # 1.16 or above has a regression in loading external jar via -j option. See FLINK-30035 for details.
 put iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar in flink/lib dir

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -83,7 +83,12 @@ Start the Flink SQL client. There is a separate `flink-runtime` module in the Ic
 # HADOOP_HOME is your hadoop root directory after unpack the binary package.
 export HADOOP_CLASSPATH=`$HADOOP_HOME/bin/hadoop classpath`   
 
+# Below works for 1.15 or less
 ./bin/sql-client.sh embedded -j <flink-runtime-directory>/iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar shell
+
+# 1.16 or above has a regression in loading external jar via -j option. See FLINK-30035 for details.
+put iceberg-flink-runtime-1.16-{{% icebergVersion %}}.jar in flink/lib dir
+./bin/sql-client.sh embedded shell
 ```
 
 By default, Iceberg ships with Hadoop jars for Hadoop catalog. To use Hive catalog, load the Hive jars when opening the Flink SQL client. Fortunately, Flink has provided a [bundled hive jar](https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-hive-2.3.9_2.12/1.16.2/flink-sql-connector-hive-2.3.9_2.12-1.16.2.jar) for the SQL client. An example on how to download the dependencies and get started:


### PR DESCRIPTION
I ran into this issue when testing Iceberg 1.1 release (with Flink 1.16) back in Nov 2022. But I forgot to update the doc. Dipankar Mazumdar asked me about the same jar loading issue. this can help other new users for just trying out Iceberg with Flink SQL.