### PR TITLE
Core: Enable strict metadata cleanup by default

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -121,9 +121,10 @@ public interface TableOperations {
    * Whether to clean up uncommitted metadata files only when a commit fails with a {@link
    * CleanableFailure} exception.
    *
-   * <p>This defaults to false: any unexpected exception will cause metadata files to be cleaned up.
+   * <p>This defaults to true: cleanup will only occur for exceptions marked as {@link
+   * CleanableFailure}
    */
   default boolean requireStrictCleanup() {
-    return false;
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -240,9 +240,4 @@ class RESTTableOperations implements TableOperations {
       }
     };
   }
-
-  @Override
-  public boolean requireStrictCleanup() {
-    return true;
-  }
 }


### PR DESCRIPTION
This  change enables strict metadata cleanup by default for the 1.4.0 release (discussed in the 09/20 community sync).