### PR TITLE
Core: Support changing compression codec for ManifestWriter

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -801,6 +801,14 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method org.apache.iceberg.view.ViewBuilder org.apache.iceberg.view.ViewBuilder::withQueryColumnNames(java.util.List<java.lang.String>)"
       justification: "Acceptable break due to updating View APIs and the View Spec"
+    org.apache.iceberg:iceberg-core:
+    - code: "java.method.abstractMethodAdded"
+      new: "method org.apache.iceberg.io.FileAppender<org.apache.iceberg.ManifestEntry<F>>\
+        \ org.apache.iceberg.ManifestWriter<F extends org.apache.iceberg.ContentFile<F\
+        \ extends org.apache.iceberg.ContentFile<F>>>::newAppender(org.apache.iceberg.PartitionSpec,\
+        \ org.apache.iceberg.io.OutputFile, java.util.Map<java.lang.String, java.lang.String>)"
+      justification: "{Adding a new method to support set file appender config for\
+        \ ManifestWriter}"
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"

--- a/build.gradle
+++ b/build.gradle
@@ -360,6 +360,8 @@ project(':iceberg-core') {
     testImplementation libs.esotericsoftware.kryo
     testImplementation libs.guava.testlib
     testImplementation libs.awaitility
+    testImplementation libs.snappy
+    testImplementation libs.zstd
   }
 }
 

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -170,7 +170,8 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
         specsById,
         newFile,
         snapshotId(),
-        summaryBuilder);
+        summaryBuilder,
+        ops.current().properties());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -138,7 +138,8 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
         current.specsById(),
         newManifestPath,
         snapshotId(),
-        summaryBuilder);
+        summaryBuilder,
+        current.properties());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -302,7 +302,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         current.specsById(),
         newManifestPath,
         snapshotId(),
-        appendedManifestsSummary);
+        appendedManifestsSummary,
+        current.properties());
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -492,12 +492,20 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec spec) {
     return ManifestFiles.write(
-        ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+        ops.current().formatVersion(),
+        spec,
+        newManifestOutput(),
+        snapshotId(),
+        ops.current().properties());
   }
 
   protected ManifestWriter<DeleteFile> newDeleteManifestWriter(PartitionSpec spec) {
     return ManifestFiles.writeDeleteManifest(
-        ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+        ops.current().formatVersion(),
+        spec,
+        newManifestOutput(),
+        snapshotId(),
+        ops.current().properties());
   }
 
   protected RollingManifestWriter<DataFile> newRollingManifestWriter(PartitionSpec spec) {

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.deletes.PositionDelete;
@@ -254,16 +255,17 @@ public class TableTestBase {
   }
 
   ManifestFile writeManifest(String fileName, ManifestEntry<?>... entries) throws IOException {
-    return writeManifest(null, fileName, entries);
+    return writeManifest(null, fileName, ImmutableMap.of(), entries);
   }
 
   ManifestFile writeManifest(Long snapshotId, ManifestEntry<?>... entries) throws IOException {
-    return writeManifest(snapshotId, "input.m0.avro", entries);
+    return writeManifest(snapshotId, "input.m0.avro", ImmutableMap.of(), entries);
   }
 
   @SuppressWarnings("unchecked")
   <F extends ContentFile<F>> ManifestFile writeManifest(
-      Long snapshotId, String fileName, ManifestEntry<?>... entries) throws IOException {
+      Long snapshotId, String fileName, Map<String, String> config, ManifestEntry<?>... entries)
+      throws IOException {
     File manifestFile = temp.newFile(fileName);
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
@@ -272,12 +274,12 @@ public class TableTestBase {
     if (entries[0].file() instanceof DataFile) {
       writer =
           (ManifestWriter<F>)
-              ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId);
+              ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId, config);
     } else {
       writer =
           (ManifestWriter<F>)
               ManifestFiles.writeDeleteManifest(
-                  formatVersion, table.spec(), outputFile, snapshotId);
+                  formatVersion, table.spec(), outputFile, snapshotId, config);
     }
     try {
       for (ManifestEntry<?> entry : entries) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,8 @@ sqlite-jdbc = "3.41.0.0"
 testcontainers = "1.17.6"
 tez010 = "0.10.2"
 tez08 = { strictly = "[0.8, 0.9[", prefer = "0.8.4"}  # see rich version usage explanation above
+snappy = "1.1.10.3"
+zstd = "1.5.5-5"
 
 [libraries]
 activation = { module = "javax.activation:activation", version.ref = "activation" }
@@ -192,3 +194,5 @@ tez010-dag = { module = "org.apache.tez:tez-dag", version.ref = "tez010" }
 tez010-mapreduce = { module = "org.apache.tez:tez-mapreduce", version.ref = "tez010" }
 tez08-dag = { module = "org.apache.tez:tez-dag", version.ref = "tez08" }
 tez08-mapreduce = { module = "org.apache.tez:tez-mapreduce", version.ref = "tez08" }
+snappy = { module = "org.xerial.snappy:snappy-java", version.ref = "snappy" }
+zstd = { module = "com.github.luben:zstd-jni", version.ref = "zstd" }


### PR DESCRIPTION
Supports changing compression codec for ManifestWriter with respect to `write.avro.compression-codec`. This PR only updates the core part codes.

The benchmark results as following:
```
Benchmark                                    (codec)  Mode  Cnt  Score   Error  Units
ManifestReadBenchmark.readManifestFile  UNCOMPRESSED    ss    5  4.627 ± 1.371   s/op
ManifestReadBenchmark.readManifestFile        SNAPPY    ss    5  4.580 ± 1.686   s/op
ManifestReadBenchmark.readManifestFile          ZSTD    ss    5  5.296 ± 2.678   s/op
ManifestReadBenchmark.readManifestFile          GZIP    ss    5  6.745 ± 2.267   s/op
```