### PR TITLE
Spark 3.4: Take into account number of shuffle partitions in parallelism

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -275,4 +275,10 @@ public class SparkReadConf {
         .defaultValue(TableProperties.ADAPTIVE_SPLIT_SIZE_ENABLED_DEFAULT)
         .parse();
   }
+
+  public int parallelism() {
+    int defaultParallelism = spark.sparkContext().defaultParallelism();
+    int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
+    return Math.max(defaultParallelism, numShufflePartitions);
+  }
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -227,7 +227,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   protected long adjustSplitSize(List<? extends ScanTask> tasks, long splitSize) {
     if (readConf.splitSizeOption() == null && readConf.adaptiveSplitSizeEnabled()) {
       long scanSize = tasks.stream().mapToLong(ScanTask::sizeBytes).sum();
-      int parallelism = sparkContext.defaultParallelism();
+      int parallelism = readConf.parallelism();
       return TableScanUtil.adjustSplitSize(scanSize, parallelism, splitSize);
     } else {
       return splitSize;


### PR DESCRIPTION
This PR is a follow-up change to #7714. The idea is to take into account the number of shuffle partitions while determining the cluster parallelism as discussed [earlier](https://github.com/apache/iceberg/pull/7714#discussion_r1275506085). I decided not to check the dynamic allocation config as the proposed approach should work reasonably well in all circumstances and is much easier.

