### PR TITLE
Core: Remove unused field from BaseSnapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -34,8 +34,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class BaseSnapshot implements Snapshot {
-  private static final long INITIAL_SEQUENCE_NUMBER = 0;
-
   private final long snapshotId;
   private final Long parentId;
   private final long sequenceNumber;


### PR DESCRIPTION
I think this field got superseded by the one from [TableMetadata](https://github.com/apache/iceberg/blob/5bd7c649e4743a61eace5f52517db9b5b56ff8e6/core/src/main/java/org/apache/iceberg/TableMetadata.java#L51). Hence, this has no callers.