### PR TITLE
Python: Delegate serialization to pydantic

### DIFF
--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -113,7 +113,7 @@ NAMESPACE_SEPARATOR = b"\x1F".decode("UTF-8")
 
 class TableResponse(IcebergBaseModel):
     metadata_location: str = Field(alias="metadata-location")
-    metadata: TableMetadata = Field()
+    metadata: TableMetadata
     config: Properties = Field(default_factory=dict)
 
 

--- a/python/pyiceberg/serializers.py
+++ b/python/pyiceberg/serializers.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import codecs
 import gzip
-import json
 from abc import ABC, abstractmethod
 from typing import Callable
 
@@ -89,9 +88,9 @@ class FromByteStream:
         with compression.stream_decompressor(byte_stream) as byte_stream:
             reader = codecs.getreader(encoding)
             json_bytes = reader(byte_stream)
-            metadata = json.load(json_bytes)
+            metadata = json_bytes.read()
 
-        return TableMetadataUtil.parse_obj(metadata)
+        return TableMetadataUtil.parse_raw(metadata)
 
 
 class FromInputFile:

--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -370,13 +370,13 @@ class CommitTableRequest(IcebergBaseModel):
 
 
 class CommitTableResponse(IcebergBaseModel):
-    metadata: TableMetadata = Field()
+    metadata: TableMetadata
     metadata_location: str = Field(alias="metadata-location")
 
 
 class Table:
     identifier: Identifier = Field()
-    metadata: TableMetadata = Field()
+    metadata: TableMetadata
     metadata_location: str = Field()
     io: FileIO
     catalog: Catalog

--- a/python/tests/catalog/test_hive.py
+++ b/python/tests/catalog/test_hive.py
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 # pylint: disable=protected-access,redefined-outer-name
-import json
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -255,9 +254,9 @@ def test_create_table(table_schema_simple: Schema, hive_database: HiveDatabase, 
     )
 
     with open(metadata_location, encoding="utf-8") as f:
-        payload = json.load(f)
+        payload = f.read()
 
-    metadata = TableMetadataUtil.parse_obj(payload)
+    metadata = TableMetadataUtil.parse_raw(payload)
 
     assert "database/table" in metadata.location
 

--- a/python/tests/table/test_metadata.py
+++ b/python/tests/table/test_metadata.py
@@ -235,7 +235,7 @@ def test_invalid_format_version() -> None:
     with pytest.raises(ValidationError) as exc_info:
         TableMetadataUtil.parse_obj(table_metadata_invalid_format_version)
 
-    assert "Unknown format version: -1" in str(exc_info.value)
+    assert "No match for discriminator 'format_version' and value -1 (allowed values: 1, 2)" in str(exc_info.value)
 
 
 def test_current_schema_not_found() -> None:

--- a/python/tests/table/test_metadata.py
+++ b/python/tests/table/test_metadata.py
@@ -76,12 +76,12 @@ def example_table_metadata_v1() -> Dict[str, Any]:
 
 def test_from_dict_v1(example_table_metadata_v1: Dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a dictionary"""
-    TableMetadataUtil.parse_obj(example_table_metadata_v1)
+    TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v1))
 
 
 def test_from_dict_v2(example_table_metadata_v2: Dict[str, Any]) -> None:
     """Test initialization of a TableMetadata instance from a dictionary"""
-    TableMetadataUtil.parse_obj(example_table_metadata_v2)
+    TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v2))
 
 
 def test_from_byte_stream(example_table_metadata_v2: Dict[str, Any]) -> None:
@@ -93,7 +93,7 @@ def test_from_byte_stream(example_table_metadata_v2: Dict[str, Any]) -> None:
 
 def test_v2_metadata_parsing(example_table_metadata_v2: Dict[str, Any]) -> None:
     """Test retrieving values from a TableMetadata instance of version 2"""
-    table_metadata = TableMetadataUtil.parse_obj(example_table_metadata_v2)
+    table_metadata = TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v2))
 
     assert table_metadata.format_version == 2
     assert table_metadata.table_uuid == UUID("9c12d441-03fe-4693-9a96-a0705ddf69c1")
@@ -233,7 +233,7 @@ def test_invalid_format_version() -> None:
     }
 
     with pytest.raises(ValidationError) as exc_info:
-        TableMetadataUtil.parse_obj(table_metadata_invalid_format_version)
+        TableMetadataUtil.parse_raw(json.dumps(table_metadata_invalid_format_version))
 
     assert "No match for discriminator 'format_version' and value -1 (allowed values: 1, 2)" in str(exc_info.value)
 
@@ -271,7 +271,7 @@ def test_current_schema_not_found() -> None:
     }
 
     with pytest.raises(ValidationError) as exc_info:
-        TableMetadataUtil.parse_obj(table_metadata_schema_not_found)
+        TableMetadataUtil.parse_raw(json.dumps(table_metadata_schema_not_found))
 
     assert "current-schema-id 2 can't be found in the schemas" in str(exc_info.value)
 
@@ -317,7 +317,7 @@ def test_sort_order_not_found() -> None:
     }
 
     with pytest.raises(ValidationError) as exc_info:
-        TableMetadataUtil.parse_obj(table_metadata_schema_not_found)
+        TableMetadataUtil.parse_raw(json.dumps(table_metadata_schema_not_found))
 
     assert "default-sort-order-id 4 can't be found" in str(exc_info.value)
 
@@ -354,7 +354,7 @@ def test_sort_order_unsorted() -> None:
         "snapshots": [],
     }
 
-    table_metadata = TableMetadataUtil.parse_obj(table_metadata_schema_not_found)
+    table_metadata = TableMetadataUtil.parse_raw(json.dumps(table_metadata_schema_not_found))
 
     # Most important here is that we correctly handle sort-order-id 0
     assert len(table_metadata.sort_orders) == 0
@@ -389,7 +389,7 @@ def test_invalid_partition_spec() -> None:
         "last-partition-id": 1000,
     }
     with pytest.raises(ValidationError) as exc_info:
-        TableMetadataUtil.parse_obj(table_metadata_spec_not_found)
+        TableMetadataUtil.parse_raw(json.dumps(table_metadata_spec_not_found))
 
     assert "default-spec-id 1 can't be found" in str(exc_info.value)
 

--- a/python/tests/table/test_sorting.py
+++ b/python/tests/table/test_sorting.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # pylint:disable=redefined-outer-name,eval-used
-
+import json
 from typing import Any, Dict
 
 import pytest
@@ -57,7 +57,7 @@ def test_deserialize_sort_order(sort_order: SortOrder) -> None:
 
 
 def test_sorting_schema(example_table_metadata_v2: Dict[str, Any]) -> None:
-    table_metadata = TableMetadataUtil.parse_obj(example_table_metadata_v2)
+    table_metadata = TableMetadataUtil.parse_raw(json.dumps(example_table_metadata_v2))
 
     assert table_metadata.sort_orders == [
         SortOrder(


### PR DESCRIPTION
(It should) closes #7982 

TableMetadataUtil has a `parse_raw` method where it receives a string that will be parsed by a pydantic model. This model will also return the correct TableMetadata version based on the field `format_version`. 
This is like a strategy method that is now handled with a pydantic model (before, there were a couple of if statements).