### PR TITLE
AWS: Add retry logic for S3InputStream and S3OutputStream

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -385,6 +385,46 @@ public class S3FileIOProperties implements Serializable {
    */
   private static final String S3_FILE_IO_USER_AGENT = "s3fileio/" + EnvironmentContext.get();
 
+  /** Number of times to retry S3 read operation. */
+  public static final String S3_READ_RETRY_NUM_RETRIES = "s3.read.retry.num-retries";
+
+  public static final int S3_READ_RETRY_NUM_RETRIES_DEFAULT = 7;
+
+  /** Minimum wait time to retry a S3 read operation */
+  public static final String S3_READ_RETRY_MIN_WAIT_MS = "s3.read.retry.min-wait-ms";
+
+  public static final long S3_READ_RETRY_MIN_WAIT_MS_DEFAULT = 500; // 0.5 seconds
+
+  /** Maximum wait time to retry a S3 read operation */
+  public static final String S3_READ_RETRY_MAX_WAIT_MS = "s3.read.retry.max-wait-ms";
+
+  public static final long S3_READ_RETRY_MAX_WAIT_MS_DEFAULT = 2 * 60 * 1000; // 2 minute
+
+  /** Total retry time for a S3 read operation */
+  public static final String S3_READ_RETRY_TOTAL_TIMEOUT_MS = "s3.read.retry.total-timeout-ms";
+
+  public static final long S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT = 10 * 60 * 1000; // 10 minutes
+
+  /** Number of times to retry S3 write operation. */
+  public static final String S3_WRITE_RETRY_NUM_RETRIES = "s3.write.retry.num-retries";
+
+  public static final int S3_WRITE_RETRY_NUM_RETRIES_DEFAULT = 7;
+
+  /** Minimum wait time to retry a S3 write operation */
+  public static final String S3_WRITE_RETRY_MIN_WAIT_MS = "s3.write.retry.min-wait-ms";
+
+  public static final long S3_WRITE_RETRY_MIN_WAIT_MS_DEFAULT = 500; // 0.5 seconds
+
+  /** Maximum wait time to retry a S3 write operation */
+  public static final String S3_WRITE_RETRY_MAX_WAIT_MS = "s3.write.retry.max-wait-ms";
+
+  public static final long S3_WRITE_RETRY_MAX_WAIT_MS_DEFAULT = 2 * 60 * 1000; // 2 minute
+
+  /** Total retry time for a S3 write operation */
+  public static final String S3_WRITE_RETRY_TOTAL_TIMEOUT_MS = "s3.write.retry.total-timeout-ms";
+
+  public static final long S3_WRITE_RETRY_TOTAL_TIMEOUT_MS_DEFAULT = 10 * 60 * 1000; // 10 minutes
+
   private String sseType;
   private String sseKey;
   private String sseMd5;
@@ -408,6 +448,14 @@ public class S3FileIOProperties implements Serializable {
   private boolean isDeleteEnabled;
   private final Map<String, String> bucketToAccessPointMapping;
   private boolean isPreloadClientEnabled;
+  private int s3ReadRetryNumRetries;
+  private long s3ReadRetryMinWaitMs;
+  private long s3ReadRetryMaxWaitMs;
+  private long s3ReadRetryTotalTimeoutMs;
+  private int s3WriteRetryNumRetries;
+  private long s3WriteRetryMinWaitMs;
+  private long s3WriteRetryMaxWaitMs;
+  private long s3WriteRetryTotalTimeoutMs;
   private boolean isDualStackEnabled;
   private boolean isPathStyleAccess;
   private boolean isUseArnRegionEnabled;
@@ -440,6 +488,14 @@ public class S3FileIOProperties implements Serializable {
     this.isDeleteEnabled = DELETE_ENABLED_DEFAULT;
     this.bucketToAccessPointMapping = Collections.emptyMap();
     this.isPreloadClientEnabled = PRELOAD_CLIENT_ENABLED_DEFAULT;
+    this.s3ReadRetryNumRetries = S3_READ_RETRY_NUM_RETRIES_DEFAULT;
+    this.s3ReadRetryMinWaitMs = S3_READ_RETRY_MIN_WAIT_MS_DEFAULT;
+    this.s3ReadRetryMaxWaitMs = S3_READ_RETRY_MAX_WAIT_MS_DEFAULT;
+    this.s3ReadRetryTotalTimeoutMs = S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT;
+    this.s3WriteRetryNumRetries = S3_WRITE_RETRY_NUM_RETRIES_DEFAULT;
+    this.s3WriteRetryMinWaitMs = S3_WRITE_RETRY_MIN_WAIT_MS_DEFAULT;
+    this.s3WriteRetryMaxWaitMs = S3_WRITE_RETRY_MAX_WAIT_MS_DEFAULT;
+    this.s3WriteRetryTotalTimeoutMs = S3_WRITE_RETRY_TOTAL_TIMEOUT_MS_DEFAULT;
     this.isDualStackEnabled = DUALSTACK_ENABLED_DEFAULT;
     this.isPathStyleAccess = PATH_STYLE_ACCESS_DEFAULT;
     this.isUseArnRegionEnabled = USE_ARN_REGION_ENABLED_DEFAULT;
@@ -532,6 +588,30 @@ public class S3FileIOProperties implements Serializable {
     this.isPreloadClientEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, PRELOAD_CLIENT_ENABLED, PRELOAD_CLIENT_ENABLED_DEFAULT);
+    this.s3ReadRetryNumRetries =
+        PropertyUtil.propertyAsInt(
+            properties, S3_READ_RETRY_NUM_RETRIES, S3_READ_RETRY_NUM_RETRIES_DEFAULT);
+    this.s3ReadRetryMinWaitMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_READ_RETRY_MIN_WAIT_MS, S3_READ_RETRY_MIN_WAIT_MS_DEFAULT);
+    this.s3ReadRetryMaxWaitMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_READ_RETRY_MAX_WAIT_MS, S3_READ_RETRY_MAX_WAIT_MS_DEFAULT);
+    this.s3ReadRetryTotalTimeoutMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_READ_RETRY_TOTAL_TIMEOUT_MS, S3_READ_RETRY_TOTAL_TIMEOUT_MS_DEFAULT);
+    this.s3WriteRetryNumRetries =
+        PropertyUtil.propertyAsInt(
+            properties, S3_WRITE_RETRY_NUM_RETRIES, S3_WRITE_RETRY_NUM_RETRIES_DEFAULT);
+    this.s3WriteRetryMinWaitMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_WRITE_RETRY_MIN_WAIT_MS, S3_WRITE_RETRY_MIN_WAIT_MS_DEFAULT);
+    this.s3WriteRetryMaxWaitMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_WRITE_RETRY_MAX_WAIT_MS, S3_WRITE_RETRY_MAX_WAIT_MS_DEFAULT);
+    this.s3WriteRetryTotalTimeoutMs =
+        PropertyUtil.propertyAsLong(
+            properties, S3_WRITE_RETRY_TOTAL_TIMEOUT_MS, S3_WRITE_RETRY_TOTAL_TIMEOUT_MS_DEFAULT);
     this.isRemoteSigningEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, REMOTE_SIGNING_ENABLED, REMOTE_SIGNING_ENABLED_DEFAULT);
@@ -721,6 +801,70 @@ public class S3FileIOProperties implements Serializable {
 
   public String writeStorageClass() {
     return writeStorageClass;
+  }
+
+  public int s3ReadRetryNumRetries() {
+    return s3ReadRetryNumRetries;
+  }
+
+  public void setS3ReadRetryNumRetries(int s3ReadRetryNumRetries) {
+    this.s3ReadRetryNumRetries = s3ReadRetryNumRetries;
+  }
+
+  public long s3ReadRetryMinWaitMs() {
+    return s3ReadRetryMinWaitMs;
+  }
+
+  public void setS3ReadRetryMinWaitMs(long s3ReadRetryMinWaitMs) {
+    this.s3ReadRetryMinWaitMs = s3ReadRetryMinWaitMs;
+  }
+
+  public long s3ReadRetryMaxWaitMs() {
+    return s3ReadRetryMaxWaitMs;
+  }
+
+  public void setS3ReadRetryMaxWaitMs(long s3ReadRetryMaxWaitMs) {
+    this.s3ReadRetryMaxWaitMs = s3ReadRetryMaxWaitMs;
+  }
+
+  public long s3ReadRetryTotalTimeoutMs() {
+    return s3ReadRetryTotalTimeoutMs;
+  }
+
+  public void setS3ReadRetryTotalTimeoutMs(long s3ReadRetryTotalTimeoutMs) {
+    this.s3ReadRetryTotalTimeoutMs = s3ReadRetryTotalTimeoutMs;
+  }
+
+  public int s3WriteRetryNumRetries() {
+    return s3WriteRetryNumRetries;
+  }
+
+  public void setS3WriteRetryNumRetries(int s3WriteRetryNumRetries) {
+    this.s3WriteRetryNumRetries = s3WriteRetryNumRetries;
+  }
+
+  public long s3WriteRetryMinWaitMs() {
+    return s3WriteRetryMinWaitMs;
+  }
+
+  public void setS3WriteRetryMinWaitMs(long s3WriteRetryMinWaitMs) {
+    this.s3WriteRetryMinWaitMs = s3WriteRetryMinWaitMs;
+  }
+
+  public long s3WriteRetryMaxWaitMs() {
+    return s3WriteRetryMaxWaitMs;
+  }
+
+  public void setS3WriteRetryMaxWaitMs(long s3WriteRetryMaxWaitMs) {
+    this.s3WriteRetryMaxWaitMs = s3WriteRetryMaxWaitMs;
+  }
+
+  public long s3WriteRetryTotalTimeoutMs() {
+    return s3WriteRetryTotalTimeoutMs;
+  }
+
+  public void setS3WriteRetryTotalTimeoutMs(long s3WriteRetryTotalTimeoutMs) {
+    this.s3WriteRetryTotalTimeoutMs = s3WriteRetryTotalTimeoutMs;
   }
 
   private Set<Tag> toS3Tags(Map<String, String> properties, String prefix) {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3InputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3InputStream.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
+import org.apache.iceberg.AssertHelpers;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
+import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class TestFuzzyS3InputStream extends TestS3InputStream {
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testReadWithFuzzyClientRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRead(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testReadWithFuzzyStreamRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRead(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testReadWithFuzzyClientRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testRead(fuzzyClient(counter, exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testReadWithFuzzyStreamRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testRead(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testSeekWithFuzzyClientRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testSeek(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testSeekWithFuzzyStreamRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testSeek(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testSeekWithFuzzyClientRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testSeek(fuzzyClient(counter, exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testSeekWithFuzzyStreamRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testSeek(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testRangeReadWithFuzzyClientRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRangeRead(fuzzyClient(new AtomicInteger(3), exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testRangeReadWithFuzzyStreamRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    testRangeRead(fuzzyStreamClient(new AtomicInteger(3), (IOException) exception), awsProperties);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testRangeReadWithFuzzyClientRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testRangeRead(fuzzyClient(counter, exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testRangeReadWithFuzzyStreamRetryFail(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    testRetryFail(
+        (counter, awsProperties) -> {
+          try {
+            testRangeRead(fuzzyStreamClient(counter, (IOException) exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        },
+        exception,
+        shouldRetry);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testExceptionNoRetry(Exception exception, boolean shouldRetry) throws Exception {
+    Assume.assumeFalse(shouldRetry);
+    testReadExceptionShouldNotRetry(exception);
+  }
+
+  private static Stream<Arguments> provideExceptionAndShouldRetry() {
+    return Stream.of(
+        Arguments.of(new IOException("random failure"), true),
+        Arguments.of(new SSLException("client connection reset"), true),
+        Arguments.of(new SocketTimeoutException("client connection reset"), true),
+        Arguments.of(new EOFException("failure"), true),
+        Arguments.of(
+            AwsServiceException.builder().statusCode(403).message("failure").build(), false),
+        Arguments.of(
+            AwsServiceException.builder().statusCode(400).message("failure").build(), false),
+        Arguments.of(S3Exception.builder().statusCode(404).message("failure").build(), false),
+        Arguments.of(S3Exception.builder().statusCode(416).message("failure").build(), false));
+  }
+
+  private void testRetryFail(
+      BiConsumer<AtomicInteger, S3FileIOProperties> runnable,
+      Exception exception,
+      boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(2);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    AtomicInteger counter = new AtomicInteger(4);
+    AssertHelpers.assertThrowsCause(
+        "Should fail after retries",
+        exception.getClass(),
+        exception.getMessage(),
+        () -> runnable.accept(counter, awsProperties));
+    Assert.assertEquals(
+        "Should have 3 invocations (1 initial call, 2 retries)", 3, 4 - counter.get());
+  }
+
+  private void testReadExceptionShouldNotRetry(Exception exception) throws Exception {
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3ReadRetryNumRetries(4);
+    awsProperties.setS3ReadRetryMinWaitMs(100);
+    AtomicInteger counter = new AtomicInteger(3);
+    AssertHelpers.assertThrowsCause(
+        "Should fail without retry",
+        exception.getClass(),
+        exception.getMessage(),
+        () -> {
+          try {
+            testRead(fuzzyClient(counter, exception), awsProperties);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        });
+    Assert.assertEquals(
+        "Should have 1 invocation (1 initial call, no retry)", 1, 3 - counter.get());
+  }
+
+  private S3Client fuzzyClient(AtomicInteger counter, Exception failure) {
+    S3Client fuzzyClient = spy(new S3ClientWrapper(s3Client()));
+    int round = counter.get();
+
+    // for every round of n invocations, only the last call succeeds
+    doAnswer(
+            invocation -> {
+              if (counter.decrementAndGet() == 0) {
+                counter.set(round);
+                return invocation.callRealMethod();
+              } else {
+                throw failure;
+              }
+            })
+        .when(fuzzyClient)
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+    return fuzzyClient;
+  }
+
+  private S3Client fuzzyStreamClient(AtomicInteger counter, IOException failure) {
+    S3Client fuzzyClient = spy(new S3ClientWrapper(s3Client()));
+    doAnswer(
+            invocation ->
+                new FuzzyResponseInputStream(invocation.callRealMethod(), counter, failure))
+        .when(fuzzyClient)
+        .getObject(any(GetObjectRequest.class), any(ResponseTransformer.class));
+    return fuzzyClient;
+  }
+
+  /** Wrapper for S3 client, used to mock the final class DefaultS3Client */
+  public static class S3ClientWrapper implements S3Client {
+
+    private final S3Client delegate;
+
+    public S3ClientWrapper(S3Client delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String serviceName() {
+      return delegate.serviceName();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public <ReturnT> ReturnT getObject(
+        GetObjectRequest getObjectRequest,
+        ResponseTransformer<GetObjectResponse, ReturnT> responseTransformer)
+        throws NoSuchKeyException, InvalidObjectStateException, AwsServiceException,
+            SdkClientException, S3Exception {
+      return delegate.getObject(getObjectRequest, responseTransformer);
+    }
+
+    @Override
+    public HeadObjectResponse headObject(HeadObjectRequest headObjectRequest)
+        throws NoSuchKeyException, AwsServiceException, SdkClientException, S3Exception {
+      return delegate.headObject(headObjectRequest);
+    }
+
+    @Override
+    public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody)
+        throws AwsServiceException, SdkClientException, S3Exception {
+      return delegate.putObject(putObjectRequest, requestBody);
+    }
+
+    @Override
+    public CreateBucketResponse createBucket(CreateBucketRequest createBucketRequest)
+        throws BucketAlreadyExistsException, BucketAlreadyOwnedByYouException, AwsServiceException,
+            SdkClientException, S3Exception {
+      return delegate.createBucket(createBucketRequest);
+    }
+  }
+
+  public static class FuzzyResponseInputStream extends InputStream {
+
+    private final ResponseInputStream<GetObjectResponse> delegate;
+    private final AtomicInteger counter;
+    private final int round;
+    private final IOException exception;
+
+    public FuzzyResponseInputStream(
+        Object invocationResponse, AtomicInteger counter, IOException exception) {
+      this.delegate = (ResponseInputStream<GetObjectResponse>) invocationResponse;
+      this.counter = counter;
+      this.round = counter.get();
+      this.exception = exception;
+    }
+
+    private void checkCounter() throws IOException {
+      // for every round of n invocations, only the last call succeeds
+      if (counter.decrementAndGet() == 0) {
+        counter.set(round);
+      } else {
+        throw exception;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      checkCounter();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+      checkCounter();
+      return delegate.read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      checkCounter();
+      return delegate.read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      return delegate.skip(n);
+    }
+
+    @Override
+    public int available() throws IOException {
+      return delegate.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+      delegate.mark(readlimit);
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      delegate.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return delegate.markSupported();
+    }
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestFuzzyS3OutputStream.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.apache.iceberg.metrics.MetricsContext.nullMetrics;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+public class TestFuzzyS3OutputStream extends TestS3OutputStream {
+
+  public TestFuzzyS3OutputStream() throws IOException {}
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testWriteWithFuzzyClientRetrySucceed(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3WriteRetryNumRetries(2);
+    awsProperties.setS3WriteRetryMinWaitMs(100);
+    byte[] data = randomData(10 * 1024 * 1024);
+    S3Client s3 = mock(S3Client.class);
+    S3Client s3Client = fuzzyClient(s3, new AtomicInteger(3), exception);
+    testWrite(data, s3Client, randomURI(), awsProperties, nullMetrics());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testWriteWithFuzzyClientRetryFailure(Exception exception, boolean shouldRetry)
+      throws IOException {
+    Assume.assumeTrue(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3WriteRetryNumRetries(1);
+    awsProperties.setS3WriteRetryMinWaitMs(100);
+    byte[] data = randomData(10 * 1024 * 1024);
+    S3Client s3 = mock(S3Client.class);
+    S3Client s3Client = fuzzyClient(s3, new AtomicInteger(3), exception);
+
+    try {
+      testWrite(data, s3Client, randomURI(), awsProperties, nullMetrics());
+    } catch (Exception ex) {
+      Assert.assertEquals(ex.getCause().getClass(), exception.getClass());
+      Assert.assertEquals(ex.getCause().getMessage(), exception.getMessage());
+    } finally {
+      verify(s3Client, times(2)).putObject((PutObjectRequest) any(), (RequestBody) any());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideExceptionAndShouldRetry")
+  public void testWriteExceptionShouldNotRetry(Exception exception, boolean shouldRetry)
+      throws Exception {
+    Assume.assumeFalse(shouldRetry);
+    S3FileIOProperties awsProperties = new S3FileIOProperties();
+    awsProperties.setS3WriteRetryNumRetries(4);
+    awsProperties.setS3WriteRetryMinWaitMs(100);
+    byte[] data = randomData(10 * 1024 * 1024);
+    S3Client s3 = mock(S3Client.class);
+    S3Client s3Client = fuzzyClient(s3, new AtomicInteger(3), exception);
+
+    try {
+      testWrite(data, s3Client, randomURI(), awsProperties, nullMetrics());
+    } catch (Exception ex) {
+      Throwable causeException = ex.getCause() == null ? ex : ex.getCause();
+      Assert.assertEquals(causeException.getClass(), exception.getClass());
+      Assert.assertEquals(causeException.getMessage(), exception.getMessage());
+    } finally {
+      verify(s3Client, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
+    }
+  }
+
+  private S3Client fuzzyClient(S3Client s3Client, AtomicInteger counter, Exception failure) {
+    S3Client fuzzyClient = spy(new TestFuzzyS3OutputStream.S3ClientWrapper(s3Client));
+    int round = counter.get();
+    // for every round of n invocations, only the last call succeeds
+    doAnswer(
+            invocation -> {
+              if (counter.decrementAndGet() == 0) {
+                counter.set(round);
+                return invocation.callRealMethod();
+              } else {
+                throw failure;
+              }
+            })
+        .when(fuzzyClient)
+        .uploadPart(any(UploadPartRequest.class), any(RequestBody.class));
+
+    doAnswer(
+            invocation -> {
+              if (counter.decrementAndGet() == 0) {
+                counter.set(round);
+                return invocation.callRealMethod();
+              } else {
+                throw failure;
+              }
+            })
+        .when(fuzzyClient)
+        .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+    return fuzzyClient;
+  }
+
+  private static Stream<Arguments> provideExceptionAndShouldRetry() {
+    return Stream.of(
+        Arguments.of(new IOException("random failure"), true),
+        Arguments.of(new SSLException("client connection reset"), true),
+        Arguments.of(new SocketTimeoutException("client connection reset"), true),
+        Arguments.of(new EOFException("failure"), true),
+        Arguments.of(
+            AwsServiceException.builder().statusCode(403).message("failure").build(), false),
+        Arguments.of(
+            AwsServiceException.builder().statusCode(400).message("failure").build(), false),
+        Arguments.of(S3Exception.builder().statusCode(404).message("failure").build(), false),
+        Arguments.of(S3Exception.builder().statusCode(416).message("failure").build(), false),
+        Arguments.of(
+            SdkServiceException.builder().statusCode(403).message("Access Denied").build(), false));
+  }
+
+  /** Wrapper for S3 client, used to mock the final class DefaultS3Client */
+  public static class S3ClientWrapper implements S3Client {
+
+    private final S3Client delegate;
+
+    public S3ClientWrapper(S3Client delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String serviceName() {
+      return delegate.serviceName();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public PutObjectResponse putObject(PutObjectRequest putObjectRequest, RequestBody requestBody)
+        throws AwsServiceException, SdkClientException, S3Exception {
+      return delegate.putObject(putObjectRequest, requestBody);
+    }
+
+    @Override
+    public AbortMultipartUploadResponse abortMultipartUpload(
+        AbortMultipartUploadRequest abortMultipartUploadRequest)
+        throws AwsServiceException, SdkClientException {
+      return delegate.abortMultipartUpload(abortMultipartUploadRequest);
+    }
+  }
+}


### PR DESCRIPTION
@danielcweeks @jackye1995 @amogh-jahagirdar @nastra 
Add retry for both S3InputStream and S3OutputStream so that when we encounter network failures (mostly SSLException for server side connection reset and SocketTimoutException for client side connection reset) or any other retriable S3 error (like throttling error), we can retry at operation level without failing the entire query.