### PR TITLE
Core: Don't persist counts for paths and positions in position delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -41,18 +41,36 @@ public class MetricsUtil {
   private MetricsUtil() {}
 
   /**
-   * Copies a metrics object without lower and upper bounds for given fields.
+   * Copies a metrics object without value, NULL and NaN counts for given fields.
    *
-   * @param excludedFieldIds field IDs for which the lower and upper bounds must be dropped
-   * @return a new metrics object without lower and upper bounds for given fields
+   * @param excludedFieldIds field IDs for which the counts must be dropped
+   * @return a new metrics object without counts for given fields
    */
-  public static Metrics copyWithoutFieldBounds(Metrics metrics, Set<Integer> excludedFieldIds) {
+  public static Metrics copyWithoutFieldCounts(Metrics metrics, Set<Integer> excludedFieldIds) {
     return new Metrics(
         metrics.recordCount(),
         metrics.columnSizes(),
-        metrics.valueCounts(),
-        metrics.nullValueCounts(),
-        metrics.nanValueCounts(),
+        copyWithoutKeys(metrics.valueCounts(), excludedFieldIds),
+        copyWithoutKeys(metrics.nullValueCounts(), excludedFieldIds),
+        copyWithoutKeys(metrics.nanValueCounts(), excludedFieldIds),
+        metrics.lowerBounds(),
+        metrics.upperBounds());
+  }
+
+  /**
+   * Copies a metrics object without counts and bounds for given fields.
+   *
+   * @param excludedFieldIds field IDs for which the counts and bounds must be dropped
+   * @return a new metrics object without lower and upper bounds for given fields
+   */
+  public static Metrics copyWithoutFieldCountsAndBounds(
+      Metrics metrics, Set<Integer> excludedFieldIds) {
+    return new Metrics(
+        metrics.recordCount(),
+        metrics.columnSizes(),
+        copyWithoutKeys(metrics.valueCounts(), excludedFieldIds),
+        copyWithoutKeys(metrics.nullValueCounts(), excludedFieldIds),
+        copyWithoutKeys(metrics.nanValueCounts(), excludedFieldIds),
         copyWithoutKeys(metrics.lowerBounds(), excludedFieldIds),
         copyWithoutKeys(metrics.upperBounds(), excludedFieldIds));
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -47,7 +47,7 @@ import org.apache.iceberg.util.CharSequenceSet;
  * records, consider using {@link SortingPositionOnlyDeleteWriter} instead.
  */
 public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWriteResult> {
-  private static final Set<Integer> SINGLE_REFERENCED_FILE_BOUNDS_ONLY =
+  private static final Set<Integer> FILE_AND_POS_FIELD_IDS =
       ImmutableSet.of(DELETE_FILE_PATH.fieldId(), DELETE_FILE_POS.fieldId());
 
   private final FileAppender<StructLike> appender;
@@ -121,9 +121,9 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
   private Metrics metrics() {
     Metrics metrics = appender.metrics();
     if (referencedDataFiles.size() > 1) {
-      return MetricsUtil.copyWithoutFieldBounds(metrics, SINGLE_REFERENCED_FILE_BOUNDS_ONLY);
+      return MetricsUtil.copyWithoutFieldCountsAndBounds(metrics, FILE_AND_POS_FIELD_IDS);
     } else {
-      return metrics;
+      return MetricsUtil.copyWithoutFieldCounts(metrics, FILE_AND_POS_FIELD_IDS);
     }
   }
 }


### PR DESCRIPTION
This PR drops count metrics for the file and position columns in position delete files. This allows us to reduce the size of persisted delete metadata and to speed up distributed planning where the stats are serialized. Such stats are redundant as the spec does not permit null values in those columns and we have `recordCount` if the number of records must be known. 

We still keep counts for the data columns if deleted rows are persisted. We also keep column sizes for the file and position columns.