### PR TITLE
FileIO: Skip stack trace log for missing Hadoop

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -379,21 +379,23 @@ public class S3FileIO
       }
     }
 
+    initMetrics(properties);
+  }
+
+  @SuppressWarnings("CatchBlockLogException")
+  private void initMetrics(Map<String, String> props) {
     // Report Hadoop metrics if Hadoop is available
     try {
       DynConstructors.Ctor<MetricsContext> ctor =
           DynConstructors.builder(MetricsContext.class)
-              .loader(S3FileIO.class.getClassLoader())
               .hiddenImpl(DEFAULT_METRICS_IMPL, String.class)
               .buildChecked();
       MetricsContext context = ctor.newInstance("s3");
-      context.initialize(properties);
+      context.initialize(props);
       this.metrics = context;
     } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
       LOG.warn(
-          "Unable to load metrics class: '{}', falling back to null metrics",
-          DEFAULT_METRICS_IMPL,
-          e);
+          "Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL);
     }
   }
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -86,7 +86,11 @@ public class EcsFileIO implements FileIO {
     this.dellProperties = new DellProperties(properties);
     this.dellClientFactory = DellClientFactories.from(properties);
     this.s3 = dellClientFactory::ecsS3;
+    initMetrics(properties);
+  }
 
+  @SuppressWarnings("CatchBlockLogException")
+  private void initMetrics(Map<String, String> properties) {
     // Report Hadoop metrics if Hadoop is available
     try {
       DynConstructors.Ctor<MetricsContext> ctor =
@@ -98,9 +102,7 @@ public class EcsFileIO implements FileIO {
       this.metrics = context;
     } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
       LOG.warn(
-          "Unable to load metrics class: '{}', falling back to null metrics",
-          DEFAULT_METRICS_IMPL,
-          e);
+          "Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL);
     }
   }
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -152,24 +152,27 @@ public class GCSFileIO implements FileIO, SupportsBulkOperations, SupportsPrefix
                     builder.setCredentials(OAuth2Credentials.create(accessToken));
                   });
 
-          // Report Hadoop metrics if Hadoop is available
-          try {
-            DynConstructors.Ctor<MetricsContext> ctor =
-                DynConstructors.builder(MetricsContext.class)
-                    .hiddenImpl(DEFAULT_METRICS_IMPL, String.class)
-                    .buildChecked();
-            MetricsContext context = ctor.newInstance("gcs");
-            context.initialize(properties);
-            this.metrics = context;
-          } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
-            LOG.warn(
-                "Unable to load metrics class: '{}', falling back to null metrics",
-                DEFAULT_METRICS_IMPL,
-                e);
-          }
-
           return builder.build().getService();
         };
+
+    initMetrics(properties);
+  }
+
+  @SuppressWarnings("CatchBlockLogException")
+  private void initMetrics(Map<String, String> props) {
+    // Report Hadoop metrics if Hadoop is available
+    try {
+      DynConstructors.Ctor<MetricsContext> ctor =
+          DynConstructors.builder(MetricsContext.class)
+              .hiddenImpl(DEFAULT_METRICS_IMPL, String.class)
+              .buildChecked();
+      MetricsContext context = ctor.newInstance("gcs");
+      context.initialize(props);
+      this.metrics = context;
+    } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
+      LOG.warn(
+          "Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL);
+    }
   }
 
   @Override


### PR DESCRIPTION
The `FileIO` implementations currently attempt to initialize `HadoopMetricsContext` and log a stack trace if Hadoop is not on the classpath. The stack trace is not particularly useful and overly verbose to indicate this state, which can lead to confusion when viewing log output. This PR changes this to log the warning but without the stack trace.

This also moves the metrics initialization outside of the client supplier in `GCSFileIO`, consistent with the other FileIO implementations.