### PR TITLE
Spark 3.4: Rewrite procedure throw better exception when filter expression cannot translate

### DIFF
--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -844,7 +844,7 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
                 sql(
                     "CALL %s.system.rewrite_data_files(table => '%s', where => 'substr(c2, 2) = \"fo\"')",
                     catalogName, tableIdent))
-        .isInstanceOf(AssertionError.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot convert Spark filter");
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -837,7 +837,7 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
                     "CALL %s.system.rewrite_data_files(table => '%s', where => 'substr(encode(c2, \"utf-8\"), 2) = \"fo\"')",
                     catalogName, tableIdent))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot translate Spark expression to data source filter");
+        .hasMessageContaining("Cannot translate Spark expression");
 
     Assertions.assertThatThrownBy(
             () ->
@@ -845,7 +845,7 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
                     "CALL %s.system.rewrite_data_files(table => '%s', where => 'substr(c2, 2) = \"fo\"')",
                     catalogName, tableIdent))
         .isInstanceOf(AssertionError.class)
-        .hasMessageContaining("Cannot convert Spark filter to Iceberg expression");
+        .hasMessageContaining("Cannot convert Spark filter");
   }
 
   private void createTable() {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -43,7 +43,6 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Assumptions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -830,32 +829,23 @@ public class TestRewriteDataFilesProcedure extends SparkExtensionsTestBase {
   }
 
   @Test
-  public void testRewriteDataFilesWithSystemFunctions() {
-    Assumptions.assumeThat(catalogName).isNotEqualTo("spark_catalog");
-
-    sql(
-        "CREATE TABLE %s (c1 INT, c2 STRING, c3 TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (days(c3)) "
-            + "TBLPROPERTIES ('%s' '%s')",
-        tableName,
-        TableProperties.WRITE_DISTRIBUTION_MODE,
-        TableProperties.WRITE_DISTRIBUTION_MODE_NONE);
-
-    sql(
-        "INSERT INTO TABLE %s VALUES (0, 'data-0', CAST('2017-11-22T09:20:44.294658+00:00' AS TIMESTAMP))",
-        tableName);
-    sql(
-        "INSERT INTO TABLE %s VALUES (1, 'data-1', CAST('2017-11-23T03:15:32.194356+00:00' AS TIMESTAMP))",
-        tableName);
-    // Test with invalid filter column col1
+  public void testRewriteWithUntranslatedOrUnconvertedFilter() {
+    createTable();
     Assertions.assertThatThrownBy(
             () ->
                 sql(
-                    "CALL %s.system.rewrite_data_files(table => '%s', where => '%s.system.years(c3) = 2017')",
-                    catalogName, tableIdent, catalogName))
+                    "CALL %s.system.rewrite_data_files(table => '%s', where => 'substr(encode(c2, \"utf-8\"), 2) = \"fo\"')",
+                    catalogName, tableIdent))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot translate Spark expression to data source filter");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_data_files(table => '%s', where => 'substr(c2, 2) = \"fo\"')",
+                    catalogName, tableIdent))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("Cannot convert Spark filter to Iceberg expression");
   }
 
   private void createTable() {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -219,7 +219,7 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
                 sql(
                     "CALL %s.system.rewrite_position_delete_files(table => '%s', where => 'substr(data, 2) = \"fo\"')",
                     catalogName, tableIdent))
-        .isInstanceOf(AssertionError.class)
+        .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot convert Spark filter");
   }
 

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -212,7 +212,7 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
                     "CALL %s.system.rewrite_position_delete_files(table => '%s', where => 'substr(encode(data, \"utf-8\"), 2) = \"fo\"')",
                     catalogName, tableIdent))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot translate Spark expression to data source filter");
+        .hasMessageContaining("Cannot translate Spark expression");
 
     Assertions.assertThatThrownBy(
             () ->
@@ -220,7 +220,7 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
                     "CALL %s.system.rewrite_position_delete_files(table => '%s', where => 'substr(data, 2) = \"fo\"')",
                     catalogName, tableIdent))
         .isInstanceOf(AssertionError.class)
-        .hasMessageContaining("Cannot convert Spark filter to Iceberg expression");
+        .hasMessageContaining("Cannot convert Spark filter");
   }
 
   private Map<String, String> snapshotSummary() {

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewritePositionDeleteFilesProcedure.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.source.SimpleRecord;
 import org.apache.spark.sql.Encoders;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -200,6 +201,26 @@ public class TestRewritePositionDeleteFilesProcedure extends SparkExtensionsTest
                     + "options => map("
                     + "'foo', 'bar'))",
                 catalogName, tableIdent));
+  }
+
+  @Test
+  public void testRewriteWithUntranslatedOrUnconvertedFilter() throws Exception {
+    createTable();
+    Assertions.assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_position_delete_files(table => '%s', where => 'substr(encode(data, \"utf-8\"), 2) = \"fo\"')",
+                    catalogName, tableIdent))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot translate Spark expression to data source filter");
+
+    Assertions.assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.rewrite_position_delete_files(table => '%s', where => 'substr(data, 2) = \"fo\"')",
+                    catalogName, tableIdent))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining("Cannot convert Spark filter to Iceberg expression");
   }
 
   private Map<String, String> snapshotSummary() {

--- a/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
+++ b/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
@@ -39,7 +39,10 @@ object SparkExpressionConverter {
     DataSourceV2Strategy.translateFilterV2(sparkExpression) match {
       case Some(filter) =>
         val converted = SparkV2Filters.convert(filter)
-        assert(converted != null, s"Cannot convert Spark filter: $filter to Iceberg expression")
+        if (converted == null) {
+          throw new IllegalArgumentException(s"Cannot convert Spark filter: $filter to Iceberg expression")
+        }
+
         converted
       case _ =>
         throw new IllegalArgumentException(s"Cannot translate Spark expression: $sparkExpression to data source filter")

--- a/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
+++ b/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
@@ -36,7 +36,14 @@ object SparkExpressionConverter {
     // Currently, it is a double conversion as we are converting Spark expression to Spark predicate
     // and then converting Spark predicate to Iceberg expression.
     // But these two conversions already exist and well tested. So, we are going with this approach.
-    SparkV2Filters.convert(DataSourceV2Strategy.translateFilterV2(sparkExpression).get)
+    DataSourceV2Strategy.translateFilterV2(sparkExpression) match {
+      case Some(filter) =>
+        val converted = SparkV2Filters.convert(filter)
+        assert(converted != null, s"Cannot convert Spark filter to Iceberg expression: $filter")
+        converted
+      case _ =>
+        throw new IllegalArgumentException(s"Cannot translate Spark expression to data source filter: $sparkExpression")
+    }
   }
 
   @throws[AnalysisException]

--- a/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
+++ b/spark/v3.4/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkExpressionConverter.scala
@@ -39,10 +39,10 @@ object SparkExpressionConverter {
     DataSourceV2Strategy.translateFilterV2(sparkExpression) match {
       case Some(filter) =>
         val converted = SparkV2Filters.convert(filter)
-        assert(converted != null, s"Cannot convert Spark filter to Iceberg expression: $filter")
+        assert(converted != null, s"Cannot convert Spark filter: $filter to Iceberg expression")
         converted
       case _ =>
-        throw new IllegalArgumentException(s"Cannot translate Spark expression to data source filter: $sparkExpression")
+        throw new IllegalArgumentException(s"Cannot translate Spark expression: $sparkExpression to data source filter")
     }
   }
 


### PR DESCRIPTION
For rewrite procedure, we should throw better exceptions when the filter condition can't be pushed down or can't convert to Iceberg. For example:
```scala
scala> spark.sql("call local.system.rewrite_data_files(table => 'db.test_rewrite', where => 'substr(data, 2) = \"fo\"')").show()
java.util.NoSuchElementException: None.get
  at scala.None$.get(Option.scala:529)
  at scala.None$.get(Option.scala:527)
  at org.apache.spark.sql.execution.datasources.SparkExpressionConverter$.convertToIcebergExpression(SparkExpressionConverter.scala:38)
  at org.apache.spark.sql.execution.datasources.SparkExpressionConverter.convertToIcebergExpression(SparkExpressionConverter.scala)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.checkAndApplyFilter(RewriteDataFilesProcedure.java:137)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.lambda$call$0(RewriteDataFilesProcedure.java:123)
  at org.apache.iceberg.spark.procedures.BaseProcedure.execute(BaseProcedure.java:107)
  at org.apache.iceberg.spark.procedures.BaseProcedure.modifyIcebergTable(BaseProcedure.java:88)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.call(RewriteDataFilesProcedure.java:103)
```

After this PR:
```scala
scala> spark.sql("call local.system.rewrite_data_files(table => 'db.test_rewrite', where => 'substr(data, 2) = \"fo\"')").show()
java.lang.IllegalArgumentException: Cannot convert Spark filter: (data IS NOT NULL) AND ((SUBSTRING(data, 2)) = 'fo') to Iceberg expression
  at org.apache.spark.sql.execution.datasources.SparkExpressionConverter$.convertToIcebergExpression(SparkExpressionConverter.scala:43)
  at org.apache.spark.sql.execution.datasources.SparkExpressionConverter.convertToIcebergExpression(SparkExpressionConverter.scala)
  at org.apache.iceberg.spark.procedures.BaseProcedure.filterExpression(BaseProcedure.java:171)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.checkAndApplyFilter(RewriteDataFilesProcedure.java:129)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.lambda$call$0(RewriteDataFilesProcedure.java:118)
  at org.apache.iceberg.spark.procedures.BaseProcedure.execute(BaseProcedure.java:107)
  at org.apache.iceberg.spark.procedures.BaseProcedure.modifyIcebergTable(BaseProcedure.java:88)
  at org.apache.iceberg.spark.procedures.RewriteDataFilesProcedure.call(RewriteDataFilesProcedure.java:100)