### PR TITLE
Spark: value list of IN/NOT_IN containing null value should not be converted to Iceberg expression

### DIFF
--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -161,10 +161,13 @@ public class SparkFilters {
 
         case IN:
           In inFilter = (In) filter;
+          Preconditions.checkArgument(
+              Stream.of(inFilter.values()).noneMatch(Objects::isNull),
+              "Expression can not be converted (in is not null-safe): %s",
+              filter);
           return in(
               unquote(inFilter.attribute()),
               Stream.of(inFilter.values())
-                  .filter(Objects::nonNull)
                   .map(SparkFilters::convertLiteral)
                   .collect(Collectors.toList()));
 
@@ -178,6 +181,10 @@ public class SparkFilters {
             // col NOT IN (1, 2) in Spark is equivalent to notNull(col) && notIn(col, 1, 2) in
             // Iceberg
             In childInFilter = (In) childFilter;
+            Preconditions.checkArgument(
+                Stream.of(childInFilter.values()).noneMatch(Objects::isNull),
+                "Expression can not be converted (notIn is not null-safe): %s",
+                filter);
             Expression notIn =
                 notIn(
                     unquote(childInFilter.attribute()),

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -433,11 +433,7 @@ public class SparkV2Filters {
                   return false;
                 }
 
-                Preconditions.checkNotNull(
-                    ((Literal<?>) lit).value(),
-                    "Expression can not be converted (in/notIn is not null-safe): %s",
-                    predicate);
-                return true;
+                return ((Literal<?>) lit).value() != null;
               });
     }
   }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -302,10 +302,16 @@ public class SparkTable
     Expression deleteExpr = Expressions.alwaysTrue();
 
     for (Predicate predicate : predicates) {
-      Expression expr = SparkV2Filters.convert(predicate);
-      if (expr != null) {
-        deleteExpr = Expressions.and(deleteExpr, expr);
-      } else {
+      try {
+        Expression expr = SparkV2Filters.convert(predicate);
+        if (expr != null) {
+          deleteExpr = Expressions.and(deleteExpr, expr);
+        } else {
+          return false;
+        }
+
+      } catch (Exception e) {
+        LOG.warn("Failed to check if table can be deleted with {}: {", predicate, e);
         return false;
       }
     }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -302,16 +302,10 @@ public class SparkTable
     Expression deleteExpr = Expressions.alwaysTrue();
 
     for (Predicate predicate : predicates) {
-      try {
-        Expression expr = SparkV2Filters.convert(predicate);
-        if (expr != null) {
-          deleteExpr = Expressions.and(deleteExpr, expr);
-        } else {
-          return false;
-        }
-
-      } catch (Exception e) {
-        LOG.warn("Failed to check if table can be deleted with {}: {", predicate, e);
+      Expression expr = SparkV2Filters.convert(predicate);
+      if (expr != null) {
+        deleteExpr = Expressions.and(deleteExpr, expr);
+      } else {
         return false;
       }
     }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -188,27 +188,19 @@ public class TestSparkFilters {
   public void testInValuesContainNull() {
     // Values only contains null
     In inNull = In.apply("col", new String[] {null});
-    Assertions.assertThatThrownBy(() -> SparkFilters.convert(inNull))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expression can not be converted (in is not null-safe)");
+    Assertions.assertThat(SparkFilters.convert(inNull)).isNull();
 
     In in = In.apply("col", new String[] {null, "abc"});
-    Assertions.assertThatThrownBy(() -> SparkFilters.convert(in))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expression can not be converted (in is not null-safe)");
+    Assertions.assertThat(SparkFilters.convert(in)).isNull();
   }
 
   @Test
   public void testNotInNull() {
     // Values only contains null
     Not notInNull = Not.apply(In.apply("col", new String[] {null}));
-    Assertions.assertThatThrownBy(() -> SparkFilters.convert(notInNull))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expression can not be converted (notIn is not null-safe)");
+    Assertions.assertThat(SparkFilters.convert(notInNull)).isNull();
 
     Not notIn = Not.apply(In.apply("col", new String[] {null, "abc"}));
-    Assertions.assertThatThrownBy(() -> SparkFilters.convert(notIn))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Expression can not be converted (notIn is not null-safe)");
+    Assertions.assertThat(SparkFilters.convert(notIn)).isNull();
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -331,14 +331,14 @@ public class TestSparkV2Filters {
 
     // Values only contains null
     Predicate inNull = new Predicate("IN", expressions(namedReference, nullValue));
-    Expression expectedInNull = Expressions.in(col);
-    Expression actualInNull = SparkV2Filters.convert(inNull);
-    assertEquals(expectedInNull, actualInNull);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(inNull))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
 
     Predicate in = new Predicate("IN", expressions(namedReference, nullValue, value1, value2));
-    Expression expectedIn = Expressions.in(col, "value1", "value2");
-    Expression actualIn = SparkV2Filters.convert(in);
-    assertEquals(expectedIn, actualIn);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(in))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
   }
 
   @Test
@@ -351,17 +351,15 @@ public class TestSparkV2Filters {
 
     // Values only contains null
     Predicate notInNull = new Not(new Predicate("IN", expressions(namedReference, nullValue)));
-    Expression expectedNotInNull =
-        Expressions.and(Expressions.notNull(col), Expressions.notIn(col));
-    Expression actualNotInNull = SparkV2Filters.convert(notInNull);
-    assertEquals(expectedNotInNull, actualNotInNull);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notInNull))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
 
     Predicate notIn =
         new Not(new Predicate("IN", expressions(namedReference, nullValue, value1, value2)));
-    Expression expectedNotIn =
-        Expressions.and(Expressions.notNull(col), Expressions.notIn(col, "value1", "value2"));
-    Expression actualNotIn = SparkV2Filters.convert(notIn);
-    assertEquals(expectedNotIn, actualNotIn);
+    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notIn))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/TestSparkV2Filters.java
@@ -331,14 +331,10 @@ public class TestSparkV2Filters {
 
     // Values only contains null
     Predicate inNull = new Predicate("IN", expressions(namedReference, nullValue));
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(inNull))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
+    Assertions.assertThat(SparkV2Filters.convert(inNull)).isNull();
 
     Predicate in = new Predicate("IN", expressions(namedReference, nullValue, value1, value2));
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(in))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
+    Assertions.assertThat(SparkV2Filters.convert(in)).isNull();
   }
 
   @Test
@@ -351,15 +347,11 @@ public class TestSparkV2Filters {
 
     // Values only contains null
     Predicate notInNull = new Not(new Predicate("IN", expressions(namedReference, nullValue)));
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notInNull))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
+    Assertions.assertThat(SparkV2Filters.convert(notInNull)).isNull();
 
     Predicate notIn =
         new Not(new Predicate("IN", expressions(namedReference, nullValue, value1, value2)));
-    Assertions.assertThatThrownBy(() -> SparkV2Filters.convert(notIn))
-        .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("Expression can not be converted (in/notIn is not null-safe)");
+    Assertions.assertThat(SparkV2Filters.convert(notIn)).isNull();
   }
 
   @Test

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -99,8 +99,14 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
         ImmutableList.of(row(3, 300, "d3")));
 
     checkOnlyIcebergFilters(
+        "dep IN ('d1', 'd2')" /* query predicate */,
+        "dep IN ('d1', 'd2')" /* Iceberg scan filters */,
+        ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
+
+    checkFilters(
         "dep IN (null, 'd1')" /* query predicate */,
-        "dep IN ('d1')" /* Iceberg scan filters */,
+        "dep IN (null,d1)" /* Spark post scan filter */,
+        "" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
@@ -538,7 +544,7 @@ public class TestFilterPushDown extends SparkTestBaseWithCatalog {
     if (sparkFilter != null) {
       Assertions.assertThat(planAsString)
           .as("Post scan filter should match")
-          .contains("Filter (" + sparkFilter + ")");
+          .containsAnyOf("Filter (" + sparkFilter + ")", "Filter " + sparkFilter);
     } else {
       Assertions.assertThat(planAsString)
           .as("Should be no post scan filter")


### PR DESCRIPTION
Address the comments: https://github.com/apache/iceberg/pull/7886#discussion_r1280860230