### PR TITLE
Python: Pin poetry to 1.5.1

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,7 +44,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install poetry
-      run: pip install poetry
+      working-directory: ./python
+      run: make install-poetry
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
@@ -53,7 +54,7 @@ jobs:
           ./python/poetry.lock
     - name: Install
       working-directory: ./python
-      run: make install
+      run: make install-dependencies
     - name: Linters
       working-directory: ./python
       run: make lint

--- a/python/Makefile
+++ b/python/Makefile
@@ -15,10 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-install:
-	pip install poetry
+install-poetry:
+	pip install poetry==1.5.1
+
+install-dependencies:
 	poetry install -E pyarrow -E hive -E s3fs -E glue -E adlfs -E duckdb -E ray -E sql-postgres -E gcsfs
 
+install: | install-poetry install-dependencies
 
 check-license:
 	./dev/check-license


### PR DESCRIPTION
Poetry 1.6.0 broke our build: https://github.com/python-poetry/poetry/pull/8336
