### PR TITLE
Nessie: avoid creating branches without explicit hashes

### DIFF
--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -124,7 +124,7 @@ public abstract class BaseTestIceberg {
     Branch defaultBranch = api.getDefaultBranch();
     initialHashOfDefaultBranch = defaultBranch.getHash();
     if (!branch.equals(defaultBranch.getName())) {
-      api.createReference().reference(Branch.of(branch, null)).create();
+      createBranch(branch, initialHashOfDefaultBranch);
     }
 
     hadoopConfig = new Configuration();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -202,6 +202,10 @@ public abstract class BaseTestIceberg {
     return new Schema(Types.StructType.of(fields).fields());
   }
 
+  void createBranch(String name) throws NessieNotFoundException, NessieConflictException {
+    createBranch(name, catalog.currentHash());
+  }
+
   void createBranch(String name, String hash)
       throws NessieNotFoundException, NessieConflictException {
     createBranch(name, hash, "main");

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -67,7 +67,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
   public void before() throws NessieNotFoundException, NessieConflictException {
     createTable(tableIdentifier1, 1); // table 1
     createTable(tableIdentifier2, 1); // table 2
-    createBranch("test", catalog.currentHash());
+    createBranch("test");
     testCatalog = initCatalog("test");
   }
 
@@ -447,7 +447,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
   @Test
   public void testWithRefAndHash() throws NessieConflictException, NessieNotFoundException {
     String testBranch = "testBranch";
-    createBranch(testBranch, null);
+    createBranch(testBranch);
     Schema schema =
         new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
 
@@ -495,8 +495,8 @@ public class TestBranchVisibility extends BaseTestIceberg {
   public void testDifferentTableSameName() throws NessieConflictException, NessieNotFoundException {
     String branch1 = "branch1";
     String branch2 = "branch2";
-    createBranch(branch1, null);
-    createBranch(branch2, null);
+    createBranch(branch1);
+    createBranch(branch2);
     Schema schema1 =
         new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
     Schema schema2 =

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -70,7 +70,7 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
   public void testWithReferenceAfterRecreatingBranch()
       throws NessieConflictException, NessieNotFoundException {
     String branch = "branchToBeDropped";
-    createBranch(branch, null);
+    createBranch(branch);
     NessieIcebergClient client = new NessieIcebergClient(api, branch, null, ImmutableMap.of());
 
     // just create a new commit on the branch and then delete & re-create it
@@ -82,7 +82,7 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
         .deleteBranch()
         .branch((Branch) client.getApi().getReference().refName(branch).get())
         .delete();
-    createBranch(branch, null);
+    createBranch(branch);
 
     // make sure the client uses the re-created branch
     Reference ref = client.getApi().getReference().refName(branch).get();


### PR DESCRIPTION
This commit modifies a few Nessie tests that were creating branches without explicitly specifying a target hash.

Nessie will soon forbid such situations, so we are proactively fixing all their occurrences.