### PR TITLE
Arrow, Spark 3.4: Support vectorized reads with struct constants

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -57,12 +57,12 @@ public class VectorHolder {
     this.icebergField = icebergField;
   }
 
-  // Only used for returning dummy holder
+  /** A constructor used for dummy holders. */
   private VectorHolder() {
     this(null);
   }
 
-  // Only used for creating constant holders for fields
+  /** A constructor used for typed constant holders. */
   private VectorHolder(Types.NestedField field) {
     columnDescriptor = null;
     vector = null;
@@ -118,6 +118,8 @@ public class VectorHolder {
     return new ConstantVectorHolder<>(icebergField, numRows, constantValue);
   }
 
+  /** @deprecated since 1.4.0, will be removed in 1.5.0; use typed constant holders instead. */
+  @Deprecated
   public static <T> VectorHolder constantHolder(int numRows, T constantValue) {
     return new ConstantVectorHolder<>(numRows, constantValue);
   }
@@ -127,7 +129,7 @@ public class VectorHolder {
   }
 
   public static VectorHolder dummyHolder(int numRows) {
-    return new ConstantVectorHolder(numRows);
+    return new ConstantVectorHolder<>(numRows);
   }
 
   public boolean isDummy() {
@@ -147,6 +149,8 @@ public class VectorHolder {
       this.constantValue = null;
     }
 
+    /** @deprecated since 1.4.0, will be removed in 1.5.0; use typed constant holders instead. */
+    @Deprecated
     public ConstantVectorHolder(int numRows, T constantValue) {
       this.numRows = numRows;
       this.constantValue = constantValue;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -59,12 +59,17 @@ public class VectorHolder {
 
   // Only used for returning dummy holder
   private VectorHolder() {
+    this(null);
+  }
+
+  // Only used for creating constant holders for fields
+  private VectorHolder(Types.NestedField field) {
     columnDescriptor = null;
     vector = null;
     isDictionaryEncoded = false;
     dictionary = null;
     nullabilityHolder = null;
-    icebergField = null;
+    icebergField = field;
   }
 
   private VectorHolder(FieldVector vec, Types.NestedField field, NullabilityHolder nulls) {
@@ -97,7 +102,7 @@ public class VectorHolder {
   }
 
   public Type icebergType() {
-    return icebergField.type();
+    return icebergField != null ? icebergField.type() : null;
   }
 
   public Types.NestedField icebergField() {
@@ -108,8 +113,13 @@ public class VectorHolder {
     return vector.getValueCount();
   }
 
+  public static <T> VectorHolder constantHolder(
+      Types.NestedField icebergField, int numRows, T constantValue) {
+    return new ConstantVectorHolder<>(icebergField, numRows, constantValue);
+  }
+
   public static <T> VectorHolder constantHolder(int numRows, T constantValue) {
-    return new ConstantVectorHolder(numRows, constantValue);
+    return new ConstantVectorHolder<>(numRows, constantValue);
   }
 
   public static VectorHolder deletedVectorHolder(int numRows) {
@@ -138,6 +148,12 @@ public class VectorHolder {
     }
 
     public ConstantVectorHolder(int numRows, T constantValue) {
+      this.numRows = numRows;
+      this.constantValue = constantValue;
+    }
+
+    public ConstantVectorHolder(Types.NestedField icebergField, int numRows, T constantValue) {
+      super(icebergField);
       this.numRows = numRows;
       this.constantValue = constantValue;
     }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -571,7 +571,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   public static class ConstantVectorReader<T> extends VectorizedArrowReader {
     private final T value;
 
-    /** @deprecated since 1.4.0, will be removed in 1.5.0. */
+    /** @deprecated since 1.4.0, will be removed in 1.5.0; use typed constant readers. */
     @Deprecated
     public ConstantVectorReader(T value) {
       this.value = value;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -93,7 +93,11 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   }
 
   private VectorizedArrowReader() {
-    this.icebergField = null;
+    this(null);
+  }
+
+  private VectorizedArrowReader(Types.NestedField icebergField) {
+    this.icebergField = icebergField;
     this.batchSize = DEFAULT_BATCH_SIZE;
     this.columnDescriptor = null;
     this.rootAlloc = null;
@@ -117,6 +121,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     TIME_MICROS,
     UUID,
     DICTIONARY
+  }
+
+  protected Types.NestedField icebergField() {
+    return icebergField;
   }
 
   @Override
@@ -563,13 +571,20 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   public static class ConstantVectorReader<T> extends VectorizedArrowReader {
     private final T value;
 
+    /** @deprecated since 1.4.0, will be removed in 1.5.0. */
+    @Deprecated
     public ConstantVectorReader(T value) {
+      this.value = value;
+    }
+
+    public ConstantVectorReader(Types.NestedField icebergField, T value) {
+      super(icebergField);
       this.value = value;
     }
 
     @Override
     public VectorHolder read(VectorHolder reuse, int numValsToRead) {
-      return VectorHolder.constantHolder(numValsToRead, value);
+      return VectorHolder.constantHolder(icebergField(), numValsToRead, value);
     }
 
     @Override

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedReaderBuilder.java
@@ -26,6 +26,8 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.arrow.ArrowAllocation;
+import org.apache.iceberg.arrow.vectorized.VectorizedArrowReader.ConstantVectorReader;
+import org.apache.iceberg.arrow.vectorized.VectorizedArrowReader.DeletedVectorReader;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -83,7 +85,7 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
       int id = field.fieldId();
       VectorizedReader<?> reader = readersById.get(id);
       if (idToConstant.containsKey(id)) {
-        reorderedFields.add(new VectorizedArrowReader.ConstantVectorReader<>(idToConstant.get(id)));
+        reorderedFields.add(new ConstantVectorReader<>(field, idToConstant.get(id)));
       } else if (id == MetadataColumns.ROW_POSITION.fieldId()) {
         if (setArrowValidityVector) {
           reorderedFields.add(VectorizedArrowReader.positionsWithSetArrowValidityVector());
@@ -91,7 +93,7 @@ public class VectorizedReaderBuilder extends TypeWithSchemaVisitor<VectorizedRea
           reorderedFields.add(VectorizedArrowReader.positions());
         }
       } else if (id == MetadataColumns.IS_DELETED.fieldId()) {
-        reorderedFields.add(new VectorizedArrowReader.DeletedVectorReader());
+        reorderedFields.add(new DeletedVectorReader());
       } else if (reader != null) {
         reorderedFields.add(reader);
       } else {

--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -127,6 +127,10 @@ public class MetadataColumns {
     return name.equals(PARTITION_COLUMN_NAME) || META_COLUMNS.containsKey(name);
   }
 
+  public static boolean isMetadataColumn(int id) {
+    return META_IDS.contains(id);
+  }
+
   public static boolean nonMetadataColumn(String name) {
     return !isMetadataColumn(name);
   }

--- a/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkPlanUtil.java
+++ b/spark/v3.4/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkPlanUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static scala.collection.JavaConverters.seqAsJavaListConverter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.execution.CommandResultExec;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper;
+import org.apache.spark.sql.execution.datasources.v2.BatchScanExec;
+import scala.collection.Seq;
+
+public class SparkPlanUtil {
+
+  private static final AdaptiveSparkPlanHelper SPARK_HELPER = new AdaptiveSparkPlanHelper() {};
+
+  private SparkPlanUtil() {}
+
+  public static List<SparkPlan> collectLeaves(SparkPlan plan) {
+    return toJavaList(SPARK_HELPER.collectLeaves(actualPlan(plan)));
+  }
+
+  public static List<SparkPlan> collectBatchScans(SparkPlan plan) {
+    List<SparkPlan> leaves = collectLeaves(plan);
+    return leaves.stream()
+        .filter(scan -> scan instanceof BatchScanExec)
+        .collect(Collectors.toList());
+  }
+
+  private static SparkPlan actualPlan(SparkPlan plan) {
+    if (plan instanceof CommandResultExec) {
+      return ((CommandResultExec) plan).commandPhysicalPlan();
+    } else {
+      return plan;
+    }
+  }
+
+  private static <T> List<T> toJavaList(Seq<T> seq) {
+    return seqAsJavaListConverter(seq).asJava();
+  }
+}

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorBuilder.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.data.vectorized;
 
 import org.apache.iceberg.arrow.vectorized.VectorHolder;
 import org.apache.iceberg.arrow.vectorized.VectorHolder.ConstantVectorHolder;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.vectorized.ColumnVector;
 
@@ -38,8 +39,10 @@ class ColumnVectorBuilder {
       if (holder instanceof VectorHolder.DeletedVectorHolder) {
         return new DeletedColumnVector(Types.BooleanType.get(), isDeleted);
       } else if (holder instanceof ConstantVectorHolder) {
-        return new ConstantColumnVector(
-            Types.IntegerType.get(), numRows, ((ConstantVectorHolder<?>) holder).getConstant());
+        ConstantVectorHolder<?> constantHolder = (ConstantVectorHolder<?>) holder;
+        Type icebergType = constantHolder.icebergType();
+        Object value = constantHolder.getConstant();
+        return new ConstantColumnVector(icebergType, numRows, value);
       } else {
         throw new IllegalStateException("Unknown dummy vector holder: " + holder);
       }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -20,7 +20,11 @@ package org.apache.iceberg.spark.data.vectorized;
 
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
@@ -28,11 +32,14 @@ import org.apache.spark.unsafe.types.UTF8String;
 
 class ConstantColumnVector extends ColumnVector {
 
+  private final Type icebergType;
   private final Object constant;
   private final int batchSize;
 
-  ConstantColumnVector(Type type, int batchSize, Object constant) {
-    super(SparkSchemaUtil.convert(type));
+  ConstantColumnVector(Type icebergType, int batchSize, Object constant) {
+    // the type may be unknown for NULL vectors
+    super(icebergType != null ? SparkSchemaUtil.convert(icebergType) : null);
+    this.icebergType = icebergType;
     this.constant = constant;
     this.batchSize = batchSize;
   }
@@ -92,12 +99,12 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public ColumnarArray getArray(int rowId) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    throw new UnsupportedOperationException(this.getClass() + " does not implement getArray");
   }
 
   @Override
   public ColumnarMap getMap(int ordinal) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    throw new UnsupportedOperationException(this.getClass() + " does not implement getMap");
   }
 
   @Override
@@ -117,6 +124,18 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    InternalRow constantAsRow = (InternalRow) constant;
+    Object childConstant = constantAsRow.get(ordinal, childType(ordinal));
+    return new ConstantColumnVector(childIcebergType(ordinal), batchSize, childConstant);
+  }
+
+  private Type childIcebergType(int ordinal) {
+    Types.StructType icebergTypeAsStruct = (Types.StructType) icebergType;
+    return icebergTypeAsStruct.fields().get(ordinal).type();
+  }
+
+  private DataType childType(int ordinal) {
+    StructType typeAsStruct = (StructType) type;
+    return typeAsStruct.fields()[ordinal].dataType();
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -19,6 +19,10 @@
 package org.apache.iceberg.spark.source;
 
 import static org.apache.iceberg.Files.localOutput;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.functions.monotonically_increasing_id;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +53,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -93,26 +98,67 @@ public class TestParquetScan extends AvroDataTest {
                 schema,
                 type -> type.isMapType() && type.asMapType().keyType() != Types.StringType.get()));
 
+    Table table = createTable(schema);
+
+    // Important: use the table's schema for the rest of the test
+    // When tables are created, the column ids are reassigned.
+    List<GenericData.Record> expected = RandomData.generateList(table.schema(), 100, 1L);
+    writeRecords(table, expected);
+
+    configureVectorization(table);
+
+    Dataset<Row> df = spark.read().format("iceberg").load(table.location());
+
+    List<Row> rows = df.collectAsList();
+    Assert.assertEquals("Should contain 100 rows", 100, rows.size());
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      TestHelpers.assertEqualsSafe(table.schema().asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+
+  @Test
+  public void testEmptyTableProjection() throws IOException {
+    Types.StructType structType =
+        Types.StructType.of(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "data", Types.StringType.get()),
+            required(102, "b", Types.BooleanType.get()),
+            optional(103, "i", Types.IntegerType.get()));
+    Table table = createTable(new Schema(structType.fields()));
+
+    List<GenericData.Record> expected = RandomData.generateList(table.schema(), 100, 1L);
+    writeRecords(table, expected);
+
+    configureVectorization(table);
+
+    List<Row> rows =
+        spark
+            .read()
+            .format("iceberg")
+            .load(table.location())
+            .select(monotonically_increasing_id())
+            .collectAsList();
+    assertThat(rows).hasSize(100);
+  }
+
+  private Table createTable(Schema schema) throws IOException {
     File parent = temp.newFolder("parquet");
     File location = new File(parent, "test");
-    File dataFolder = new File(location, "data");
+    HadoopTables tables = new HadoopTables(CONF);
+    return tables.create(schema, PartitionSpec.unpartitioned(), location.toString());
+  }
+
+  private void writeRecords(Table table, List<GenericData.Record> records) throws IOException {
+    File dataFolder = new File(table.location(), "data");
     dataFolder.mkdirs();
 
     File parquetFile =
         new File(dataFolder, FileFormat.PARQUET.addExtension(UUID.randomUUID().toString()));
 
-    HadoopTables tables = new HadoopTables(CONF);
-    Table table = tables.create(schema, PartitionSpec.unpartitioned(), location.toString());
-
-    // Important: use the table's schema for the rest of the test
-    // When tables are created, the column ids are reassigned.
-    Schema tableSchema = table.schema();
-
-    List<GenericData.Record> expected = RandomData.generateList(tableSchema, 100, 1L);
-
     try (FileAppender<GenericData.Record> writer =
-        Parquet.write(localOutput(parquetFile)).schema(tableSchema).build()) {
-      writer.addAll(expected);
+        Parquet.write(localOutput(parquetFile)).schema(table.schema()).build()) {
+      writer.addAll(records);
     }
 
     DataFile file =
@@ -123,18 +169,12 @@ public class TestParquetScan extends AvroDataTest {
             .build();
 
     table.newAppend().appendFile(file).commit();
+  }
+
+  private void configureVectorization(Table table) {
     table
         .updateProperties()
         .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, String.valueOf(vectorized))
         .commit();
-
-    Dataset<Row> df = spark.read().format("iceberg").load(location.toString());
-
-    List<Row> rows = df.collectAsList();
-    Assert.assertEquals("Should contain 100 rows", 100, rows.size());
-
-    for (int i = 0; i < expected.size(); i += 1) {
-      TestHelpers.assertEqualsSafe(tableSchema.asStruct(), expected.get(i), rows.get(i));
-    }
   }
 }


### PR DESCRIPTION
Our merge-on-read queries can't benefit from vectorized reads because of `_partition` metadata column being projected for the write distribution. This PR adapts our Arrow and Spark 3.4 logic to support such structs.