### PR TITLE
Add docs for failed_data_files_count

### DIFF
--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -360,6 +360,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `rewritten_data_files_count` | int | Number of data which were re-written by this command |
 | `added_data_files_count`     | int | Number of new data files which were written by this command |
 | `rewritten_bytes_count`      | long | Number of bytes which were written by this command |
+| `failed_data_files_count`    | int | Number of data files that failed to write if `partial-progress.enabled` is true |
 
 #### Examples
 

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -360,7 +360,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `rewritten_data_files_count` | int | Number of data which were re-written by this command |
 | `added_data_files_count`     | int | Number of new data files which were written by this command |
 | `rewritten_bytes_count`      | long | Number of bytes which were written by this command |
-| `failed_data_files_count`    | int | Number of data files that failed to write if `partial-progress.enabled` is true |
+| `failed_data_files_count`    | int | Number of data files that failed to be rewritten when `partial-progress.enabled` is true |
 
 #### Examples
 


### PR DESCRIPTION
(unfiled) Noticed while running a `rewrite_data_files` job that there was an extra field in my output that's not present in the docs. 