### PR TITLE
Fix Iceberg to handle literal short and byte

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literal.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literal.java
@@ -35,6 +35,14 @@ public interface Literal<T> extends Serializable {
     return new Literals.BooleanLiteral(value);
   }
 
+  static Literal<Byte> of(byte value) {
+    return new Literals.ByteLiteral(value);
+  }
+
+  static Literal<Short> of(short value) {
+    return new Literals.ShortLiteral(value);
+  }
+
   static Literal<Integer> of(int value) {
     return new Literals.IntegerLiteral(value);
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -269,7 +269,7 @@ class Literals {
           int scale = ((Types.DecimalType) type).scale();
           // rounding mode isn't necessary, but pass one to avoid warnings
           return (Literal<T>)
-                  new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
+              new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
         default:
           return null;
       }
@@ -306,7 +306,7 @@ class Literals {
           int scale = ((Types.DecimalType) type).scale();
           // rounding mode isn't necessary, but pass one to avoid warnings
           return (Literal<T>)
-                  new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
+              new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
         default:
           return null;
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -80,6 +80,10 @@ class Literals {
       return (Literal<T>) new Literals.BinaryLiteral((ByteBuffer) value);
     } else if (value instanceof BigDecimal) {
       return (Literal<T>) new Literals.DecimalLiteral((BigDecimal) value);
+    } else if (value instanceof Short) {
+      return (Literal<T>) new Literals.ShortLiteral((Short) value);
+    } else if (value instanceof Byte) {
+      return (Literal<T>) new Literals.ByteLiteral((Byte) value);
     }
 
     throw new IllegalArgumentException(
@@ -235,6 +239,82 @@ class Literals {
     @Override
     protected Type.TypeID typeId() {
       return Type.TypeID.BOOLEAN;
+    }
+  }
+
+  static class ByteLiteral extends ComparableLiteral<Byte> {
+    ByteLiteral(Byte value) {
+      super(value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Literal<T> to(Type type) {
+      switch (type.typeId()) {
+        case BYTE:
+          return (Literal<T>) this;
+        case SHORT:
+          return (Literal<T>) new ShortLiteral(value().shortValue());
+        case INTEGER:
+          return (Literal<T>) new IntegerLiteral(value().intValue());
+        case LONG:
+          return (Literal<T>) new LongLiteral(value().longValue());
+        case FLOAT:
+          return (Literal<T>) new FloatLiteral(value().floatValue());
+        case DOUBLE:
+          return (Literal<T>) new DoubleLiteral(value().doubleValue());
+        case DATE:
+          return (Literal<T>) new DateLiteral(value().intValue());
+        case DECIMAL:
+          int scale = ((Types.DecimalType) type).scale();
+          // rounding mode isn't necessary, but pass one to avoid warnings
+          return (Literal<T>)
+                  new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
+        default:
+          return null;
+      }
+    }
+
+    @Override
+    protected Type.TypeID typeId() {
+      return Type.TypeID.BYTE;
+    }
+  }
+
+  static class ShortLiteral extends ComparableLiteral<Short> {
+    ShortLiteral(Short value) {
+      super(value);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Literal<T> to(Type type) {
+      switch (type.typeId()) {
+        case SHORT:
+          return (Literal<T>) this;
+        case INTEGER:
+          return (Literal<T>) new IntegerLiteral(value().intValue());
+        case LONG:
+          return (Literal<T>) new LongLiteral(value().longValue());
+        case FLOAT:
+          return (Literal<T>) new FloatLiteral(value().floatValue());
+        case DOUBLE:
+          return (Literal<T>) new DoubleLiteral(value().doubleValue());
+        case DATE:
+          return (Literal<T>) new DateLiteral(value().intValue());
+        case DECIMAL:
+          int scale = ((Types.DecimalType) type).scale();
+          // rounding mode isn't necessary, but pass one to avoid warnings
+          return (Literal<T>)
+                  new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
+        default:
+          return null;
+      }
+    }
+
+    @Override
+    protected Type.TypeID typeId() {
+      return Type.TypeID.SHORT;
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Type.java
+++ b/api/src/main/java/org/apache/iceberg/types/Type.java
@@ -30,6 +30,8 @@ import org.apache.iceberg.StructLike;
 public interface Type extends Serializable {
   enum TypeID {
     BOOLEAN(Boolean.class),
+    BYTE(Integer.class),
+    SHORT(Integer.class),
     INTEGER(Integer.class),
     LONG(Long.class),
     FLOAT(Float.class),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
@@ -32,8 +32,8 @@ public class TestLiteralSerialization {
     Literal[] literals =
         new Literal[] {
           Literal.of(false),
-          Literal.of(new Byte("3")),
-          Literal.of(new Short("3")),
+          Literal.of(Byte.parseByte("3")),
+          Literal.of(Short.parseShort("3")),
           Literal.of(34),
           Literal.of(35L),
           Literal.of(36.75F),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestLiteralSerialization.java
@@ -32,6 +32,8 @@ public class TestLiteralSerialization {
     Literal[] literals =
         new Literal[] {
           Literal.of(false),
+          Literal.of(new Byte("3")),
+          Literal.of(new Short("3")),
           Literal.of(34),
           Literal.of(35L),
           Literal.of(36.75F),


### PR DESCRIPTION
Spark 3 fail to plan query with filter on short type literal 

i.e. `select * from some_hive_table_with_smallint_column where small_int_column = 1`

where `small_int_column` is a smallint type column. So even if the 1 is cast as int or the `small_int_column` is cast as int, Spark will convert the 1 literal to short type. When this filter (with short type literal) is pushed down to Iceberg, Iceberg throws an Exception saying that Cannot create expression literal from java.lang.Short

This problem is also reproducible when the column is tinyint. In this case, Iceberg throws an Exception saying that Cannot create expression literal from java.lang.Byte

Note that this query works in Spark 2.4 as Spark 2.4 doesn't push down the query to Iceberg.