### PR TITLE
API: Remove Immutables dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,8 +291,6 @@ project(':iceberg-api') {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compileOnly libs.errorprone.annotations
     compileOnly libs.findbugs.jsr305
-    annotationProcessor libs.immutables.value
-    compileOnly libs.immutables.value
     testImplementation libs.avro.avro
     testImplementation libs.esotericsoftware.kryo
   }


### PR DESCRIPTION
We removed `@Value.Immutable` usage from `iceberg-api` (by moving it to `iceberg-core`), so we can remove the dependency now