### PR TITLE
Docs: Improve the Spark Structured Streaming jobs

### DIFF
--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -58,7 +58,9 @@ data.writeStream
     .toTable("database.table_name")
 ```
 
-In the case of the directory based Hadoop catalog:
+If you're using Spark 3.0 or earlier, you need to use `.option("path", "database.table_name").start()`, instead of `.toTable("database.table_name")`.
+
+In the case of the directory-based Hadoop catalog:
 
 ```scala
 data.writeStream

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -124,5 +124,5 @@ The amount of data written from a streaming process is typically small, which ca
 
 ### Rewrite manifests
 
-To optimize write latency on streaming workload, Iceberg may write the new snapshot with a "fast" append that does not automatically compact manifests.
+To optimize write latency on a streaming workload, Iceberg can write the new snapshot with a "fast" append that does not automatically compact manifests.
 This could lead lots of small manifest files. Manifests can be [rewritten to optimize queries and to compact](../maintenance#rewrite-manifests). Iceberg and Spark [comes with the `rewrite_manifests` procedure](../spark-procedures/#rewrite_manifests).

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -99,7 +99,7 @@ data.writeStream
     .toTable("database.table_name")
 ```
 
-Fanout writer opens the files per partition value and doesn't close these files till write task is finished. This option is discouraged for batch writing, as explicit sort against output rows is cheap for batch workloads.
+Fanout writer opens the files per partition value and doesn't close these files till the write task finishes. Avoid using the fanout writer for batch writing, as explicit sort against output rows is cheap for batch workloads.
 
 ## Maintenance for streaming tables
 

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -107,7 +107,7 @@ is highly recommended.
 
 ### Tune the rate of commits
 
-Having high rate of commits produces data files, manifests, and snapshots which leads to additional maintenance. We encourage having trigger interval 1 minute at minimum, and increase the interval if needed.
+Having a high rate of commits produces data files, manifests, and snapshots which leads to additional maintenance. It is recommended to have a trigger interval of 1 minute at the minimum and increase the interval if needed.
 
 The triggers section in [Structured Streaming Programming Guide](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#triggers)
 documents how to configure the interval.

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -83,7 +83,7 @@ Iceberg doesn't support experimental [continuous processing](https://spark.apach
 
 ### Partitioned table
 
-Iceberg requires the data to be sorted according to the partition spec per task (Spark partition) in prior to write
+Iceberg requires sorting data by partition per task prior to writing the data. In Spark tasks are split by Spark partition.
 against partitioned table. For batch queries you're encouraged to do explicit sort to fulfill the requirement
 (see [here](../spark-writes/#writing-to-partitioned-tables)), but the approach would bring additional latency as
 repartition and sort are considered as heavy operations for streaming workload. To avoid additional latency, you can

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -125,4 +125,4 @@ The amount of data written from a streaming process is typically small, which ca
 ### Rewrite manifests
 
 To optimize write latency on a streaming workload, Iceberg can write the new snapshot with a "fast" append that does not automatically compact manifests.
-This could lead lots of small manifest files. Manifests can be [rewritten to optimize queries and to compact](../maintenance#rewrite-manifests). Iceberg and Spark [comes with the `rewrite_manifests` procedure](../spark-procedures/#rewrite_manifests).
+This could lead lots of small manifest files. Iceberg can [rewrite the number of manifest files to improve query performance](../maintenance#rewrite-manifests). Iceberg and Spark [come with the `rewrite_manifests` procedure](../spark-procedures/#rewrite_manifests).

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -116,7 +116,7 @@ documents how to configure the interval.
 
 ### Expire old snapshots
 
-Each batch written to a table produces a new snapshot, that is tracked in table metadata until they are expired. Snapshots accumulate quickly with frequent commits, so it is highly recommended that tables written by streaming queries are [regularly maintained](../maintenance#expire-snapshots). [Snapshot expiration](../spark-procedures/#expire_snapshots) is the procedure of removing the metadata and any data files that are no longer needed. By default, the procedure will expire the snapshots older than 5 days. 
+Each batch written to a table produces a new snapshot. Iceberg tracks snapshots in table metadata until they are expired. Snapshots accumulate quickly with frequent commits, so it is highly recommended that tables written by streaming queries are [regularly maintained](../maintenance#expire-snapshots). [Snapshot expiration](../spark-procedures/#expire_snapshots) is the procedure of removing the metadata and any data files that are no longer needed. By default, the procedure will expire the snapshots older than five days. 
 
 ### Compacting data files
 

--- a/docs/spark-structured-streaming.md
+++ b/docs/spark-structured-streaming.md
@@ -77,7 +77,7 @@ Iceberg supports `append` and `complete` output modes:
 * `append`: appends the rows of every micro-batch to the table
 * `complete`: replaces the table contents every micro-batch
 
-The table should be created in prior to start the streaming query. Refer [SQL create table](../spark-ddl/#create-table) on Spark page to see how to create the Iceberg table.
+Prior to starting the streaming query, ensure you created the table. Refer to the [SQL create table](../spark-ddl/#create-table) documentation to learn how to create the Iceberg table.
 
 Iceberg doesn't support experimental [continuous processing](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#continuous-processing), as it doesn't provide the interface to "commit" the output.
 


### PR DESCRIPTION
Promote usage of using `toTable(...)` instead of `.option("path", ...)` because I've found that the `.start()` might not inject the catalog functions when doing the query planning. If the catalog is missing, this causes issues when using partitioned tables, since the transforms are not available.

Details in https://github.com/apache/iceberg/issues/7226