### PR TITLE
Java: Fix issue where the genericreader does not propagate case sensitivity

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -119,6 +119,7 @@ class GenericReader implements Serializable {
                     fileSchema ->
                         GenericParquetReaders.buildReader(fileProjection, fileSchema, partition))
                 .split(task.start(), task.length())
+                .caseSensitive(caseSensitive)
                 .filter(task.residual());
 
         if (reuseContainers) {
@@ -138,6 +139,7 @@ class GenericReader implements Serializable {
                     fileSchema ->
                         GenericOrcReader.buildReader(fileProjection, fileSchema, partition))
                 .split(task.start(), task.length())
+                .caseSensitive(caseSensitive)
                 .filter(task.residual());
 
         return orc.build();

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -295,6 +295,13 @@ public class TestLocalScan {
         Sets.newHashSet(file1FirstSnapshotRecords),
         Sets.newHashSet(result));
 
+    result = IcebergGenerics.read(sharedTable).where(lessThan("iD", 3)).caseInsensitive().build();
+
+    Assert.assertEquals(
+        "Records should match file 1",
+        Sets.newHashSet(file1FirstSnapshotRecords),
+        Sets.newHashSet(result));
+
     result = IcebergGenerics.read(sharedTable).where(lessThanOrEqual("id", 1)).build();
 
     Assert.assertEquals(
@@ -306,6 +313,7 @@ public class TestLocalScan {
   @Test
   public void testProject() {
     verifyProjectIdColumn(IcebergGenerics.read(sharedTable).select("id").build());
+    verifyProjectIdColumn(IcebergGenerics.read(sharedTable).select("iD").caseInsensitive().build());
   }
 
   private void verifyProjectIdColumn(Iterable<Record> results) {


### PR DESCRIPTION
Problem:

Our application is using the following to read from the table
```
        IcebergGenerics.ScanBuilder scanBuilder = IcebergGenerics.read(iceberg_table);
        CloseableIterable<Record> records = scanBuilder.useSnapshot(snapshotId).build();
        List<List<String>> output = new ArrayList<List<String>>();
        for (Record record : records) {
 ```
however when I apply a case insensitive filter like
```
        	Expression filterExpr = ExpressionParser.fromJson(m_scanFilter);
        	scanBuilder = scanBuilder.where(filterExpr).caseInsensitive();
```
I get the below error despite setting the scan to caseInsensitive
```
2023-07-28 11:17:45.000208 EDT INFO: Scan of 'test.usethestats' using provided filter: '{"type":"eq","term":"V1","value":1}'
Records in test.usethestats :
Error processing the request: Cannot find field 'V1' in struct: struct<1: v1: optional int>
```

Solution:
The GenericReader is initializing a ParquetReader but not propagating the caseSensitivity argument down to that reader...the same is true for the Orc reader (and avro but I do not see that the avro reader has such an argument). I've tested the fix with Parquet file using our application...I don't have a good way to test with orc.

Testing:
* added caseinsensitive scenarios to existing projection and filter tests
```
With Filter:
2023-07-28 11:19:16.000684 EDT INFO: Scan of 'test.usethestats' using provided filter: '{"type":"eq","term":"V1","value":1}'
Records in test.usethestats :
1

Output Without Filter (just to verify)
Records in test.usethestats :
1
20
200
```

let me know what additional things are needed to land this. I'm assuming that the CI will run all the standard tests...maybe I should add a test for this somewhere?