### PR TITLE
Python: Add checks after building the wheels

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04, windows-2019, macos-11 ]
+        os: [ ubuntu-22.04, windows-2022, macos-11 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -46,11 +46,10 @@ jobs:
           python-version: '3.8'
 
       - name: Install poetry
-        run: pip3 install poetry
-        working-directory: ./python
+        run: pip install poetry
 
       - name: Set version
-        run: python3 -m poetry version "${{ inputs.version }}"
+        run: python -m poetry version "${{ inputs.version }}"
         working-directory: ./python
         if: "${{ github.event.inputs.version != 'master' }}"
 
@@ -69,6 +68,15 @@ jobs:
           config-file: "python/pyproject.toml"
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
+          CIBW_TEST_REQUIRES: "pytest moto"
+          CIBW_TEST_EXTRAS: "s3fs,glue"
+          # The -Werror is important. It will fail when PyIceberg falls back to the
+          # pure Python implementation, because that will emit a warning.
+          CIBW_TEST_COMMAND: "pytest -Werror {project}/python/tests/avro/test_decoder.py"
+          # There is an upstream issue with installing on MacOSX
+          # https://github.com/pypa/cibuildwheel/issues/1603
+          # disable those tests for now, we already know that it works
+          CIBW_TEST_SKIP: "*macosx*"
 
       - name: Add source distribution
         if: "${{ matrix.os == 'ubuntu-20.04' }}"

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -67,16 +67,17 @@ jobs:
           output-dir: wheelhouse
           config-file: "python/pyproject.toml"
         env:
+          # Ignore 32 bit architectures
+          CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
           CIBW_TEST_REQUIRES: "pytest moto"
           CIBW_TEST_EXTRAS: "s3fs,glue"
-          # The -Werror is important. It will fail when PyIceberg falls back to the
-          # pure Python implementation, because that will emit a warning.
           CIBW_TEST_COMMAND: "pytest -Werror {project}/python/tests/avro/test_decoder.py"
           # There is an upstream issue with installing on MacOSX
           # https://github.com/pypa/cibuildwheel/issues/1603
-          # disable those tests for now, we already know that it works
-          CIBW_TEST_SKIP: "*macosx*"
+          # Ignore tests for pypy since not all dependencies are compiled for it
+          # and would require a local rust build chain
+          CIBW_TEST_SKIP: "pp* *macosx*"
 
       - name: Add source distribution
         if: "${{ matrix.os == 'ubuntu-20.04' }}"

--- a/python/build-module.py
+++ b/python/build-module.py
@@ -25,8 +25,8 @@ allowed_to_fail = False
 
 
 def build_cython_extensions() -> None:
-    import Cython.Compiler.Options  # pyright: ignore [reportMissingImports]
-    from Cython.Build import build_ext, cythonize  # pyright: ignore [reportMissingImports]
+    import Cython.Compiler.Options
+    from Cython.Build import build_ext, cythonize
     from setuptools import Extension
     from setuptools.dist import Distribution
 
@@ -40,28 +40,20 @@ def build_cython_extensions() -> None:
         extra_compile_args = [
             "-O3",
         ]
-    # Relative to project root directory
-    include_dirs = {
-        "pyiceberg/",
-    }
 
-    extensions = [
-        Extension(
-            # Your .pyx file will be available to cpython at this location.
-            "pyiceberg.avro.decoder_fast",
-            [
-                "pyiceberg/avro/decoder_fast.pyx",
-            ],
-            include_dirs=list(include_dirs),
-            extra_compile_args=extra_compile_args,
-            language="c",
-        ),
-    ]
+    package_path = "pyiceberg"
 
-    for extension in extensions:
-        include_dirs.update(extension.include_dirs)
+    extension = Extension(
+        # Your .pyx file will be available to cpython at this location.
+        name="pyiceberg.avro.decoder_fast",
+        sources=[
+            os.path.join(package_path, "avro", "decoder_fast.pyx"),
+        ],
+        extra_compile_args=extra_compile_args,
+        language="c",
+    )
 
-    ext_modules = cythonize(extensions, include_path=list(include_dirs), language_level=3, annotate=True)
+    ext_modules = cythonize([extension], include_path=list(package_path), language_level=3, annotate=True)
     dist = Distribution({"ext_modules": ext_modules})
     cmd = build_ext(dist)
     cmd.ensure_finalized()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,7 +41,8 @@ packages = [
 ]
 include = [
   { path = "dev", format = "sdist" },
-  { path = "pyiceberg/**/*.so", format = "wheel" }
+  { path = "pyiceberg/**/*.so", format = "wheel" },
+  { path = "pyiceberg/**/*.pyd", format = "wheel" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This will run the Avro tests after building the wheel. Also refactored the `conftest.py` a bit so we can load the fixtures without pyarrow installed (this speeds up the tests quite a bit, since it will re-install it for every environment).

I've validated on my own fork: https://github.com/Fokko/incubator-iceberg/actions/runs/6133147394