### PR TITLE
Docs: correct iceberg-metadata uri

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -58,7 +58,7 @@ In addition to row-level deletes, version 2 makes some requirements stricter for
 
 ## Overview
 
-![Iceberg snapshot structure](../../../img/iceberg-metadata.png)
+![Iceberg snapshot structure](https://iceberg.apache.org/img/iceberg-metadata.png)
 
 This table format tracks individual data files in a table instead of directories. This allows writers to create data files in-place and only adds files to the table in an explicit commit.
 


### PR DESCRIPTION
`../../../img/iceberg-metadata.png` could't be found, maybe we should use `https://iceberg.apache.org/img/iceberg-metadata.png`