### PR TITLE
Arrow: Propagate correct field info while reading metadata columns

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.arrow.vectorized;
 
 import org.apache.arrow.vector.FieldVector;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -183,6 +184,7 @@ public class VectorHolder {
     private final int numRows;
 
     public DeletedVectorHolder(int numRows) {
+      super(MetadataColumns.IS_DELETED);
       this.numRows = numRows;
     }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -493,6 +493,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     private NullabilityHolder nulls;
 
     PositionVectorReader(boolean setArrowValidityVector) {
+      super(MetadataColumns.ROW_POSITION);
       this.setArrowValidityVector = setArrowValidityVector;
     }
 
@@ -605,7 +606,9 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
    * Holder which indicates whether a given row is deleted.
    */
   public static class DeletedVectorReader extends VectorizedArrowReader {
-    public DeletedVectorReader() {}
+    public DeletedVectorReader() {
+      super(MetadataColumns.IS_DELETED);
+    }
 
     @Override
     public VectorHolder read(VectorHolder reuse, int numValsToRead) {


### PR DESCRIPTION
As a follow-up to #8466, this PR propagates correct field info while reading metadata columns.