### PR TITLE
Spark 3.4: Supports empty map and empty array expressions

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v3.4/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -171,11 +171,11 @@ constant
     ;
 
 stringMap
-    : MAP '(' constant (',' constant)* ')'
+    : MAP '(' (constant (',' constant)*)? ')'
     ;
 
 stringArray
-    : ARRAY '(' constant (',' constant)* ')'
+    : ARRAY '(' (constant (',' constant)*)? ')'
     ;
 
 booleanValue

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -179,22 +179,20 @@ public class TestCallStatementParser {
   public void testCallWithEmptyCollectionArg() throws ParseException {
     CallStatement call =
         (CallStatement) parser.parsePlan("CALL cat.system.func('test', Map(), Array())");
-    Assert.assertEquals(
-        ImmutableList.of("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+    Assertions.assertThat(JavaConverters.seqAsJavaList(call.name()))
+        .isEqualTo(ImmutableList.of("cat", "system", "func"));
 
-    Assert.assertEquals(3, call.args().size());
+    Assertions.assertThat(call.args().size()).isEqualTo(3);
 
     checkArg(call, 0, "test", DataTypes.StringType);
     // the map expr will be parsed as unresolved function ('Map())
     Expression actualMapExpr = call.args().apply(1).expr();
-    Assert.assertTrue(
-        "Arg must be unresolved function", actualMapExpr instanceof UnresolvedFunction);
-    Assert.assertEquals("Arg must match", "'Map()", actualMapExpr.toString());
+    Assertions.assertThat(actualMapExpr).isInstanceOf(UnresolvedFunction.class);
+    Assertions.assertThat(actualMapExpr.toString()).isEqualTo("'Map()");
     // the array expr will be parsed as unresolved function ('Array())
     Expression actualArrayExpr = call.args().apply(2).expr();
-    Assert.assertTrue(
-        "Arg must be unresolved function", actualArrayExpr instanceof UnresolvedFunction);
-    Assert.assertEquals("Arg must match", "'Array()", actualArrayExpr.toString());
+    Assertions.assertThat(actualArrayExpr).isInstanceOf(UnresolvedFunction.class);
+    Assertions.assertThat(actualArrayExpr.toString()).isEqualTo("'Array()");
   }
 
   private void checkArg(


### PR DESCRIPTION
closes #8448

IcebergSqlExtensions support parsing empty map and empty array expressions.