### PR TITLE
Spark: Correct partition transform functions to match spec.md

### DIFF
--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -180,6 +180,82 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void testAddYearPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddMonthPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddDayPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddHourPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
   public void testAddNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -182,9 +182,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddYearPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -205,9 +203,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddMonthPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -228,9 +224,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddDayPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -251,9 +245,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddHourPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -186,7 +187,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
 
@@ -195,7 +198,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -205,7 +210,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
 
@@ -214,7 +221,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -224,7 +233,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
 
@@ -233,7 +244,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -243,7 +256,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
 
@@ -252,7 +267,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -374,14 +374,18 @@ public class Spark3Util {
         return org.apache.iceberg.expressions.Expressions.ref(colName);
       case "bucket":
         return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+      case "year":
       case "years":
         return org.apache.iceberg.expressions.Expressions.year(colName);
+      case "month":
       case "months":
         return org.apache.iceberg.expressions.Expressions.month(colName);
       case "date":
+      case "day":
       case "days":
         return org.apache.iceberg.expressions.Expressions.day(colName);
       case "date_hour":
+      case "hour":
       case "hours":
         return org.apache.iceberg.expressions.Expressions.hour(colName);
       case "truncate":

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -421,17 +421,21 @@ public class Spark3Util {
         case "bucket":
           builder.bucket(colName, findWidth(transform));
           break;
+        case "year":
         case "years":
           builder.year(colName);
           break;
+        case "month":
         case "months":
           builder.month(colName);
           break;
         case "date":
+        case "day":
         case "days":
           builder.day(colName);
           break;
         case "date_hour":
+        case "hour":
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -64,6 +64,26 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformSingularForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hour(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
+  public void testTransformPluralForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hours(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -180,6 +180,82 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void testAddYearPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddMonthPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddDayPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddHourPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
   public void testAddNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -182,9 +182,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddYearPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -205,9 +203,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddMonthPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -228,9 +224,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddDayPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -251,9 +245,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddHourPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -186,7 +187,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
 
@@ -195,7 +198,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -205,7 +210,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
 
@@ -214,7 +221,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -224,7 +233,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
 
@@ -233,7 +244,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -243,7 +256,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
 
@@ -252,7 +267,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -345,7 +345,7 @@ public class Spark3Util {
         case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
-        case "month"
+        case "month":
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -342,14 +342,18 @@ public class Spark3Util {
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
           return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+        case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
+        case "month"
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":
+        case "day":
         case "days":
           return org.apache.iceberg.expressions.Expressions.day(colName);
         case "date_hour":
+        case "hour":
         case "hours":
           return org.apache.iceberg.expressions.Expressions.hour(colName);
         case "truncate":

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -403,17 +403,21 @@ public class Spark3Util {
         case "bucket":
           builder.bucket(colName, findWidth(transform));
           break;
+        case "year":
         case "years":
           builder.year(colName);
           break;
+        case "month":
         case "months":
           builder.month(colName);
           break;
         case "date":
+        case "day":
         case "days":
           builder.day(colName);
           break;
         case "date_hour":
+        case "hour":
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -64,6 +64,26 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformSingularForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hour(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
+  public void testTransformPluralForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hours(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -180,6 +180,82 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void testAddYearPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddMonthPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddDayPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddHourPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
   public void testAddNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -182,9 +182,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddYearPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -205,9 +203,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddMonthPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -228,9 +224,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddDayPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -251,9 +245,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddHourPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -186,7 +187,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
 
@@ -195,7 +198,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -205,7 +210,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
 
@@ -214,7 +221,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -224,7 +233,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
 
@@ -233,7 +244,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -243,7 +256,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
 
@@ -252,7 +267,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -359,14 +359,18 @@ public class Spark3Util {
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
           return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+        case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
+        case "month":
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":
+        case "day":
         case "days":
           return org.apache.iceberg.expressions.Expressions.day(colName);
         case "date_hour":
+        case "hour":
         case "hours":
           return org.apache.iceberg.expressions.Expressions.hour(colName);
         case "truncate":

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -420,17 +420,21 @@ public class Spark3Util {
         case "bucket":
           builder.bucket(colName, findWidth(transform));
           break;
+        case "year":
         case "years":
           builder.year(colName);
           break;
+        case "month":
         case "months":
           builder.month(colName);
           break;
         case "date":
+        case "day":
         case "days":
           builder.day(colName);
           break;
         case "date_hour":
+        case "hour"
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -434,7 +434,7 @@ public class Spark3Util {
           builder.day(colName);
           break;
         case "date_hour":
-        case "hour"
+        case "hour":
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -64,6 +64,26 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformSingularForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hour(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
+  public void testTransformPluralForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hours(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -180,6 +180,82 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
   }
 
   @Test
+  public void testAddYearPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddMonthPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddDayPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
+  public void testAddHourPartition() {
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
+        tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
+
+    Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+  @Test
   public void testAddNamedPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -182,9 +182,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddYearPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -205,9 +203,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddMonthPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -228,9 +224,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddDayPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())
@@ -251,9 +245,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
   @Test
   public void testAddHourPartition() {
-    sql(
-        "CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg",
-        tableName);
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
 
     Assertions.assertThat(table.spec().isUnpartitioned())

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -186,7 +187,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
 
@@ -195,7 +198,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -205,7 +210,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
 
@@ -214,7 +221,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -224,7 +233,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
 
@@ -233,7 +244,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -243,7 +256,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         tableName);
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Assert.assertTrue("Table should start unpartitioned", table.spec().isUnpartitioned());
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
 
     sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
 
@@ -252,7 +267,9 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assert.assertEquals("Should have new spec field", expected, table.spec());
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -368,7 +368,7 @@ public class Spark3Util {
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
           return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
-        case "year"
+        case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
         case "month"

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -371,7 +371,7 @@ public class Spark3Util {
         case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
-        case "month"
+        case "month":
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -429,17 +429,21 @@ public class Spark3Util {
         case "bucket":
           builder.bucket(colName, findWidth(transform));
           break;
+        case "year":
         case "years":
           builder.year(colName);
           break;
+        case "month":
         case "months":
           builder.month(colName);
           break;
         case "date":
+        case "day":
         case "days":
           builder.day(colName);
           break;
         case "date_hour":
+        case "hour":
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -368,14 +368,18 @@ public class Spark3Util {
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
           return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+        case "year"
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
+        case "month"
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":
+        case "day":
         case "days":
           return org.apache.iceberg.expressions.Expressions.day(colName);
         case "date_hour":
+        case "hour":
         case "hours":
           return org.apache.iceberg.expressions.Expressions.hour(colName);
         case "truncate":

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -64,6 +64,26 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformSingularForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hour(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
+  public void testTransformPluralForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hours(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -27,11 +27,11 @@ import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.connector.catalog.CatalogManager;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
-import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -180,7 +180,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     Assert.assertEquals("Should have new spec field", expected, table.spec());
   }
 
-@Test
+  @Test
   public void testAddYearPartition() {
     createTable("id bigint NOT NULL, category string, ts timestamp, data string");
     Table table = validationCatalog.loadTable(tableIdent);
@@ -196,9 +196,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
 
-    Assertions.assertThat(table.spec())
-        .as("Should have new spec field")
-        .isEqualTo(expected);
+    Assertions.assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
   @Test
@@ -217,9 +215,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
 
-    Assertions.assertThat(table.spec())
-        .as("Should have new spec field")
-        .isEqualTo(expected);
+    Assertions.assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
   @Test
@@ -238,9 +234,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
 
-    Assertions.assertThat(table.spec())
-        .as("Should have new spec field")
-        .isEqualTo(expected);
+    Assertions.assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
   @Test
@@ -259,9 +253,7 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
     PartitionSpec expected =
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
-    Assertions.assertThat(table.spec())
-        .as("Should have new spec field")
-        .isEqualTo(expected);
+    Assertions.assertThat(table.spec()).as("Should have new spec field").isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
+import org.assertj.core.api.Assertions;
 
 public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
@@ -177,6 +178,90 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
         PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
 
     Assert.assertEquals("Should have new spec field", expected, table.spec());
+  }
+
+@Test
+  public void testAddYearPartition() {
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD year(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).year("ts").build();
+
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testAddMonthPartition() {
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD month(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).month("ts").build();
+
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testAddDayPartition() {
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD day(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).day("ts").build();
+
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void testAddHourPartition() {
+    createTable("id bigint NOT NULL, category string, ts timestamp, data string");
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assertions.assertThat(table.spec().isUnpartitioned())
+        .as("Table should start unpartitioned")
+        .isTrue();
+
+    sql("ALTER TABLE %s ADD PARTITION FIELD hour(ts)", tableName);
+
+    table.refresh();
+
+    PartitionSpec expected =
+        PartitionSpec.builderFor(table.schema()).withSpecId(1).hour("ts").build();
+
+    Assertions.assertThat(table.spec())
+        .as("Should have new spec field")
+        .isEqualTo(expected);
   }
 
   @Test

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -429,17 +429,21 @@ public class Spark3Util {
         case "bucket":
           builder.bucket(colName, findWidth(transform));
           break;
+        case "year":
         case "years":
           builder.year(colName);
           break;
+        case "month":
         case "months":
           builder.month(colName);
           break;
         case "date":
+        case "day":
         case "days":
           builder.day(colName);
           break;
         case "date_hour":
+        case "hour":
         case "hours":
           builder.hour(colName);
           break;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -368,14 +368,18 @@ public class Spark3Util {
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
           return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+        case "year":
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
+        case "month":
         case "months":
           return org.apache.iceberg.expressions.Expressions.month(colName);
         case "date":
+        case "day":
         case "days":
           return org.apache.iceberg.expressions.Expressions.day(colName);
         case "date_hour":
+        case "hour":
         case "hours":
           return org.apache.iceberg.expressions.Expressions.hour(colName);
         case "truncate":

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -64,6 +64,26 @@ public class TestCreateTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testTransformSingularForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hour(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
+  public void testTransformPluralForm() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql(
+        "CREATE TABLE IF NOT EXISTS %s (id BIGINT NOT NULL, ts timestamp) "
+            + "USING iceberg partitioned by (hours(ts))",
+        tableName);
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(tableIdent));
+  }
+
+  @Test
   public void testCreateTable() {
     Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
 


### PR DESCRIPTION
Given the spec for the time transform functions, this PR adds the singular (instead of plural) names of the transform functions.  

The spec specifies `year, month, hour, day`, but previously Spark only supported the plural version of these words (`years, months, etc`).

Hopefully this saves someone else a few cycles of debugging :)