### PR TITLE
Python: Set version prior `sdist` release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -49,17 +49,17 @@ jobs:
         run: pip3 install poetry
         working-directory: ./python
 
+      - name: Set version
+        run: python3 -m poetry version "${{ inputs.version }}"
+        working-directory: ./python
+        if: "${{ github.event.inputs.version != 'master' }}"
+
       # Publish the source distribution with the version that's in
       # the repository, otherwise the tests will fail
       - name: Compile source distribution
         run: python3 -m poetry build --format=sdist
         if: "${{ matrix.os == 'ubuntu-20.04' }}"
         working-directory: ./python
-
-      - name: Set version
-        run: python3 -m poetry version "${{ inputs.version }}"
-        working-directory: ./python
-        if: "${{ github.event.inputs.version != 'master' }}"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0


### PR DESCRIPTION
Otherwise, the `sdist` version will be set to a non-RC when releasing an RC version:

<img width="1379" alt="image" src="https://github.com/apache/iceberg/assets/1134248/82973254-f1f2-4d2f-8f87-9ded2c893e64">

Luckily this was caught before uploading.