### PR TITLE
Cache filesToImport variable in importSparkPartitions to avoid duplicated compute

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -607,6 +607,7 @@ public class SparkTableUtil {
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {
+      filesToImport.cache();
       Dataset<Row> importedFiles =
           filesToImport
               .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -601,6 +601,7 @@ public class SparkTableUtil {
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {
+      filesToImport.cache();
       Dataset<Row> importedFiles =
           filesToImport
               .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -602,6 +602,7 @@ public class SparkTableUtil {
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {
+      filesToImport.cache();
       Dataset<Row> importedFiles =
           filesToImport
               .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -565,6 +565,7 @@ public class SparkTableUtil {
             Encoders.javaSerialization(DataFile.class));
 
     if (checkDuplicateFiles) {
+      filesToImport.cache();
       Dataset<Row> importedFiles =
           filesToImport
               .map((MapFunction<DataFile, String>) f -> f.path().toString(), Encoders.STRING())


### PR DESCRIPTION
Add file operation with checkDuplicateFiles being false (default case) will lead to `filesToImport` being computed multiple times, this lead to slower of add file application.