### PR TITLE
AWS: Update S3V4RestSignerClient to send body for DeleteObjects requests

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.aws.s3.signer;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalListener;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
@@ -55,6 +57,8 @@ import software.amazon.awssdk.auth.signer.params.AwsS3V4SignerParams;
 import software.amazon.awssdk.core.checksums.SdkChecksum;
 import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpMethod;
+import software.amazon.awssdk.utils.IoUtils;
 
 @Value.Immutable
 public abstract class S3V4RestSignerClient
@@ -286,6 +290,7 @@ public abstract class S3V4RestSignerClient
             .uri(request.getUri())
             .headers(request.headers())
             .properties(requestPropertiesSupplier().get())
+            .body(bodyAsString(request))
             .build();
 
     Key cacheKey = Key.from(remoteSigningRequest);
@@ -326,6 +331,27 @@ public abstract class S3V4RestSignerClient
     reconstructHeaders(signedComponent.headers(), mutableRequest);
 
     return mutableRequest.build();
+  }
+
+  /**
+   * Only add body for DeleteObjectsRequest. Refer to
+   * https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html#API_DeleteObjects_RequestSyntax
+   */
+  private String bodyAsString(SdkHttpFullRequest request) {
+    if (isDeleteObjectsRequest(request) && request.contentStreamProvider().isPresent()) {
+      try (InputStream is = request.contentStreamProvider().get().newStream()) {
+        return IoUtils.toUtf8String(is);
+      } catch (IOException e) {
+        LOG.debug("Failed to determine body for S3 sign request", e);
+      }
+    }
+
+    return null;
+  }
+
+  private boolean isDeleteObjectsRequest(SdkHttpFullRequest request) {
+    return request.method() == SdkHttpMethod.POST
+        && request.rawQueryParameters().containsKey("delete");
   }
 
   private void reconstructHeaders(

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/S3SignerServlet.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws.s3.signer;
 import static java.lang.String.format;
 import static org.apache.iceberg.rest.RESTCatalogAdapter.castRequest;
 import static org.apache.iceberg.rest.RESTCatalogAdapter.castResponse;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStreamReader;
@@ -32,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServlet;
@@ -41,6 +43,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.iceberg.exceptions.RESTException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.io.CharStreams;
@@ -78,8 +81,40 @@ public class S3SignerServlet extends HttpServlet {
       ImmutableMap.of(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
   private final ObjectMapper mapper;
 
+  private List<SignRequestValidator> s3SignRequestValidators = Lists.newArrayList();
+
+  /**
+   * SignRequestValidator is a wrapper class used for validating the contents of the S3SignRequest
+   * and thus verifying the behavior of the client during testing.
+   */
+  public static class SignRequestValidator {
+    private final Predicate<S3SignRequest> requestMatcher;
+    private final Predicate<S3SignRequest> requestExpectation;
+    private final String assertMessage;
+
+    public SignRequestValidator(
+        Predicate<S3SignRequest> requestExpectation,
+        Predicate<S3SignRequest> requestMatcher,
+        String assertMessage) {
+      this.requestExpectation = requestExpectation;
+      this.requestMatcher = requestMatcher;
+      this.assertMessage = assertMessage;
+    }
+
+    void validateRequest(S3SignRequest request) {
+      if (requestMatcher.test(request)) {
+        assertThat(requestExpectation.test(request)).as(assertMessage).isTrue();
+      }
+    }
+  }
+
   public S3SignerServlet(ObjectMapper mapper) {
     this.mapper = mapper;
+  }
+
+  public S3SignerServlet(ObjectMapper mapper, List<SignRequestValidator> s3SignRequestValidators) {
+    this.mapper = mapper;
+    this.s3SignRequestValidators = s3SignRequestValidators;
   }
 
   @Override
@@ -188,6 +223,7 @@ public class S3SignerServlet extends HttpServlet {
         S3SignRequest s3SignRequest =
             castRequest(
                 S3SignRequest.class, mapper.readValue(request.getReader(), S3SignRequest.class));
+        s3SignRequestValidators.forEach(validator -> validator.validateRequest(s3SignRequest));
         S3SignResponse s3SignResponse = signRequest(s3SignRequest);
         if (CACHEABLE_METHODS.contains(SdkHttpMethod.fromValue(s3SignRequest.method()))) {
           // tell the client this can be cached


### PR DESCRIPTION
 Update S3V4RestSignerClient to send body for DeleteObjects (bulk delete) requests. Added a test which tests against a MinIO container.  Follow up to https://github.com/apache/iceberg/pull/8361