### PR TITLE
Python: Add __repr__ method to Table class

### DIFF
--- a/python/pyiceberg/table/__init__.py
+++ b/python/pyiceberg/table/__init__.py
@@ -390,6 +390,10 @@ class Table:
         self.io = io
         self.catalog = catalog
 
+    def __repr__(self) -> str:
+        """Returns the string representation of the Table class."""
+        return f"Table({self.identifier})"
+
     def transaction(self) -> Transaction:
         return Transaction(self)
 


### PR DESCRIPTION
### Description

This PR adds a `__repr__` method to the `Table` class.

Closes #8295 