### PR TITLE
Spark: Add cause to rewrite_data_files exception when parsing 'where'

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -130,7 +130,7 @@ class RewriteDataFilesProcedure extends BaseProcedure {
             SparkExpressionConverter.collectResolvedSparkExpression(spark(), tableName, where);
         return action.filter(SparkExpressionConverter.convertToIcebergExpression(expression));
       } catch (AnalysisException e) {
-        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where);
+        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
       }
     }
     return action;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -134,7 +134,7 @@ class RewriteDataFilesProcedure extends BaseProcedure {
             SparkExpressionConverter.collectResolvedSparkExpression(spark(), tableName, where);
         return action.filter(SparkExpressionConverter.convertToIcebergExpression(expression));
       } catch (AnalysisException e) {
-        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where);
+        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
       }
     }
     return action;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -134,7 +134,7 @@ class RewriteDataFilesProcedure extends BaseProcedure {
             SparkExpressionConverter.collectResolvedSparkExpression(spark(), tableName, where);
         return action.filter(SparkExpressionConverter.convertToIcebergExpression(expression));
       } catch (AnalysisException e) {
-        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where);
+        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
       }
     }
     return action;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RewriteDataFilesProcedure.java
@@ -136,7 +136,7 @@ class RewriteDataFilesProcedure extends BaseProcedure {
             SparkExpressionConverter.collectResolvedSparkExpression(spark(), tableName, where);
         return action.filter(SparkExpressionConverter.convertToIcebergExpression(expression));
       } catch (AnalysisException e) {
-        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where);
+        throw new IllegalArgumentException("Cannot parse predicates in where option: " + where, e);
       }
     }
     return action;


### PR DESCRIPTION
Noticed while doing #8289, rewrite_data_files exception when getting parse exception for the where clause, does not contain the spark parse exception, leaving user to have to do some guesswork.