### PR TITLE
Core: Add table metadata supplier to allow lazy loading of metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -344,11 +344,8 @@ public class RESTSessionCatalog extends BaseSessionCatalog
           TableMetadata.buildFrom(response.tableMetadata())
               .withMetadataLocation(response.metadataLocation())
               .setPreviousFileLocation(null)
-              .setSnapshotsSupplier(
-                  () ->
-                      loadInternal(context, finalIdentifier, SnapshotMode.ALL)
-                          .tableMetadata()
-                          .snapshots())
+              .setMetadataSupplier(
+                  () -> loadInternal(context, finalIdentifier, SnapshotMode.ALL).tableMetadata())
               .discardChanges()
               .build();
     } else {


### PR DESCRIPTION
This allows to send a slimmer version of `TableMetadata` and fetch the full version via the supplier when needed. I'll add some additional unit tests (similar to `TestSnapshotLoading`) in case we decide to go with this approach