### PR TITLE
Python: Inline the Filesystem imports

### DIFF
--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -301,6 +301,8 @@ class PyArrowFileIO(FileIO):
 
     def _get_fs(self, scheme: str) -> FileSystem:
         if scheme in {"s3", "s3a", "s3n"}:
+            from pyarrow.fs import S3FileSystem
+
             client_kwargs = {
                 "endpoint_override": self.properties.get(S3_ENDPOINT),
                 "access_key": self.properties.get(S3_ACCESS_KEY_ID),
@@ -312,10 +314,10 @@ class PyArrowFileIO(FileIO):
             if proxy_uri := self.properties.get(S3_PROXY_URI):
                 client_kwargs["proxy_options"] = proxy_uri
 
-            from pyarrow.fs import S3FileSystem
-
             return S3FileSystem(**client_kwargs)
         elif scheme == "hdfs":
+            from pyarrow.fs import HadoopFileSystem
+
             hdfs_kwargs: Dict[str, Any] = {}
             if host := self.properties.get(HDFS_HOST):
                 hdfs_kwargs["host"] = host
@@ -326,10 +328,11 @@ class PyArrowFileIO(FileIO):
                 hdfs_kwargs["user"] = user
             if kerb_ticket := self.properties.get(HDFS_KERB_TICKET):
                 hdfs_kwargs["kerb_ticket"] = kerb_ticket
-            from pyarrow.fs import HadoopFileSystem
 
             return HadoopFileSystem(**hdfs_kwargs)
         elif scheme in {"gs", "gcs"}:
+            from pyarrow.fs import GcsFileSystem
+
             gcs_kwargs: Dict[str, Any] = {}
             if access_token := self.properties.get(GCS_TOKEN):
                 gcs_kwargs["access_token"] = access_token
@@ -341,7 +344,6 @@ class PyArrowFileIO(FileIO):
                 url_parts = urlparse(endpoint)
                 gcs_kwargs["scheme"] = url_parts.scheme
                 gcs_kwargs["endpoint_override"] = url_parts.netloc
-            from pyarrow.fs import GcsFileSystem
 
             return GcsFileSystem(**gcs_kwargs)
         elif scheme == "file":

--- a/python/pyiceberg/io/pyarrow.py
+++ b/python/pyiceberg/io/pyarrow.py
@@ -58,11 +58,6 @@ from pyarrow.fs import (
     FileSystem,
     FileType,
     FSSpecHandler,
-    GcsFileSystem,
-    HadoopFileSystem,
-    LocalFileSystem,
-    PyFileSystem,
-    S3FileSystem,
 )
 from sortedcontainers import SortedList
 
@@ -317,6 +312,8 @@ class PyArrowFileIO(FileIO):
             if proxy_uri := self.properties.get(S3_PROXY_URI):
                 client_kwargs["proxy_options"] = proxy_uri
 
+            from pyarrow.fs import S3FileSystem
+
             return S3FileSystem(**client_kwargs)
         elif scheme == "hdfs":
             hdfs_kwargs: Dict[str, Any] = {}
@@ -329,6 +326,8 @@ class PyArrowFileIO(FileIO):
                 hdfs_kwargs["user"] = user
             if kerb_ticket := self.properties.get(HDFS_KERB_TICKET):
                 hdfs_kwargs["kerb_ticket"] = kerb_ticket
+            from pyarrow.fs import HadoopFileSystem
+
             return HadoopFileSystem(**hdfs_kwargs)
         elif scheme in {"gs", "gcs"}:
             gcs_kwargs: Dict[str, Any] = {}
@@ -342,8 +341,12 @@ class PyArrowFileIO(FileIO):
                 url_parts = urlparse(endpoint)
                 gcs_kwargs["scheme"] = url_parts.scheme
                 gcs_kwargs["endpoint_override"] = url_parts.netloc
+            from pyarrow.fs import GcsFileSystem
+
             return GcsFileSystem(**gcs_kwargs)
         elif scheme == "file":
+            from pyarrow.fs import LocalFileSystem
+
             return LocalFileSystem()
         else:
             raise ValueError(f"Unrecognized filesystem type in URI: {scheme}")
@@ -899,6 +902,8 @@ def project_table(
             from pyiceberg.io.fsspec import FsspecFileIO
 
             if isinstance(table.io, FsspecFileIO):
+                from pyarrow.fs import PyFileSystem
+
                 fs = PyFileSystem(FSSpecHandler(table.io.get_fs(scheme)))
             else:
                 raise ValueError(f"Expected PyArrowFileIO or FsspecFileIO, got: {table.io}")


### PR DESCRIPTION
It can be that certain build flags are turned off:

```
-DARROW_GCS=ON: Build Arrow with GCS support (requires the GCloud SDK for C++)
-DARROW_HDFS=ON: Arrow integration with libhdfs for accessing the Hadoop Filesystem
```
From: https://arrow.apache.org/docs/dev/developers/cpp/building.html#optional-components

This will cause an `ImportError` when importing `pyarrow.py`, while it can be that you don't want to use a missing FS. Therefore it is better to inline the imports