### PR TITLE
Parquet: Fix decimal data reading from ParquetAvroValueReaders

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
@@ -191,9 +191,9 @@ public class ParquetAvroValueReaders {
               case FIXED_LEN_BYTE_ARRAY:
                 return new DecimalReader(desc, decimal.getScale());
               case INT64:
-                return new IntegerAsDecimalReader(desc, decimal.getScale());
-              case INT32:
                 return new LongAsDecimalReader(desc, decimal.getScale());
+              case INT32:
+                return new IntegerAsDecimalReader(desc, decimal.getScale());
               default:
                 throw new UnsupportedOperationException(
                     "Unsupported base type for decimal: " + primitive.getPrimitiveTypeName());

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/data/TestParquetAvroReader.java
@@ -84,7 +84,8 @@ public class TestParquetAvroReader {
                       optional(22, "jumpy", Types.DoubleType.get()),
                       required(23, "koala", Types.TimeType.get()),
                       required(24, "couch rope", Types.IntegerType.get())))),
-          optional(2, "slide", Types.StringType.get()));
+          optional(2, "slide", Types.StringType.get()),
+          required(25, "foo", Types.DecimalType.of(7, 5)));
 
   @Ignore
   public void testStructSchema() throws IOException {


### PR DESCRIPTION
During write, Int64 decimal data is written as `long` and `Int32` decimal data is written as `int`.
https://github.com/apache/iceberg/blob/b64446ce8eb139f06903691158d7acf93e18be88/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroWriter.java#L158-L161

But during read, `Int32` data is read as `long` and `Int64` data is read as `int`. Hence the exception. 

Fixes: https://github.com/apache/iceberg/issues/8245