### PR TITLE
API: Build accessor from struct directly

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Accessors.java
+++ b/api/src/main/java/org/apache/iceberg/Accessors.java
@@ -51,6 +51,10 @@ public class Accessors {
     throw new IllegalArgumentException("Cannot convert nested accessor to position");
   }
 
+  public static Map<Integer, Accessor<StructLike>> forStruct(Types.StructType struct) {
+    return TypeUtil.visit(struct, new BuildPositionAccessors());
+  }
+
   static Map<Integer, Accessor<StructLike>> forSchema(Schema schema) {
     return TypeUtil.visit(schema, new BuildPositionAccessors());
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/NamedReference.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.expressions;
 
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
@@ -38,14 +37,12 @@ public class NamedReference<T> implements UnboundTerm<T>, Reference<T> {
 
   @Override
   public BoundReference<T> bind(Types.StructType struct, boolean caseSensitive) {
-    Schema schema = new Schema(struct.fields());
     Types.NestedField field =
-        caseSensitive ? schema.findField(name) : schema.caseInsensitiveFindField(name);
+        caseSensitive ? struct.field(name) : struct.caseInsensitiveField(name);
 
-    ValidationException.check(
-        field != null, "Cannot find field '%s' in struct: %s", name, schema.asStruct());
+    ValidationException.check(field != null, "Cannot find field '%s' in struct: %s", name, struct);
 
-    return new BoundReference<>(field, schema.accessorForField(field.fieldId()), name);
+    return new BoundReference<>(field, struct.accessorForField(field.fieldId()), name);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -566,14 +566,6 @@ public class Types {
       return lazyIdToAccessor().get(id);
     }
 
-    private Map<Integer, Accessor<StructLike>> lazyIdToAccessor() {
-      if (idToAccessor == null) {
-        idToAccessor = Accessors.forStruct(this);
-      }
-
-      return idToAccessor;
-    }
-
     @Override
     public List<NestedField> fields() {
       return lazyFieldList();
@@ -636,6 +628,14 @@ public class Types {
     @Override
     public int hashCode() {
       return Objects.hash(NestedField.class, Arrays.hashCode(fields));
+    }
+
+    private Map<Integer, Accessor<StructLike>> lazyIdToAccessor() {
+      if (idToAccessor == null) {
+        idToAccessor = Accessors.forStruct(this);
+      }
+
+      return idToAccessor;
     }
 
     private List<NestedField> lazyFieldList() {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -647,9 +647,10 @@ public class Types {
 
     private Map<String, NestedField> lazyFieldsByName() {
       if (fieldsByName == null) {
+        Map<String, Integer> nameToId = TypeUtil.indexByName(this);
         ImmutableMap.Builder<String, NestedField> byNameBuilder = ImmutableMap.builder();
-        for (NestedField field : fields) {
-          byNameBuilder.put(field.name(), field);
+        for (Map.Entry<String, Integer> entry : nameToId.entrySet()) {
+          byNameBuilder.put(entry.getKey(), field(entry.getValue()));
         }
         fieldsByName = byNameBuilder.build();
       }
@@ -658,9 +659,10 @@ public class Types {
 
     private Map<String, NestedField> lazyFieldsByLowerCaseName() {
       if (fieldsByLowerCaseName == null) {
+        Map<String, Integer> nameToId = TypeUtil.indexByLowerCaseName(this);
         ImmutableMap.Builder<String, NestedField> byLowerCaseNameBuilder = ImmutableMap.builder();
-        for (NestedField field : fields) {
-          byLowerCaseNameBuilder.put(field.name().toLowerCase(Locale.ROOT), field);
+        for (Map.Entry<String, Integer> entry : nameToId.entrySet()) {
+          byLowerCaseNameBuilder.put(entry.getKey(), field(entry.getValue()));
         }
         fieldsByLowerCaseName = byLowerCaseNameBuilder.build();
       }
@@ -669,11 +671,7 @@ public class Types {
 
     private Map<Integer, NestedField> lazyFieldsById() {
       if (fieldsById == null) {
-        ImmutableMap.Builder<Integer, NestedField> byIdBuilder = ImmutableMap.builder();
-        for (NestedField field : fields) {
-          byIdBuilder.put(field.fieldId(), field);
-        }
-        this.fieldsById = byIdBuilder.build();
+        this.fieldsById = ImmutableMap.copyOf(TypeUtil.indexById(this));
       }
       return fieldsById;
     }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -559,7 +559,7 @@ public class Types {
      *
      * <p>Accessors do not retrieve data contained in lists or maps.
      *
-     * @param id a column id in this schema
+     * @param id the field id in this struct
      * @return an {@link Accessor} to retrieve values from a {@link StructLike} row
      */
     public Accessor<StructLike> accessorForField(int id) {

--- a/api/src/test/java/org/apache/iceberg/TestAccessors.java
+++ b/api/src/test/java/org/apache/iceberg/TestAccessors.java
@@ -31,15 +31,21 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestAccessors {
 
-  private static Accessor<StructLike> direct(Type type) {
+  private static Accessor<StructLike> direct(Type type, boolean structAccessor) {
     Schema schema = new Schema(required(17, "field_" + type.typeId(), type));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private static Accessor<StructLike> nested1(Type type) {
+  private static Accessor<StructLike> nested1(Type type, boolean structAccessor) {
     Schema schema =
         new Schema(
             required(
@@ -47,10 +53,14 @@ public class TestAccessors {
                 "struct1",
                 Types.StructType.of(
                     Types.NestedField.required(17, "field_" + type.typeId(), type))));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private static Accessor<StructLike> nested2(Type type) {
+  private static Accessor<StructLike> nested2(Type type, boolean structAccessor) {
     Schema schema =
         new Schema(
             required(
@@ -62,10 +72,14 @@ public class TestAccessors {
                         "s2",
                         Types.StructType.of(
                             Types.NestedField.required(17, "field_" + type.typeId(), type))))));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private static Accessor<StructLike> nested3(Type type) {
+  private static Accessor<StructLike> nested3(Type type, boolean structAccessor) {
     Schema schema =
         new Schema(
             required(
@@ -82,10 +96,14 @@ public class TestAccessors {
                                 Types.StructType.of(
                                     Types.NestedField.required(
                                         17, "field_" + type.typeId(), type))))))));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private static Accessor<StructLike> nested3optional(Type type) {
+  private static Accessor<StructLike> nested3optional(Type type, boolean structAccessor) {
     Schema schema =
         new Schema(
             optional(
@@ -102,10 +120,14 @@ public class TestAccessors {
                                 Types.StructType.of(
                                     Types.NestedField.optional(
                                         17, "field_" + type.typeId(), type))))))));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private static Accessor<StructLike> nested4(Type type) {
+  private static Accessor<StructLike> nested4(Type type, boolean structAccessor) {
     Schema schema =
         new Schema(
             required(
@@ -126,123 +148,162 @@ public class TestAccessors {
                                         Types.StructType.of(
                                             Types.NestedField.required(
                                                 17, "field_" + type.typeId(), type))))))))));
-    return schema.accessorForField(17);
+    if (structAccessor) {
+      return schema.asStruct().accessorForField(17);
+    } else {
+      return schema.accessorForField(17);
+    }
   }
 
-  private void assertAccessorReturns(Type type, Object value) {
-    assertThat(direct(type).get(Row.of(value))).isEqualTo(value);
+  private void assertAccessorReturns(Type type, Object value, boolean structAccessor) {
+    assertThat(direct(type, structAccessor).get(Row.of(value))).isEqualTo(value);
 
-    assertThat(nested1(type).get(Row.of(Row.of(value)))).isEqualTo(value);
-    assertThat(nested2(type).get(Row.of(Row.of(Row.of(value))))).isEqualTo(value);
-    assertThat(nested3(type).get(Row.of(Row.of(Row.of(Row.of(value)))))).isEqualTo(value);
-    assertThat(nested4(type).get(Row.of(Row.of(Row.of(Row.of(Row.of(value))))))).isEqualTo(value);
+    assertThat(nested1(type, structAccessor).get(Row.of(Row.of(value)))).isEqualTo(value);
+    assertThat(nested2(type, structAccessor).get(Row.of(Row.of(Row.of(value))))).isEqualTo(value);
+    assertThat(nested3(type, structAccessor).get(Row.of(Row.of(Row.of(Row.of(value))))))
+        .isEqualTo(value);
+    assertThat(nested4(type, structAccessor).get(Row.of(Row.of(Row.of(Row.of(Row.of(value)))))))
+        .isEqualTo(value);
 
-    assertThat(nested3optional(type).get(Row.of(Row.of(Row.of(Row.of(value)))))).isEqualTo(value);
+    assertThat(nested3optional(type, structAccessor).get(Row.of(Row.of(Row.of(Row.of(value))))))
+        .isEqualTo(value);
   }
 
-  @Test
-  public void testBoolean() {
-    assertAccessorReturns(Types.BooleanType.get(), true);
-    assertAccessorReturns(Types.BooleanType.get(), false);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testBoolean(boolean structAccessor) {
+    assertAccessorReturns(Types.BooleanType.get(), true, structAccessor);
+    assertAccessorReturns(Types.BooleanType.get(), false, structAccessor);
   }
 
-  @Test
-  public void testInt() {
-    assertAccessorReturns(Types.IntegerType.get(), 123);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testInt(boolean structAccessor) {
+    assertAccessorReturns(Types.IntegerType.get(), 123, structAccessor);
   }
 
-  @Test
-  public void testLong() {
-    assertAccessorReturns(Types.LongType.get(), 123L);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testLong(boolean structAccessor) {
+    assertAccessorReturns(Types.LongType.get(), 123L, structAccessor);
   }
 
-  @Test
-  public void testFloat() {
-    assertAccessorReturns(Types.FloatType.get(), 1.23f);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testFloat(boolean structAccessor) {
+    assertAccessorReturns(Types.FloatType.get(), 1.23f, structAccessor);
   }
 
-  @Test
-  public void testDouble() {
-    assertAccessorReturns(Types.DoubleType.get(), 1.23d);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testDouble(boolean structAccessor) {
+    assertAccessorReturns(Types.DoubleType.get(), 1.23d, structAccessor);
   }
 
-  @Test
-  public void testDate() {
-    assertAccessorReturns(Types.DateType.get(), 123);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testDate(boolean structAccessor) {
+    assertAccessorReturns(Types.DateType.get(), 123, structAccessor);
   }
 
-  @Test
-  public void testTime() {
-    assertAccessorReturns(Types.TimeType.get(), 123L);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testTime(boolean structAccessor) {
+    assertAccessorReturns(Types.TimeType.get(), 123L, structAccessor);
   }
 
-  @Test
-  public void testTimestamp() {
-    assertAccessorReturns(Types.TimestampType.withoutZone(), 123L);
-    assertAccessorReturns(Types.TimestampType.withZone(), 123L);
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testTimestamp(boolean structAccessor) {
+    assertAccessorReturns(Types.TimestampType.withoutZone(), 123L, structAccessor);
+    assertAccessorReturns(Types.TimestampType.withZone(), 123L, structAccessor);
   }
 
-  @Test
-  public void testString() {
-    assertAccessorReturns(Types.StringType.get(), "abc");
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testString(boolean structAccessor) {
+    assertAccessorReturns(Types.StringType.get(), "abc", structAccessor);
   }
 
-  @Test
-  public void testUuid() {
-    assertAccessorReturns(Types.UUIDType.get(), UUID.randomUUID());
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testUuid(boolean structAccessor) {
+    assertAccessorReturns(Types.UUIDType.get(), UUID.randomUUID(), structAccessor);
   }
 
-  @Test
-  public void testFixed() {
-    assertAccessorReturns(Types.FixedType.ofLength(3), ByteBuffer.wrap(new byte[] {1, 2, 3}));
-  }
-
-  @Test
-  public void testBinary() {
-    assertAccessorReturns(Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {1, 2, 3}));
-  }
-
-  @Test
-  public void testDecimal() {
-    assertAccessorReturns(Types.DecimalType.of(5, 7), BigDecimal.valueOf(123.456));
-  }
-
-  @Test
-  public void testList() {
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testFixed(boolean structAccessor) {
     assertAccessorReturns(
-        Types.ListType.ofRequired(18, Types.IntegerType.get()), ImmutableList.of(1, 2, 3));
-    assertAccessorReturns(
-        Types.ListType.ofRequired(18, Types.StringType.get()), ImmutableList.of("a", "b", "c"));
+        Types.FixedType.ofLength(3), ByteBuffer.wrap(new byte[] {1, 2, 3}), structAccessor);
   }
 
-  @Test
-  public void testMap() {
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testBinary(boolean structAccessor) {
+    assertAccessorReturns(
+        Types.BinaryType.get(), ByteBuffer.wrap(new byte[] {1, 2, 3}), structAccessor);
+  }
+
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testDecimal(boolean structAccessor) {
+    assertAccessorReturns(Types.DecimalType.of(5, 7), BigDecimal.valueOf(123.456), structAccessor);
+  }
+
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testList(boolean structAccessor) {
+    assertAccessorReturns(
+        Types.ListType.ofRequired(18, Types.IntegerType.get()),
+        ImmutableList.of(1, 2, 3),
+        structAccessor);
+    assertAccessorReturns(
+        Types.ListType.ofRequired(18, Types.StringType.get()),
+        ImmutableList.of("a", "b", "c"),
+        structAccessor);
+  }
+
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testMap(boolean structAccessor) {
     assertAccessorReturns(
         Types.MapType.ofRequired(18, 19, Types.StringType.get(), Types.IntegerType.get()),
-        ImmutableMap.of("a", 1, "b", 2));
+        ImmutableMap.of("a", 1, "b", 2),
+        structAccessor);
   }
 
-  @Test
-  public void testStructAsObject() {
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testStructAsObject(boolean structAccessor) {
     assertAccessorReturns(
         Types.StructType.of(
             Types.NestedField.optional(18, "str19", Types.StringType.get()),
             Types.NestedField.optional(19, "int19", Types.IntegerType.get())),
-        Row.of("a", 1));
+        Row.of("a", 1),
+        structAccessor);
   }
 
-  @Test
-  public void testEmptyStructAsObject() {
+  @ParameterizedTest(name = "Accessor for struct {0}")
+  @ValueSource(booleans = {true, false})
+  public void testEmptyStructAsObject(boolean structAccessor) {
     assertAccessorReturns(
         Types.StructType.of(Types.NestedField.optional(19, "int19", Types.IntegerType.get())),
-        Row.of());
+        Row.of(),
+        structAccessor);
 
-    assertAccessorReturns(Types.StructType.of(), Row.of());
+    assertAccessorReturns(Types.StructType.of(), Row.of(), structAccessor);
   }
 
   @Test
   public void testEmptySchema() {
     Schema emptySchema = new Schema();
     assertThat(emptySchema.accessorForField(17)).isNull();
+  }
+
+  @Test
+  public void testEmptyStruct() {
+    Types.StructType emptyStruct = Types.StructType.of();
+    assertThat(emptyStruct.accessorForField(17)).isNull();
   }
 }


### PR DESCRIPTION
Closes #8196

We bind a UnboundTerm with a struct, however, we need to create a schema from the struct to build the `Accessor`. This is costly when there are many columns when creating the schema.  In this PR add support to build the `Accessor` from the struct directly.