### PR TITLE
Spark 3.4: Remove unused parameters

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -371,8 +371,7 @@ class IcebergParseException(
     val builder = new StringBuilder
     builder ++= "\n" ++= message
     start match {
-      case Origin(
-          Some(l), Some(p), Some(startIndex), Some(stopIndex), Some(sqlText), Some(objectType), Some(objectName)) =>
+      case Origin(Some(l), Some(p), _, _, _, _, _) =>
         builder ++= s"(line $l, pos $p)\n"
         command.foreach { cmd =>
           val (above, below) = cmd.split("\n").splitAt(l)


### PR DESCRIPTION
closes #8462

refer: https://github.com/apache/spark/blob/fd7acd32895ed79094ff75aef8ff133966627ee4/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala#L232

before:

![before](https://github.com/apache/iceberg/assets/17894939/c48288fc-0fc8-42fa-a874-99964cdaf54e)

after:

![after](https://github.com/apache/iceberg/assets/17894939/dd89b046-ecdb-4960-9f60-a824d1239461)

