### PR TITLE
Python: Restore Inferring Iceberg UUIDType from parquet files

### DIFF
--- a/python/pyiceberg/schema.py
+++ b/python/pyiceberg/schema.py
@@ -1367,3 +1367,12 @@ def _(file_type: DecimalType, read_type: IcebergType) -> IcebergType:
             raise ResolveError(f"Cannot reduce precision from {file_type} to {read_type}")
     else:
         raise ResolveError(f"Cannot promote an decimal to {read_type}")
+
+
+@promote.register(FixedType)
+def _(file_type: FixedType, read_type: IcebergType) -> IcebergType:
+    if isinstance(read_type, UUIDType) and len(file_type) == 16:
+        # Since pyarrow reads parquet UUID as fixed 16-byte binary, the promotion is needed to ensure read compatibility
+        return read_type
+    else:
+        raise ResolveError(f"Cannot promote {file_type} to {read_type}")


### PR DESCRIPTION
I've noticed that the read support for UUIDType, initially introduced in PR #7523, was removed in PR #7873, likely due to a rebase issue.

This PR restores this functionality. However, if the deletion was purposeful, please let me know.

cc: @Fokko @maxdebayser 

Thank you for your time and review.