### PR TITLE
Python: Fix positional argument issue for load_catalog API

### DIFF
--- a/python/pyiceberg/catalog/__init__.py
+++ b/python/pyiceberg/catalog/__init__.py
@@ -164,7 +164,7 @@ def infer_catalog_type(name: str, catalog_properties: RecursiveDict) -> Optional
     )
 
 
-def load_catalog(name: Optional[str], **properties: Optional[str]) -> Catalog:
+def load_catalog(name: Optional[str] = None, **properties: Optional[str]) -> Catalog:
     """Load the catalog based on the properties.
 
     Will look up the properties from the config, based on the name.


### PR DESCRIPTION
* `load_catalog` API does not require the name of the catalog to be passed in as it can figure that out from ENV var or Config files.

Test code
```
from pyiceberg.catalog import load_catalog

catalog = load_catalog() # <- should load the default-catalog

catalog.list_namespaces()
```
Before PR

```
TypeError: load_catalog() missing 1 required positional argument: 'name'
```

After PR 
```
Above code should load the default catalog and not throw any error.
```
