### PR TITLE
Spark 3.3, 3.4: Add where filter to rewrite_position_delete_files procedure

### DIFF
--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -158,7 +158,6 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
     sql("DELETE FROM %s WHERE id = 3 and data='g'", tableName);
     sql("DELETE FROM %s WHERE id = 3 and data='h'", tableName);
 
-
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertEquals(6, TestHelpers.deleteFiles(table).size());
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -55,16 +55,22 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
         Lists.newArrayList(
             new SimpleRecord(1, "a"),
             new SimpleRecord(1, "b"),
-            new SimpleRecord(2, "c"),
+            new SimpleRecord(1, "c"),
             new SimpleRecord(2, "d"),
-            new SimpleRecord(3, "e"),
-            new SimpleRecord(3, "f"),
-            new SimpleRecord(4, "g"),
-            new SimpleRecord(4, "h"),
-            new SimpleRecord(5, "i"),
-            new SimpleRecord(5, "j"),
-            new SimpleRecord(6, "k"),
-            new SimpleRecord(6, "l"));
+            new SimpleRecord(2, "e"),
+            new SimpleRecord(2, "f"),
+            new SimpleRecord(3, "g"),
+            new SimpleRecord(3, "h"),
+            new SimpleRecord(3, "i"),
+            new SimpleRecord(4, "j"),
+            new SimpleRecord(4, "k"),
+            new SimpleRecord(4, "l"),
+            new SimpleRecord(5, "m"),
+            new SimpleRecord(5, "n"),
+            new SimpleRecord(5, "o"),
+            new SimpleRecord(6, "p"),
+            new SimpleRecord(6, "q"),
+            new SimpleRecord(6, "r"));
     spark
         .createDataset(records, Encoders.bean(SimpleRecord.class))
         .coalesce(1)
@@ -145,12 +151,16 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
   public void testExpireDeleteFilesFilter() throws Exception {
     createTable(true);
 
-    sql("DELETE FROM %s WHERE data='a'", tableName);
-    sql("DELETE FROM %s WHERE data='c'", tableName);
-    sql("DELETE FROM %s WHERE data='e'", tableName);
+    sql("DELETE FROM %s WHERE id = 1 and data='a'", tableName);
+    sql("DELETE FROM %s WHERE id = 1 and data='b'", tableName);
+    sql("DELETE FROM %s WHERE id = 2 and data='d'", tableName);
+    sql("DELETE FROM %s WHERE id = 2 and data='e'", tableName);
+    sql("DELETE FROM %s WHERE id = 3 and data='g'", tableName);
+    sql("DELETE FROM %s WHERE id = 3 and data='h'", tableName);
+
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals(3, TestHelpers.deleteFiles(table).size());
+    Assert.assertEquals(6, TestHelpers.deleteFiles(table).size());
 
     List<Object[]> output =
         sql(
@@ -165,16 +175,16 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
 
     Map<String, String> snapshotSummary = snapshotSummary();
     assertEquals(
-        "Should delete 2 delete files and add 2",
+        "Should delete 4 delete files and add 2",
         ImmutableList.of(
             row(
-                2,
+                4,
                 2,
                 Long.valueOf(snapshotSummary.get(REMOVED_FILE_SIZE_PROP)),
                 Long.valueOf(snapshotSummary.get(ADDED_FILE_SIZE_PROP)))),
         output);
 
-    Assert.assertEquals(3, TestHelpers.deleteFiles(table).size());
+    Assert.assertEquals(4, TestHelpers.deleteFiles(table).size());
   }
 
   @Test

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -46,6 +46,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 import org.apache.spark.sql.execution.CacheManager;
+import org.apache.spark.sql.execution.datasources.SparkExpressionConverter;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -165,9 +165,9 @@ abstract class BaseProcedure implements Procedure {
 
   protected Expression filterExpression(Identifier ident, String where) {
     try {
-      String name = Spark3Util.quotedFullIdentifier(tableCatalog().name(), ident);
+      String name = Spark3Util.quotedFullIdentifier(tableCatalog.name(), ident);
       org.apache.spark.sql.catalyst.expressions.Expression expression =
-          SparkExpressionConverter.collectResolvedSparkExpression(spark(), name, where);
+          SparkExpressionConverter.collectResolvedSparkExpression(spark, name, where);
       return SparkExpressionConverter.convertToIcebergExpression(expression);
     } catch (AnalysisException e) {
       throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -32,6 +33,7 @@ import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -158,6 +160,17 @@ abstract class BaseProcedure implements Procedure {
     DataSourceV2Relation relation =
         DataSourceV2Relation.create(table, Option.apply(tableCatalog), Option.apply(ident));
     cacheManager.recacheByPlan(spark, relation);
+  }
+
+  protected Expression filterExpression(Identifier ident, String where) {
+    try {
+      String name = Spark3Util.quotedFullIdentifier(tableCatalog().name(), ident);
+      org.apache.spark.sql.catalyst.expressions.Expression expression =
+          SparkExpressionConverter.collectResolvedSparkExpression(spark(), name, where);
+      return SparkExpressionConverter.convertToIcebergExpression(expression);
+    } catch (AnalysisException e) {
+      throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
+    }
   }
 
   protected InternalRow newInternalRow(Object... values) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
@@ -96,10 +96,12 @@ public class RewritePositionDeleteFilesProcedure extends BaseProcedure {
         table -> {
           RewritePositionDeleteFiles action =
               actions().rewritePositionDeletes(table).options(options);
+
           if (where != null) {
             Expression whereExpression = filterExpression(tableIdent, where);
             action = action.filter(whereExpression);
           }
+
           Result result = action.execute();
           return new InternalRow[] {toOutputRow(result)};
         });

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -158,7 +158,6 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
     sql("DELETE FROM %s WHERE id = 3 and data='g'", tableName);
     sql("DELETE FROM %s WHERE id = 3 and data='h'", tableName);
 
-
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertEquals(6, TestHelpers.deleteFiles(table).size());
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -55,16 +55,22 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
         Lists.newArrayList(
             new SimpleRecord(1, "a"),
             new SimpleRecord(1, "b"),
-            new SimpleRecord(2, "c"),
+            new SimpleRecord(1, "c"),
             new SimpleRecord(2, "d"),
-            new SimpleRecord(3, "e"),
-            new SimpleRecord(3, "f"),
-            new SimpleRecord(4, "g"),
-            new SimpleRecord(4, "h"),
-            new SimpleRecord(5, "i"),
-            new SimpleRecord(5, "j"),
-            new SimpleRecord(6, "k"),
-            new SimpleRecord(6, "l"));
+            new SimpleRecord(2, "e"),
+            new SimpleRecord(2, "f"),
+            new SimpleRecord(3, "g"),
+            new SimpleRecord(3, "h"),
+            new SimpleRecord(3, "i"),
+            new SimpleRecord(4, "j"),
+            new SimpleRecord(4, "k"),
+            new SimpleRecord(4, "l"),
+            new SimpleRecord(5, "m"),
+            new SimpleRecord(5, "n"),
+            new SimpleRecord(5, "o"),
+            new SimpleRecord(6, "p"),
+            new SimpleRecord(6, "q"),
+            new SimpleRecord(6, "r"));
     spark
         .createDataset(records, Encoders.bean(SimpleRecord.class))
         .coalesce(1)
@@ -145,12 +151,16 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
   public void testExpireDeleteFilesFilter() throws Exception {
     createTable(true);
 
-    sql("DELETE FROM %s WHERE data='a'", tableName);
-    sql("DELETE FROM %s WHERE data='c'", tableName);
-    sql("DELETE FROM %s WHERE data='e'", tableName);
+    sql("DELETE FROM %s WHERE id = 1 and data='a'", tableName);
+    sql("DELETE FROM %s WHERE id = 1 and data='b'", tableName);
+    sql("DELETE FROM %s WHERE id = 2 and data='d'", tableName);
+    sql("DELETE FROM %s WHERE id = 2 and data='e'", tableName);
+    sql("DELETE FROM %s WHERE id = 3 and data='g'", tableName);
+    sql("DELETE FROM %s WHERE id = 3 and data='h'", tableName);
+
 
     Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertEquals(3, TestHelpers.deleteFiles(table).size());
+    Assert.assertEquals(6, TestHelpers.deleteFiles(table).size());
 
     List<Object[]> output =
         sql(
@@ -165,16 +175,16 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
 
     Map<String, String> snapshotSummary = snapshotSummary();
     assertEquals(
-        "Should delete 2 delete files and add 2",
+        "Should delete 4 delete files and add 2",
         ImmutableList.of(
             row(
-                2,
+                4,
                 2,
                 Long.valueOf(snapshotSummary.get(REMOVED_FILE_SIZE_PROP)),
                 Long.valueOf(snapshotSummary.get(ADDED_FILE_SIZE_PROP)))),
         output);
 
-    Assert.assertEquals(3, TestHelpers.deleteFiles(table).size());
+    Assert.assertEquals(4, TestHelpers.deleteFiles(table).size());
   }
 
   @Test

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -32,6 +33,7 @@ import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -44,6 +46,7 @@ import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.Procedure;
 import org.apache.spark.sql.execution.CacheManager;
+import org.apache.spark.sql.execution.datasources.SparkExpressionConverter;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
@@ -158,6 +161,17 @@ abstract class BaseProcedure implements Procedure {
     DataSourceV2Relation relation =
         DataSourceV2Relation.create(table, Option.apply(tableCatalog), Option.apply(ident));
     cacheManager.recacheByPlan(spark, relation);
+  }
+
+  protected Expression filterExpression(Identifier ident, String where) {
+    try {
+      String name = Spark3Util.quotedFullIdentifier(tableCatalog().name(), ident);
+      org.apache.spark.sql.catalyst.expressions.Expression expression =
+          SparkExpressionConverter.collectResolvedSparkExpression(spark(), name, where);
+      return SparkExpressionConverter.convertToIcebergExpression(expression);
+    } catch (AnalysisException e) {
+      throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
+    }
   }
 
   protected InternalRow newInternalRow(Object... values) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -165,9 +165,9 @@ abstract class BaseProcedure implements Procedure {
 
   protected Expression filterExpression(Identifier ident, String where) {
     try {
-      String name = Spark3Util.quotedFullIdentifier(tableCatalog().name(), ident);
+      String name = Spark3Util.quotedFullIdentifier(tableCatalog.name(), ident);
       org.apache.spark.sql.catalyst.expressions.Expression expression =
-          SparkExpressionConverter.collectResolvedSparkExpression(spark(), name, where);
+          SparkExpressionConverter.collectResolvedSparkExpression(spark, name, where);
       return SparkExpressionConverter.convertToIcebergExpression(expression);
     } catch (AnalysisException e) {
       throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewritePositionDeleteFilesProcedure.java
@@ -96,10 +96,12 @@ public class RewritePositionDeleteFilesProcedure extends BaseProcedure {
         table -> {
           RewritePositionDeleteFiles action =
               actions().rewritePositionDeletes(table).options(options);
+
           if (where != null) {
             Expression whereExpression = filterExpression(tableIdent, where);
             action = action.filter(whereExpression);
           }
+
           Result result = action.execute();
           return new InternalRow[] {toOutputRow(result)};
         });


### PR DESCRIPTION
This is similar to the 'where' procedure option of rewrite_data_files Spark procedure.