### PR TITLE
Core: Fix skipped file counts in ManifestReader with deleted entries

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanPlanningAndReporting.java
@@ -215,19 +215,24 @@ public class TestScanPlanningAndReporting extends TableTestBase {
     Table table =
         TestTables.create(
             tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
-    table.newAppend().appendFile(FILE_A).appendFile(FILE_D).commit();
-    table.newAppend().appendFile(FILE_B).appendFile(FILE_C).commit();
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).appendFile(FILE_D).commit();
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_A2).commit();
+    table.newAppend().appendFile(FILE_C).commit();
     TableScan tableScan = table.newScan();
 
+    List<FileScanTask> fileTasks = Lists.newArrayList();
     try (CloseableIterable<FileScanTask> fileScanTasks =
         tableScan.filter(Expressions.equal("data", "1")).planFiles()) {
-      fileScanTasks.forEach(task -> {});
+      fileScanTasks.forEach(fileTasks::add);
     }
+    assertThat(fileTasks)
+        .singleElement()
+        .satisfies(task -> assertThat(task.file().path()).isEqualTo(FILE_D.path()));
 
     ScanReport scanReport = reporter.lastReport();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo(tableName);
-    assertThat(scanReport.snapshotId()).isEqualTo(2L);
+    assertThat(scanReport.snapshotId()).isEqualTo(3L);
     ScanMetricsResult result = scanReport.scanMetrics();
     assertThat(result.skippedDataFiles().value()).isEqualTo(1);
     assertThat(result.skippedDeleteFiles().value()).isEqualTo(0);
@@ -236,9 +241,9 @@ public class TestScanPlanningAndReporting extends TableTestBase {
     assertThat(result.resultDeleteFiles().value()).isEqualTo(0);
     assertThat(result.scannedDataManifests().value()).isEqualTo(1);
     assertThat(result.scannedDeleteManifests().value()).isEqualTo(0);
-    assertThat(result.skippedDataManifests().value()).isEqualTo(1);
+    assertThat(result.skippedDataManifests().value()).isEqualTo(2);
     assertThat(result.skippedDeleteManifests().value()).isEqualTo(0);
-    assertThat(result.totalDataManifests().value()).isEqualTo(2);
+    assertThat(result.totalDataManifests().value()).isEqualTo(3);
     assertThat(result.totalDeleteManifests().value()).isEqualTo(0);
     assertThat(result.totalFileSizeInBytes().value()).isEqualTo(10L);
     assertThat(result.totalDeleteFileSizeInBytes().value()).isEqualTo(0L);
@@ -250,20 +255,25 @@ public class TestScanPlanningAndReporting extends TableTestBase {
     Table table =
         TestTables.create(
             tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
-    table.newAppend().appendFile(FILE_A).appendFile(FILE_D).commit();
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).appendFile(FILE_D).commit();
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_A2).commit();
     table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_D2_DELETES).commit();
     table.newRowDelta().addDeletes(FILE_B_DELETES).addDeletes(FILE_C2_DELETES).commit();
     TableScan tableScan = table.newScan();
 
+    List<FileScanTask> fileTasks = Lists.newArrayList();
     try (CloseableIterable<FileScanTask> fileScanTasks =
         tableScan.filter(Expressions.equal("data", "1")).planFiles()) {
-      fileScanTasks.forEach(task -> {});
+      fileScanTasks.forEach(fileTasks::add);
     }
+    assertThat(fileTasks)
+        .singleElement()
+        .satisfies(task -> assertThat(task.file().path()).isEqualTo(FILE_D.path()));
 
     ScanReport scanReport = reporter.lastReport();
     assertThat(scanReport).isNotNull();
     assertThat(scanReport.tableName()).isEqualTo(tableName);
-    assertThat(scanReport.snapshotId()).isEqualTo(3L);
+    assertThat(scanReport.snapshotId()).isEqualTo(4L);
     ScanMetricsResult result = scanReport.scanMetrics();
     assertThat(result.totalPlanningDuration().totalDuration()).isGreaterThan(Duration.ZERO);
     assertThat(result.resultDataFiles().value()).isEqualTo(1);
@@ -272,9 +282,9 @@ public class TestScanPlanningAndReporting extends TableTestBase {
     assertThat(result.skippedDeleteFiles().value()).isEqualTo(1);
     assertThat(result.scannedDataManifests().value()).isEqualTo(1);
     assertThat(result.scannedDeleteManifests().value()).isEqualTo(1);
-    assertThat(result.skippedDataManifests().value()).isEqualTo(0);
+    assertThat(result.skippedDataManifests().value()).isEqualTo(1);
     assertThat(result.skippedDeleteManifests().value()).isEqualTo(1);
-    assertThat(result.totalDataManifests().value()).isEqualTo(1);
+    assertThat(result.totalDataManifests().value()).isEqualTo(2);
     assertThat(result.totalDeleteManifests().value()).isEqualTo(2);
     assertThat(result.totalFileSizeInBytes().value()).isEqualTo(10L);
     assertThat(result.totalDeleteFileSizeInBytes().value()).isEqualTo(10L);


### PR DESCRIPTION
This PR fixes skipped file counts in `ManifestReader` with deleted entries as discussed [here](https://github.com/apache/iceberg/pull/8123#discussion_r1275561171).