### PR TITLE
Core: Move a column with the same name as a deleted column

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -569,6 +569,14 @@ class SchemaUpdate implements UpdateSchema {
       this.deletes = deletes;
       this.updates = updates;
       this.adds = adds;
+      this.moves = reconstructMoveOps(oldSchema, deletes, adds, moves);
+    }
+
+    private static Multimap<Integer, Move> reconstructMoveOps(
+        Schema oldSchema,
+        List<Integer> deletes,
+        Multimap<Integer, Types.NestedField> adds,
+        Multimap<Integer, Move> moves) {
       Multimap<Integer, Move> reconstructedMap = Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
       Collection<Types.NestedField> addedFields = adds.values();
       for (Integer k: moves.keys()) {
@@ -589,14 +597,14 @@ class SchemaUpdate implements UpdateSchema {
               reconstructedMap.put(k, newMoveOp);
             } else {
               throw new IllegalArgumentException("cannot move the field " + deletedFieldName + " which was deleted" +
-                      " without adding it back");
+                  " without adding it back");
             }
           } else {
             reconstructedMap.put(k, move);
           }
         }
       }
-      this.moves = reconstructedMap;
+      return reconstructedMap;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -575,14 +575,16 @@ class SchemaUpdate implements UpdateSchema {
         List<Integer> deletes,
         Multimap<Integer, Types.NestedField> adds,
         Multimap<Integer, Move> moves) {
-      Multimap<Integer, Move> reconstructedMap = Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
+      Multimap<Integer, Move> reconstructedMap =
+          Multimaps.newListMultimap(Maps.newHashMap(), Lists::newArrayList);
       Collection<Types.NestedField> addedFields = adds.values();
-      for (Integer k: moves.keys()) {
+      for (Integer k : moves.keys()) {
         Collection<Move> moveOps = moves.get(k);
-        for (Move move: moveOps) {
+        for (Move move : moveOps) {
           if (deletes.contains(move.fieldId)) {
             String deletedFieldName = oldSchema.findField(move.fieldId).name();
-            Optional<Types.NestedField> addedBackField = findFieldWithName(addedFields, deletedFieldName);
+            Optional<Types.NestedField> addedBackField =
+                findFieldWithName(addedFields, deletedFieldName);
             if (addedBackField.isPresent()) {
               Move newMoveOp = null;
               if (move.type == Move.MoveType.FIRST) {
@@ -594,8 +596,11 @@ class SchemaUpdate implements UpdateSchema {
               }
               reconstructedMap.put(k, newMoveOp);
             } else {
-              throw new IllegalArgumentException("cannot move the field " + deletedFieldName + " which was deleted" +
-                  " without adding it back");
+              throw new IllegalArgumentException(
+                  "cannot move the field "
+                      + deletedFieldName
+                      + " which was deleted"
+                      + " without adding it back");
             }
           } else {
             reconstructedMap.put(k, move);
@@ -781,10 +786,11 @@ class SchemaUpdate implements UpdateSchema {
     return newFields;
   }
 
-  private static Optional<Types.NestedField> findFieldWithName(Collection<Types.NestedField> addedFields, String fieldName) {
+  private static Optional<Types.NestedField> findFieldWithName(
+      Collection<Types.NestedField> addedFields, String fieldName) {
     return addedFields.stream()
-            .filter(nestedField -> nestedField.name().equals(fieldName))
-            .findFirst();
+        .filter(nestedField -> nestedField.name().equals(fieldName))
+        .findFirst();
   }
 
   @SuppressWarnings({"checkstyle:IllegalType", "JdkObsolete"})

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -841,7 +841,11 @@ class SchemaUpdate implements UpdateSchema {
 
     @Override
     public String toString() {
-      return "Move column " + fieldId + " " + type.toString() + " field " + referenceFieldId;
+      String suffix = "";
+      if (type != MoveType.FIRST) {
+        suffix = " field " + referenceFieldId;
+      }
+      return "Move column " + fieldId + " " + type.toString() + suffix;
     }
 
     static Move first(int fieldId) {

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -750,6 +750,7 @@ class SchemaUpdate implements UpdateSchema {
     return newFields;
   }
 
+  @SuppressWarnings({"checkstyle:IllegalType", "JdkObsolete"})
   private static List<Types.NestedField> moveFields(
       List<Types.NestedField> fields, Collection<Move> moves) {
     LinkedList<Types.NestedField> reordered = Lists.newLinkedList(fields);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -535,7 +535,7 @@ class SchemaUpdate implements UpdateSchema {
 
     // apply schema changes
     Types.StructType struct =
-        TypeUtil.visit(schema, new ApplyChanges(schema, deletes, updates, adds, moves))
+        TypeUtil.visit(schema, new ApplyChanges(deletes, updates, adds, moves))
             .asNestedType()
             .asStructType();
 

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,7 +26,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.swing.text.html.Option;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -765,7 +763,6 @@ class SchemaUpdate implements UpdateSchema {
       List<Types.NestedField> fields, Collection<Types.NestedField> adds, Collection<Move> moves) {
     if (adds != null && !adds.isEmpty()) {
       if (moves != null && !moves.isEmpty()) {
-
         // always apply adds first so that added fields can be moved
         return moveFields(addFields(fields, adds), moves);
       } else {
@@ -879,5 +876,4 @@ class SchemaUpdate implements UpdateSchema {
   private Types.NestedField findField(String fieldName) {
     return caseSensitive ? schema.findField(fieldName) : schema.caseInsensitiveFindField(fieldName);
   }
-
 }


### PR DESCRIPTION
currently, users are not allowed to do the following operation which is valid use case when we want to change a column type and don't care about old data anymore

```java

// tableSchema as below
//        new Schema(
//            required(1, "id", Types.LongType.get()),
//            required(2, "data", Types.StringType.get()),
//            required(3, "data_1", Types.StringType.get()));

// id is deleted and added back with a different type and then we want to move this new column after an existing column "data"
new SchemaUpdate(schema, 3)
    .allowIncompatibleChanges()
    .deleteColumn("id")
    .addRequiredColumn("id", Types.IntegerType.get())
    .moveAfter("id", "data")
    .apply();
```

(of course we can add/delete columns, commit and then move columns and commit again, but this workaround brings two transactions which leaves a batch data application in the risk of a partially updated schema when it failed in the middle)

when user run the above code, the below line will throw an NoSuchElement 
 exception https://github.com/apache/iceberg/blob/bb36f28abc948529602e52f35a5fe4a62ef1e156/core/src/main/java/org/apache/iceberg/SchemaUpdate.java#L754)

more details analysis: [code](https://github.com/apache/iceberg/blob/bb36f28abc948529602e52f35a5fe4a62ef1e156/core/src/main/java/org/apache/iceberg/SchemaUpdate.java#L748C2-L749C64)

because `List<Types.NestedField>  fields` only contains undeleted column: in the above example, id (with field 1) is not there. Additionally, when we build the `Collection<Move> moves` the ` .moveAfter("id", "data")` will refer to field 1 instead of 4 (representing the column with the same name added by `addRequiredColumn("id", Types.IntegerType.get())`)



the proposal in this PR is essentially to reconstruct `moves` in the constructor of [ApplyChanges](https://github.com/apache/iceberg/blob/bb36f28abc948529602e52f35a5fe4a62ef1e156/core/src/main/java/org/apache/iceberg/SchemaUpdate.java#L554C24-L554C36) by replacing the references to the deleted column with a reference to the newly added column with the same name