### PR TITLE
Python: Check if identifier fields are valid

### DIFF
--- a/python/pyiceberg/schema.py
+++ b/python/pyiceberg/schema.py
@@ -291,13 +291,16 @@ class Schema(IcebergBaseModel):
         """
         field = id_to_field.get(field_id)
         if field is None:
-            raise ValueError("Cannot add fieldId %s as an identifier field: field does not exist" % field_id)
+            raise ValueError(f"Cannot add fieldId {field_id} as an identifier field: field does not exist")
+
         if not field.field_type.is_primitive:
-            raise ValueError("Cannot add field %s as an identifier field: not a primitive type field" % field.name)
+            raise ValueError(f"Cannot add field {field.name} as an identifier field: not a primitive type field")
+
         if not field.required:
-            raise ValueError("Cannot add field %s as an identifier field: not a required field" % field.name)
+            raise ValueError(f"Cannot add field {field.name} as an identifier field: not a required field")
+
         if isinstance(field.field_type, DoubleType) or isinstance(field.field_type, FloatType):
-            raise ValueError("Cannot add field %s as an identifier field: must not be float or double field" % field.name)
+            raise ValueError(f"Cannot add field {field.name} as an identifier field: must not be float or double field")
 
         # Check whether the nested field is in a chain of required struct fields
         # Exploring from root for better error message for list and map types
@@ -311,10 +314,10 @@ class Schema(IcebergBaseModel):
             parent: Optional[NestedField] = id_to_field.get(fields.pop())
             if parent and not parent.field_type.is_struct:
                 raise ValueError(f"Cannot add field {field.name} as an identifier field: must not be nested in {parent}")
+
             if parent and not parent.required:
                 raise ValueError(
-                    "Cannot add field %s as an identifier field: must not be nested in an optional field %s"
-                    % (field.name, parent)
+                    f"Cannot add field {field.name} as an identifier field: must not be nested in an optional field {parent}"
                 )
 
 

--- a/python/pyiceberg/schema.py
+++ b/python/pyiceberg/schema.py
@@ -949,6 +949,7 @@ class _IndexParents(SchemaVisitor[Dict[int, int]]):
             if parent_id is not None:
                 # fields in the root struct are not added
                 self.id_to_parent[field.field_id] = parent_id
+
         return self.id_to_parent
 
     def field(self, field: NestedField, field_result: Dict[int, int]) -> Dict[int, int]:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -148,7 +148,7 @@ def table_schema_simple() -> Schema:
 @pytest.fixture(scope="session")
 def table_schema_nested() -> Schema:
     return schema.Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
         NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         NestedField(
@@ -227,13 +227,13 @@ def table_schema_nested_with_struct_key_map() -> Schema:
                 key_id=18,
                 value_id=19,
                 key_type=StructType(
-                    NestedField(field_id=21, name="address", field_type=StringType(), required=False),
-                    NestedField(field_id=22, name="city", field_type=StringType(), required=False),
-                    NestedField(field_id=23, name="zip", field_type=IntegerType(), required=False),
+                    NestedField(field_id=21, name="address", field_type=StringType(), required=True),
+                    NestedField(field_id=22, name="city", field_type=StringType(), required=True),
+                    NestedField(field_id=23, name="zip", field_type=IntegerType(), required=True),
                 ),
                 value_type=StructType(
-                    NestedField(field_id=13, name="latitude", field_type=FloatType(), required=False),
-                    NestedField(field_id=14, name="longitude", field_type=FloatType(), required=False),
+                    NestedField(field_id=13, name="latitude", field_type=FloatType(), required=True),
+                    NestedField(field_id=14, name="longitude", field_type=FloatType(), required=True),
                 ),
                 value_required=True,
             ),
@@ -248,8 +248,23 @@ def table_schema_nested_with_struct_key_map() -> Schema:
             ),
             required=False,
         ),
+        NestedField(
+            field_id=24,
+            name="points",
+            field_type=ListType(
+                element_id=25,
+                element_type=StructType(
+                    NestedField(field_id=26, name="x", field_type=LongType(), required=True),
+                    NestedField(field_id=27, name="y", field_type=LongType(), required=True),
+                ),
+                element_required=False,
+            ),
+            required=False,
+        ),
+        NestedField(field_id=28, name="float", field_type=FloatType(), required=True),
+        NestedField(field_id=29, name="double", field_type=DoubleType(), required=True),
         schema_id=1,
-        identifier_field_ids=[1],
+        identifier_field_ids=[2],
     )
 
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -148,7 +148,7 @@ def table_schema_simple() -> Schema:
 @pytest.fixture(scope="session")
 def table_schema_nested() -> Schema:
     return schema.Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
         NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         NestedField(
@@ -192,14 +192,14 @@ def table_schema_nested() -> Schema:
             required=False,
         ),
         schema_id=1,
-        identifier_field_ids=[1],
+        identifier_field_ids=[2],
     )
 
 
 @pytest.fixture(scope="session")
 def table_schema_nested_with_struct_key_map() -> Schema:
     return schema.Schema(
-        NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
+        NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
         NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         NestedField(
@@ -264,7 +264,7 @@ def table_schema_nested_with_struct_key_map() -> Schema:
         NestedField(field_id=28, name="float", field_type=FloatType(), required=True),
         NestedField(field_id=29, name="double", field_type=DoubleType(), required=True),
         schema_id=1,
-        identifier_field_ids=[2],
+        identifier_field_ids=[1],
     )
 
 

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -490,7 +490,6 @@ def bound_double_reference() -> BoundReference[float]:
     schema = Schema(
         NestedField(field_id=1, name="foo", field_type=DoubleType(), required=False),
         schema_id=1,
-        identifier_field_ids=[2],
     )
     return BoundReference(schema.find_field(1), schema.accessor_for_field(1))
 

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -490,6 +490,7 @@ def bound_double_reference() -> BoundReference[float]:
     schema = Schema(
         NestedField(field_id=1, name="foo", field_type=DoubleType(), required=False),
         schema_id=1,
+        identifier_field_ids=[],
     )
     return BoundReference(schema.find_field(1), schema.accessor_for_field(1))
 

--- a/python/tests/io/test_pyarrow_visitor.py
+++ b/python/tests/io/test_pyarrow_visitor.py
@@ -260,7 +260,7 @@ def test_round_schema_conversion_simple(table_schema_simple: Schema) -> None:
 def test_round_schema_conversion_nested(table_schema_nested: Schema) -> None:
     actual = str(pyarrow_to_schema(schema_to_pyarrow(table_schema_nested)))
     expected = """table {
-  1: foo: optional string
+  1: foo: required string
   2: bar: required int
   3: baz: optional boolean
   4: qux: required list<string>

--- a/python/tests/io/test_pyarrow_visitor.py
+++ b/python/tests/io/test_pyarrow_visitor.py
@@ -260,7 +260,7 @@ def test_round_schema_conversion_simple(table_schema_simple: Schema) -> None:
 def test_round_schema_conversion_nested(table_schema_nested: Schema) -> None:
     actual = str(pyarrow_to_schema(schema_to_pyarrow(table_schema_nested)))
     expected = """table {
-  1: foo: required string
+  1: foo: optional string
   2: bar: required int
   3: baz: optional boolean
   4: qux: required list<string>

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -123,7 +123,7 @@ def test_schema_index_by_id_visitor(table_schema_nested: Schema) -> None:
     """Test index_by_id visitor function"""
     index = schema.index_by_id(table_schema_nested)
     assert index == {
-        1: NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
+        1: NestedField(field_id=1, name="foo", field_type=StringType(), required=False),
         2: NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
         3: NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         4: NestedField(
@@ -431,14 +431,14 @@ def test_deserialize_schema(table_schema_simple: Schema) -> None:
     assert actual == expected
 
 
-def test_prune_columns_string(table_schema_nested: Schema) -> None:
-    assert prune_columns(table_schema_nested, {1}, False) == Schema(
+def test_prune_columns_string(table_schema_nested_with_struct_key_map: Schema) -> None:
+    assert prune_columns(table_schema_nested_with_struct_key_map, {1}, False) == Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), required=True), schema_id=1, identifier_field_ids=[1]
     )
 
 
-def test_prune_columns_string_full(table_schema_nested: Schema) -> None:
-    assert prune_columns(table_schema_nested, {1}, True) == Schema(
+def test_prune_columns_string_full(table_schema_nested_with_struct_key_map: Schema) -> None:
+    assert prune_columns(table_schema_nested_with_struct_key_map, {1}, True) == Schema(
         NestedField(field_id=1, name="foo", field_type=StringType(), required=True),
         schema_id=1,
         identifier_field_ids=[1],
@@ -694,7 +694,7 @@ def test_schema_select(table_schema_nested: Schema) -> None:
         NestedField(field_id=2, name="bar", field_type=IntegerType(), required=True),
         NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
         schema_id=1,
-        identifier_field_ids=[],
+        identifier_field_ids=[2],
     )
 
 
@@ -732,8 +732,8 @@ def test_identifier_fields_fails(table_schema_nested_with_struct_key_map: Schema
     assert str(exc_info.value) == "Cannot add fieldId 999 as an identifier field: field does not exist"
 
     with pytest.raises(ValueError) as exc_info:
-        Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[1])
-    assert str(exc_info.value) == "Cannot add field foo as an identifier field: not a required field"
+        Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[3])
+    assert str(exc_info.value) == "Cannot add field baz as an identifier field: not a required field"
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[28])

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -113,7 +113,7 @@ def test_schema_raise_on_duplicate_names() -> None:
             NestedField(field_id=3, name="baz", field_type=BooleanType(), required=False),
             NestedField(field_id=4, name="baz", field_type=BooleanType(), required=False),
             schema_id=1,
-            identifier_field_ids=[1],
+            identifier_field_ids=[2],
         )
 
     assert "Invalid schema, multiple fields for name baz: 3 and 4" in str(exc_info.value)
@@ -729,42 +729,42 @@ def should_promote(file_type: IcebergType, read_type: IcebergType) -> bool:
 def test_identifier_fields_fails(table_schema_nested_with_struct_key_map: Schema) -> None:
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[999])
-    assert str(exc_info.value) == "Cannot add fieldId 999 as an identifier field: field does not exist"
+    assert "Cannot add fieldId 999 as an identifier field: field does not exist" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[3])
-    assert str(exc_info.value) == "Cannot add field baz as an identifier field: not a required field"
+    assert "Cannot add field baz as an identifier field: not a required field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[28])
-    assert str(exc_info.value) == "Cannot add field float as an identifier field: must not be float or double field"
+    assert "Cannot add field float as an identifier field: must not be float or double field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[29])
-    assert str(exc_info.value) == "Cannot add field double as an identifier field: must not be float or double field"
+    assert "Cannot add field double as an identifier field: must not be float or double field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[23])
-    assert str(
-        exc_info.value
-    ) == "Cannot add field zip as an identifier field: must not be nested in %s" % table_schema_nested_with_struct_key_map.find_field(
-        "location"
+    assert (
+        "Cannot add field zip as an identifier field: must not be nested in %s"
+        % table_schema_nested_with_struct_key_map.find_field("location")
+        in str(exc_info.value)
     )
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[26])
-    assert str(
-        exc_info.value
-    ) == "Cannot add field x as an identifier field: must not be nested in %s" % table_schema_nested_with_struct_key_map.find_field(
-        "points"
+    assert (
+        "Cannot add field x as an identifier field: must not be nested in %s"
+        % table_schema_nested_with_struct_key_map.find_field("points")
+        in str(exc_info.value)
     )
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[17])
-    assert str(
-        exc_info.value
-    ) == "Cannot add field age as an identifier field: must not be nested in an optional field %s" % table_schema_nested_with_struct_key_map.find_field(
-        "person"
+    assert (
+        "Cannot add field age as an identifier field: must not be nested in an optional field %s"
+        % table_schema_nested_with_struct_key_map.find_field("person")
+        in str(exc_info.value)
     )
 
 

--- a/python/tests/test_schema.py
+++ b/python/tests/test_schema.py
@@ -729,19 +729,23 @@ def should_promote(file_type: IcebergType, read_type: IcebergType) -> bool:
 def test_identifier_fields_fails(table_schema_nested_with_struct_key_map: Schema) -> None:
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[999])
-    assert "Cannot add fieldId 999 as an identifier field: field does not exist" in str(exc_info.value)
+    assert "Could not find field with id: 999" in str(exc_info.value)
+
+    with pytest.raises(ValueError) as exc_info:
+        Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[11])
+    assert "Identifier field 11 invalid: not a primitive type field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[3])
-    assert "Cannot add field baz as an identifier field: not a required field" in str(exc_info.value)
+    assert "Identifier field 3 invalid: not a required field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[28])
-    assert "Cannot add field float as an identifier field: must not be float or double field" in str(exc_info.value)
+    assert "Identifier field 28 invalid: must not be float or double field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[29])
-    assert "Cannot add field double as an identifier field: must not be float or double field" in str(exc_info.value)
+    assert "Identifier field 29 invalid: must not be float or double field" in str(exc_info.value)
 
     with pytest.raises(ValueError) as exc_info:
         Schema(*table_schema_nested_with_struct_key_map.fields, schema_id=1, identifier_field_ids=[23])


### PR DESCRIPTION
Fix #8386

Note: This pr only did validity checks when creating the Schema, not when it evolves, need to integrate with https://github.com/apache/iceberg/pull/8374.