### PR TITLE
Core: Optimize offset splits handling

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
@@ -22,12 +22,10 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Ordering;
+import org.apache.iceberg.util.ArrayUtil;
 
 abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends ContentFile<F>>
     implements ContentScanTask<F>, SplittableScanTask<ThisT> {
-
-  private static final Ordering<Comparable<Long>> OFFSET_ORDERING = Ordering.natural();
 
   private final F file;
   private final String schemaString;
@@ -93,12 +91,18 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
   }
 
   @Override
+  public long estimatedRowsCount() {
+    return estimatedRowsCount(length(), file);
+  }
+
+  @Override
   public Iterable<ThisT> split(long targetSplitSize) {
     if (file.format().isSplittable()) {
-      if (file.splitOffsets() != null && OFFSET_ORDERING.isOrdered(file.splitOffsets())) {
+      long[] splitOffsets = splitOffsets(file);
+      if (splitOffsets != null && ArrayUtil.isStrictlyOrdered(splitOffsets)) {
         return () ->
             new OffsetsAwareSplitScanTaskIterator<>(
-                self(), length(), file.splitOffsets(), this::newSplitTask);
+                self(), length(), splitOffsets, this::newSplitTask);
       } else {
         return () ->
             new FixedSizeSplitScanTaskIterator<>(
@@ -116,5 +120,20 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
         .add("partition_data", file().partition())
         .add("residual", residual())
         .toString();
+  }
+
+  public static long estimatedRowsCount(long length, ContentFile<?> file) {
+    long[] splitOffsets = splitOffsets(file);
+    long splitOffset = splitOffsets != null ? splitOffsets[0] : 0L;
+    double scannedFileFraction = ((double) length) / (file.fileSizeInBytes() - splitOffset);
+    return (long) (scannedFileFraction * file.recordCount());
+  }
+
+  private static long[] splitOffsets(ContentFile<?> file) {
+    if (file instanceof BaseFile) {
+      return ((BaseFile<?>) file).splitOffsetArray();
+    } else {
+      return ArrayUtil.toLongArray(file.splitOffsets());
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java
@@ -92,14 +92,14 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
 
   @Override
   public long estimatedRowsCount() {
-    return estimatedRowsCount(length(), file);
+    return estimateRowsCount(length(), file);
   }
 
   @Override
   public Iterable<ThisT> split(long targetSplitSize) {
     if (file.format().isSplittable()) {
       long[] splitOffsets = splitOffsets(file);
-      if (splitOffsets != null && ArrayUtil.isStrictlyOrdered(splitOffsets)) {
+      if (splitOffsets != null && ArrayUtil.isStrictlyAscending(splitOffsets)) {
         return () ->
             new OffsetsAwareSplitScanTaskIterator<>(
                 self(), length(), splitOffsets, this::newSplitTask);
@@ -122,7 +122,7 @@ abstract class BaseContentScanTask<ThisT extends ContentScanTask<F>, F extends C
         .toString();
   }
 
-  public static long estimatedRowsCount(long length, ContentFile<?> file) {
+  static long estimateRowsCount(long length, ContentFile<?> file) {
     long[] splitOffsets = splitOffsets(file);
     long splitOffset = splitOffsets != null ? splitOffsets[0] : 0L;
     double scannedFileFraction = ((double) length) / (file.fileSizeInBytes() - splitOffset);

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -82,6 +82,9 @@ abstract class BaseFile<F>
   // cached schema
   private transient Schema avroSchema = null;
 
+  // lazy variables
+  private transient volatile List<Long> splitOffsetList = null;
+
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   BaseFile(Schema avroSchema) {
     this.avroSchema = avroSchema;
@@ -460,7 +463,15 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    return ArrayUtil.toLongList(splitOffsets);
+    if (splitOffsetList == null && splitOffsets != null) {
+      this.splitOffsetList = ArrayUtil.toUnmodifiableLongList(splitOffsets);
+    }
+
+    return splitOffsetList;
+  }
+
+  long[] splitOffsetArray() {
+    return splitOffsets;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -102,7 +102,7 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
 
     @Override
     public long estimatedRowsCount() {
-      return BaseContentScanTask.estimatedRowsCount(len, fileScanTask.file());
+      return BaseContentScanTask.estimateRowsCount(len, fileScanTask.file());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -101,6 +101,11 @@ public class BaseFileScanTask extends BaseContentScanTask<FileScanTask, DataFile
     }
 
     @Override
+    public long estimatedRowsCount() {
+      return BaseContentScanTask.estimatedRowsCount(len, fileScanTask.file());
+    }
+
+    @Override
     public Expression residual() {
       return fileScanTask.residual();
     }

--- a/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
@@ -20,10 +20,7 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Ordering;
+import org.apache.iceberg.util.ArrayUtil;
 
 /**
  * An iterator that splits tasks using split offsets such as row group offsets in Parquet.
@@ -31,38 +28,41 @@ import org.apache.iceberg.relocated.com.google.common.collect.Ordering;
  * @param <T> the Java type of tasks produced by this iterator
  */
 class OffsetsAwareSplitScanTaskIterator<T extends ScanTask> implements SplitScanTaskIterator<T> {
-  private static final Ordering<Comparable<Long>> OFFSET_ORDERING = Ordering.natural();
-
   private final T parentTask;
   private final SplitScanTaskCreator<T> splitTaskCreator;
-  private final List<Long> offsets;
-  private final List<Long> splitSizes;
+  private final long[] offsets;
+  private final long[] splitSizes;
   private int splitIndex = 0;
 
   OffsetsAwareSplitScanTaskIterator(
       T parentTask,
       long parentTaskLength,
-      List<Long> offsetList,
+      List<Long> offsets,
       SplitScanTaskCreator<T> splitTaskCreator) {
-    Preconditions.checkArgument(
-        OFFSET_ORDERING.isStrictlyOrdered(offsetList), "Offsets must be sorted in asc order");
+    this(parentTask, parentTaskLength, ArrayUtil.toLongArray(offsets), splitTaskCreator);
+  }
 
+  OffsetsAwareSplitScanTaskIterator(
+      T parentTask,
+      long parentTaskLength,
+      long[] offsets,
+      SplitScanTaskCreator<T> splitTaskCreator) {
     this.parentTask = parentTask;
     this.splitTaskCreator = splitTaskCreator;
-    this.offsets = ImmutableList.copyOf(offsetList);
-    this.splitSizes = Lists.newArrayListWithCapacity(offsets.size());
-    if (offsets.size() > 0) {
-      int lastIndex = offsets.size() - 1;
+    this.offsets = offsets;
+    this.splitSizes = new long[offsets.length];
+    if (offsets.length > 0) {
+      int lastIndex = offsets.length - 1;
       for (int index = 0; index < lastIndex; index++) {
-        splitSizes.add(offsets.get(index + 1) - offsets.get(index));
+        splitSizes[index] = offsets[index + 1] - offsets[index];
       }
-      splitSizes.add(parentTaskLength - offsets.get(lastIndex));
+      splitSizes[offsets.length - 1] = parentTaskLength - offsets[lastIndex];
     }
   }
 
   @Override
   public boolean hasNext() {
-    return splitIndex < splitSizes.size();
+    return splitIndex < splitSizes.length;
   }
 
   @Override
@@ -70,8 +70,8 @@ class OffsetsAwareSplitScanTaskIterator<T extends ScanTask> implements SplitScan
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
-    long offset = offsets.get(splitIndex);
-    long splitSize = splitSizes.get(splitIndex);
+    long offset = offsets[splitIndex];
+    long splitSize = splitSizes[splitIndex];
     splitIndex += 1; // create 1 split per offset
     return splitTaskCreator.create(parentTask, offset, splitSize);
   }

--- a/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
+++ b/core/src/main/java/org/apache/iceberg/OffsetsAwareSplitScanTaskIterator.java
@@ -56,7 +56,7 @@ class OffsetsAwareSplitScanTaskIterator<T extends ScanTask> implements SplitScan
       for (int index = 0; index < lastIndex; index++) {
         splitSizes[index] = offsets[index + 1] - offsets[index];
       }
-      splitSizes[offsets.length - 1] = parentTaskLength - offsets[lastIndex];
+      splitSizes[lastIndex] = parentTaskLength - offsets[lastIndex];
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -311,7 +311,7 @@ public class ArrayUtil {
     return Array.newInstance(newArrayComponentType, 1);
   }
 
-  public static boolean isStrictlyOrdered(long[] array) {
+  public static boolean isStrictlyAscending(long[] array) {
     for (int index = 1; index < array.length; index++) {
       if (array[index] <= array[index - 1]) {
         return false;

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.util;
 
 import java.lang.reflect.Array;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
+import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 
 public class ArrayUtil {
   private ArrayUtil() {}
@@ -54,6 +56,14 @@ public class ArrayUtil {
   public static List<Long> toLongList(long[] longs) {
     if (longs != null) {
       return LongStream.of(longs).boxed().collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  public static List<Long> toUnmodifiableLongList(long[] longs) {
+    if (longs != null) {
+      return Collections.unmodifiableList(Longs.asList(longs));
     } else {
       return null;
     }
@@ -299,5 +309,15 @@ public class ArrayUtil {
       return newArray;
     }
     return Array.newInstance(newArrayComponentType, 1);
+  }
+
+  public static boolean isStrictlyOrdered(long[] array) {
+    for (int index = 1; index < array.length; index++) {
+      if (array[index] <= array[index - 1]) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestArrayUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TestArrayUtil {
+
+  @Test
+  public void testStrictlyAscendingLongArrays() {
+    long[] emptyArray = new long[0];
+    assertThat(ArrayUtil.isStrictlyAscending(emptyArray)).isTrue();
+
+    long[] singleElementArray = new long[] {1};
+    assertThat(ArrayUtil.isStrictlyAscending(singleElementArray)).isTrue();
+
+    long[] strictlyAscendingArray = new long[] {1, 2, 3};
+    assertThat(ArrayUtil.isStrictlyAscending(strictlyAscendingArray)).isTrue();
+
+    long[] descendingArray = new long[] {3, 2, 1};
+    assertThat(ArrayUtil.isStrictlyAscending(descendingArray)).isFalse();
+
+    long[] ascendingArray = new long[] {1, 2, 2, 3};
+    assertThat(ArrayUtil.isStrictlyAscending(ascendingArray)).isFalse();
+  }
+}

--- a/spark/v3.4/spark-extensions/src/jmh/java/org/apache/iceberg/spark/TaskGroupPlanningBenchmark.java
+++ b/spark/v3.4/spark-extensions/src/jmh/java/org/apache/iceberg/spark/TaskGroupPlanningBenchmark.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.apache.spark.sql.functions.lit;
+
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.FormatString;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.ScanTask;
+import org.apache.iceberg.ScanTaskGroup;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions;
+import org.apache.iceberg.util.TableScanUtil;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.types.StructType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * A benchmark that evaluates the task group planning performance.
+ *
+ * <p>To run this benchmark for spark-3.4: <code>
+ *   ./gradlew -DsparkVersions=3.4 :iceberg-spark:iceberg-spark-extensions-3.4_2.12:jmh
+ *       -PjmhIncludeRegex=TaskGroupPlanningBenchmark
+ *       -PjmhOutputPath=benchmark/iceberg-task-group-planning-benchmark.txt
+ * </code>
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Timeout(time = 30, timeUnit = TimeUnit.MINUTES)
+@BenchmarkMode(Mode.SingleShotTime)
+public class TaskGroupPlanningBenchmark {
+
+  private static final String TABLE_NAME = "test_table";
+  private static final String PARTITION_COLUMN = "ss_ticket_number";
+
+  private static final int NUM_PARTITIONS = 150;
+  private static final int NUM_REAL_DATA_FILES_PER_PARTITION = 5;
+  private static final int NUM_REPLICA_DATA_FILES_PER_PARTITION = 50_000;
+  private static final int NUM_DELETE_FILES_PER_PARTITION = 25;
+  private static final int NUM_ROWS_PER_DATA_FILE = 150;
+
+  private final Configuration hadoopConf = new Configuration();
+  private SparkSession spark;
+  private Table table;
+
+  private List<ScanTask> fileTasks;
+
+  @Setup
+  public void setupBenchmark() throws NoSuchTableException, ParseException {
+    setupSpark();
+    initTable();
+    initDataAndDeletes();
+    loadFileTasks();
+  }
+
+  @TearDown
+  public void tearDownBenchmark() {
+    dropTable();
+    tearDownSpark();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void planTaskGroups(Blackhole blackhole) {
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    List<ScanTaskGroup<ScanTask>> taskGroups =
+        TableScanUtil.planTaskGroups(
+            fileTasks,
+            readConf.splitSize(),
+            readConf.splitLookback(),
+            readConf.splitOpenFileCost());
+
+    long rowsCount = 0L;
+    for (ScanTaskGroup<ScanTask> taskGroup : taskGroups) {
+      rowsCount += taskGroup.estimatedRowsCount();
+    }
+    blackhole.consume(rowsCount);
+
+    long filesCount = 0L;
+    for (ScanTaskGroup<ScanTask> taskGroup : taskGroups) {
+      filesCount += taskGroup.filesCount();
+    }
+    blackhole.consume(filesCount);
+
+    long sizeBytes = 0L;
+    for (ScanTaskGroup<ScanTask> taskGroup : taskGroups) {
+      sizeBytes += taskGroup.sizeBytes();
+    }
+    blackhole.consume(sizeBytes);
+  }
+
+  private void loadFileTasks() {
+    table.refresh();
+
+    try (CloseableIterable<ScanTask> fileTasksIterable = table.newBatchScan().planFiles()) {
+      this.fileTasks = Lists.newArrayList(fileTasksIterable);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private DataFile loadAddedDataFile() {
+    table.refresh();
+
+    Iterable<DataFile> addedDataFiles = table.currentSnapshot().addedDataFiles(table.io());
+    return Iterables.getOnlyElement(addedDataFiles);
+  }
+
+  private DeleteFile loadAddedDeleteFile() {
+    table.refresh();
+
+    Iterable<DeleteFile> addedDeleteFiles = table.currentSnapshot().addedDeleteFiles(table.io());
+    return Iterables.getOnlyElement(addedDeleteFiles);
+  }
+
+  private void initDataAndDeletes() throws NoSuchTableException {
+    Schema schema = table.schema();
+    PartitionSpec spec = table.spec();
+    LocationProvider locations = table.locationProvider();
+
+    for (int partitionOrdinal = 0; partitionOrdinal < NUM_PARTITIONS; partitionOrdinal++) {
+      Dataset<Row> inputDF =
+          randomDataDF(schema, NUM_ROWS_PER_DATA_FILE)
+              .drop(PARTITION_COLUMN)
+              .withColumn(PARTITION_COLUMN, lit(partitionOrdinal));
+
+      for (int fileOrdinal = 0; fileOrdinal < NUM_REAL_DATA_FILES_PER_PARTITION; fileOrdinal++) {
+        appendAsFile(inputDF);
+      }
+
+      DataFile dataFile = loadAddedDataFile();
+
+      sql(
+          "DELETE FROM %s WHERE ss_item_sk IS NULL AND %s = %d",
+          TABLE_NAME, PARTITION_COLUMN, partitionOrdinal);
+
+      DeleteFile deleteFile = loadAddedDeleteFile();
+
+      AppendFiles append = table.newFastAppend();
+
+      for (int fileOrdinal = 0; fileOrdinal < NUM_REPLICA_DATA_FILES_PER_PARTITION; fileOrdinal++) {
+        String replicaFileName = UUID.randomUUID() + "-replica.parquet";
+        DataFile replicaDataFile =
+            DataFiles.builder(spec)
+                .copy(dataFile)
+                .withPath(locations.newDataLocation(spec, dataFile.partition(), replicaFileName))
+                .build();
+        append.appendFile(replicaDataFile);
+      }
+
+      append.commit();
+
+      RowDelta rowDelta = table.newRowDelta();
+
+      for (int fileOrdinal = 0; fileOrdinal < NUM_DELETE_FILES_PER_PARTITION; fileOrdinal++) {
+        String replicaFileName = UUID.randomUUID() + "-replica.parquet";
+        DeleteFile replicaDeleteFile =
+            FileMetadata.deleteFileBuilder(spec)
+                .copy(deleteFile)
+                .withPath(locations.newDataLocation(spec, deleteFile.partition(), replicaFileName))
+                .build();
+        rowDelta.addDeletes(replicaDeleteFile);
+      }
+
+      rowDelta.commit();
+    }
+  }
+
+  private void appendAsFile(Dataset<Row> df) throws NoSuchTableException {
+    df.coalesce(1).writeTo(TABLE_NAME).append();
+  }
+
+  private Dataset<Row> randomDataDF(Schema schema, int numRows) {
+    Iterable<InternalRow> rows = RandomData.generateSpark(schema, numRows, 0);
+    JavaSparkContext context = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    JavaRDD<InternalRow> rowRDD = context.parallelize(Lists.newArrayList(rows));
+    StructType rowSparkType = SparkSchemaUtil.convert(schema);
+    return spark.internalCreateDataFrame(JavaRDD.toRDD(rowRDD), rowSparkType, false);
+  }
+
+  private void setupSpark() {
+    this.spark =
+        SparkSession.builder()
+            .config("spark.ui.enabled", false)
+            .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+            .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+            .config("spark.sql.catalog.spark_catalog", SparkSessionCatalog.class.getName())
+            .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+            .config("spark.sql.catalog.spark_catalog.warehouse", newWarehouseDir())
+            .master("local[*]")
+            .getOrCreate();
+  }
+
+  private void tearDownSpark() {
+    spark.stop();
+  }
+
+  private void initTable() throws NoSuchTableException, ParseException {
+    sql(
+        "CREATE TABLE %s ( "
+            + " `ss_sold_date_sk` INT, "
+            + " `ss_sold_time_sk` INT, "
+            + " `ss_item_sk` INT, "
+            + " `ss_customer_sk` STRING, "
+            + " `ss_cdemo_sk` STRING, "
+            + " `ss_hdemo_sk` STRING, "
+            + " `ss_addr_sk` STRING, "
+            + " `ss_store_sk` STRING, "
+            + " `ss_promo_sk` STRING, "
+            + " `ss_ticket_number` INT, "
+            + " `ss_quantity` STRING, "
+            + " `ss_wholesale_cost` STRING, "
+            + " `ss_list_price` STRING, "
+            + " `ss_sales_price` STRING, "
+            + " `ss_ext_discount_amt` STRING, "
+            + " `ss_ext_sales_price` STRING, "
+            + " `ss_ext_wholesale_cost` STRING, "
+            + " `ss_ext_list_price` STRING, "
+            + " `ss_ext_tax` STRING, "
+            + " `ss_coupon_amt` STRING, "
+            + " `ss_net_paid` STRING, "
+            + " `ss_net_paid_inc_tax` STRING, "
+            + " `ss_net_profit` STRING "
+            + ")"
+            + "USING iceberg "
+            + "PARTITIONED BY (%s) "
+            + "TBLPROPERTIES ("
+            + " '%s' '%b',"
+            + " '%s' '%s',"
+            + " '%s' '%d')",
+        TABLE_NAME,
+        PARTITION_COLUMN,
+        TableProperties.MANIFEST_MERGE_ENABLED,
+        false,
+        TableProperties.DELETE_MODE,
+        RowLevelOperationMode.MERGE_ON_READ.modeName(),
+        TableProperties.FORMAT_VERSION,
+        2);
+
+    this.table = Spark3Util.loadIcebergTable(spark, TABLE_NAME);
+  }
+
+  private void dropTable() {
+    sql("DROP TABLE IF EXISTS %s PURGE", TABLE_NAME);
+  }
+
+  private String newWarehouseDir() {
+    return hadoopConf.get("hadoop.tmp.dir") + UUID.randomUUID();
+  }
+
+  @FormatMethod
+  private void sql(@FormatString String query, Object... args) {
+    spark.sql(String.format(query, args));
+  }
+}


### PR DESCRIPTION
This PR optimizes how we handle offset splits during planning to reduce the amount of garbage and improve performance.

Results prior to this change:

```
Benchmark                                         Mode  Cnt  Score   Error  Units
TaskGroupPlanningBenchmark.planTaskGroups           ss   10  3.144 ± 0.064   s/op
TaskGroupPlanningBenchmark.planTaskGroups:·async    ss         NaN            ---
```

Results after this change:

```
Benchmark                                         Mode  Cnt  Score   Error  Units
TaskGroupPlanningBenchmark.planTaskGroups           ss   10  1.955 ± 0.027   s/op
TaskGroupPlanningBenchmark.planTaskGroups:·async    ss         NaN            ---
```
