### PR TITLE
Core: fix `NullPointerException` when calling `InMemoryLockManager#release` using Hadoop catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.util;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -253,7 +254,8 @@ public class LockManagers {
         return false;
       }
 
-      HEARTBEATS.remove(entityId).cancel(false);
+      Optional.ofNullable(HEARTBEATS.remove(entityId))
+          .ifPresent(future -> future.cancel(false));
       LOCKS.remove(entityId);
       return true;
     }

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -254,8 +254,7 @@ public class LockManagers {
         return false;
       }
 
-      Optional.ofNullable(HEARTBEATS.remove(entityId))
-          .ifPresent(future -> future.cancel(false));
+      Optional.ofNullable(HEARTBEATS.remove(entityId)).ifPresent(future -> future.cancel(false));
       LOCKS.remove(entityId);
       return true;
     }


### PR DESCRIPTION
This is a fix for an `NPE` problem that occurs when calling [InMemoryLockManager#release](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/util/LockManagers.java#L240C2-L240C2) using Hadoop catalog, as described in this issue(#4550). The problem arises when `lockManager#release` is finally called after renaming metadata ([HadoopTableOperations#renameToFinal](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java#L361C20-L361C20)).

The immediate cause of `NPE` is that the locked `entityId` has been removed from the [`HEARTBEATS`](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/util/LockManagers.java#L168), but still exists in `LOCKS`. Some concurrent operations, such as calling [InMemoryLockManager#close](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/util/LockManagers.java#L262), may result in this situation.

This `NPE` can potentially cause the manifest list files to be cleaned ([SnapshotProducer#cleanAll](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/SnapshotProducer.java#L402)). However, this could be a mistaken cleanup since when the `NPE` is thrown, the renaming metadata file may have already been completed. In this case, Iceberg considers the operation to be completed (although the `version-hint.text` has not yet been updated).

Closes #4550.