### PR TITLE
Spark3.2, Spark3.3: Return empty changed rows when there are no snapshots between start time and end time

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -66,7 +66,8 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
       IncrementalChangelogScan scan,
       SparkReadConf readConf,
       Schema expectedSchema,
-      List<Expression> filters) {
+      List<Expression> filters,
+      boolean emptyScan) {
 
     SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), expectedSchema);
 
@@ -79,6 +80,9 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
     this.startSnapshotId = readConf.startSnapshotId();
     this.endSnapshotId = readConf.endSnapshotId();
     this.readTimestampWithoutZone = readConf.handleTimestampWithoutZone();
+    if (emptyScan) {
+      this.taskGroups = Collections.emptyList();
+    }
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -249,6 +249,7 @@ public class SparkScanBuilder
     return new SparkBatchQueryScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
   }
 
+  @SuppressWarnings("CyclomaticComplexity")
   public Scan buildChangelogScan() {
     Preconditions.checkArgument(
         readConf.snapshotId() == null && readConf.asOfTimestamp() == null,
@@ -281,12 +282,20 @@ public class SparkScanBuilder
           SparkReadOptions.END_TIMESTAMP);
     }
 
+    boolean emptyScan = false;
     if (startTimestamp != null) {
       startSnapshotId = getStartSnapshotId(startTimestamp);
+      if (startSnapshotId == null && endTimestamp == null) {
+        emptyScan = true;
+      }
     }
 
     if (endTimestamp != null) {
-      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp);
+      endSnapshotId = SnapshotUtil.nullableSnapshotIdAsOfTime(table, endTimestamp);
+      if ((startSnapshotId == null && endSnapshotId == null)
+          || (startSnapshotId != null && startSnapshotId.equals(endSnapshotId))) {
+        emptyScan = true;
+      }
     }
 
     Schema expectedSchema = schemaWithMetadataColumns();
@@ -308,18 +317,16 @@ public class SparkScanBuilder
 
     scan = configureSplitPlanning(scan);
 
-    return new SparkChangelogScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
+    return new SparkChangelogScan(
+        spark, table, scan, readConf, expectedSchema, filterExpressions, emptyScan);
   }
 
   private Long getStartSnapshotId(Long startTimestamp) {
     Snapshot oldestSnapshotAfter = SnapshotUtil.oldestAncestorAfter(table, startTimestamp);
-    Preconditions.checkArgument(
-        oldestSnapshotAfter != null,
-        "Cannot find a snapshot older than %s for table %s",
-        startTimestamp,
-        table.name());
 
-    if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
+    if (oldestSnapshotAfter == null) {
+      return null;
+    } else if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
       return oldestSnapshotAfter.snapshotId();
     } else {
       return oldestSnapshotAfter.parentId();

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -69,7 +69,8 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
       IncrementalChangelogScan scan,
       SparkReadConf readConf,
       Schema expectedSchema,
-      List<Expression> filters) {
+      List<Expression> filters,
+      boolean emptyScan) {
 
     SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), expectedSchema);
 
@@ -82,6 +83,9 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
     this.startSnapshotId = readConf.startSnapshotId();
     this.endSnapshotId = readConf.endSnapshotId();
     this.readTimestampWithoutZone = readConf.handleTimestampWithoutZone();
+    if (emptyScan) {
+      this.taskGroups = Collections.emptyList();
+    }
   }
 
   @Override

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -480,6 +480,7 @@ public class SparkScanBuilder
     return new SparkBatchQueryScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
   }
 
+  @SuppressWarnings("CyclomaticComplexity")
   public Scan buildChangelogScan() {
     Preconditions.checkArgument(
         readConf.snapshotId() == null
@@ -517,12 +518,20 @@ public class SparkScanBuilder
           SparkReadOptions.END_TIMESTAMP);
     }
 
+    boolean emptyScan = false;
     if (startTimestamp != null) {
       startSnapshotId = getStartSnapshotId(startTimestamp);
+      if (startSnapshotId == null && endTimestamp == null) {
+        emptyScan = true;
+      }
     }
 
     if (endTimestamp != null) {
-      endSnapshotId = SnapshotUtil.snapshotIdAsOfTime(table, endTimestamp);
+      endSnapshotId = SnapshotUtil.nullableSnapshotIdAsOfTime(table, endTimestamp);
+      if ((startSnapshotId == null && endSnapshotId == null)
+          || (startSnapshotId != null && startSnapshotId.equals(endSnapshotId))) {
+        emptyScan = true;
+      }
     }
 
     Schema expectedSchema = schemaWithMetadataColumns();
@@ -544,18 +553,16 @@ public class SparkScanBuilder
 
     scan = configureSplitPlanning(scan);
 
-    return new SparkChangelogScan(spark, table, scan, readConf, expectedSchema, filterExpressions);
+    return new SparkChangelogScan(
+        spark, table, scan, readConf, expectedSchema, filterExpressions, emptyScan);
   }
 
   private Long getStartSnapshotId(Long startTimestamp) {
     Snapshot oldestSnapshotAfter = SnapshotUtil.oldestAncestorAfter(table, startTimestamp);
-    Preconditions.checkArgument(
-        oldestSnapshotAfter != null,
-        "Cannot find a snapshot older than %s for table %s",
-        startTimestamp,
-        table.name());
 
-    if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
+    if (oldestSnapshotAfter == null) {
+      return null;
+    } else if (oldestSnapshotAfter.timestampMillis() == startTimestamp) {
       return oldestSnapshotAfter.snapshotId();
     } else {
       return oldestSnapshotAfter.parentId();


### PR DESCRIPTION
Back-port of https://github.com/apache/iceberg/pull/8133 to `spark/v3.3` and `spark/v3.2`