### PR TITLE
Prevent dropping last column.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -439,6 +439,8 @@ class SchemaUpdate implements UpdateSchema {
   @Override
   public void commit() {
     TableMetadata update = applyChangesToMetadata(base.updateSchema(apply(), lastColumnId));
+    if (update.schema().columns().size() == 0)
+      throw new UnsupportedOperationException("Unable to commit table without any columns.");
     ops.commit(base, update);
   }
 


### PR DESCRIPTION
This code intends to address the problem of allowing API dropping the last column of a table mentioned here: https://github.com/apache/iceberg/issues/8522