### PR TITLE
Make FanoutWriter a package public class

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.util.StructLikeMap;
  * writer may potentially consume substantially more memory compared to {@link ClusteredWriter}. Use
  * this writer only when clustering by spec/partition is not possible (e.g. streaming).
  */
-abstract class FanoutWriter<T, R> implements PartitioningWriter<T, R> {
+public abstract class FanoutWriter<T, R> implements PartitioningWriter<T, R> {
 
   private final Map<Integer, StructLikeMap<FileWriter<T, R>>> writers = Maps.newHashMap();
   private boolean closed = false;


### PR DESCRIPTION
It looks like FanoutWriter is not public by mistake. Right now the only way to implement FanoutWriter is to implement FanoutDataWriter which is not ideal. The analogous class PartitionedFanoutWriter was made public in this PR: https://github.com/apache/iceberg/pull/1774