### PR TITLE
AWS, GCP: Allow access to underlying storage client in FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -323,7 +323,7 @@ public class S3FileIO
     deleteFiles(() -> Streams.stream(listPrefix(prefix)).map(FileInfo::location).iterator());
   }
 
-  private S3Client client() {
+  public S3Client client() {
     if (client == null) {
       synchronized (this) {
         if (client == null) {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -111,7 +111,7 @@ public class GCSFileIO implements FileIO {
     return properties.immutableMap();
   }
 
-  private Storage client() {
+  public Storage client() {
     if (storage == null) {
       synchronized (this) {
         if (storage == null) {


### PR DESCRIPTION
This PR makes the `client()` methods in `S3FileIO` and `GCSFileIO` public, which allows more flexibility in using a file IO instance for storage operations that might not be defined in the interface.