### PR TITLE
Docs: Clarified Partition Transform

### DIFF
--- a/docs/docs/partitioning.md
+++ b/docs/docs/partitioning.md
@@ -84,7 +84,7 @@ This leads to several problems:
 
 Iceberg produces partition values by taking a column value and optionally transforming it. Iceberg is responsible for converting `event_time` into `event_date`, and keeps track of the relationship.
 
-Table partitioning is configured using these relationships. The `logs` table would be partitioned by `date(event_time)` and `level`.
+Table partitioning is configured using these relationships. The `logs` table would be partitioned by `day(event_time)` and `level`.
 
 Because Iceberg doesn't require user-maintained partition columns, it can hide partitioning. Partition values are produced correctly every time and always used to speed up queries, when possible. Producers and consumers wouldn't even see `event_date`.
 


### PR DESCRIPTION
As an Iceberg newbie, I was very confused by the difference between the partitioning overview and the partition transform spec documentation.  The partitioning overview page seemed to reference a transform named "date".  However, this transform does not actually exist.  Instead "date" was intended to be a pseudo transform demonstrating the possibilities of Iceberg's partition transforms.

This use of "date" pseudo transform resulted in confusion for me as I could not find any such partition transform.  After digging into the spec docs more, I realized the "day" partition transform is the same as this "date" pseudo transform.

This commit updates the doc to use the actual "day" transform and includes a brief explanation.