### PR TITLE
Core: Use lazy iterable in DeleteFileIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.metrics.ScanMetrics;
+import org.apache.iceberg.metrics.ScanMetricsUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -480,7 +481,6 @@ class DeleteFileIndex {
       ListMultimap<Pair<Integer, StructLikeWrapper>, IndexedDeleteFile> deleteFilesByPartition =
           Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
       for (DeleteFile file : files) {
-        scanMetrics.indexedDeleteFile(file);
         int specId = file.specId();
         PartitionSpec spec = specsById.get(specId);
         StructLikeWrapper wrapper =
@@ -488,6 +488,7 @@ class DeleteFileIndex {
                 .computeIfAbsent(specId, id -> StructLikeWrapper.forType(spec.partitionType()))
                 .copyFor(file.partition());
         deleteFilesByPartition.put(Pair.of(specId, wrapper), new IndexedDeleteFile(spec, file));
+        ScanMetricsUtil.indexedDeleteFile(scanMetrics, file);
       }
 
       // sort the entries in each map value by sequence number and split into sequence numbers and

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.metrics;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.immutables.value.Value;
 
 /** Carries all metrics for a particular scan */
@@ -125,6 +127,16 @@ public abstract class ScanMetrics {
   @Value.Derived
   public Counter positionalDeleteFiles() {
     return metricsContext().counter(POSITIONAL_DELETE_FILES);
+  }
+
+  public void indexedDeleteFile(DeleteFile deleteFile) {
+    indexedDeleteFiles().increment();
+
+    if (deleteFile.content() == FileContent.POSITION_DELETES) {
+      positionalDeleteFiles().increment();
+    } else if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+      equalityDeleteFiles().increment();
+    }
   }
 
   public static ScanMetrics of(MetricsContext metricsContext) {

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetrics.java
@@ -19,8 +19,6 @@
 package org.apache.iceberg.metrics;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileContent;
 import org.immutables.value.Value;
 
 /** Carries all metrics for a particular scan */
@@ -127,16 +125,6 @@ public abstract class ScanMetrics {
   @Value.Derived
   public Counter positionalDeleteFiles() {
     return metricsContext().counter(POSITIONAL_DELETE_FILES);
-  }
-
-  public void indexedDeleteFile(DeleteFile deleteFile) {
-    indexedDeleteFiles().increment();
-
-    if (deleteFile.content() == FileContent.POSITION_DELETES) {
-      positionalDeleteFiles().increment();
-    } else if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
-      equalityDeleteFiles().increment();
-    }
   }
 
   public static ScanMetrics of(MetricsContext metricsContext) {

--- a/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/ScanMetricsUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+
+public class ScanMetricsUtil {
+
+  private ScanMetricsUtil() {}
+
+  public static void indexedDeleteFile(ScanMetrics metrics, DeleteFile deleteFile) {
+    metrics.indexedDeleteFiles().increment();
+
+    if (deleteFile.content() == FileContent.POSITION_DELETES) {
+      metrics.positionalDeleteFiles().increment();
+    } else if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+      metrics.equalityDeleteFiles().increment();
+    }
+  }
+}


### PR DESCRIPTION
This PR avoids an extra copy of the passed iterable of delete files when creating an index from files.