### PR TITLE
Core: Plan concurrently if there are multiple delete manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -87,7 +87,7 @@ public class DataTableScan extends BaseTableScan {
       manifestGroup = manifestGroup.ignoreResiduals();
     }
 
-    if (dataManifests.size() > 1 && shouldPlanWithExecutor()) {
+    if (shouldPlanWithExecutor() && (dataManifests.size() > 1 || deleteManifests.size() > 1)) {
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 


### PR DESCRIPTION
This PR ensures that data scans use a thread pool when there are more than 1 delete manifest, regardless of the number of data manifests