### PR TITLE
AWS: Update S3 signer spec to allow an optional string body in S3SignRequest.

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequest.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequest.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws.s3.signer;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.iceberg.rest.RESTRequest;
 import org.immutables.value.Value;
 
@@ -35,6 +36,12 @@ public interface S3SignRequest extends RESTRequest {
   Map<String, List<String>> headers();
 
   Map<String, String> properties();
+
+  @Value.Default
+  @Nullable
+  default String body() {
+    return null;
+  }
 
   @Override
   default void validate() {}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequestParser.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3SignRequestParser.java
@@ -36,6 +36,7 @@ public class S3SignRequestParser {
   private static final String URI = "uri";
   private static final String HEADERS = "headers";
   private static final String PROPERTIES = "properties";
+  private static final String BODY = "body";
 
   private S3SignRequestParser() {}
 
@@ -61,6 +62,10 @@ public class S3SignRequestParser {
       JsonUtil.writeStringMap(PROPERTIES, request.properties(), gen);
     }
 
+    if (request.body() != null && !request.body().isEmpty()) {
+      gen.writeStringField(BODY, request.body());
+    }
+
     gen.writeEndObject();
   }
 
@@ -83,6 +88,10 @@ public class S3SignRequestParser {
 
     if (json.has(PROPERTIES)) {
       builder.properties(JsonUtil.getStringMap(PROPERTIES, json));
+    }
+
+    if (json.has(BODY)) {
+      builder.body(JsonUtil.getString(BODY, json));
     }
 
     return builder.build();

--- a/aws/src/main/resources/s3-signer-open-api.yaml
+++ b/aws/src/main/resources/s3-signer-open-api.yaml
@@ -121,6 +121,10 @@ components:
           type: object
           additionalProperties:
             type: string
+        body:
+          type: string
+          description: Optional body of the S3 request to send to the signing API. This should only be populated
+            for S3 requests which do not have the relevant data in the URI itself (e.g. DeleteObjects requests)
 
 
   #############################

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3SignRequestParser.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3SignRequestParser.java
@@ -185,4 +185,46 @@ public class TestS3SignRequestParser {
                 + "  }\n"
                 + "}");
   }
+
+  @Test
+  public void roundTripWithBody() {
+    ImmutableS3SignRequest s3SignRequest =
+        ImmutableS3SignRequest.builder()
+            .uri(URI.create("http://localhost:49208/iceberg-signer-test"))
+            .method("PUT")
+            .region("us-west-2")
+            .headers(
+                ImmutableMap.of(
+                    "amz-sdk-request",
+                    Arrays.asList("attempt=1", "max=4"),
+                    "Content-Length",
+                    Arrays.asList("191"),
+                    "Content-Type",
+                    Arrays.asList("application/json"),
+                    "User-Agent",
+                    Arrays.asList("aws-sdk-java/2.20.18", "Linux/5.4.0-126")))
+            .properties(ImmutableMap.of("k1", "v1"))
+            .body("some-body")
+            .build();
+
+    String json = S3SignRequestParser.toJson(s3SignRequest, true);
+    Assertions.assertThat(S3SignRequestParser.fromJson(json)).isEqualTo(s3SignRequest);
+    Assertions.assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"region\" : \"us-west-2\",\n"
+                + "  \"method\" : \"PUT\",\n"
+                + "  \"uri\" : \"http://localhost:49208/iceberg-signer-test\",\n"
+                + "  \"headers\" : {\n"
+                + "    \"amz-sdk-request\" : [ \"attempt=1\", \"max=4\" ],\n"
+                + "    \"Content-Length\" : [ \"191\" ],\n"
+                + "    \"Content-Type\" : [ \"application/json\" ],\n"
+                + "    \"User-Agent\" : [ \"aws-sdk-java/2.20.18\", \"Linux/5.4.0-126\" ]\n"
+                + "  },\n"
+                + "  \"properties\" : {\n"
+                + "    \"k1\" : \"v1\"\n"
+                + "  },\n"
+                + "  \"body\" : \"some-body\"\n"
+                + "}");
+  }
 }


### PR DESCRIPTION
This change does the following:

1.) Updates the S3 Signer Spec to allow an optional string body in `S3SignRequest`
2.) Updates  `S3SignRequestParser` to support serialization and deserialization of the body.

Note: The body field will only be populated for requests which do not have the relevant information for signing in the URI itself (e..g DeleteObjectsRequest)

cc: @danielcweeks @nastra @jackye1995 