### PR TITLE
Python: add support for returning empty files in scans if requested.

### DIFF
--- a/python/pyiceberg/expressions/visitors.py
+++ b/python/pyiceberg/expressions/visitors.py
@@ -1095,13 +1095,16 @@ class _InclusiveMetricsEvaluator(BoundBooleanExpressionVisitor[bool]):
     lower_bounds: Dict[int, bytes]
     upper_bounds: Dict[int, bytes]
 
-    def __init__(self, schema: Schema, expr: BooleanExpression, case_sensitive: bool = True) -> None:
+    def __init__(
+        self, schema: Schema, expr: BooleanExpression, case_sensitive: bool = True, include_empty_files: bool = False
+    ) -> None:
         self.struct = schema.as_struct()
+        self.include_empty_files = include_empty_files
         self.expr = bind(schema, rewrite_not(expr), case_sensitive)
 
     def eval(self, file: DataFile) -> bool:
         """Test whether the file may contain records that match the expression."""
-        if file.record_count == 0:
+        if not self.include_empty_files and file.record_count == 0:
             return ROWS_CANNOT_MATCH
 
         if file.record_count < 0:

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -766,7 +766,9 @@ class DataScan(TableScan):
         # this filter depends on the partition spec used to write the manifest file
 
         partition_evaluators: Dict[int, Callable[[DataFile], bool]] = KeyDefaultDict(self._build_partition_evaluator)
-        metrics_evaluator = _InclusiveMetricsEvaluator(self.table.schema(), self.row_filter, self.case_sensitive).eval
+        metrics_evaluator = _InclusiveMetricsEvaluator(
+            self.table.schema(), self.row_filter, self.case_sensitive, self.options.get("include_empty_files") == "true"
+        ).eval
 
         min_data_sequence_number = _min_data_file_sequence_number(manifests)
 


### PR DESCRIPTION
There are times when scanning a table that you want the empty files to be returned, this allows that to happen via an option to the scan.