### PR TITLE
Core, Spark 3.4:  Write properties of `PositionDeletesTable` should respect ones of `BaseTable`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -166,7 +166,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
 
   @Override
   public Map<String, String> properties() {
-    return table().properties();
+    return ImmutableMap.of();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -166,7 +166,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
 
   @Override
   public Map<String, String> properties() {
-    return ImmutableMap.of();
+    return table.properties();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -166,7 +166,7 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
 
   @Override
   public Map<String, String> properties() {
-    return table.properties();
+    return table().properties();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
+++ b/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
@@ -21,9 +21,11 @@ package org.apache.iceberg;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
@@ -91,6 +93,16 @@ public class PositionDeletesTable extends BaseMetadataTable {
   @Override
   public Map<Integer, PartitionSpec> specs() {
     return specs;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    // The write properties are needed by PositionDeletesRewriteAction,
+    // these properties should respect the ones of BaseTable.
+    return Collections.unmodifiableMap(
+        table().properties().entrySet().stream()
+            .filter(entry -> entry.getKey().startsWith("write."))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
   private Schema calculateSchema() {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -195,7 +195,6 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
       Assertions.assertThat(getCompressionType(inputFile))
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
-
   }
 
   private String getCompressionType(InputFile inputFile) throws Exception {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -182,21 +182,20 @@ public class TestCompressionSettings extends SparkCatalogTestBase {
           .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
 
-    if (PARQUET.equals(format)) {
-      SparkActions.get(spark)
-          .rewritePositionDeletes(table)
-          .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
-          .execute();
-      table.refresh();
-      deleteManifestFiles = table.currentSnapshot().deleteManifests(table.io());
-      try (ManifestReader<DeleteFile> reader =
-          ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
-        DeleteFile file = reader.iterator().next();
-        InputFile inputFile = table.io().newInputFile(file.path().toString());
-        Assertions.assertThat(getCompressionType(inputFile))
-            .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
-      }
+    SparkActions.get(spark)
+        .rewritePositionDeletes(table)
+        .option(SizeBasedFileRewriter.REWRITE_ALL, "true")
+        .execute();
+    table.refresh();
+    deleteManifestFiles = table.currentSnapshot().deleteManifests(table.io());
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(deleteManifestFiles.get(0), table.io(), specMap)) {
+      DeleteFile file = reader.iterator().next();
+      InputFile inputFile = table.io().newInputFile(file.path().toString());
+      Assertions.assertThat(getCompressionType(inputFile))
+          .isEqualToIgnoringCase(properties.get(COMPRESSION_CODEC));
     }
+
   }
 
   private String getCompressionType(InputFile inputFile) throws Exception {


### PR DESCRIPTION
Address the comment https://github.com/apache/iceberg/pull/8313#discussion_r1295749631