### PR TITLE
Build: Fix Gradle issue for consuming projects with Maven classifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -374,10 +374,7 @@ project(':iceberg-data') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar
@@ -734,10 +731,7 @@ project(':iceberg-orc') {
       exclude group: 'org.tukaani' // xz compression is not supported
     }
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/build.gradle
+++ b/build.gradle
@@ -678,10 +678,7 @@ project(':iceberg-hive-metastore') {
     // that's really old. We use the core classifier to be able to override our guava
     // version. Luckily, hive-exec seems to work okay so far with this version of guava
     // See: https://github.com/apache/hive/blob/master/ql/pom.xml#L911 for more context.
-    testImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    testImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -36,11 +36,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // for dropwizard histogram metrics implementation
     compileOnly libs.flink115.metrics.dropwizard
     compileOnly libs.flink115.streaming.java
-    compileOnly(libs.flink115.streaming.java) {
-      artifact {
-        classifier = 'tests'
-      }
-    }
+    compileOnly "${libs.flink115.streaming.java.get().module}:${libs.flink115.streaming.java.get().getVersion()}:tests"
     compileOnly libs.flink115.table.api.java.bridge
     compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${libs.versions.flink115.get()}"
     compileOnly libs.flink115.connector.base
@@ -89,10 +85,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // that's really old. We use the core classifier to be able to override our guava
     // version. Luckily, hive-exec seems to work okay so far with this version of guava
     // See: https://github.com/apache/hive/blob/master/ql/pom.xml#L911 for more context.
-    testImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    testImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency
@@ -206,10 +199,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.zaxxer', module: 'HikariCP'
     }
 
-    integrationImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    integrationImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency

--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -61,10 +61,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     compileOnly libs.avro.avro
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -36,11 +36,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // for dropwizard histogram metrics implementation
     compileOnly libs.flink116.metrics.dropwizard
     compileOnly libs.flink116.streaming.java
-    compileOnly(libs.flink116.streaming.java) {
-      artifact {
-        classifier = 'tests'
-      }
-    }
+    compileOnly "${libs.flink116.streaming.java.get().module}:${libs.flink116.streaming.java.get().getVersion()}:tests"
     compileOnly libs.flink116.table.api.java.bridge
     compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${libs.versions.flink116.get()}"
     compileOnly libs.flink116.connector.base
@@ -89,10 +85,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // that's really old. We use the core classifier to be able to override our guava
     // version. Luckily, hive-exec seems to work okay so far with this version of guava
     // See: https://github.com/apache/hive/blob/master/ql/pom.xml#L911 for more context.
-    testImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    testImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency
@@ -206,10 +199,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.zaxxer', module: 'HikariCP'
     }
 
-    integrationImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    integrationImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -61,10 +61,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     compileOnly libs.avro.avro
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -36,11 +36,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // for dropwizard histogram metrics implementation
     compileOnly libs.flink117.metrics.dropwizard
     compileOnly libs.flink117.streaming.java
-    compileOnly(libs.flink117.streaming.java) {
-      artifact {
-        classifier = 'tests'
-      }
-    }
+    compileOnly "${libs.flink117.streaming.java.get().module}:${libs.flink117.streaming.java.get().getVersion()}:tests"
     compileOnly libs.flink117.table.api.java.bridge
     compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${libs.versions.flink117.get()}"
     compileOnly libs.flink117.connector.base
@@ -89,10 +85,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     // that's really old. We use the core classifier to be able to override our guava
     // version. Luckily, hive-exec seems to work okay so far with this version of guava
     // See: https://github.com/apache/hive/blob/master/ql/pom.xml#L911 for more context.
-    testImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    testImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency
@@ -206,10 +199,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       exclude group: 'com.zaxxer', module: 'HikariCP'
     }
 
-    integrationImplementation(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    integrationImplementation("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.pentaho' // missing dependency

--- a/flink/v1.17/build.gradle
+++ b/flink/v1.17/build.gradle
@@ -61,10 +61,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
 
     compileOnly libs.avro.avro
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/hive3/build.gradle
+++ b/hive3/build.gradle
@@ -50,10 +50,7 @@ project(':iceberg-hive3') {
       exclude group: 'org.apache.avro', module: 'avro'
     }
 
-    compileOnly(libs.hive3.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    compileOnly("${libs.hive3.exec.get().module}:${libs.hive3.exec.get().getVersion()}:core") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
       exclude group: 'com.google.guava'
       exclude group: 'com.google.protobuf', module: 'protobuf-java'
@@ -65,10 +62,7 @@ project(':iceberg-hive3') {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
     }
 
-    compileOnly(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    compileOnly("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -38,10 +38,7 @@ project(':iceberg-mr') {
       exclude group: 'org.apache.avro', module: 'avro'
     }
 
-    compileOnly(libs.hive2.exec) {
-      artifact {
-        classifier = 'core'
-      }
+    compileOnly("${libs.hive2.exec.get().module}:${libs.hive2.exec.get().getVersion()}:core") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
       exclude group: 'com.google.guava'
       exclude group: 'com.google.protobuf', module: 'protobuf-java'

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -77,10 +77,7 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
     implementation libs.parquet.column
     implementation libs.parquet.hadoop
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -78,10 +78,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation libs.parquet.column
     implementation libs.parquet.hadoop
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/spark/v3.3/build.gradle
+++ b/spark/v3.3/build.gradle
@@ -75,10 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation libs.parquet.column
     implementation libs.parquet.hadoop
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -75,10 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation libs.parquet.column
     implementation libs.parquet.hadoop
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -75,10 +75,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     implementation libs.parquet.column
     implementation libs.parquet.hadoop
 
-    implementation(libs.orc.core) {
-      artifact {
-        classifier = 'nohive'
-      }
+    implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'
       exclude group: 'commons-lang'
       // These artifacts are shaded and included in the orc-core fat jar


### PR DESCRIPTION
For some reason, Gradle has issues to detect the maven classifier properly in a consuming project from Gradle module metadata.

The issue has been reported in
https://youtrack.jetbrains.com/issue/IDEA-327421/IJ-fails-to-import-Gradle-project-with-dependency-with-classifier and in https://github.com/gradle/gradle/issues/15756.

https://youtrack.jetbrains.com/issue/IDEA-327421/IJ-fails-to-import-Gradle-project-with-dependency-with-classifier reported a workaround that ignores Gradle metadata when using Iceberg artifacts.
I talked to @snazy and https://github.com/projectnessie/nessie/blob/main/settings.gradle.kts#L46-L57 shows how he worked around the issue it when consuming the latest Iceberg snapshot release.
However, I don't think we want to go down that route, because every consumer of an Iceberg artifact would have to do the same unfortunately.

I'm able to verify that this workaround fixes the issue for consuming projects.

Note that this is a blocker for the Iceberg 1.4.0 release, as otherwise users will have issues to consume 1.4.0 artifacts that depend on the `orc-core-nohive` artifact (which are all of the Flink + Spark runtime jars)