### PR TITLE
core: initial support of multi-arg bucket

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -745,6 +745,14 @@ acceptedBreaks:
         \ of type erasure and the original type is always returned"
   "1.3.0":
     org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.PartitionField"
+      new: "class org.apache.iceberg.PartitionField"
+      justification: "Added a new field"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.SortField"
+      new: "class org.apache.iceberg.SortField"
+      justification: "Added a new field"
     - code: "java.class.removed"
       old: "class org.apache.iceberg.actions.ImmutableDeleteOrphanFiles"
       justification: "Moving from iceberg-api to iceberg-core"

--- a/api/src/main/java/org/apache/iceberg/PartitionKey.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionKey.java
@@ -53,7 +53,12 @@ public class PartitionKey implements StructLike, Serializable {
     Schema schema = spec.schema();
     for (int i = 0; i < size; i += 1) {
       PartitionField field = fields.get(i);
-      Accessor<StructLike> accessor = inputSchema.accessorForField(field.sourceId());
+      Accessor<StructLike> accessor;
+      if (field.sourceIds().length == 1) {
+        accessor = inputSchema.accessorForField(field.sourceId());
+      } else {
+        accessor = inputSchema.accessorForFields(field.sourceIds());
+      }
       Preconditions.checkArgument(
           accessor != null,
           "Cannot build accessor for field: " + schema.findField(field.sourceId()));

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
@@ -103,7 +104,11 @@ public class PartitionSpec implements Serializable {
 
     for (PartitionField field : fields) {
       builder.addField(
-          field.transform().toString(), field.sourceId(), field.fieldId(), field.name());
+          field.transform().toString(),
+          field.sourceId(),
+          field.sourceIds(),
+          field.fieldId(),
+          field.name());
     }
 
     return builder.build();
@@ -354,24 +359,20 @@ public class PartitionSpec implements Serializable {
       return lastAssignedFieldId.incrementAndGet();
     }
 
-    private void checkAndAddPartitionName(String name) {
-      checkAndAddPartitionName(name, null);
-    }
-
     Builder checkConflicts(boolean check) {
       checkConflicts = check;
       return this;
     }
 
-    private void checkAndAddPartitionName(String name, Integer sourceColumnId) {
+    private void checkAndAddPartitionName(String name, int... sourceIds) {
       Types.NestedField schemaField = schema.findField(name);
       if (checkConflicts) {
-        if (sourceColumnId != null) {
+        if (sourceIds.length == 1) {
           // for identity transform case we allow conflicts between partition and schema field name
           // as
           //   long as they are sourced from the same schema field
           Preconditions.checkArgument(
-              schemaField == null || schemaField.fieldId() == sourceColumnId,
+              schemaField == null || schemaField.fieldId() == sourceIds[0],
               "Cannot create identity partition sourced from different field in schema: %s",
               name);
         } else {
@@ -504,6 +505,20 @@ public class PartitionSpec implements Serializable {
       return hour(sourceName, sourceName + "_hour");
     }
 
+    public Builder bucket(String[] sourceNames, int numBuckets, String targetName) {
+      Types.NestedField[] sourceColumns = new Types.NestedField[sourceNames.length];
+      int[] sourceColumnIds = new int[sourceNames.length];
+      for (int i = 0; i < sourceNames.length; i++) {
+        sourceColumns[i] = findSourceColumn(sourceNames[i]);
+        sourceColumnIds[i] = sourceColumns[i].fieldId();
+      }
+      Types.StructType type = Types.StructType.of(sourceColumns);
+      fields.add(
+          new PartitionField(
+              sourceColumnIds, nextFieldId(), targetName, Transforms.bucket(type, numBuckets)));
+      return this;
+    }
+
     public Builder bucket(String sourceName, int numBuckets, String targetName) {
       checkAndAddPartitionName(targetName);
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
@@ -518,6 +533,16 @@ public class PartitionSpec implements Serializable {
 
     public Builder bucket(String sourceName, int numBuckets) {
       return bucket(sourceName, numBuckets, sourceName + "_bucket");
+    }
+
+    public Builder bucket(String[] sourceNames, int numBuckets) {
+      Preconditions.checkArgument(sourceNames != null && sourceNames.length >= 1);
+      if (sourceNames.length == 1) {
+        return bucket(sourceNames[0], numBuckets);
+      } else {
+        String targetName = Joiner.on("_").join(sourceNames);
+        return bucket(sourceNames, numBuckets, targetName + "_bucket");
+      }
     }
 
     public Builder truncate(String sourceName, int width, String targetName) {
@@ -556,9 +581,20 @@ public class PartitionSpec implements Serializable {
       return add(sourceId, nextFieldId(), name, transform);
     }
 
+    Builder add(int[] sourceIds, String name, Transform<?, ?> transform) {
+      return add(sourceIds, nextFieldId(), name, transform);
+    }
+
     Builder add(int sourceId, int fieldId, String name, Transform<?, ?> transform) {
       checkAndAddPartitionName(name, sourceId);
       fields.add(new PartitionField(sourceId, fieldId, name, transform));
+      lastAssignedFieldId.getAndAccumulate(fieldId, Math::max);
+      return this;
+    }
+
+    Builder add(int[] sourceIds, int fieldId, String name, Transform<?, ?> transform) {
+      checkAndAddPartitionName(name, sourceIds);
+      fields.add(new PartitionField(sourceIds, fieldId, name, transform));
       lastAssignedFieldId.getAndAccumulate(fieldId, Math::max);
       return this;
     }
@@ -576,25 +612,28 @@ public class PartitionSpec implements Serializable {
 
   static void checkCompatibility(PartitionSpec spec, Schema schema) {
     for (PartitionField field : spec.fields) {
-      Type sourceType = schema.findType(field.sourceId());
       Transform<?, ?> transform = field.transform();
-      // In the case of a Version 1 partition-spec field gets deleted,
-      // it is replaced with a void transform, see:
-      // https://iceberg.apache.org/spec/#partition-transforms
-      // We don't care about the source type since a VoidTransform is always compatible and skip the
-      // checks
-      if (!transform.equals(Transforms.alwaysNull())) {
-        ValidationException.check(
-            sourceType != null, "Cannot find source column for partition field: %s", field);
-        ValidationException.check(
-            sourceType.isPrimitiveType(),
-            "Cannot partition by non-primitive source field: %s",
-            sourceType);
-        ValidationException.check(
-            transform.canTransform(sourceType),
-            "Invalid source type %s for transform: %s",
-            sourceType,
-            transform);
+      for (int id : field.sourceIds()) {
+        Type sourceType = schema.findType(id);
+        // In the case of a Version 1 partition-spec field gets deleted,
+        // it is replaced with a void transform, see:
+        // https://iceberg.apache.org/spec/#partition-transforms
+        // We don't care about the source type since a VoidTransform is always compatible and skip
+        // the
+        // checks
+        if (!transform.equals(Transforms.alwaysNull())) {
+          ValidationException.check(
+              sourceType != null, "Cannot find source column for partition field: %s", field);
+          ValidationException.check(
+              sourceType.isPrimitiveType(),
+              "Cannot partition by non-primitive source field: %s",
+              sourceType);
+          ValidationException.check(
+              transform.canTransform(sourceType),
+              "Invalid source type %s for transform: %s",
+              sourceType,
+              transform);
+        }
       }
     }
   }

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -413,6 +413,13 @@ public class Schema implements Serializable {
     return lazyIdToAccessor().get(id);
   }
 
+  public Accessor<StructLike> accessorForFields(int[] ids) {
+    if (ids.length == 1) {
+      return accessorForField(ids[0]);
+    }
+    return Accessors.projectFields(this, ids);
+  }
+
   /**
    * Creates a projection schema for a subset of columns, selected by name.
    *

--- a/api/src/main/java/org/apache/iceberg/expressions/Bound.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Bound.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.iceberg.StructLike;
 
 /**
@@ -28,6 +30,11 @@ import org.apache.iceberg.StructLike;
 public interface Bound<T> {
   /** Returns the underlying reference. */
   BoundReference<?> ref();
+
+  /** Returns all the underlying references */
+  default List<BoundReference<?>> refs() {
+    return Collections.singletonList(ref());
+  }
 
   /**
    * Produce a value from the struct for this expression.

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundTransform.java
@@ -18,10 +18,18 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializableFunction;
+import org.apache.iceberg.util.StructProjection;
 
 /**
  * A transform expression.
@@ -30,24 +38,65 @@ import org.apache.iceberg.util.SerializableFunction;
  * @param <T> the Java type of values returned by the function.
  */
 public class BoundTransform<S, T> implements BoundTerm<T> {
-  private final BoundReference<S> ref;
+  private final BoundReference<?>[] refs;
+  private final StructProjection projection;
+  private Type inputType;
   private final Transform<S, T> transform;
   private final SerializableFunction<S, T> func;
 
   BoundTransform(BoundReference<S> ref, Transform<S, T> transform) {
-    this.ref = ref;
+    this.refs = Collections.singletonList(ref).toArray(new BoundReference<?>[0]);
     this.transform = transform;
+    this.projection = null;
     this.func = transform.bind(ref.type());
   }
 
-  @Override
-  public T eval(StructLike struct) {
-    return func.apply(ref.eval(struct));
+  BoundTransform(
+      List<BoundReference<?>> refs, StructProjection projection, Transform<S, T> transform) {
+    Preconditions.checkArgument(
+        refs != null && refs.size() >= 1, "At least one reference should be provided");
+    if (refs.size() == 1) {
+      Preconditions.checkArgument(
+          projection == null, "For singe arg transform, projection should be null");
+    }
+    this.refs = refs.toArray(new BoundReference<?>[0]);
+    this.transform = transform;
+    this.projection = projection;
+    this.func = transform.bind(lazyInputType());
+  }
+
+  private Type lazyInputType() {
+    if (inputType == null) {
+      if (this.refs.length == 1) {
+        inputType = refs[0].type();
+      } else {
+        List<Types.NestedField> fields =
+            Arrays.stream(refs).map(BoundReference::field).collect(Collectors.toList());
+        inputType = Types.StructType.of(fields);
+      }
+    }
+    return inputType;
   }
 
   @Override
+  @SuppressWarnings("unchecked")
+  public T eval(StructLike struct) {
+    if (projection == null) {
+      return func.apply(ref().eval(struct));
+    } else {
+      return func.apply((S) projection.wrap(struct));
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public BoundReference<S> ref() {
-    return ref;
+    return (BoundReference<S>) refs[0];
+  }
+
+  @Override
+  public List<BoundReference<?>> refs() {
+    return Arrays.asList(this.refs);
   }
 
   public Transform<S, T> transform() {
@@ -56,16 +105,30 @@ public class BoundTransform<S, T> implements BoundTerm<T> {
 
   @Override
   public Type type() {
-    return transform.getResultType(ref.type());
+    return transform.getResultType(lazyInputType());
+  }
+
+  private boolean areRefsEquivalent(List<BoundReference<?>> left, List<BoundReference<?>> right) {
+    if (left.size() != right.size()) {
+      return false;
+    }
+    Iterator<BoundReference<?>> leftIter = left.iterator();
+    Iterator<BoundReference<?>> rightIter = right.iterator();
+    while (leftIter.hasNext() && rightIter.hasNext()) {
+      if (!leftIter.next().isEquivalentTo(rightIter.next())) {
+        return false;
+      }
+    }
+    return !leftIter.hasNext() && !rightIter.hasNext();
   }
 
   @Override
   public boolean isEquivalentTo(BoundTerm<?> other) {
     if (other instanceof BoundTransform) {
       BoundTransform<?, ?> bound = (BoundTransform<?, ?>) other;
-      return ref.isEquivalentTo(bound.ref()) && transform.equals(bound.transform());
+      return areRefsEquivalent(this.refs(), other.refs()) && transform.equals(bound.transform());
     } else if (transform.isIdentity() && other instanceof BoundReference) {
-      return ref.isEquivalentTo(other);
+      return refs.length == 1 && ref().isEquivalentTo(other);
     }
 
     return false;
@@ -73,6 +136,10 @@ public class BoundTransform<S, T> implements BoundTerm<T> {
 
   @Override
   public String toString() {
-    return transform + "(" + ref + ")";
+    if (refs.length == 1) {
+      return transform + "(" + ref() + ")";
+    } else {
+      return transform + "(" + Arrays.toString(refs) + ")";
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression.Operation;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -75,6 +78,18 @@ public class Expressions {
   public static <T> UnboundTerm<T> bucket(String name, int numBuckets) {
     Transform<?, T> transform = (Transform<?, T>) Transforms.bucket(numBuckets);
     return new UnboundTransform<>(ref(name), transform);
+  }
+
+  public static <T> UnboundTerm<T> bucket(int numBuckets, String... names) {
+    if (names.length == 1) {
+      return bucket(names[0], numBuckets);
+    }
+    Transform<?, T> transform = (Transform<?, T>) Transforms.bucket(numBuckets);
+    NamedReference<?>[] references = new NamedReference<?>[names.length];
+    for (int i = 0; i < names.length; i++) {
+      references[i] = ref(names[i]);
+    }
+    return new UnboundTransform<>(Arrays.asList(references), transform);
   }
 
   @SuppressWarnings("unchecked")
@@ -307,6 +322,12 @@ public class Expressions {
    */
   public static <T> UnboundTerm<T> transform(String name, Transform<?, T> transform) {
     return new UnboundTransform<>(ref(name), transform);
+  }
+
+  public static <T> UnboundTerm<T> transform(List<String> names, Transform<?, T> transform) {
+    List<NamedReference<?>> refs =
+        names.stream().map(Expressions::ref).collect(Collectors.toList());
+    return new UnboundTransform<>(refs, transform);
   }
 
   public static <T> UnboundAggregate<T> count(String name) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Unbound.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Unbound.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.iceberg.types.Types;
 
 /**
@@ -39,4 +41,8 @@ public interface Unbound<T, B> {
 
   /** Returns this expression's underlying reference. */
   NamedReference<?> ref();
+
+  default List<NamedReference<?>> refs() {
+    return Collections.singletonList(ref());
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundTransform.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundTransform.java
@@ -18,22 +18,42 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.util.StructProjection;
 
 public class UnboundTransform<S, T> implements UnboundTerm<T>, Term {
-  private final NamedReference<S> ref;
+  private final NamedReference<?>[] refs;
   private final Transform<S, T> transform;
 
   UnboundTransform(NamedReference<S> ref, Transform<S, T> transform) {
-    this.ref = ref;
+    this.refs = Collections.singletonList(ref).toArray(new NamedReference[0]);
     this.transform = transform;
   }
 
+  UnboundTransform(List<NamedReference<?>> refs, Transform<S, T> transform) {
+    Preconditions.checkArgument(
+        refs != null && refs.size() >= 1, "At least one reference should be provided");
+    this.refs = refs.toArray(new NamedReference[0]);
+    this.transform = transform;
+  }
+
+  @SuppressWarnings("unchecked")
   @Override
   public NamedReference<S> ref() {
-    return ref;
+    return (NamedReference<S>) refs[0];
+  }
+
+  @Override
+  public List<NamedReference<?>> refs() {
+    return Arrays.asList(refs);
   }
 
   public Transform<S, T> transform() {
@@ -42,26 +62,61 @@ public class UnboundTransform<S, T> implements UnboundTerm<T>, Term {
 
   @Override
   public BoundTransform<S, T> bind(Types.StructType struct, boolean caseSensitive) {
-    BoundReference<S> boundRef = ref.bind(struct, caseSensitive);
+    if (refs.length == 1) {
+      BoundReference<S> boundRef = ref().bind(struct, caseSensitive);
+      return bindSingleRef(boundRef);
+    } else {
+      List<BoundReference<?>> boundRefs =
+          Arrays.stream(refs).map(x -> x.bind(struct, caseSensitive)).collect(Collectors.toList());
+      return bindRefs(struct, boundRefs);
+    }
+  }
 
+  private BoundTransform<S, T> bindSingleRef(BoundReference<S> boundRef) {
     try {
       ValidationException.check(
           transform.canTransform(boundRef.type()),
           "Cannot bind: %s cannot transform %s values from '%s'",
           transform,
           boundRef.type(),
-          ref.name());
+          ref().name());
     } catch (IllegalArgumentException e) {
       throw new ValidationException(
           "Cannot bind: %s cannot transform %s values from '%s'",
-          transform, boundRef.type(), ref.name());
+          transform, boundRef.type(), ref().name());
     }
 
     return new BoundTransform<>(boundRef, transform);
   }
 
+  private BoundTransform<S, T> bindRefs(
+      Types.StructType structType, List<BoundReference<?>> boundedRefs) {
+    StructType projectedType =
+        StructType.of(boundedRefs.stream().map(BoundReference::field).collect(Collectors.toList()));
+    StructProjection projection = StructProjection.create(structType, projectedType);
+    String refNames =
+        boundedRefs.stream().map(BoundReference::name).collect(Collectors.joining("(", ",", ")"));
+    try {
+      ValidationException.check(
+          transform.canTransform(projectedType),
+          "Cannot bind: %s cannot transform %s values from '%s'",
+          transform,
+          projectedType,
+          refNames);
+    } catch (IllegalArgumentException e) {
+      throw new ValidationException(
+          "Cannot bind: %s cannot transform %s values from '%s'",
+          transform, projectedType, refNames);
+    }
+    return new BoundTransform<>(boundedRefs, projection, transform);
+  }
+
   @Override
   public String toString() {
-    return transform + "(" + ref + ")";
+    if (refs.length == 1) {
+      return transform + "(" + ref() + ")";
+    } else {
+      return transform + "(" + Arrays.toString(refs) + ")";
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/BucketUtil.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
+import org.apache.iceberg.relocated.com.google.common.hash.Hasher;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 
 /**
@@ -96,5 +97,9 @@ public class BucketUtil {
 
   public static int hash(BigDecimal value) {
     return MURMUR3.hashBytes(value.unscaledValue().toByteArray()).asInt();
+  }
+
+  public static Hasher hasher() {
+    return MURMUR3.newHasher();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -36,6 +36,7 @@ public class SortOrderParser {
   private static final String NULL_ORDER = "null-order";
   private static final String TRANSFORM = "transform";
   private static final String SOURCE_ID = "source-id";
+  private static final String SOURCE_IDS = "source-ids";
 
   private SortOrderParser() {}
 
@@ -70,6 +71,15 @@ public class SortOrderParser {
       generator.writeStartObject();
       generator.writeStringField(TRANSFORM, field.transform().toString());
       generator.writeNumberField(SOURCE_ID, field.sourceId());
+      if (field.sourceIds().length > 1) {
+        // fieldName: SOURCE_IDS, array: sourceIds.
+        generator.writeFieldName(SOURCE_IDS);
+        generator.writeStartArray();
+        for (int i : field.sourceIds()) {
+          generator.writeNumber(i);
+        }
+        generator.writeEndArray();
+      }
       generator.writeStringField(DIRECTION, toJson(field.direction()));
       generator.writeStringField(NULL_ORDER, toJson(field.nullOrder()));
       generator.writeEndObject();
@@ -152,6 +162,8 @@ public class SortOrderParser {
 
       String transform = JsonUtil.getString(TRANSFORM, element);
       int sourceId = JsonUtil.getInt(SOURCE_ID, element);
+      int[] sourceIds = JsonUtil.getIntArrayOrNull(SOURCE_IDS, element);
+      sourceIds = sourceIds == null ? new int[] {sourceId} : sourceIds;
 
       String directionAsString = JsonUtil.getString(DIRECTION, element);
       SortDirection direction = SortDirection.fromString(directionAsString);
@@ -159,7 +171,7 @@ public class SortOrderParser {
       String nullOrderingAsString = JsonUtil.getString(NULL_ORDER, element);
       NullOrder nullOrder = toNullOrder(nullOrderingAsString);
 
-      builder.addSortField(transform, sourceId, direction, nullOrder);
+      builder.addSortField(transform, sourceId, sourceIds, direction, nullOrder);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -108,10 +109,22 @@ public class TableMetadata implements Serializable {
     PartitionSpec.Builder specBuilder =
         PartitionSpec.builderFor(freshSchema).withSpecId(INITIAL_SPEC_ID);
     for (PartitionField field : spec.fields()) {
-      // look up the name of the source field in the old schema to get the new schema's id
-      String sourceName = schema.findColumnName(field.sourceId());
-      // reassign all partition fields with fresh partition field Ids to ensure consistency
-      specBuilder.add(freshSchema.findField(sourceName).fieldId(), field.name(), field.transform());
+      if (field.sourceIds().length == 1) {
+        // look up the name of the source field in the old schema to get the new schema's id
+        String sourceName = schema.findColumnName(field.sourceId());
+        // reassign all partition fields with fresh partition field Ids to ensure consistency
+        specBuilder.add(
+            freshSchema.findField(sourceName).fieldId(), field.name(), field.transform());
+      } else {
+        int[] originalSourceIds = field.sourceIds();
+        int[] sourceIds =
+            Arrays.stream(originalSourceIds)
+                .mapToObj(schema::findColumnName)
+                .map(x -> freshSchema.findField(x).fieldId())
+                .mapToInt(x -> x)
+                .toArray();
+        specBuilder.add(sourceIds, field.name(), field.transform());
+      }
     }
     PartitionSpec freshSpec = specBuilder.build();
 
@@ -731,18 +744,33 @@ public class TableMetadata implements Serializable {
     UnboundPartitionSpec.Builder specBuilder = UnboundPartitionSpec.builder().withSpecId(specId);
 
     for (PartitionField field : partitionSpec.fields()) {
-      // look up the name of the source field in the old schema to get the new schema's id
-      String sourceName = partitionSpec.schema().findColumnName(field.sourceId());
+      if (field.sourceIds().length == 1) { // single arg transform
+        // look up the name of the source field in the old schema to get the new schema's id
+        String sourceName = partitionSpec.schema().findColumnName(field.sourceId());
 
-      final int fieldId;
-      if (sourceName != null) {
-        fieldId = schema.findField(sourceName).fieldId();
-      } else {
-        // In the case of a null sourceName, the column has been deleted.
-        // This only happens in V1 tables where the reference is still around as a void transform
-        fieldId = field.sourceId();
+        final int sourceId;
+        if (sourceName != null) {
+          sourceId = schema.findField(sourceName).fieldId();
+        } else {
+          // In the case of a null sourceName, the column has been deleted.
+          // This only happens in V1 tables where the reference is still around as a void transform
+          sourceId = field.sourceId();
+        }
+        final int[] sourceIds = new int[] {sourceId};
+        // todo: handle spec evolution
+        specBuilder.addField(
+            field.transform().toString(), sourceId, sourceIds, field.fieldId(), field.name());
+      } else { // multi-args transform
+        int[] originalSourceIds = field.sourceIds();
+        int[] sourceIds =
+            Arrays.stream(originalSourceIds)
+                .mapToObj(x -> partitionSpec.schema().findColumnName(x))
+                .map(x -> schema.findField(x).fieldId())
+                .mapToInt(x -> x)
+                .toArray();
+        specBuilder.addField(
+            field.transform().toString(), -1, sourceIds, field.fieldId(), field.name());
       }
-      specBuilder.addField(field.transform().toString(), fieldId, field.fieldId(), field.name());
     }
 
     return specBuilder.build().bind(schema);
@@ -756,12 +784,22 @@ public class TableMetadata implements Serializable {
     }
 
     for (SortField field : sortOrder.fields()) {
-      // look up the name of the source field in the old schema to get the new schema's id
-      String sourceName = sortOrder.schema().findColumnName(field.sourceId());
-      // reassign all sort fields with fresh sort field IDs
-      int newSourceId = schema.findField(sourceName).fieldId();
+      int[] newSourceIds = new int[field.sourceIds().length];
+      int idx = 0;
+      for (int sourceId : field.sourceIds()) {
+        // look up the name of the source field in the old schema to get the new schema's id
+        String sourceName = sortOrder.schema().findColumnName(sourceId);
+        // reassign all sort fields with fresh sort field IDs
+        int newSourceId = schema.findField(sourceName).fieldId();
+        newSourceIds[idx++] = newSourceId;
+      }
+      int newSourceId = newSourceIds.length > 1 ? -1 : newSourceIds[0];
       builder.addSortField(
-          field.transform().toString(), newSourceId, field.direction(), field.nullOrder());
+          field.transform().toString(),
+          newSourceId,
+          newSourceIds,
+          field.direction(),
+          field.nullOrder());
     }
 
     return builder.build().bind(schema);

--- a/core/src/main/java/org/apache/iceberg/util/CopySortOrderFields.java
+++ b/core/src/main/java/org/apache/iceberg/util/CopySortOrderFields.java
@@ -49,6 +49,17 @@ class CopySortOrderFields implements SortOrderVisitor<Void> {
   }
 
   @Override
+  public Void bucket(
+      String[] sourceNames,
+      int[] sourceIds,
+      int numBuckets,
+      SortDirection direction,
+      NullOrder nullOrder) {
+    builder.sortBy(Expressions.bucket(numBuckets, sourceNames), direction, nullOrder);
+    return null;
+  }
+
+  @Override
   public Void truncate(
       String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder) {
     builder.sortBy(Expressions.truncate(sourceName, width), direction, nullOrder);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -49,6 +49,17 @@ class SortOrderToSpark implements SortOrderVisitor<SortOrder> {
   }
 
   @Override
+  public SortOrder bucket(
+      String[] sourceNames, int[] ids, int width, SortDirection direction, NullOrder nullOrder) {
+    String[] quotedNames = new String[ids.length];
+    for (int i = 0; i < ids.length; i++) {
+      quotedNames[i] = quotedName(ids[i]);
+    }
+    return Expressions.sort(
+        Expressions.bucket(width, quotedNames), toSpark(direction), toSpark(nullOrder));
+  }
+
+  @Override
   public SortOrder truncate(
       String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
     return Expressions.sort(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -100,7 +100,9 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
 
     for (PartitionSpec spec : specs()) {
       for (PartitionField field : spec.fields()) {
-        partitionFieldSourceIds.add(field.sourceId());
+        for (int sourceId : field.sourceIds()) {
+          partitionFieldSourceIds.add(sourceId);
+        }
       }
     }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -49,6 +49,17 @@ class SortOrderToSpark implements SortOrderVisitor<SortOrder> {
   }
 
   @Override
+  public SortOrder bucket(
+      String[] sourceNames, int[] ids, int width, SortDirection direction, NullOrder nullOrder) {
+    String[] quotedNames = new String[ids.length];
+    for (int i = 0; i < ids.length; i++) {
+      quotedNames[i] = quotedName(ids[i]);
+    }
+    return Expressions.sort(
+        Expressions.bucket(width, quotedNames), toSpark(direction), toSpark(nullOrder));
+  }
+
+  @Override
   public SortOrder truncate(
       String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
     return Expressions.sort(

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -97,6 +97,7 @@ public class Spark3Util {
   private static final Set<String> RESERVED_PROPERTIES =
       ImmutableSet.of(TableCatalog.PROP_LOCATION, TableCatalog.PROP_PROVIDER);
   private static final Joiner DOT = Joiner.on(".");
+  private static final Set<String> MULTI_ARGS_TRANSFORMS = ImmutableSet.of("zorder", "bucket");
 
   private Spark3Util() {}
 
@@ -308,6 +309,15 @@ public class Spark3Util {
     }
 
     @Override
+    public Transform bucket(String[] sourceNames, int[] sourceIds, int numBuckets) {
+      String[] quotedNames = new String[sourceIds.length];
+      for (int i = 0; i < sourceIds.length; i++) {
+        quotedNames[i] = quotedName(sourceIds[i]);
+      }
+      return Expressions.bucket(numBuckets, quotedNames);
+    }
+
+    @Override
     public Transform truncate(String sourceName, int sourceId, int width) {
       NamedReference column = Expressions.column(quotedName(sourceId));
       return Expressions.apply("truncate", Expressions.literal(width), column);
@@ -357,7 +367,7 @@ public class Spark3Util {
     if (expr instanceof Transform) {
       Transform transform = (Transform) expr;
       Preconditions.checkArgument(
-          "zorder".equals(transform.name()) || transform.references().length == 1,
+          MULTI_ARGS_TRANSFORMS.contains(transform.name()) || transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s",
           transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
@@ -365,7 +375,11 @@ public class Spark3Util {
         case "identity":
           return org.apache.iceberg.expressions.Expressions.ref(colName);
         case "bucket":
-          return org.apache.iceberg.expressions.Expressions.bucket(colName, findWidth(transform));
+          String[] cols =
+              Stream.of(transform.references())
+                  .map(ref -> DOT.join(ref.fieldNames()))
+                  .toArray(String[]::new);
+          return org.apache.iceberg.expressions.Expressions.bucket(findWidth(transform), cols);
         case "years":
           return org.apache.iceberg.expressions.Expressions.year(colName);
         case "months":
@@ -412,7 +426,7 @@ public class Spark3Util {
     PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
     for (Transform transform : partitioning) {
       Preconditions.checkArgument(
-          transform.references().length == 1,
+          MULTI_ARGS_TRANSFORMS.contains(transform.name()) || transform.references().length == 1,
           "Cannot convert transform with more than one column reference: %s",
           transform);
       String colName = DOT.join(transform.references()[0].fieldNames());
@@ -421,7 +435,11 @@ public class Spark3Util {
           builder.identity(colName);
           break;
         case "bucket":
-          builder.bucket(colName, findWidth(transform));
+          String[] colNames =
+              Arrays.stream(transform.references())
+                  .map(ref -> DOT.join(ref.fieldNames()))
+                  .toArray(String[]::new);
+          builder.bucket(colNames, findWidth(transform));
           break;
         case "years":
           builder.year(colName);
@@ -949,6 +967,18 @@ public class Spark3Util {
         org.apache.iceberg.SortDirection direction,
         NullOrder nullOrder) {
       return String.format("bucket(%s, %s) %s %s", numBuckets, sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String bucket(
+        String[] sourceNames,
+        int[] sourceIds,
+        int numBuckets,
+        org.apache.iceberg.SortDirection direction,
+        NullOrder nullOrder) {
+      String sourceNameList = String.join(", ", sourceNames);
+      return String.format(
+          "bucket(%s, %s) %s %s", numBuckets, sourceNameList, direction, nullOrder);
     }
 
     @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/functions/BucketFunction.java
@@ -81,7 +81,7 @@ public class BucketFunction implements UnboundFunction {
   public BoundFunction bind(StructType inputType) {
     if (inputType.size() < 2) {
       throw new UnsupportedOperationException(
-          "Wrong number of inputs (expected numBuckets and varg value)");
+          "Wrong number of inputs (expected numBuckets and values)");
     }
 
     StructField numBucketsField = inputType.fields()[NUM_BUCKETS_ORDINAL];
@@ -376,6 +376,7 @@ public class BucketFunction implements UnboundFunction {
       return inputTypes;
     }
 
+    @SuppressWarnings("CyclomaticComplexity")
     @Override
     public Integer produceResult(InternalRow input) {
       if (input.isNullAt(NUM_BUCKETS_ORDINAL)) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -102,7 +102,9 @@ class SparkBatchQueryScan extends SparkPartitioningAwareScan<PartitionScanTask>
 
     for (PartitionSpec spec : specs()) {
       for (PartitionField field : spec.fields()) {
-        partitionFieldSourceIds.add(field.sourceId());
+        for (int sourceId : field.sourceIds()) {
+          partitionFieldSourceIds.add(sourceId);
+        }
       }
     }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkBucketFunction.java
@@ -200,17 +200,12 @@ public class TestSparkBucketFunction extends SparkTestBaseWithCatalog {
     Assertions.assertThatThrownBy(() -> scalarSql("SELECT system.bucket()"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'bucket' cannot process input: (): Wrong number of inputs (expected numBuckets and value)");
+            "Function 'bucket' cannot process input: (): Wrong number of inputs (expected numBuckets and values)");
 
     Assertions.assertThatThrownBy(() -> scalarSql("SELECT system.bucket(1)"))
         .isInstanceOf(AnalysisException.class)
         .hasMessageStartingWith(
-            "Function 'bucket' cannot process input: (int): Wrong number of inputs (expected numBuckets and value)");
-
-    Assertions.assertThatThrownBy(() -> scalarSql("SELECT system.bucket(1, 1L, 1)"))
-        .isInstanceOf(AnalysisException.class)
-        .hasMessageStartingWith(
-            "Function 'bucket' cannot process input: (int, bigint, int): Wrong number of inputs (expected numBuckets and value)");
+            "Function 'bucket' cannot process input: (int): Wrong number of inputs (expected numBuckets and values)");
   }
 
   @Test


### PR DESCRIPTION
This commit makes one simple E2E of multi-arg bucket transform works on spark 3.3 and spark 3.4

this should resolves #8258 