### PR TITLE
ORC: ExpressionToSearchArgument should only convert reference term

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.Literal;
@@ -270,7 +271,8 @@ class ExpressionToSearchArgument
 
   @Override
   public <T> Action predicate(BoundPredicate<T> pred) {
-    if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())) {
+    if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())
+        || !(pred.term() instanceof BoundReference)) {
       // Cannot push down predicates for types which cannot be represented in PredicateLeaf.Type, so
       // return
       // TruthValue.YES_NO_NULL which signifies that this predicate cannot help with filtering

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -31,6 +31,7 @@ import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNaN;
 import static org.apache.iceberg.expressions.Expressions.notNull;
+import static org.apache.iceberg.expressions.Expressions.year;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -474,6 +475,21 @@ public class TestExpressionToSearchArgument {
             .build();
 
     SearchArgument actual = ExpressionToSearchArgument.convert(boundFilter, readSchema);
+    Assertions.assertThat(actual.toString()).isEqualTo(expected.toString());
+  }
+
+  @Test
+  public void testExpressionContainsNonReferenceTerm() {
+    Schema schema = new Schema(required(1, "ts", Types.TimestampType.withoutZone()));
+
+    // all operations for these types should resolve to YES_NO_NULL
+    Expression expr = equal(year("ts"), 10);
+    Expression boundFilter = Binder.bind(schema.asStruct(), expr, true);
+    SearchArgument expected =
+        SearchArgumentFactory.newBuilder().literal(TruthValue.YES_NO_NULL).build();
+
+    SearchArgument actual =
+        ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));
     Assertions.assertThat(actual.toString()).isEqualTo(expected.toString());
   }
 }


### PR DESCRIPTION
ExpressionToSearchArgument should only convert those reference terms. Otherwise, we will get incorrect conversions or exceptions. For example, converting `equal(year("ts"), 10)`:
```java
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long

	at org.apache.iceberg.orc.ExpressionToSearchArgument.literal(ExpressionToSearchArgument.java:329)
	at org.apache.iceberg.orc.ExpressionToSearchArgument.lambda$eq$13(ExpressionToSearchArgument.java:209)
	at org.apache.iceberg.orc.ExpressionToSearchArgument.convert(ExpressionToSearchArgument.java:52)
	at org.apache.iceberg.orc.TestExpressionToSearchArgument.testExpressionContainsNonReferenceTerm(TestExpressionToSearchArgument.java:492)
```