### PR TITLE
Core: check location for conflict before creating table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -192,6 +192,14 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
       String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
       tableProperties.putAll(tableOverrideProperties());
+
+      if (Boolean.parseBoolean(tableProperties.get(TableProperties.UNIQUE_LOCATION))) {
+        boolean alreadyExists = ops.io().newInputFile(baseLocation).exists();
+        if (alreadyExists) {
+          throw new AlreadyExistsException("Table location already in use: %s", baseLocation);
+        }
+      }
+
       TableMetadata metadata =
           TableMetadata.newTableMetadata(schema, spec, sortOrder, baseLocation, tableProperties);
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -365,4 +365,7 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String UNIQUE_LOCATION = "location.unique";
+  public static final boolean UNIQUE_LOCATION_DEFAULT = false;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -366,6 +366,7 @@ public class TableProperties {
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
 
-  public static final String UNIQUE_LOCATION = "location.unique";
-  public static final boolean UNIQUE_LOCATION_DEFAULT = false;
+  public static final String LOCATION_CONFLICT_DETECTION_ENABLED =
+      "location.conflict-detection.enabled";
+  public static final boolean LOCATION_CONFLICT_DETECTION_ENABLED_DEFAULT = false;
 }


### PR DESCRIPTION
close #7238 for create table check on location uniqueness.

Instead of putting it as catalog property, I ended up using table property as it allow for catalog enforcement as well as per table overwrite. 