### PR TITLE
Core: Fix REST catalog tests with default v2 tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1141,7 +1141,7 @@ public class TableMetadata implements Serializable {
           snapshot.snapshotId());
 
       ValidationException.check(
-          formatVersion == 1 || snapshot.sequenceNumber() > lastSequenceNumber,
+          formatVersion == 1 || snapshot.sequenceNumber() > lastSequenceNumber || snapshot.parentId() == null,
           "Cannot add snapshot with sequence number %s older than last sequence number %s",
           snapshot.sequenceNumber(),
           lastSequenceNumber);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1141,7 +1141,9 @@ public class TableMetadata implements Serializable {
           snapshot.snapshotId());
 
       ValidationException.check(
-          formatVersion == 1 || snapshot.sequenceNumber() > lastSequenceNumber || snapshot.parentId() == null,
+          formatVersion == 1
+              || snapshot.sequenceNumber() > lastSequenceNumber
+              || snapshot.parentId() == null,
           "Cannot add snapshot with sequence number %s older than last sequence number %s",
           snapshot.sequenceNumber(),
           lastSequenceNumber);

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -60,7 +60,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
-import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.assertj.core.api.Assertions;
@@ -2183,9 +2182,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testConcurrentReplaceTransactions() {
     C catalog = catalog();
 
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
-
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
     }
@@ -2237,9 +2233,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testConcurrentReplaceTransactionSchema() {
     C catalog = catalog();
 
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
-
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
     }
@@ -2278,9 +2271,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   @Test
   public void testConcurrentReplaceTransactionSchema2() {
     C catalog = catalog();
-
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
@@ -2361,9 +2351,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testConcurrentReplaceTransactionPartitionSpec() {
     C catalog = catalog();
 
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
-
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
     }
@@ -2403,9 +2390,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   @Test
   public void testConcurrentReplaceTransactionPartitionSpec2() {
     C catalog = catalog();
-
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
@@ -2487,9 +2471,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   public void testConcurrentReplaceTransactionSortOrder() {
     C catalog = catalog();
 
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
-
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);
     }
@@ -2529,9 +2510,6 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   @Test
   public void testConcurrentReplaceTransactionSortOrderConflict() {
     C catalog = catalog();
-
-    // TODO: temporarily ignore this test for REST catalogs (issue #8390)
-    Assumptions.assumeFalse(catalog instanceof RESTCatalog);
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(NS);


### PR DESCRIPTION
This fixes #8390, which was a problem from #8381. The REST catalog was failing standard catalog tests because it would reuse a sequence number when a concurrent commit that added a snapshot.

The fix is to allow a reused sequence number when the entire table state is replaced; that is, when the snapshot has no parent. That is the easiest fix because the replace table code does not currently rewrite snapshot metadata on retry. Rewriting snapshot metadata in that case isn't necessary because there is no previous data so reusing a sequence number is safe.