### PR TITLE
open-api: Add namespaceExist API

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -319,7 +319,7 @@ paths:
       summary: Check if a namespace exists
       operationId: namespaceExists
       description:
-        Check if a namespace exists. This response does not return a body.
+        Check if a namespace exists. The response does not contain a body.
       responses:
         204:
           description: Success, no content
@@ -809,7 +809,7 @@ paths:
       summary: Check if a table exists
       operationId: tableExists
       description:
-        Check if a table exists within a given namespace. This response does not return a body.
+        Check if a table exists within a given namespace. The response does not contain a body.
       responses:
         204:
           description: Success, no content

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -313,6 +313,29 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+    head:
+      tags:
+        - Catalog API
+      summary: Check if a namespace exists
+      operationId: namespaceExists
+      description:
+        Check if a namespaces exists. This request does not return a response body.
+      responses:
+        204:
+          description: Success, no content
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized
+        404:
+          description: Not Found
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
     delete:
       tags:
         - Catalog API

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -319,16 +319,25 @@ paths:
       summary: Check if a namespace exists
       operationId: namespaceExists
       description:
-        Check if a namespaces exists. This request does not return a response body.
+        Check if a namespace exists. This response does not return a body.
       responses:
         204:
           description: Success, no content
         400:
-          description: Bad Request
+          $ref: '#/components/responses/BadRequestErrorResponse'
         401:
-          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
         404:
-          description: Not Found
+          description: Not Found - Namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+              examples:
+                NoSuchNamespaceExample:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:
@@ -800,16 +809,26 @@ paths:
       summary: Check if a table exists
       operationId: tableExists
       description:
-        Check if a table exists within a given namespace. This request does not return a response body.
+        Check if a table exists within a given namespace. This response does not return a body.
       responses:
         204:
           description: Success, no content
         400:
-          description: Bad Request
+          $ref: '#/components/responses/BadRequestErrorResponse'
         401:
-          description: Unauthorized
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
         404:
-          description: Not Found
+          description:
+            Not Found - NoSuchTableException, Table not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorModel'
+              examples:
+                TableToLoadDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         503:


### PR DESCRIPTION
Add a new namespaceExists API which are HEAD http call to namespace resource, it's similar to tableExists API already defined in open-api spec.

This is spec change only as I dont think we need to change any part of the code in rest package, since both [tableExists](https://github.com/apache/iceberg/blob/cf32bdead13815daf26c9feceebc6cd606a7bab8/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java#L180-L187) and [namespaceExists](https://github.com/apache/iceberg/blob/cf32bdead13815daf26c9feceebc6cd606a7bab8/api/src/main/java/org/apache/iceberg/catalog/SessionCatalog.java#L356-L363) and defined as default method in SessionCatalog interface.

both `make lint && make generate` are happy

Can you guys take a look? @Fokko @nastra @rdblue

CC @haizhou-zhao