### PR TITLE
Spark 3.4: Only override the JobGroupInfo property if it does not exist

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/JobGroupUtils.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/JobGroupUtils.java
@@ -40,12 +40,12 @@ public class JobGroupUtils {
     return new JobGroupInfo(groupId, description, Boolean.parseBoolean(interruptOnCancel));
   }
 
-  public static void setJobGroupInfo(
-      SparkContext sparkContext, JobGroupInfo info, Boolean override) {
-    if (override || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_GROUP_ID))) {
+  private static void setJobGroupInfo(
+      SparkContext sparkContext, JobGroupInfo info, boolean overwrite) {
+    if (overwrite || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_GROUP_ID))) {
       sparkContext.setLocalProperty(JOB_GROUP_ID, info.groupId());
     }
-    if (override || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_INTERRUPT_ON_CANCEL))) {
+    if (overwrite || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_INTERRUPT_ON_CANCEL))) {
       sparkContext.setLocalProperty(
           JOB_INTERRUPT_ON_CANCEL, String.valueOf(info.interruptOnCancel()));
     }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/JobGroupUtils.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/JobGroupUtils.java
@@ -40,15 +40,21 @@ public class JobGroupUtils {
     return new JobGroupInfo(groupId, description, Boolean.parseBoolean(interruptOnCancel));
   }
 
-  private static void setJobGroupInfo(
+  public static void setJobGroupInfo(SparkContext sparkContext, JobGroupInfo info) {
+    setJobGroupInfo(sparkContext, info, true);
+  }
+
+  public static void setJobGroupInfo(
       SparkContext sparkContext, JobGroupInfo info, boolean overwrite) {
     if (overwrite || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_GROUP_ID))) {
       sparkContext.setLocalProperty(JOB_GROUP_ID, info.groupId());
     }
+
     if (overwrite || StringUtils.isBlank(sparkContext.getLocalProperty(JOB_INTERRUPT_ON_CANCEL))) {
       sparkContext.setLocalProperty(
           JOB_INTERRUPT_ON_CANCEL, String.valueOf(info.interruptOnCancel()));
     }
+
     sparkContext.setLocalProperty(JOB_GROUP_DESC, info.description());
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.actions;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.spark.JobGroupInfo;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.spark.scheduler.SparkListener;
+import org.apache.spark.scheduler.SparkListenerJobStart;
+import org.apache.spark.sql.SparkSession;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestBaseSparkAction extends SparkTestBase {
+
+  @Test
+  public void testCancelSparkActionJob() throws InterruptedException {
+    String groupId = "test-group-001";
+    AtomicReference<Boolean> result = new AtomicReference<>();
+    CountDownLatch latch = new CountDownLatch(1);
+    spark
+        .sparkContext()
+        .addSparkListener(
+            new SparkListener() {
+              @Override
+              public void onJobStart(SparkListenerJobStart jobStart) {
+                latch.countDown();
+              }
+            });
+    Thread thread =
+        new Thread(
+            () -> {
+              sparkContext.setJobGroup(groupId, "test-cancel-spark-action-job", true);
+              String expectedErrMsg = "cancelled job group " + groupId;
+              SleepSparkAction action = new SleepSparkAction(spark, 10000L, expectedErrMsg);
+              result.set(action.execute());
+            });
+    thread.start();
+    latch.await();
+    sparkContext.cancelJobGroup(groupId);
+    thread.join();
+    Assert.assertFalse(result.get());
+  }
+
+  private class SleepSparkAction extends BaseSparkAction<SleepSparkAction> {
+
+    private Long sleep;
+    private String expectedErrMsg;
+
+    protected SleepSparkAction(SparkSession spark, Long sleep, String expectedErrMsg) {
+      super(spark);
+      this.sleep = sleep;
+      this.expectedErrMsg = expectedErrMsg;
+    }
+
+    private Boolean execute() {
+      JobGroupInfo info = newJobGroupInfo("TEST-SLEEP", "Test Sleep");
+      return withJobGroupInfo(info, this::doExecute);
+    }
+
+    private Boolean doExecute() {
+      try {
+        spark().sql("select java_method('java.lang.Thread', 'sleep', " + sleep + "L)").collect();
+        return true;
+      } catch (Exception e) {
+        Assert.assertTrue(e.getMessage().contains(expectedErrMsg));
+        return false;
+      }
+    }
+
+    @Override
+    protected SleepSparkAction self() {
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
close #8422