### PR TITLE
Core: Add a validation API to DeleteFiles which validates files exist prior to attempting to deletion.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DeleteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFiles.java
@@ -81,4 +81,15 @@ public interface DeleteFiles extends SnapshotUpdate<DeleteFiles> {
    * @return this for method chaining
    */
   DeleteFiles caseSensitive(boolean caseSensitive);
+
+  /**
+   * Enables validation that any files that are part of the deletion still exist when committing the
+   * operation.
+   *
+   * @return this for method chaining
+   */
+  default DeleteFiles validateFilesExist() {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " doesn't implement validateFilesExist");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/StreamingDelete.java
+++ b/core/src/main/java/org/apache/iceberg/StreamingDelete.java
@@ -28,6 +28,8 @@ import org.apache.iceberg.expressions.Expression;
  * CommitFailedException}.
  */
 public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implements DeleteFiles {
+  private boolean validateFilesToDeleteExist = false;
+
   protected StreamingDelete(String tableName, TableOperations ops) {
     super(tableName, ops);
   }
@@ -61,8 +63,21 @@ public class StreamingDelete extends MergingSnapshotProducer<DeleteFiles> implem
   }
 
   @Override
+  public DeleteFiles validateFilesExist() {
+    this.validateFilesToDeleteExist = true;
+    return this;
+  }
+
+  @Override
   public StreamingDelete toBranch(String branch) {
     targetBranch(branch);
     return this;
+  }
+
+  @Override
+  protected void validate(TableMetadata base, Snapshot parent) {
+    if (validateFilesToDeleteExist) {
+      failMissingDeletePaths();
+    }
   }
 }


### PR DESCRIPTION
Currently there is no validation on delete files API for verifying that the file to be deleted actually exists prior to the commit. This can cause unexpected behavior, for example:

1.) Rewrite Data files compacts FILE_A + some delete files
2.) Concurrently a DeleteFiles call was done for FILE_A.
3.) Deletion gets retried after 1 completes. At the point it retries, FILE_A no longer exists due to the compaction so the deletion is a no-op.

From a user's perspective when they go and query the table after 3, they'll still see the contents of FILE_A, even though the wouldn't expect it since they received a successful delete of FILE_A.

This change currently adds a new validation API as opposed to changing the behavior to always do strict validation for purpose of backwards compatibility. I wanted to open this up and discuss with the community to see about if we want the new API or if we just want to change this behavior since it's mainly just used by maintenance procedures and I'm not sure where the current behavior would be desired.

Also I'd need to compare what serializable isolation vs snapshot isolation should guarantee in this concurrent delete scenario.