### PR TITLE
Open-API: Add last-sequence-number to TableMetadata

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -682,6 +682,7 @@ class TableMetadata(BaseModel):
     snapshots: Optional[List[Snapshot]] = None
     refs: Optional[SnapshotReferences] = None
     current_snapshot_id: Optional[int] = Field(None, alias='current-snapshot-id')
+    last_sequence_number: Optional[int] = Field(None, alias='last-sequence-number')
     snapshot_log: Optional[SnapshotLog] = Field(None, alias='snapshot-log')
     metadata_log: Optional[MetadataLog] = Field(None, alias='metadata-log')
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1621,6 +1621,9 @@ components:
         current-snapshot-id:
           type: integer
           format: int64
+        last-sequence-number:
+          type: integer
+          format: int64
         # logs
         snapshot-log:
           $ref: '#/components/schemas/SnapshotLog'


### PR DESCRIPTION
The `last-sequence-number` is a required field of [TableMetadata](https://github.com/apache/iceberg/blob/master/format/spec.md#table-metadata-fields) for V2.