### PR TITLE
Core: Re-apply Hadoop conf if it's null after Kryo ser/de in ResolvingFileIO

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -133,6 +133,15 @@ public class ResolvingFileIO implements FileIO, HadoopConfigurable {
     String impl = implFromLocation(location);
     FileIO io = ioInstances.get(impl);
     if (io != null) {
+      if (io instanceof HadoopConfigurable && ((HadoopConfigurable) io).getConf() == null) {
+        synchronized (ioInstances) {
+          if (((HadoopConfigurable) io).getConf() == null) {
+            // re-apply the config in case it's null after Kryo serialization
+            ((HadoopConfigurable) io).setConf(hadoopConf.get());
+          }
+        }
+      }
+
       return io;
     }
 


### PR DESCRIPTION
I noticed this issue while working on https://github.com/apache/iceberg/pull/7370 / https://github.com/apache/iceberg/pull/8032 and reproduced this in a small test.

Without this fix, the test fails with 
```
Cannot invoke "org.apache.hadoop.conf.Configuration.get(String, String)" because "conf" is null
java.lang.NullPointerException: Cannot invoke "org.apache.hadoop.conf.Configuration.get(String, String)" because "conf" is null
  at org.apache.hadoop.fs.FileSystem.getDefaultUri(FileSystem.java:180)
  at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:172)
  at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:357)
  at org.apache.hadoop.fs.Path.getFileSystem(Path.java:295)
  at org.apache.iceberg.hadoop.Util.getFs(Util.java:56)
  at org.apache.iceberg.hadoop.HadoopInputFile.fromLocation(HadoopInputFile.java:56)
  at org.apache.iceberg.hadoop.HadoopFileIO.newInputFile(HadoopFileIO.java:90)
  at org.apache.iceberg.io.ResolvingFileIO.newInputFile(ResolvingFileIO.java:71)
  at org.apache.iceberg.io.TestResolvingIO.testResolvingFileIOWithHadoopFileIOKryoSerialization(TestResolvingIO.java:62)

```