### PR TITLE
Python: Configurable Authentication URL for Rest Catalog

### DIFF
--- a/python/mkdocs/docs/configuration.md
+++ b/python/mkdocs/docs/configuration.md
@@ -115,6 +115,7 @@ catalog:
   default:
     uri: http://rest-catalog/ws/
     credential: t-1234:secret
+    authurl: https://auth-service/cc
 
   default-mtls-secured-catalog:
     uri: https://rest-catalog/ws/
@@ -125,14 +126,15 @@ catalog:
       cabundle: /absolute/path/to/cabundle.pem
 ```
 
-| Key                 | Example                 | Description                                                                |
-| ------------------- | ----------------------- | -------------------------------------------------------------------------- |
-| uri                 | https://rest-catalog/ws | URI identifying the REST Server                                            |
-| credential          | t-1234:secret           | Credential to use for OAuth2 credential flow when initializing the catalog |
-| token               | FEW23.DFSDF.FSDF        | Bearer token value to use for `Authorization` header                       |
-| rest.sigv4-enabled  | true                    | Sign requests to the REST Server using AWS SigV4 protocol                  |
-| rest.signing-region | us-east-1               | The region to use when SigV4 signing a request                             |
-| rest.signing-name   | execute-api             | The service signing name to use when SigV4 signing a request               |
+| Key                 | Example                 | Description                                                                                        |
+| ------------------- | ----------------------- | -------------------------------------------------------------------------------------------------- |
+| uri                 | https://rest-catalog/ws | URI identifying the REST Server                                                                    |
+| credential          | t-1234:secret           | Credential to use for OAuth2 credential flow when initializing the catalog                         |
+| authurl             | https://auth-service/cc | Authentication URL to use for client credentials authentication (default: uri + 'v1/oauth/tokens') |
+| token               | FEW23.DFSDF.FSDF        | Bearer token value to use for `Authorization` header                                               |
+| rest.sigv4-enabled  | true                    | Sign requests to the REST Server using AWS SigV4 protocol                                          |
+| rest.signing-region | us-east-1               | The region to use when SigV4 signing a request                                                     |
+| rest.signing-name   | execute-api             | The service signing name to use when SigV4 signing a request                                       |
 
 ## SQL Catalog
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -110,9 +110,11 @@ def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
         request_headers=OAUTH_TEST_HEADERS,
     )
     assert (
-        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL)._session.headers[
+        RestCatalog(
+            "rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL
+        )._session.headers[  # pylint: disable=W0212
             "Authorization"
-        ]  # pylint: disable=W0212
+        ]
         == f"Bearer {TEST_TOKEN}"
     )
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -110,7 +110,9 @@ def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
         request_headers=OAUTH_TEST_HEADERS,
     )
     assert (
-        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL)._session.headers["Authorization"]  # pylint: disable=W0212
+        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL)._session.headers[
+            "Authorization"
+        ]  # pylint: disable=W0212
         == f"Bearer {TEST_TOKEN}"
     )
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -47,6 +47,7 @@ from pyiceberg.types import (
 
 TEST_URI = "https://iceberg-test-catalog/"
 TEST_CREDENTIALS = "client:secret"
+TEST_AUTH_URL = "https://auth-endpoint/"
 TEST_TOKEN = "some_jwt_token"
 TEST_HEADERS = {
     "Content-type": "application/json",
@@ -92,6 +93,24 @@ def test_token_200(rest_mock: Mocker) -> None:
     )
     assert (
         RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS)._session.headers["Authorization"]  # pylint: disable=W0212
+        == f"Bearer {TEST_TOKEN}"
+    )
+
+
+def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
+    rest_mock.post(
+        TEST_AUTH_URL,
+        json={
+            "access_token": TEST_TOKEN,
+            "token_type": "Bearer",
+            "expires_in": 86400,
+            "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        },
+        status_code=200,
+        request_headers=OAUTH_TEST_HEADERS,
+    )
+    assert (
+        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL)._session.headers["Authorization"]  # pylint: disable=W0212
         == f"Bearer {TEST_TOKEN}"
     )
 

--- a/python/tests/catalog/test_rest.py
+++ b/python/tests/catalog/test_rest.py
@@ -109,14 +109,12 @@ def test_token_200_w_auth_url(rest_mock: Mocker) -> None:
         status_code=200,
         request_headers=OAUTH_TEST_HEADERS,
     )
+    # pylint: disable=W0212
     assert (
-        RestCatalog(
-            "rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL
-        )._session.headers[  # pylint: disable=W0212
-            "Authorization"
-        ]
+        RestCatalog("rest", uri=TEST_URI, credential=TEST_CREDENTIALS, authurl=TEST_AUTH_URL)._session.headers["Authorization"]
         == f"Bearer {TEST_TOKEN}"
     )
+    # pylint: enable=W0212
 
 
 def test_config_200(requests_mock: Mocker) -> None:


### PR DESCRIPTION
This PR follows up a suggestion that was made on the Slack discussion thread between @Fokko and I.

Our understanding is that the existing Authentication flow in PyIceberg is actually an [ROPC (Resource Owner Password Flow), instead of Client Credentials Flow](https://stackoverflow.com/questions/22077487/difference-between-the-resource-owner-password-flow-and-the-client-credential).

Assuming that the Auth server is a separate entity from the Rest Catalog, [adopting ROPC introduces a security threat](https://www.scottbrady91.com/oauth/why-the-resource-owner-password-credentials-grant-type-is-not-authentication-nor-suitable-for-modern-applications) to the workflow because in this model, the Rest Catalog is becoming an intermediary that gains access to the client credentials. This mode of relaying the client credentials to the Auth server can be thought of impersonation, rather than authentication.

Hence, in this PR we are introducing a capability to make the authentication endpoint configurable so that it can hit a separate address from the Rest Catalog. This way, we could have the PyIceberg session hitting the Auth server for authentication, instead of having the Rest Catalog act as an intermediary for identity verification. And as long as PyIceberg follows the [OAuth2 standard](https://docs.pingidentity.com/r/en-us/developer/ceb1601508084099) (which it does), it will be able to retrieve the access_token from various OAuth providers.