### PR TITLE
Spark 3.4, Docs: Add RemoveOrphanFiles time-interval specification and testing option to the exception message

### DIFF
--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -277,6 +277,10 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
 | `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 
+{{< hint warning >}}
+The timestamp within 24 hours cannot be set to `older_than`. For testing `remove_orphan_files`, configure `spark.testing` to true in the SparkSession object.
+{{< /hint >}}
+
 #### Output
 
 | Output Name | Type | Description |

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -278,7 +278,8 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 
 {{< hint warning >}}
-The timestamp within 24 hours cannot be set to `older_than`. For testing `remove_orphan_files`, configure `spark.testing` to true in the SparkSession object.
+The timestamp within 24 hours cannot be set to `older_than` because running this procedure with a short interval potentially causes the table corruption when other operations are running simultaneously.
+If there are no concerns for running this procedure with a short interval for testing purpose, it’s possible to set the interval within 24 hours by configuring `spark.testing` to true in SparkSession. If you set the interval within 24 hours,  recommend setting `dry_run` option to true together.
 {{< /hint >}}
 
 #### Output

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -212,7 +212,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
               + "at the same time. If you are absolutely confident that no concurrent operations will be "
               + "affected by removing orphan files with such a short interval, you can use the Action API "
               + "to remove orphan files with an arbitrary interval."
-              + "If you test remove orphan files, configure spark.testing to true in your SparkSession object.");
+              + "If you test remove orphan files, configure spark.testing to true in SparkSession.");
     }
   }
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -211,7 +211,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
               + "procedure with a short interval may corrupt the table if other operations are happening "
               + "at the same time. If you are absolutely confident that no concurrent operations will be "
               + "affected by removing orphan files with such a short interval, you can use the Action API "
-              + "to remove orphan files with an arbitrary interval.");
+              + "to remove orphan files with an arbitrary interval."
+              + "If you test remove orphan files, configure spark.testing to true in your SparkSession object.");
     }
   }
 


### PR DESCRIPTION
## Changes
Add the time-interval specification in `older_that` parameter in `remove_orphan_files`, and testing option to the exception message.

`remove_orphan_files` limits the time-interval "after 24 hours" in its parameter `older_than`. 
There's no description about in the [`remove_orphan_files` section](https://iceberg.apache.org/docs/latest/spark-procedures/#remove_orphan_files). There are some Iceberg users who see this error, but don't know how to avoid waiting for 24 hours. `spark.testing` option is also not described in any Iceberg docs even if it's in the source code. This commit would help them use the `remove_orphan_files` operation.