### PR TITLE
Nessie: Permit Iceberg GC via explicit property overrides

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -63,6 +63,10 @@ public class NessieCatalog extends BaseMetastoreCatalog
   private static final Map<String, String> DEFAULT_CATALOG_OPTIONS =
       ImmutableMap.<String, String>builder()
           .put(CatalogProperties.TABLE_DEFAULT_PREFIX + TableProperties.GC_ENABLED, "false")
+          .put(
+              CatalogProperties.TABLE_DEFAULT_PREFIX
+                  + TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED,
+              "false") // just in case METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT changes
           .build();
 
   private NessieIcebergClient client;

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -24,10 +24,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -58,12 +60,18 @@ public class NessieCatalog extends BaseMetastoreCatalog
   private static final Logger LOG = LoggerFactory.getLogger(NessieCatalog.class);
   private static final Joiner SLASH = Joiner.on("/");
   private static final String NAMESPACE_LOCATION_PROPS = "location";
+
+  private static final Map<String, String> DEFAULT_CATALOG_OPTIONS =
+      ImmutableMap.<String, String>builder()
+          .put(CatalogProperties.TABLE_DEFAULT_PREFIX + TableProperties.GC_ENABLED, "false")
+          .build();
+
   private NessieIcebergClient client;
   private String warehouseLocation;
   private Object config;
   private String name;
   private FileIO fileIO;
-  private Map<String, String> catalogOptions;
+  @Nonnull private Map<String, String> catalogOptions = DEFAULT_CATALOG_OPTIONS;
   private CloseableGroup closeableGroup;
 
   public NessieCatalog() {}
@@ -128,7 +136,10 @@ public class NessieCatalog extends BaseMetastoreCatalog
     this.client = Preconditions.checkNotNull(client, "client must be non-null");
     this.fileIO = Preconditions.checkNotNull(fileIO, "fileIO must be non-null");
     this.catalogOptions =
-        Preconditions.checkNotNull(catalogOptions, "catalogOptions must be non-null");
+        ImmutableMap.<String, String>builder()
+            .putAll(DEFAULT_CATALOG_OPTIONS)
+            .putAll(Preconditions.checkNotNull(catalogOptions, "catalogOptions must be non-null"))
+            .buildKeepingLast();
     this.warehouseLocation = validateWarehouseLocation(name, catalogOptions);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(client);
@@ -346,6 +357,6 @@ public class NessieCatalog extends BaseMetastoreCatalog
 
   @Override
   protected Map<String, String> properties() {
-    return catalogOptions == null ? ImmutableMap.of() : catalogOptions;
+    return catalogOptions;
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
-import javax.annotation.Nonnull;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -71,7 +70,7 @@ public class NessieCatalog extends BaseMetastoreCatalog
   private Object config;
   private String name;
   private FileIO fileIO;
-  @Nonnull private Map<String, String> catalogOptions = DEFAULT_CATALOG_OPTIONS;
+  private Map<String, String> catalogOptions = DEFAULT_CATALOG_OPTIONS;
   private CloseableGroup closeableGroup;
 
   public NessieCatalog() {}

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -55,6 +55,8 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
    */
   public static final String NESSIE_COMMIT_ID_PROPERTY = "nessie.commit.id";
 
+  public static final String NESSIE_GC_NO_WARNING_PROPERTY = "nessie.gc.no-warning";
+
   private final NessieIcebergClient client;
   private final ContentKey key;
   private IcebergTable table;

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -23,7 +23,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -136,10 +138,15 @@ public abstract class BaseTestIceberg {
   }
 
   NessieCatalog initCatalog(String ref, String hash) {
+    return initCatalog(ref, hash, Collections.emptyMap());
+  }
+
+  NessieCatalog initCatalog(String ref, String hash, Map<String, String> extraOptions) {
     NessieCatalog newCatalog = new NessieCatalog();
     newCatalog.setConf(hadoopConfig);
     ImmutableMap.Builder<String, String> options =
         ImmutableMap.<String, String>builder()
+            .putAll(extraOptions)
             .put("ref", ref)
             .put(CatalogProperties.URI, uri)
             .put("auth-type", "NONE")

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
@@ -53,6 +54,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
@@ -573,7 +575,7 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   @Test
-  public void testGCEnabled() {
+  public void testGCDisabled() {
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
 
     Assertions.assertThat(icebergTable.properties().get(TableProperties.GC_ENABLED))
@@ -589,18 +591,43 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   @Test
-  public void testTableMetadataFilesCleanupDisable() throws NessieNotFoundException {
+  public void testGCEnabled() {
+    Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
+    icebergTable.updateProperties().set(TableProperties.GC_ENABLED, "true").commit();
+    Assertions.assertThat(icebergTable.properties().get(TableProperties.GC_ENABLED))
+        .isEqualTo("true");
+
+    Assertions.assertThatCode(
+            () ->
+                icebergTable.expireSnapshots().expireOlderThan(System.currentTimeMillis()).commit())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testGCEnabledViaCatalogProperties() {
+    catalog.dropTable(TABLE_IDENTIFIER, false); // pre-created in @BeforeEach
+
+    catalog =
+        initCatalog(
+            branch,
+            null,
+            ImmutableMap.<String, String>builder()
+                .put(CatalogProperties.TABLE_DEFAULT_PREFIX + TableProperties.GC_ENABLED, "true")
+                .build());
+
+    // Create the table again using updated config defaults.
+    tableLocation = createTable(TABLE_IDENTIFIER, schema).location().replaceFirst("file:", "");
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
 
-    // Forceful setting of property also should get override with false
-    icebergTable
-        .updateProperties()
-        .set(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED, "true")
-        .commit();
-    Assertions.assertThat(
-            icebergTable.properties().get(TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED))
-        .isNotNull()
-        .isEqualTo("false");
+    Assertions.assertThatCode(
+            () ->
+                icebergTable.expireSnapshots().expireOlderThan(System.currentTimeMillis()).commit())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testTableMetadataFilesCleanupDisable() throws NessieNotFoundException {
+    Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
 
     icebergTable
         .updateProperties()

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -604,7 +604,7 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   @Test
-  public void testGCEnabledViaCatalogProperties() {
+  public void testGCEnabledViaTableDefaultCatalogProperty() {
     catalog.dropTable(TABLE_IDENTIFIER, false); // pre-created in @BeforeEach
 
     catalog =

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -578,9 +578,8 @@ public class TestNessieTable extends BaseTestIceberg {
   public void testGCDisabled() {
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
 
-    Assertions.assertThat(icebergTable.properties().get(TableProperties.GC_ENABLED))
-        .isNotNull()
-        .isEqualTo("false");
+    Assertions.assertThat(icebergTable.properties())
+        .containsEntry(TableProperties.GC_ENABLED, "false");
 
     Assertions.assertThatThrownBy(
             () ->
@@ -594,8 +593,8 @@ public class TestNessieTable extends BaseTestIceberg {
   public void testGCEnabled() {
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
     icebergTable.updateProperties().set(TableProperties.GC_ENABLED, "true").commit();
-    Assertions.assertThat(icebergTable.properties().get(TableProperties.GC_ENABLED))
-        .isEqualTo("true");
+    Assertions.assertThat(icebergTable.properties())
+        .containsEntry(TableProperties.GC_ENABLED, "true");
 
     Assertions.assertThatCode(
             () ->


### PR DESCRIPTION
Introduce a new config property specific to Nessie to allow advanced users, who are aware of implications (see code comments), to use standard Iceberg GC tools in Nessie Catalogs.

The default behaviour is unchanged, that is Iceberg GC is disabled in Nessie Catalogs.

CC: @snazy @ajantha-bhat @nastra 