### PR TITLE
Spark 3.4: disallow update identifier fields through alter table set tblproperties

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -313,6 +313,10 @@ public class SparkCatalog extends BaseCatalog {
           throw new UnsupportedOperationException(
               "Cannot specify the 'sort-order' because it's a reserved table "
                   + "property. Please use the command 'ALTER TABLE ... WRITE ORDERED BY' to specify write sort-orders.");
+        } else if ("identifier-fields".equalsIgnoreCase(set.property())) {
+          throw new UnsupportedOperationException(
+              "Cannot specify the 'identifier-fields' because it's a reserved table property. "
+                  + "Please use the command 'ALTER TABLE ... SET IDENTIFIER FIELDS' to specify identifier fields.");
         } else {
           propertyChanges.add(set);
         }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -93,8 +92,6 @@ public class SparkTable
         SupportsMetadataColumns {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
-  private static final String SORT_ORDER = "sort-order";
-  private static final String IDENTIFIER_FIELDS = "identifier-fields";
 
   private static final Set<String> RESERVED_PROPERTIES =
       ImmutableSet.of(
@@ -103,10 +100,8 @@ public class SparkTable
           CURRENT_SNAPSHOT_ID,
           "location",
           FORMAT_VERSION,
-          SORT_ORDER,
-          IDENTIFIER_FIELDS);
-  private static final Set<String> ICEBERG_RESERVED_PROPERTIES_FOR_UPDATE =
-      ImmutableSet.of(SORT_ORDER, IDENTIFIER_FIELDS);
+          "sort-order",
+          "identifier-fields");
   private static final Set<TableCapability> CAPABILITIES =
       ImmutableSet.of(
           TableCapability.BATCH_READ,
@@ -391,11 +386,6 @@ public class SparkTable
     }
 
     deleteFiles.commit();
-  }
-
-  @VisibleForTesting
-  public static Set<String> reservedUpdateProperties() {
-    return ICEBERG_RESERVED_PROPERTIES_FOR_UPDATE;
   }
 
   @Override

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -92,6 +93,8 @@ public class SparkTable
         SupportsMetadataColumns {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
+  private static final String SORT_ORDER = "sort-order";
+  private static final String IDENTIFIER_FIELDS = "identifier-fields";
 
   private static final Set<String> RESERVED_PROPERTIES =
       ImmutableSet.of(
@@ -100,8 +103,10 @@ public class SparkTable
           CURRENT_SNAPSHOT_ID,
           "location",
           FORMAT_VERSION,
-          "sort-order",
-          "identifier-fields");
+          SORT_ORDER,
+          IDENTIFIER_FIELDS);
+  private static final Set<String> ICEBERG_RESERVED_PROPERTIES_FOR_UPDATE =
+      ImmutableSet.of(SORT_ORDER, IDENTIFIER_FIELDS);
   private static final Set<TableCapability> CAPABILITIES =
       ImmutableSet.of(
           TableCapability.BATCH_READ,
@@ -386,6 +391,11 @@ public class SparkTable
     }
 
     deleteFiles.commit();
+  }
+
+  @VisibleForTesting
+  public static Set<String> reservedUpdateProperties() {
+    return ICEBERG_RESERVED_PROPERTIES_FOR_UPDATE;
   }
 
   @Override

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -21,13 +21,11 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Iterator;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
-import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.spark.SparkException;
@@ -321,9 +319,8 @@ public class TestAlterTable extends SparkCatalogTestBase {
         .as("Should not have the removed table property")
         .isNull();
 
-    Iterator<String> iter = SparkTable.reservedUpdateProperties().iterator();
-    while (iter.hasNext()) {
-      String reservedProp = iter.next();
+    String[] reservedProperties = new String[] {"sort-order", "identifier-fields"};
+    for (String reservedProp : reservedProperties) {
       assertThatThrownBy(
               () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('%s'='value')", tableName, reservedProp))
           .isInstanceOf(UnsupportedOperationException.class)


### PR DESCRIPTION
Unlike `sort-order`, I noticed it's still allowed to update the `identifier-fields` property through alter table when browsing related code. Although both `sort-order` and `identifier-fields` have been overwrote in `org.apache.iceberg.spark.source.SparkTable#properties` method, it wouldn't cause any correctness problems. I think it's better to throw an exception for `identifier-fields` as well.