### PR TITLE
API: Fix ContentFile doc on value counts

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -63,7 +63,8 @@ public interface ContentFile<F> {
   Map<Integer, Long> columnSizes();
 
   /**
-   * Returns if collected, map from column ID to the count of its non-null values, null otherwise.
+   * Returns if collected, map from column ID to the count of its values (including null and NaN
+   * values), null otherwise.
    */
   Map<Integer, Long> valueCounts();
 


### PR DESCRIPTION
This PR fixes our Javadoc for `ContentFile` on value counts to match the spec and implementation.

```
Map from column id to number of values in the column (including null and NaN values)
```