### PR TITLE
Python: Add integration tests for use_ref

### DIFF
--- a/python/dev/provision.py
+++ b/python/dev/provision.py
@@ -136,6 +136,25 @@ VALUES
 
 spark.sql(
     """
+ALTER TABLE default.test_positional_mor_deletes CREATE TAG tag_12
+    """
+)
+
+spark.sql(
+    """
+ALTER TABLE default.test_positional_mor_deletes CREATE BRANCH without_5
+    """
+)
+
+spark.sql(
+    """
+DELETE FROM default.test_positional_mor_deletes.branch_without_5 WHERE number = 5
+    """
+)
+
+
+spark.sql(
+    """
 DELETE FROM default.test_positional_mor_deletes WHERE number = 9
 """
 )

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -352,3 +352,15 @@ def test_unpartitioned_fixed_table(catalog: Catalog) -> None:
         b"12345678901234567ass12345",
         b"qweeqwwqq1231231231231111",
     ]
+
+
+@pytest.mark.integration
+def test_scan_tag(test_positional_mor_deletes: Table) -> None:
+    arrow_table = test_positional_mor_deletes.scan().use_ref("tag_12").to_arrow()
+    assert arrow_table["number"].to_pylist() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+
+
+@pytest.mark.integration
+def test_scan_branch(test_positional_mor_deletes: Table) -> None:
+    arrow_table = test_positional_mor_deletes.scan().use_ref("without_5").to_arrow()
+    assert arrow_table["number"].to_pylist() == [1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12]


### PR DESCRIPTION
Was going through the python codebase, noticed we didn't have any integ tests for use_ref so just added some simple integration tests which create a branch and tag, perform writes on a branch and then verifies the Python scan returns the expected records.