### PR TITLE
Nessie: Update NessieCatalog Javadoc about namespaces

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -51,14 +51,7 @@ import org.projectnessie.model.TableReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Nessie implementation of Iceberg Catalog.
- *
- * <p>A note on namespaces: Nessie namespaces are implicit and do not need to be explicitly created
- * or deleted. The create and delete namespace methods are no-ops for the NessieCatalog. One can
- * still list namespaces that have objects stored in them to assist with namespace-centric catalog
- * exploration.
- */
+/** Nessie implementation of Iceberg Catalog. */
 public class NessieCatalog extends BaseMetastoreCatalog
     implements AutoCloseable, SupportsNamespaces, Configurable<Object> {
 


### PR DESCRIPTION
Namespaces are not implicit anymore after Nessie 0.52.3 
https://projectnessie.org/blog/namespace-enforcement/