### PR TITLE
Python: Add `unmarked` pytest marker

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -70,7 +70,7 @@ jobs:
           # Ignore 32 bit architectures
           CIBW_ARCHS: "auto64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.12"
-          CIBW_TEST_REQUIRES: "pytest moto"
+          CIBW_TEST_REQUIRES: "pytest==7.4.2 moto==4.2.2"
           CIBW_TEST_EXTRAS: "s3fs,glue"
           CIBW_TEST_COMMAND: "pytest -Werror {project}/python/tests/avro/test_decoder.py"
           # There is an upstream issue with installing on MacOSX

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -114,6 +114,7 @@ gcsfs = ["gcsfs"]
 
 [tool.pytest.ini_options]
 markers = [
+  "unmarked: marks a test as a unittest",
   "s3: marks a test as requiring access to s3 compliant storage (use with --aws-access-key-id, --aws-secret-access-key, and --endpoint args)",
   "adlfs: marks a test as requiring access to adlfs compliant storage (use with --adlfs.account-name, --adlfs.account-key, and --adlfs.endpoint args)",
   "integration: marks integration tests against Apache Spark",


### PR DESCRIPTION
We mark the test that don't have a specific marker (integration tests, s3, gcp, azure etc) with unmarked: https://github.com/apache/iceberg/blob/9ad9976551e8697d60ed7e0169ba0776ff1cffe5/python/tests/conftest.py#L96-L99

The marked was indeed missing, and I'm unsure why this works for the regular tests, but when validating the wheels we get an error: 

```
  INTERNALERROR> Traceback (most recent call last):
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/main.py", line 271, in wrap_session
  INTERNALERROR>     session.exitstatus = doit(config, session) or 0
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/main.py", line 324, in _main
  INTERNALERROR>     config.hook.pytest_collection(session=session)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_hooks.py", line 493, in __call__
  INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_manager.py", line 115, in _hookexec
  INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_callers.py", line 152, in _multicall
  INTERNALERROR>     return outcome.get_result()
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_result.py", line 114, in get_result
  INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_callers.py", line 77, in _multicall
  INTERNALERROR>     res = hook_impl.function(*args)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/main.py", line 335, in pytest_collection
  INTERNALERROR>     session.perform_collect()
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/main.py", line 678, in perform_collect
  INTERNALERROR>     hook.pytest_collection_modifyitems(
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_hooks.py", line 493, in __call__
  INTERNALERROR>     return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_manager.py", line 115, in _hookexec
  INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_callers.py", line 152, in _multicall
  INTERNALERROR>     return outcome.get_result()
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_result.py", line 114, in get_result
  INTERNALERROR>     raise exc.with_traceback(exc.__traceback__)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/pluggy/_callers.py", line 77, in _multicall
  INTERNALERROR>     res = hook_impl.function(*args)
  INTERNALERROR>   File "/project/python/tests/conftest.py", line 99, in pytest_collection_modifyitems
  INTERNALERROR>     item.add_marker("unmarked")
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/nodes.py", line 356, in add_marker
  INTERNALERROR>     marker_ = getattr(MARK_GEN, marker)
  INTERNALERROR>   File "/tmp/tmp.Mofg6cKvZN/venv/lib/python3.8/site-packages/_pytest/mark/structures.py", line 547, in __getattr__
  INTERNALERROR>     warnings.warn(
  INTERNALERROR> pytest.PytestUnknownMarkWarning: Unknown pytest.mark.unmarked - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```

From: https://github.com/apache/iceberg/actions/runs/6139468866/job/16657410349#step:7:662

After adding the marker, it has been fixed: https://github.com/Fokko/incubator-iceberg/actions/runs/6139600045/job/16657654272