### PR TITLE
Docs: Fix CREATE BRANCH syntax and broken link in Writing to Branches section

### DIFF
--- a/docs/branching-and-tagging.md
+++ b/docs/branching-and-tagging.md
@@ -79,7 +79,7 @@ ALTER TABLE prod.db.table CREATE TAG `EOY-2023` AS OF VERSION 365
 4. Create a temporary "test-branch" which is retained for 7 days and the latest 2 snapshots on the branch are retained.
 ```sql
 -- Create a branch "test-branch" which will be retained for 7 days along with the  latest 2 snapshots
-ALTER TABLE prod.db.table CREATE BRANCH `test-branch` RETAIN 7 DAYS WITH SNAPSHOT RETENTION 2
+ALTER TABLE prod.db.table CREATE BRANCH `test-branch` RETAIN 7 DAYS WITH SNAPSHOT RETENTION 2 SNAPSHOTS
 ```
 
 ### Audit Branch

--- a/docs/branching-and-tagging.md
+++ b/docs/branching-and-tagging.md
@@ -79,7 +79,7 @@ ALTER TABLE prod.db.table CREATE TAG `EOY-2023` AS OF VERSION 365
 4. Create a temporary "test-branch" which is retained for 7 days and the latest 2 snapshots on the branch are retained.
 ```sql
 -- Create a branch "test-branch" which will be retained for 7 days along with the  latest 2 snapshots
-ALTER TABLE prod.db.table CREATE BRANCH `test-branch` RETAIN 7 DAYS WITH RETENTION 2 SNAPSHOTS
+ALTER TABLE prod.db.table CREATE BRANCH `test-branch` RETAIN 7 DAYS WITH SNAPSHOT RETENTION 2
 ```
 
 ### Audit Branch
@@ -91,7 +91,7 @@ The above diagram shows an example of using an audit branch for validating a wri
 1. First ensure `write.wap.enabled` is set.
 ```sql
 ALTER TABLE db.table SET TBLPROPERTIES (
-    'write.wap.enabled''true'
+    'write.wap.enabled'='true'
 )
 ```
 2. Create `audit-branch` starting from snapshot 3, which will be written to and retained for 1 week.

--- a/docs/spark-ddl.md
+++ b/docs/spark-ddl.md
@@ -500,7 +500,7 @@ AS OF VERSION 1234
 -- CREATE audit-branch at snapshot 1234, retain audit-branch for 31 days, and retain the latest 31 days. The latest 3 snapshot snapshots, and 2 days worth of snapshots. 
 ALTER TABLE prod.db.sample CREATE BRANCH `audit-branch`
 AS OF VERSION 1234 RETAIN 30 DAYS 
-WITH RETENTION 3 SNAPSHOTS 2 DAYS
+WITH SNAPSHOT RETENTION 3 SNAPSHOTS 2 DAYS
 ```
 
 #### `ALTER TABLE ... CREATE TAG`

--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -210,7 +210,7 @@ Branch writes can also be performed as part of a write-audit-publish (WAP) workf
 Note WAP branch and branch identifier cannot both be specified.
 Also, the branch must exist before performing the write. 
 The operation does **not** create the branch if it does not exist. 
-For more information on branches please refer to [branches](../tables/branching)
+For more information on branches please refer to [branches](../branching)
  
 ```sql
 -- INSERT (1,' a') (2, 'b') into the audit branch.

--- a/docs/spark-writes.md
+++ b/docs/spark-writes.md
@@ -210,7 +210,7 @@ Branch writes can also be performed as part of a write-audit-publish (WAP) workf
 Note WAP branch and branch identifier cannot both be specified.
 Also, the branch must exist before performing the write. 
 The operation does **not** create the branch if it does not exist. 
-For more information on branches please refer to [branches](../branching)
+For more information on branches please refer to [branches](../tables/branching)
  
 ```sql
 -- INSERT (1,' a') (2, 'b') into the audit branch.


### PR DESCRIPTION
## Changes
* Fix `CREATE BRANCH` syntax in *Branching and Tagging* part and Spark DDL
* Fix broken link in *Writing to Branches* section in Spark Writes

## Details
There are several syntax descriptions that don't follow the current design in the doc.

The current doc shows the CREATE BRANCH in Branching and Tagging part like;

```sql
-- Create a branch "test-branch" which will be retained for 7 days along with the  latest 2 snapshots
ALTER TABLE prod.db.table CREATE BRANCH test-branch RETAIN 7 DAYS WITH RETENTION 2 SNAPSHOTS

```

If you run the query, the query fails with the following error;

```scala
scala> spark.sql("ALTER TABLE catalog.db.tbl CREATE BRANCH branch3 RETAIN 2 DAYS WITH RETENTION 3 SNAPSHOTS")
org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException:
no viable alternative at input 'WITH RETENTION'
== SQL ==
ALTER TABLE glue_catalog.garbagedb.iceberg_branch CREATE BRANCH branch3 RETAIN 2 DAYS WITH RETENTION 3 SNAPSHOTS
  at org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException.withCommand(IcebergSparkSqlExtensionsParser.scala:393)
  at org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser.parse(IcebergSparkSqlExtensionsParser.scala:252)
  at org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser.parsePlan(IcebergSparkSqlExtensionsParser.scala:129)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$2(SparkSession.scala:633)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:192)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:632)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:827)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:630)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:671)
  ... 47 elided

```

Based on the [antlr source](https://github.com/apache/iceberg/blob/master/spark/v3.4/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4#L101) in the Iceberg, the following query looks correct (this query worked well in Spark 3.4 and the latest Iceberg built from source).

```scala
scala> spark.sql("ALTER TABLE catalog.db.tbl CREATE BRANCH branch5 RETAIN 2 DAYS WITH SNAPSHOT RETENTION 3 SNAPSHOTS").
res2: org.apache.spark.sql.DataFrame = []
```