### PR TITLE
Core: Add KLL Datasketch as standard blob types to puffin file

### DIFF
--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -28,9 +28,10 @@ public final class StandardBlobTypes {
   public static final String APACHE_DATASKETCHES_THETA_V1 = "apache-datasketches-theta-v1";
 
   /**
-   * A serialized form of Hive column stats object. The full list of available stats are provided in the
-   * <a href="https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics">
-   *     Hive columns stats wiki </a>
+   * A serialized form of Hive column stats object. The full list of available stats are provided in
+   * the <a
+   * href="https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics">Hive
+   * columns stats wiki </a>
    */
   public static final String HIVE_COLUMN_STATS_OBJ = "hive-column-statistics-obj";
 

--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -28,14 +28,14 @@ public final class StandardBlobTypes {
   public static final String APACHE_DATASKETCHES_THETA_V1 = "apache-datasketches-theta-v1";
 
   /**
-   * A serialized form of HIVE_COLUMN_STATS_OBJ. The full list of available stats are provided in the
+   * A serialized form of Hive column stats object. The full list of available stats are provided in the
    * <a href="https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics">
    *     Hive columns stats wiki </a>
    */
-  public static final String HIVE_COLUMN_STATS_OBJ = "column-statistics-obj";
+  public static final String HIVE_COLUMN_STATS_OBJ = "hive-column-statistics-obj";
 
   /**
-   * A serialized form of KLL sketch produced by the <a
+   * A serialized form of a KLL sketch produced by the <a
    * href="https://datasketches.apache.org/">Apache DataSketches</a> library
    */
   public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache-datasketches-kll-sketch";

--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -28,9 +28,9 @@ public final class StandardBlobTypes {
   public static final String APACHE_DATASKETCHES_THETA_V1 = "apache-datasketches-theta-v1";
 
   /**
-   * A serialized form of <a
-   * href="https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java#L854C17">
-   * HIVE_COLUMN_STATS_OBJ</a>
+   * A serialized form of HIVE_COLUMN_STATS_OBJ. The full list of available stats are provided in the
+   * <a href="https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics">
+   *     Hive columns stats wiki </a>
    */
   public static final String HIVE_COLUMN_STATS_OBJ = "column-statistics-obj";
 
@@ -38,7 +38,7 @@ public final class StandardBlobTypes {
    * A serialized form of KLL sketch produced by the <a
    * href="https://datasketches.apache.org/">Apache DataSketches</a> library
    */
-  public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache_datasketches_kll_sketch";
+  public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache-datasketches-kll-sketch";
 
   /** A serialized deletion vector according to the Iceberg spec */
   public static final String DV_V1 = "deletion-vector-v1";

--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -27,6 +27,19 @@ public final class StandardBlobTypes {
    */
   public static final String APACHE_DATASKETCHES_THETA_V1 = "apache-datasketches-theta-v1";
 
+  /**
+   * A serialized form of <a
+   * href="https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java#L854C17">
+   * HIVE_COLUMN_STATS_OBJ</a>
+   */
+  public static final String HIVE_COLUMN_STATS_OBJ = "column-statistics-obj";
+
+  /**
+   * A serialized form of KLL sketch produced by the <a
+   * href="https://datasketches.apache.org/">Apache DataSketches</a> library
+   */
+  public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache_datasketches_kll_sketch";
+
   /** A serialized deletion vector according to the Iceberg spec */
   public static final String DV_V1 = "deletion-vector-v1";
 }

--- a/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java
@@ -28,18 +28,10 @@ public final class StandardBlobTypes {
   public static final String APACHE_DATASKETCHES_THETA_V1 = "apache-datasketches-theta-v1";
 
   /**
-   * A serialized form of Hive column stats object. The full list of available stats are provided in
-   * the <a
-   * href="https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics">Hive
-   * columns stats wiki </a>
-   */
-  public static final String HIVE_COLUMN_STATS_OBJ = "hive-column-statistics-obj";
-
-  /**
-   * A serialized form of a KLL sketch produced by the <a
+   * A serialized form of a KLL sketch, a very compact quantiles sketch, produced by the <a
    * href="https://datasketches.apache.org/">Apache DataSketches</a> library
    */
-  public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache-datasketches-kll-sketch";
+  public static final String APACHE_DATASKETCHES_KLL_SKETCH = "apache-datasketches-kll-v1";
 
   /** A serialized deletion vector according to the Iceberg spec */
   public static final String DV_V1 = "deletion-vector-v1";

--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -185,7 +185,7 @@ for Puffin v1.
 
 A serialized form of Hive ColumnStatsObject.
 
-The columnStatsObject supports Histograms, NDV, Min and Max values, Number of nulls, Number of trues, column name, type.
+The ColumnStatsObject supports Histograms, NDV, Min and Max values, Number of nulls, Number of trues, column name, type.
 A full list of supported statistics is listed in the table here:
 [ColumnStatistics](https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics)
 

--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -181,22 +181,14 @@ for Puffin v1.
 [roaring-bitmap-portable-serialization]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#extension-for-64-bit-implementations
 [roaring-bitmap-general-layout]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#general-layout
 
-#### `hive-column-statistics-obj` blob type
+#### `apache-datasketches-kll-v1` blob type
 
-A serialized form of Hive ColumnStatsObject.
-
-The ColumnStatsObject supports Histograms, NDV, Min and Max values, Number of nulls, Number of trues, column name, type.
-A full list of supported statistics is listed in the table here:
-[ColumnStatistics](https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics)
-
-#### `apache-datasketches-KLL-sketch` blob type
-
-A serialized form of a "compact" KLL-sketch produced by the [Apache
-DataSketches](https://datasketches.apache.org/) library.
-Apache-Datasketches-KLL-sketch is an implementation of a very compact quantiles
-sketch with lazy compaction scheme and nearly optimal accuracy per bit.
-
-Histograms are derived from this sketch.
+A serialized form of a KLL sketch, a very compact quantiles sketch, produced by the 
+[Apache DataSketches](https://datasketches.apache.org/) library.
+KLL quantiles sketch is a mergeable streaming algorithm to estimate 
+the distribution of values, and approximately answer queries about the rank of a value, 
+probability mass function of the distribution (PMF) or histogram, 
+cumulative distribution function (CDF), and quantiles (median, min, max, 95th percentile and such)
 
 ### Compression codecs
 

--- a/format/puffin-spec.md
+++ b/format/puffin-spec.md
@@ -181,6 +181,23 @@ for Puffin v1.
 [roaring-bitmap-portable-serialization]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#extension-for-64-bit-implementations
 [roaring-bitmap-general-layout]: https://github.com/RoaringBitmap/RoaringFormatSpec?tab=readme-ov-file#general-layout
 
+#### `hive-column-statistics-obj` blob type
+
+A serialized form of Hive ColumnStatsObject.
+
+The columnStatsObject supports Histograms, NDV, Min and Max values, Number of nulls, Number of trues, column name, type.
+A full list of supported statistics is listed in the table here:
+[ColumnStatistics](https://cwiki.apache.org/confluence/display/Hive/StatsDev#StatsDev-ColumnStatistics)
+
+#### `apache-datasketches-KLL-sketch` blob type
+
+A serialized form of a "compact" KLL-sketch produced by the [Apache
+DataSketches](https://datasketches.apache.org/) library.
+Apache-Datasketches-KLL-sketch is an implementation of a very compact quantiles
+sketch with lazy compaction scheme and nearly optimal accuracy per bit.
+
+Histograms are derived from this sketch.
+
 ### Compression codecs
 
 The data can also be uncompressed. If it is compressed the codec should be one of


### PR DESCRIPTION
…b types to puffin file

Issue: 
https://github.com/apache/iceberg/issues/8198


Hi Everyone,

Hive now supports writing column statistics to puffin files.

The statistics calculated by Hive include histograms, NDV (Number of Distinct Values), Min and Max values, the number of nulls, the number of true values, column name, and column type. You can find the full list of supported stats here: [Link to GitHub](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java#L854C17-L854C30).

We are updating the description of this PR to request incorporating the KLL datasketch for histograms.

As a result, we are looking to add  KLL datasketch as standard blob types for the puffin file. [Link to GitHub](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/puffin/StandardBlobTypes.java)

Any feedback would be greatly appreciated.

Thanks!