### PR TITLE
Spark 3.4: Set metricsReporter for CopyOnWriteScan/MergeOnReadScan/IncrementalAppendScan/ChangelogScan

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -480,7 +480,8 @@ public class SparkScanBuilder
             .fromSnapshotExclusive(startSnapshotId)
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
-            .project(expectedSchema);
+            .project(expectedSchema)
+            .metricsReporter(metricsReporter);
 
     if (endSnapshotId != null) {
       scan = scan.toSnapshot(endSnapshotId);
@@ -559,7 +560,8 @@ public class SparkScanBuilder
             .newIncrementalChangelogScan()
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
-            .project(expectedSchema);
+            .project(expectedSchema)
+            .metricsReporter(metricsReporter);
 
     if (startSnapshotId != null) {
       scan = scan.fromSnapshotExclusive(startSnapshotId);
@@ -630,7 +632,8 @@ public class SparkScanBuilder
             .useSnapshot(snapshotId)
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
-            .project(expectedSchema);
+            .project(expectedSchema)
+            .metricsReporter(metricsReporter);
 
     scan = configureSplitPlanning(scan);
 
@@ -666,7 +669,8 @@ public class SparkScanBuilder
             .ignoreResiduals()
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
-            .project(expectedSchema);
+            .project(expectedSchema)
+            .metricsReporter(metricsReporter);
 
     scan = configureSplitPlanning(scan);
 


### PR DESCRIPTION
close #8444

test sql:

```
CREATE TABLE wangzhen_test_iceberg_20230824_t3 (id bigint, name string)
USING iceberg;

INSERT INTO wangzhen_test_iceberg_20230824_t3 VALUES (4, 'd'),(5, 'e'),(6, 'f');
delete from wangzhen_test_iceberg_20230824_t3 where id = 5;
```

ui before:
![image](https://github.com/apache/iceberg/assets/17894939/e9ec1460-ce50-471e-baac-fe2d08f6042a)

after:
![after](https://github.com/apache/iceberg/assets/17894939/16d9574f-003f-480e-b646-9ac731c655bb)

