### PR TITLE
AWS: Throw relevant exception at namespaceExists check usage in Glue Catalog

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -287,7 +287,12 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    namespaceExists(namespace);
+    // check if namespace exists
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException(
+          "Cannot list tables of namespace %s because namespace %s does not exist",
+          namespace, namespace);
+    }
     // should be safe to list all before returning the list, instead of dynamically load the list.
     String nextToken = null;
     List<TableIdentifier> results = Lists.newArrayList();
@@ -524,7 +529,11 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    namespaceExists(namespace);
+    // check if namespace exists
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException(
+          "Cannot drop namespace %s because namespace %s does not exist.", namespace, namespace);
+    }
 
     GetTablesResponse response =
         glue.getTables(

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -286,12 +286,11 @@ public class GlueCatalog extends BaseMetastoreCatalog
   }
 
   @Override
-  public List<TableIdentifier> listTables(Namespace namespace) {
+  public List<TableIdentifier> listTables(Namespace namespace) throws NoSuchNamespaceException {
     // check if namespace exists
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
-          "Cannot list tables of namespace %s because namespace %s does not exist",
-          namespace, namespace);
+          "Cannot list tables of namespace %s because it does not exist", namespace);
     }
     // should be safe to list all before returning the list, instead of dynamically load the list.
     String nextToken = null;
@@ -531,8 +530,8 @@ public class GlueCatalog extends BaseMetastoreCatalog
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
     // check if namespace exists
     if (!namespaceExists(namespace)) {
-      throw new NoSuchNamespaceException(
-          "Cannot drop namespace %s because namespace %s does not exist.", namespace, namespace);
+      LOG.error("Cannot drop namespace {} because it does not exist.", namespace);
+      return false;
     }
 
     GetTablesResponse response =

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -287,7 +287,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) throws NoSuchNamespaceException {
-    // check if namespace exists
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
           "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
@@ -528,9 +527,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    // check if namespace exists
     if (!namespaceExists(namespace)) {
-      LOG.error("Cannot drop namespace {} because it does not exist.", namespace);
       return false;
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -290,7 +290,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     // check if namespace exists
     if (!namespaceExists(namespace)) {
       throw new NoSuchNamespaceException(
-          "Cannot list tables of namespace %s because it does not exist", namespace);
+          "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
     }
     // should be safe to list all before returning the list, instead of dynamically load the list.
     String nextToken = null;

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -559,7 +559,7 @@ public class TestGlueCatalog {
   }
 
   @Test
-  public void testDropNamespaceThatDoesNotExists() {
+  public void testDropNonExistingNamespace() {
     Mockito.doThrow(EntityNotFoundException.class)
         .when(glue)
         .getDatabase(Mockito.any(GetDatabaseRequest.class));

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -271,7 +271,7 @@ public class TestGlueCatalog {
   }
 
   @Test
-  public void testListTablesWithNamespaceDoesNotExists() {
+  public void testListTablesWithNonExistingNamespace() {
     Mockito.doThrow(EntityNotFoundException.class)
         .when(glue)
         .getDatabase(Mockito.any(GetDatabaseRequest.class));

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -277,7 +277,7 @@ public class TestGlueCatalog {
         .getDatabase(Mockito.any(GetDatabaseRequest.class));
     Assertions.assertThatThrownBy(() -> glueCatalog.listTables(Namespace.of("non_existent_db")))
         .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessage("Cannot list tables of namespace non_existent_db because it does not exist");
+        .hasMessage("Cannot list tables for namespace. Namespace does not exist: non_existent_db");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -275,10 +275,9 @@ public class TestGlueCatalog {
     Mockito.doThrow(EntityNotFoundException.class)
         .when(glue)
         .getDatabase(Mockito.any(GetDatabaseRequest.class));
-    Assertions.assertThatThrownBy(() -> glueCatalog.listTables(Namespace.of("invalid_db")))
+    Assertions.assertThatThrownBy(() -> glueCatalog.listTables(Namespace.of("non_existent_db")))
         .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessage(
-            "Cannot list tables of namespace invalid_db because namespace invalid_db does not exist");
+        .hasMessage("Cannot list tables of namespace non_existent_db because it does not exist");
   }
 
   @Test
@@ -564,10 +563,7 @@ public class TestGlueCatalog {
     Mockito.doThrow(EntityNotFoundException.class)
         .when(glue)
         .getDatabase(Mockito.any(GetDatabaseRequest.class));
-    Assertions.assertThatThrownBy(() -> glueCatalog.dropNamespace(Namespace.of("invalid_db")))
-        .isInstanceOf(NoSuchNamespaceException.class)
-        .hasMessage(
-            "Cannot drop namespace invalid_db because namespace invalid_db does not exist.");
+    Assertions.assertThat(glueCatalog.dropNamespace(Namespace.of("non_existent_db"))).isFalse();
   }
 
   @Test


### PR DESCRIPTION
**Context :**

- The `namespaceExists` check in [SupportsNamespaces](https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/catalog/SupportsNamespaces.java#L151-L164) behaviour of catalog returns either true or false but doesn't throw NoSuchNamespaceException if namespace doesn't exists.

**Usage in Glue Catalog :**

- Below methods of Glue Catalog does `namespaceExists` validation as a pre-check.
    - `listTables(Namespace namespace)`
    - `dropNamespace(Namespace namespace)`
- Current pre-check is no-op as it doesn't take any action when namespace doesn't exists.

**PR Contents :**

- This PR attempts to make below changes when `namespaceExists` returns false as a pre-check, 
    -  `listTables` to throw `NoSuchNamespaceException`
    - `dropNamespace` returns `false` 
- `listTables` method signature includes `NoSuchNamespaceException` for consumers to handle.
