### PR TITLE
Python: fix glue catalog when using aws credentials

### DIFF
--- a/python/pyiceberg/catalog/glue.py
+++ b/python/pyiceberg/catalog/glue.py
@@ -56,7 +56,7 @@ from pyiceberg.table.metadata import new_table_metadata
 from pyiceberg.table.sorting import UNSORTED_SORT_ORDER, SortOrder
 from pyiceberg.typedef import EMPTY_DICT
 
-BOTO_SESSION_CONFIG_KEYS = ["aws_secret_key_id", "aws_secret_access_key", "aws_session_token", "region_name", "profile_name"]
+BOTO_SESSION_CONFIG_KEYS = ["aws_access_key_id", "aws_secret_access_key", "aws_session_token", "region_name", "profile_name"]
 
 GLUE_CLIENT = "glue"
 

--- a/python/tests/catalog/test_glue.py
+++ b/python/tests/catalog/test_glue.py
@@ -442,7 +442,7 @@ def test_update_namespace_properties_overlap_update_removal(
 @mock_glue
 def test_passing_profile_name() -> None:
     session_properties = {
-        "aws_secret_key_id": "abc",
+        "aws_access_key_id": "abc",
         "aws_secret_access_key": "def",
         "aws_session_token": "ghi",
         "region_name": "eu-central-1",


### PR DESCRIPTION
Fixes #8047 by using the right parameters in session initialization