### PR TITLE
Core: Avoid NPE when getting updateEvent in FastAppend

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -872,8 +872,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     Map<String, String> summary;
     if (justSaved == null) {
       // The snapshot just saved may not be present if the latest metadata couldn't be loaded due to
-      // eventual
-      // consistency problems in refresh.
+      // eventual consistency problems in refresh.
       LOG.warn("Failed to load committed snapshot: omitting sequence number from notifications");
       summary = summary();
     } else {


### PR DESCRIPTION
Similar to #2552, the NPE may also occur in the `FastAppend#updateEvent` method, and we should avoid it like that.