### PR TITLE
Core: Fails the branch creation on an empty table when the branch exists

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -75,6 +75,8 @@ public class SnapshotManager implements ManageSnapshots {
       return createBranch(name, currentSnapshot.snapshotId());
     }
 
+    SnapshotRef existingRef = transaction.currentMetadata().ref(name);
+    Preconditions.checkArgument(existingRef == null, "Ref %s already exists", name);
     // Create an empty snapshot for the branch
     transaction.newFastAppend().toBranch(name).commit();
     return this;

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -263,7 +263,7 @@ public class TestSnapshotManager extends TableTestBase {
   }
 
   @Test
-  public void testCreateBranchFailsOnEmptyTableWhenRefAlreadyExists() {
+  public void testCreateBranchOnEmptyTableFailsWhenRefAlreadyExists() {
     table.manageSnapshots().createBranch("branch1").commit();
 
     // Trying to create a branch with an existing name should fail

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -263,6 +263,22 @@ public class TestSnapshotManager extends TableTestBase {
   }
 
   @Test
+  public void testCreateBranchFailsOnEmptyTableWhenRefAlreadyExists() {
+    table.manageSnapshots().createBranch("branch1").commit();
+
+    // Trying to create a branch with an existing name should fail
+    Assertions.assertThatThrownBy(() -> table.manageSnapshots().createBranch("branch1").commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Ref branch1 already exists");
+
+    // Trying to create another branch within the same chain
+    Assertions.assertThatThrownBy(
+            () -> table.manageSnapshots().createBranch("branch2").createBranch("branch2").commit())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Ref branch2 already exists");
+  }
+
+  @Test
   public void testCreateBranchFailsWhenRefAlreadyExists() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();


### PR DESCRIPTION
This is a follow-up for #8072 to fix the problems of creating a branch which is already existed and add UT for it.