### PR TITLE
Flink: port table refresh (#8555) to v1.15 and v1.16

### DIFF
--- a/flink/v1.15/build.gradle
+++ b/flink/v1.15/build.gradle
@@ -114,6 +114,11 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     }
 
     testImplementation libs.awaitility
+    testImplementation libs.assertj.core
+  }
+
+  test {
+    useJUnitPlatform()
   }
 }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.TimeUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -57,6 +59,10 @@ class FlinkConfParser {
 
   public StringConfParser stringConf() {
     return new StringConfParser();
+  }
+
+  public DurationConfParser durationConf() {
+    return new DurationConfParser();
   }
 
   class BooleanConfParser extends ConfParser<BooleanConfParser, Boolean> {
@@ -177,6 +183,29 @@ class FlinkConfParser {
 
     public E parseOptional() {
       return parse(s -> Enum.valueOf(enumClass, s), null);
+    }
+  }
+
+  class DurationConfParser extends ConfParser<DurationConfParser, Duration> {
+    private Duration defaultValue;
+
+    @Override
+    protected DurationConfParser self() {
+      return this;
+    }
+
+    public DurationConfParser defaultValue(Duration value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public Duration parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(TimeUtils::parseDuration, defaultValue);
+    }
+
+    public Duration parseOptional() {
+      return parse(TimeUtils::parseDuration, null);
     }
   }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
 import java.util.Map;
+import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
@@ -183,5 +185,21 @@ public class FlinkWriteConf {
 
   public Integer writeParallelism() {
     return confParser.intConf().option(FlinkWriteOptions.WRITE_PARALLELISM.key()).parseOptional();
+  }
+
+  /**
+   * NOTE: This may be removed or changed in a future release. This value specifies the interval for
+   * refreshing the table instances in sink writer subtasks. If not specified then the default
+   * behavior is to not refresh the table.
+   *
+   * @return the interval for refreshing the table in sink writer subtasks
+   */
+  @Experimental
+  public Duration tableRefreshInterval() {
+    return confParser
+        .durationConf()
+        .option(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key())
+        .flinkConfig(FlinkWriteOptions.TABLE_REFRSH_INTERVAL)
+        .parseOptional();
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -198,8 +198,8 @@ public class FlinkWriteConf {
   public Duration tableRefreshInterval() {
     return confParser
         .durationConf()
-        .option(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key())
-        .flinkConfig(FlinkWriteOptions.TABLE_REFRSH_INTERVAL)
+        .option(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key())
+        .flinkConfig(FlinkWriteOptions.TABLE_REFRESH_INTERVAL)
         .parseOptional();
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.flink;
 
 import java.time.Duration;
 import java.util.Map;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
+import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;
@@ -64,4 +66,8 @@ public class FlinkWriteOptions {
 
   public static final ConfigOption<Integer> WRITE_PARALLELISM =
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
+
+  @Experimental
+  public static final ConfigOption<Duration> TABLE_REFRSH_INTERVAL =
+      ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -68,6 +68,6 @@ public class FlinkWriteOptions {
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
 
   @Experimental
-  public static final ConfigOption<Duration> TABLE_REFRSH_INTERVAL =
+  public static final ConfigOption<Duration> TABLE_REFRESH_INTERVAL =
       ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink;
 
 import java.time.Duration;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -38,6 +38,8 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
 
   void open();
 
+  boolean isOpen();
+
   Table loadTable();
 
   /** Clone a TableLoader */
@@ -73,6 +75,11 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
     @Override
     public void open() {
       tables = new HadoopTables(hadoopConf.get());
+    }
+
+    @Override
+    public boolean isOpen() {
+      return tables != null;
     }
 
     @Override
@@ -116,6 +123,11 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
     }
 
     @Override
+    public boolean isOpen() {
+      return catalog != null;
+    }
+
+    @Override
     public Table loadTable() {
       FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
@@ -126,6 +138,8 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
       if (catalog instanceof Closeable) {
         ((Closeable) catalog).close();
       }
+
+      catalog = null;
     }
 
     @Override

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.time.Duration;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A table loader that will only reload a table after a certain interval has passed. WARNING: This
+ * table loader should be used carefully when used with writer tasks. It could result in heavy load
+ * on a catalog for jobs with many writers.
+ */
+class CachingTableSupplier implements SerializableSupplier<Table> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachingTableSupplier.class);
+
+  private final Table initialTable;
+  private final TableLoader tableLoader;
+  private final Duration tableRefreshInterval;
+  private long lastLoadTimeMillis;
+  private transient Table table;
+
+  CachingTableSupplier(
+      SerializableTable initialTable, TableLoader tableLoader, Duration tableRefreshInterval) {
+    Preconditions.checkArgument(initialTable != null, "initialTable cannot be null");
+    Preconditions.checkArgument(tableLoader != null, "tableLoader cannot be null");
+    Preconditions.checkArgument(
+        tableRefreshInterval != null, "tableRefreshInterval cannot be null");
+    this.initialTable = initialTable;
+    this.table = initialTable;
+    this.tableLoader = tableLoader;
+    this.tableRefreshInterval = tableRefreshInterval;
+    this.lastLoadTimeMillis = System.currentTimeMillis();
+  }
+
+  @Override
+  public Table get() {
+    if (table == null) {
+      this.table = initialTable;
+    }
+    return table;
+  }
+
+  Table initialTable() {
+    return initialTable;
+  }
+
+  void refreshTable() {
+    if (System.currentTimeMillis() > lastLoadTimeMillis + tableRefreshInterval.toMillis()) {
+      try {
+        if (!tableLoader.isOpen()) {
+          tableLoader.open();
+        }
+
+        this.table = tableLoader.loadTable();
+        this.lastLoadTimeMillis = System.currentTimeMillis();
+
+        LOG.info(
+            "Table {} reloaded, next min load time threshold is {}",
+            table.name(),
+            DateTimeUtil.formatTimestampMillis(
+                lastLoadTimeMillis + tableRefreshInterval.toMillis()));
+      } catch (Exception e) {
+        LOG.warn("An error occurred reloading table {}, table was not reloaded", table.name(), e);
+      }
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -24,13 +24,11 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
@@ -64,16 +62,14 @@ class FlinkManifestUtil {
   }
 
   static ManifestOutputFileFactory createOutputFileFactory(
-      Table table, String flinkJobId, String operatorUniqueId, int subTaskId, long attemptNumber) {
-    TableOperations ops = ((HasTableOperations) table).operations();
+      Supplier<Table> tableSupplier,
+      Map<String, String> tableProps,
+      String flinkJobId,
+      String operatorUniqueId,
+      int subTaskId,
+      long attemptNumber) {
     return new ManifestOutputFileFactory(
-        ops,
-        table.io(),
-        table.properties(),
-        flinkJobId,
-        operatorUniqueId,
-        subTaskId,
-        attemptNumber);
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber);
   }
 
   /**

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -28,6 +28,7 @@ import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +68,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.SerializableSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -330,7 +332,10 @@ public class FlinkSink {
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 
       if (table == null) {
-        tableLoader.open();
+        if (!tableLoader.isOpen()) {
+          tableLoader.open();
+        }
+
         try (TableLoader loader = tableLoader) {
           this.table = loader.loadTable();
         } catch (IOException e) {
@@ -462,8 +467,19 @@ public class FlinkSink {
         }
       }
 
+      SerializableTable serializableTable = (SerializableTable) SerializableTable.copyOf(table);
+      Duration tableRefreshInterval = flinkWriteConf.tableRefreshInterval();
+
+      SerializableSupplier<Table> tableSupplier;
+      if (tableRefreshInterval != null) {
+        tableSupplier =
+            new CachingTableSupplier(serializableTable, tableLoader, tableRefreshInterval);
+      } else {
+        tableSupplier = () -> serializableTable;
+      }
+
       IcebergStreamWriter<RowData> streamWriter =
-          createStreamWriter(table, flinkWriteConf, flinkRowType, equalityFieldIds);
+          createStreamWriter(tableSupplier, flinkWriteConf, flinkRowType, equalityFieldIds);
 
       int parallelism =
           flinkWriteConf.writeParallelism() == null
@@ -580,24 +596,25 @@ public class FlinkSink {
   }
 
   static IcebergStreamWriter<RowData> createStreamWriter(
-      Table table,
+      SerializableSupplier<Table> tableSupplier,
       FlinkWriteConf flinkWriteConf,
       RowType flinkRowType,
       List<Integer> equalityFieldIds) {
-    Preconditions.checkArgument(table != null, "Iceberg table shouldn't be null");
+    Preconditions.checkArgument(tableSupplier != null, "Iceberg table supplier shouldn't be null");
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table initTable = tableSupplier.get();
     FileFormat format = flinkWriteConf.dataFileFormat();
     TaskWriterFactory<RowData> taskWriterFactory =
         new RowDataTaskWriterFactory(
-            serializableTable,
+            tableSupplier,
             flinkRowType,
             flinkWriteConf.targetDataFileSize(),
             format,
-            writeProperties(table, format, flinkWriteConf),
+            writeProperties(initTable, format, flinkWriteConf),
             equalityFieldIds,
             flinkWriteConf.upsertMode());
-    return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
+
+    return new IcebergStreamWriter<>(initTable.name(), taskWriterFactory);
   }
 
   /**

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -160,7 +160,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     int attemptId = getRuntimeContext().getAttemptNumber();
     this.manifestOutputFileFactory =
         FlinkManifestUtil.createOutputFileFactory(
-            table, flinkJobId, operatorUniqueId, subTaskId, attemptId);
+            () -> table, table.properties(), flinkJobId, operatorUniqueId, subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
@@ -247,6 +247,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
           checkpointId,
           maxCommittedCheckpointId);
     }
+
+    // reload the table in case new configuration is needed
+    this.table = tableLoader.loadTable();
   }
 
   private void commitUpToCheckpoint(

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.flink.sink;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
@@ -31,8 +33,7 @@ class ManifestOutputFileFactory {
   // properties.
   static final String FLINK_MANIFEST_LOCATION = "flink.manifests.location";
 
-  private final TableOperations ops;
-  private final FileIO io;
+  private final Supplier<Table> tableSupplier;
   private final Map<String, String> props;
   private final String flinkJobId;
   private final String operatorUniqueId;
@@ -41,15 +42,13 @@ class ManifestOutputFileFactory {
   private final AtomicInteger fileCount = new AtomicInteger(0);
 
   ManifestOutputFileFactory(
-      TableOperations ops,
-      FileIO io,
+      Supplier<Table> tableSupplier,
       Map<String, String> props,
       String flinkJobId,
       String operatorUniqueId,
       int subTaskId,
       long attemptNumber) {
-    this.ops = ops;
-    this.io = io;
+    this.tableSupplier = tableSupplier;
     this.props = props;
     this.flinkJobId = flinkJobId;
     this.operatorUniqueId = operatorUniqueId;
@@ -71,6 +70,7 @@ class ManifestOutputFileFactory {
 
   OutputFile create(long checkpointId) {
     String flinkManifestDir = props.get(FLINK_MANIFEST_LOCATION);
+    TableOperations ops = ((HasTableOperations) tableSupplier.get()).operations();
 
     String newManifestFullPath;
     if (Strings.isNullOrEmpty(flinkManifestDir)) {
@@ -81,7 +81,7 @@ class ManifestOutputFileFactory {
           String.format("%s/%s", stripTrailingSlash(flinkManifestDir), generatePath(checkpointId));
     }
 
-    return io.newOutputFile(newManifestFullPath);
+    return tableSupplier.get().io().newOutputFile(newManifestFullPath);
   }
 
   private static String stripTrailingSlash(String path) {

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkConfParser.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestFlinkConfParser.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestFlinkConfParser {
+
+  @Test
+  public void testDurationConf() {
+    Map<String, String> writeOptions = ImmutableMap.of("write-prop", "111s");
+
+    ConfigOption<Duration> configOption =
+        ConfigOptions.key("conf-prop").durationType().noDefaultValue();
+    Configuration flinkConf = new Configuration();
+    flinkConf.setString(configOption.key(), "222s");
+
+    Table table = mock(Table.class);
+    when(table.properties()).thenReturn(ImmutableMap.of("table-prop", "333s"));
+
+    FlinkConfParser confParser = new FlinkConfParser(table, writeOptions, flinkConf);
+    Duration defaultVal = Duration.ofMillis(999);
+
+    Duration result =
+        confParser.durationConf().option("write-prop").defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(111));
+
+    result = confParser.durationConf().flinkConfig(configOption).defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(222));
+
+    result = confParser.durationConf().tableProperty("table-prop").defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(333));
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestTableLoader.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/TestTableLoader.java
@@ -37,6 +37,11 @@ public class TestTableLoader implements TableLoader {
   public void open() {}
 
   @Override
+  public boolean isOpen() {
+    return true;
+  }
+
+  @Override
   public Table loadTable() {
     return TestTables.load(dir, "test");
   }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestCachingTableSupplier.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestCachingTableSupplier.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class TestCachingTableSupplier {
+
+  @Test
+  public void testCheckArguments() {
+    SerializableTable initialTable = mock(SerializableTable.class);
+
+    Table loadedTable = mock(Table.class);
+    TableLoader tableLoader = mock(TableLoader.class);
+    when(tableLoader.loadTable()).thenReturn(loadedTable);
+
+    new CachingTableSupplier(initialTable, tableLoader, Duration.ofMillis(100));
+
+    assertThatThrownBy(() -> new CachingTableSupplier(initialTable, tableLoader, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tableRefreshInterval cannot be null");
+    assertThatThrownBy(() -> new CachingTableSupplier(null, tableLoader, Duration.ofMillis(100)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("initialTable cannot be null");
+    assertThatThrownBy(() -> new CachingTableSupplier(initialTable, null, Duration.ofMillis(100)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tableLoader cannot be null");
+  }
+
+  @Test
+  public void testTableReload() {
+    SerializableTable initialTable = mock(SerializableTable.class);
+
+    Table loadedTable = mock(Table.class);
+    TableLoader tableLoader = mock(TableLoader.class);
+    when(tableLoader.loadTable()).thenReturn(loadedTable);
+
+    CachingTableSupplier cachingTableSupplier =
+        new CachingTableSupplier(initialTable, tableLoader, Duration.ofMillis(100));
+
+    // refresh shouldn't do anything as the min reload interval hasn't passed
+    cachingTableSupplier.refreshTable();
+    assertThat(cachingTableSupplier.get()).isEqualTo(initialTable);
+
+    // refresh after waiting past the min reload interval
+    Awaitility.await()
+        .atLeast(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              cachingTableSupplier.refreshTable();
+              assertThat(cachingTableSupplier.get()).isEqualTo(loadedTable);
+            });
+  }
+}

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
@@ -215,7 +215,7 @@ public class TestCompressionSettings {
             icebergTable, override, new org.apache.flink.configuration.Configuration());
 
     IcebergStreamWriter<RowData> streamWriter =
-        FlinkSink.createStreamWriter(icebergTable, flinkWriteConfig, flinkRowType, null);
+        FlinkSink.createStreamWriter(() -> icebergTable, flinkWriteConfig, flinkRowType, null);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
         new OneInputStreamOperatorTestHarness<>(streamWriter, 1, 1, 0);
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -400,7 +400,7 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
             .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
 
     Configuration flinkConf = new Configuration();
-    flinkConf.setString(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key(), "100ms");
+    flinkConf.setString(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key(), "100ms");
 
     FlinkSink.forRowData(dataStream)
         .table(table)

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -389,5 +390,29 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
           env.execute("Test Iceberg DataStream.");
           return null;
         });
+  }
+
+  @Test
+  public void testWriteRowWithTableRefreshInterval() throws Exception {
+    List<Row> rows = Lists.newArrayList(Row.of(1, "hello"), Row.of(2, "world"), Row.of(3, "foo"));
+    DataStream<RowData> dataStream =
+        env.addSource(createBoundedSource(rows), ROW_TYPE_INFO)
+            .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
+
+    Configuration flinkConf = new Configuration();
+    flinkConf.setString(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key(), "100ms");
+
+    FlinkSink.forRowData(dataStream)
+        .table(table)
+        .tableLoader(tableLoader)
+        .flinkConf(flinkConf)
+        .writeParallelism(parallelism)
+        .append();
+
+    // Execute the program.
+    env.execute("Test Iceberg DataStream");
+
+    // Assert the iceberg table's records.
+    SimpleDataUtil.assertTableRows(table, convertToRowData(rows));
   }
 }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.Table;
@@ -94,7 +93,8 @@ public class TestFlinkManifest {
     String operatorId = newOperatorUniqueId();
     for (long checkpointId = 1; checkpointId <= 3; checkpointId++) {
       ManifestOutputFileFactory factory =
-          FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+          FlinkManifestUtil.createOutputFileFactory(
+              () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
       final long curCkpId = checkpointId;
 
       List<DataFile> dataFiles = generateDataFiles(10);
@@ -135,14 +135,7 @@ public class TestFlinkManifest {
     Map<String, String> props =
         ImmutableMap.of(FLINK_MANIFEST_LOCATION, userProvidedFolder.getAbsolutePath() + "///");
     ManifestOutputFileFactory factory =
-        new ManifestOutputFileFactory(
-            ((HasTableOperations) table).operations(),
-            table.io(),
-            props,
-            flinkJobId,
-            operatorId,
-            1,
-            1);
+        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(5);
     DeltaManifests deltaManifests =
@@ -177,7 +170,8 @@ public class TestFlinkManifest {
     String flinkJobId = newFlinkJobId();
     String operatorId = newOperatorUniqueId();
     ManifestOutputFileFactory factory =
-        FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+        FlinkManifestUtil.createOutputFileFactory(
+            () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(10);
     List<DeleteFile> eqDeleteFiles = generateEqDeleteFiles(10);
@@ -214,7 +208,8 @@ public class TestFlinkManifest {
     String flinkJobId = newFlinkJobId();
     String operatorId = newOperatorUniqueId();
     ManifestOutputFileFactory factory =
-        FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+        FlinkManifestUtil.createOutputFileFactory(
+            () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(10);
     ManifestFile manifest =

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -376,7 +376,7 @@ public class TestIcebergStreamWriter {
             icebergTable, Maps.newHashMap(), new org.apache.flink.configuration.Configuration());
 
     IcebergStreamWriter<RowData> streamWriter =
-        FlinkSink.createStreamWriter(icebergTable, flinkWriteConfig, flinkRowType, null);
+        FlinkSink.createStreamWriter(() -> icebergTable, flinkWriteConfig, flinkRowType, null);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
         new OneInputStreamOperatorTestHarness<>(streamWriter, 1, 1, 0);
 

--- a/flink/v1.16/build.gradle
+++ b/flink/v1.16/build.gradle
@@ -114,6 +114,11 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     }
 
     testImplementation libs.awaitility
+    testImplementation libs.assertj.core
+  }
+
+  test {
+    useJUnitPlatform()
   }
 }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.util.TimeUtils;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -57,6 +59,10 @@ class FlinkConfParser {
 
   public StringConfParser stringConf() {
     return new StringConfParser();
+  }
+
+  public DurationConfParser durationConf() {
+    return new DurationConfParser();
   }
 
   class BooleanConfParser extends ConfParser<BooleanConfParser, Boolean> {
@@ -177,6 +183,29 @@ class FlinkConfParser {
 
     public E parseOptional() {
       return parse(s -> Enum.valueOf(enumClass, s), null);
+    }
+  }
+
+  class DurationConfParser extends ConfParser<DurationConfParser, Duration> {
+    private Duration defaultValue;
+
+    @Override
+    protected DurationConfParser self() {
+      return this;
+    }
+
+    public DurationConfParser defaultValue(Duration value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public Duration parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(TimeUtils::parseDuration, defaultValue);
+    }
+
+    public Duration parseOptional() {
+      return parse(TimeUtils::parseDuration, null);
     }
   }
 

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
 import java.util.Map;
+import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
@@ -183,5 +185,21 @@ public class FlinkWriteConf {
 
   public Integer writeParallelism() {
     return confParser.intConf().option(FlinkWriteOptions.WRITE_PARALLELISM.key()).parseOptional();
+  }
+
+  /**
+   * NOTE: This may be removed or changed in a future release. This value specifies the interval for
+   * refreshing the table instances in sink writer subtasks. If not specified then the default
+   * behavior is to not refresh the table.
+   *
+   * @return the interval for refreshing the table in sink writer subtasks
+   */
+  @Experimental
+  public Duration tableRefreshInterval() {
+    return confParser
+        .durationConf()
+        .option(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key())
+        .flinkConfig(FlinkWriteOptions.TABLE_REFRSH_INTERVAL)
+        .parseOptional();
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -198,8 +198,8 @@ public class FlinkWriteConf {
   public Duration tableRefreshInterval() {
     return confParser
         .durationConf()
-        .option(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key())
-        .flinkConfig(FlinkWriteOptions.TABLE_REFRSH_INTERVAL)
+        .option(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key())
+        .flinkConfig(FlinkWriteOptions.TABLE_REFRESH_INTERVAL)
         .parseOptional();
   }
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.flink;
 
 import java.time.Duration;
 import java.util.Map;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink;
 
+import java.time.Duration;
+import org.apache.calcite.linq4j.function.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;
@@ -64,4 +66,8 @@ public class FlinkWriteOptions {
 
   public static final ConfigOption<Integer> WRITE_PARALLELISM =
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
+
+  @Experimental
+  public static final ConfigOption<Duration> TABLE_REFRSH_INTERVAL =
+      ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -68,6 +68,6 @@ public class FlinkWriteOptions {
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
 
   @Experimental
-  public static final ConfigOption<Duration> TABLE_REFRSH_INTERVAL =
+  public static final ConfigOption<Duration> TABLE_REFRESH_INTERVAL =
       ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
 }

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink;
 
 import java.time.Duration;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -38,6 +38,8 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
 
   void open();
 
+  boolean isOpen();
+
   Table loadTable();
 
   /** Clone a TableLoader */
@@ -73,6 +75,11 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
     @Override
     public void open() {
       tables = new HadoopTables(hadoopConf.get());
+    }
+
+    @Override
+    public boolean isOpen() {
+      return tables != null;
     }
 
     @Override
@@ -116,6 +123,11 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
     }
 
     @Override
+    public boolean isOpen() {
+      return catalog != null;
+    }
+
+    @Override
     public Table loadTable() {
       FlinkEnvironmentContext.init();
       return catalog.loadTable(TableIdentifier.parse(identifier));
@@ -126,6 +138,8 @@ public interface TableLoader extends Closeable, Serializable, Cloneable {
       if (catalog instanceof Closeable) {
         ((Closeable) catalog).close();
       }
+
+      catalog = null;
     }
 
     @Override

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/CachingTableSupplier.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import java.time.Duration;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.SerializableSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A table loader that will only reload a table after a certain interval has passed. WARNING: This
+ * table loader should be used carefully when used with writer tasks. It could result in heavy load
+ * on a catalog for jobs with many writers.
+ */
+class CachingTableSupplier implements SerializableSupplier<Table> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachingTableSupplier.class);
+
+  private final Table initialTable;
+  private final TableLoader tableLoader;
+  private final Duration tableRefreshInterval;
+  private long lastLoadTimeMillis;
+  private transient Table table;
+
+  CachingTableSupplier(
+      SerializableTable initialTable, TableLoader tableLoader, Duration tableRefreshInterval) {
+    Preconditions.checkArgument(initialTable != null, "initialTable cannot be null");
+    Preconditions.checkArgument(tableLoader != null, "tableLoader cannot be null");
+    Preconditions.checkArgument(
+        tableRefreshInterval != null, "tableRefreshInterval cannot be null");
+    this.initialTable = initialTable;
+    this.table = initialTable;
+    this.tableLoader = tableLoader;
+    this.tableRefreshInterval = tableRefreshInterval;
+    this.lastLoadTimeMillis = System.currentTimeMillis();
+  }
+
+  @Override
+  public Table get() {
+    if (table == null) {
+      this.table = initialTable;
+    }
+    return table;
+  }
+
+  Table initialTable() {
+    return initialTable;
+  }
+
+  void refreshTable() {
+    if (System.currentTimeMillis() > lastLoadTimeMillis + tableRefreshInterval.toMillis()) {
+      try {
+        if (!tableLoader.isOpen()) {
+          tableLoader.open();
+        }
+
+        this.table = tableLoader.loadTable();
+        this.lastLoadTimeMillis = System.currentTimeMillis();
+
+        LOG.info(
+            "Table {} reloaded, next min load time threshold is {}",
+            table.name(),
+            DateTimeUtil.formatTimestampMillis(
+                lastLoadTimeMillis + tableRefreshInterval.toMillis()));
+      } catch (Exception e) {
+        LOG.warn("An error occurred reloading table {}, table was not reloaded", table.name(), e);
+      }
+    }
+  }
+}

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkManifestUtil.java
@@ -24,13 +24,11 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
@@ -64,16 +62,14 @@ class FlinkManifestUtil {
   }
 
   static ManifestOutputFileFactory createOutputFileFactory(
-      Table table, String flinkJobId, String operatorUniqueId, int subTaskId, long attemptNumber) {
-    TableOperations ops = ((HasTableOperations) table).operations();
+      Supplier<Table> tableSupplier,
+      Map<String, String> tableProps,
+      String flinkJobId,
+      String operatorUniqueId,
+      int subTaskId,
+      long attemptNumber) {
     return new ManifestOutputFileFactory(
-        ops,
-        table.io(),
-        table.properties(),
-        flinkJobId,
-        operatorUniqueId,
-        subTaskId,
-        attemptNumber);
+        tableSupplier, tableProps, flinkJobId, operatorUniqueId, subTaskId, attemptNumber);
   }
 
   /**

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -28,6 +28,7 @@ import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +68,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.SerializableSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -330,7 +332,10 @@ public class FlinkSink {
       DataStream<RowData> rowDataInput = inputCreator.apply(uidPrefix);
 
       if (table == null) {
-        tableLoader.open();
+        if (!tableLoader.isOpen()) {
+          tableLoader.open();
+        }
+
         try (TableLoader loader = tableLoader) {
           this.table = loader.loadTable();
         } catch (IOException e) {
@@ -462,8 +467,19 @@ public class FlinkSink {
         }
       }
 
+      SerializableTable serializableTable = (SerializableTable) SerializableTable.copyOf(table);
+      Duration tableRefreshInterval = flinkWriteConf.tableRefreshInterval();
+
+      SerializableSupplier<Table> tableSupplier;
+      if (tableRefreshInterval != null) {
+        tableSupplier =
+            new CachingTableSupplier(serializableTable, tableLoader, tableRefreshInterval);
+      } else {
+        tableSupplier = () -> serializableTable;
+      }
+
       IcebergStreamWriter<RowData> streamWriter =
-          createStreamWriter(table, flinkWriteConf, flinkRowType, equalityFieldIds);
+          createStreamWriter(tableSupplier, flinkWriteConf, flinkRowType, equalityFieldIds);
 
       int parallelism =
           flinkWriteConf.writeParallelism() == null
@@ -580,24 +596,25 @@ public class FlinkSink {
   }
 
   static IcebergStreamWriter<RowData> createStreamWriter(
-      Table table,
+      SerializableSupplier<Table> tableSupplier,
       FlinkWriteConf flinkWriteConf,
       RowType flinkRowType,
       List<Integer> equalityFieldIds) {
-    Preconditions.checkArgument(table != null, "Iceberg table shouldn't be null");
+    Preconditions.checkArgument(tableSupplier != null, "Iceberg table supplier shouldn't be null");
 
-    Table serializableTable = SerializableTable.copyOf(table);
+    Table initTable = tableSupplier.get();
     FileFormat format = flinkWriteConf.dataFileFormat();
     TaskWriterFactory<RowData> taskWriterFactory =
         new RowDataTaskWriterFactory(
-            serializableTable,
+            tableSupplier,
             flinkRowType,
             flinkWriteConf.targetDataFileSize(),
             format,
-            writeProperties(table, format, flinkWriteConf),
+            writeProperties(initTable, format, flinkWriteConf),
             equalityFieldIds,
             flinkWriteConf.upsertMode());
-    return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
+
+    return new IcebergStreamWriter<>(initTable.name(), taskWriterFactory);
   }
 
   /**

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -160,7 +160,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     int attemptId = getRuntimeContext().getAttemptNumber();
     this.manifestOutputFileFactory =
         FlinkManifestUtil.createOutputFileFactory(
-            table, flinkJobId, operatorUniqueId, subTaskId, attemptId);
+            () -> table, table.properties(), flinkJobId, operatorUniqueId, subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
@@ -247,6 +247,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
           checkpointId,
           maxCommittedCheckpointId);
     }
+
+    // reload the table in case new configuration is needed
+    this.table = tableLoader.loadTable();
   }
 
   private void commitUpToCheckpoint(

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/ManifestOutputFileFactory.java
@@ -20,9 +20,11 @@ package org.apache.iceberg.flink.sink;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 
@@ -31,8 +33,7 @@ class ManifestOutputFileFactory {
   // properties.
   static final String FLINK_MANIFEST_LOCATION = "flink.manifests.location";
 
-  private final TableOperations ops;
-  private final FileIO io;
+  private final Supplier<Table> tableSupplier;
   private final Map<String, String> props;
   private final String flinkJobId;
   private final String operatorUniqueId;
@@ -41,15 +42,13 @@ class ManifestOutputFileFactory {
   private final AtomicInteger fileCount = new AtomicInteger(0);
 
   ManifestOutputFileFactory(
-      TableOperations ops,
-      FileIO io,
+      Supplier<Table> tableSupplier,
       Map<String, String> props,
       String flinkJobId,
       String operatorUniqueId,
       int subTaskId,
       long attemptNumber) {
-    this.ops = ops;
-    this.io = io;
+    this.tableSupplier = tableSupplier;
     this.props = props;
     this.flinkJobId = flinkJobId;
     this.operatorUniqueId = operatorUniqueId;
@@ -71,6 +70,7 @@ class ManifestOutputFileFactory {
 
   OutputFile create(long checkpointId) {
     String flinkManifestDir = props.get(FLINK_MANIFEST_LOCATION);
+    TableOperations ops = ((HasTableOperations) tableSupplier.get()).operations();
 
     String newManifestFullPath;
     if (Strings.isNullOrEmpty(flinkManifestDir)) {
@@ -81,7 +81,7 @@ class ManifestOutputFileFactory {
           String.format("%s/%s", stripTrailingSlash(flinkManifestDir), generatePath(checkpointId));
     }
 
-    return io.newOutputFile(newManifestFullPath);
+    return tableSupplier.get().io().newOutputFile(newManifestFullPath);
   }
 
   private static String stripTrailingSlash(String path) {

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkConfParser.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestFlinkConfParser.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestFlinkConfParser {
+
+  @Test
+  public void testDurationConf() {
+    Map<String, String> writeOptions = ImmutableMap.of("write-prop", "111s");
+
+    ConfigOption<Duration> configOption =
+        ConfigOptions.key("conf-prop").durationType().noDefaultValue();
+    Configuration flinkConf = new Configuration();
+    flinkConf.setString(configOption.key(), "222s");
+
+    Table table = mock(Table.class);
+    when(table.properties()).thenReturn(ImmutableMap.of("table-prop", "333s"));
+
+    FlinkConfParser confParser = new FlinkConfParser(table, writeOptions, flinkConf);
+    Duration defaultVal = Duration.ofMillis(999);
+
+    Duration result =
+        confParser.durationConf().option("write-prop").defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(111));
+
+    result = confParser.durationConf().flinkConfig(configOption).defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(222));
+
+    result = confParser.durationConf().tableProperty("table-prop").defaultValue(defaultVal).parse();
+    assertThat(result).isEqualTo(Duration.ofSeconds(333));
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestTableLoader.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/TestTableLoader.java
@@ -37,6 +37,11 @@ public class TestTableLoader implements TableLoader {
   public void open() {}
 
   @Override
+  public boolean isOpen() {
+    return true;
+  }
+
+  @Override
   public Table loadTable() {
     return TestTables.load(dir, "test");
   }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCachingTableSupplier.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCachingTableSupplier.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+public class TestCachingTableSupplier {
+
+  @Test
+  public void testCheckArguments() {
+    SerializableTable initialTable = mock(SerializableTable.class);
+
+    Table loadedTable = mock(Table.class);
+    TableLoader tableLoader = mock(TableLoader.class);
+    when(tableLoader.loadTable()).thenReturn(loadedTable);
+
+    new CachingTableSupplier(initialTable, tableLoader, Duration.ofMillis(100));
+
+    assertThatThrownBy(() -> new CachingTableSupplier(initialTable, tableLoader, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tableRefreshInterval cannot be null");
+    assertThatThrownBy(() -> new CachingTableSupplier(null, tableLoader, Duration.ofMillis(100)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("initialTable cannot be null");
+    assertThatThrownBy(() -> new CachingTableSupplier(initialTable, null, Duration.ofMillis(100)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tableLoader cannot be null");
+  }
+
+  @Test
+  public void testTableReload() {
+    SerializableTable initialTable = mock(SerializableTable.class);
+
+    Table loadedTable = mock(Table.class);
+    TableLoader tableLoader = mock(TableLoader.class);
+    when(tableLoader.loadTable()).thenReturn(loadedTable);
+
+    CachingTableSupplier cachingTableSupplier =
+        new CachingTableSupplier(initialTable, tableLoader, Duration.ofMillis(100));
+
+    // refresh shouldn't do anything as the min reload interval hasn't passed
+    cachingTableSupplier.refreshTable();
+    assertThat(cachingTableSupplier.get()).isEqualTo(initialTable);
+
+    // refresh after waiting past the min reload interval
+    Awaitility.await()
+        .atLeast(100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              cachingTableSupplier.refreshTable();
+              assertThat(cachingTableSupplier.get()).isEqualTo(loadedTable);
+            });
+  }
+}

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestCompressionSettings.java
@@ -215,7 +215,7 @@ public class TestCompressionSettings {
             icebergTable, override, new org.apache.flink.configuration.Configuration());
 
     IcebergStreamWriter<RowData> streamWriter =
-        FlinkSink.createStreamWriter(icebergTable, flinkWriteConfig, flinkRowType, null);
+        FlinkSink.createStreamWriter(() -> icebergTable, flinkWriteConfig, flinkRowType, null);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
         new OneInputStreamOperatorTestHarness<>(streamWriter, 1, 1, 0);
 

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -400,7 +400,7 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
             .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
 
     Configuration flinkConf = new Configuration();
-    flinkConf.setString(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key(), "100ms");
+    flinkConf.setString(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key(), "100ms");
 
     FlinkSink.forRowData(dataStream)
         .table(table)

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -389,5 +390,29 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
           env.execute("Test Iceberg DataStream.");
           return null;
         });
+  }
+
+  @Test
+  public void testWriteRowWithTableRefreshInterval() throws Exception {
+    List<Row> rows = Lists.newArrayList(Row.of(1, "hello"), Row.of(2, "world"), Row.of(3, "foo"));
+    DataStream<RowData> dataStream =
+        env.addSource(createBoundedSource(rows), ROW_TYPE_INFO)
+            .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
+
+    Configuration flinkConf = new Configuration();
+    flinkConf.setString(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key(), "100ms");
+
+    FlinkSink.forRowData(dataStream)
+        .table(table)
+        .tableLoader(tableLoader)
+        .flinkConf(flinkConf)
+        .writeParallelism(parallelism)
+        .append();
+
+    // Execute the program.
+    env.execute("Test Iceberg DataStream");
+
+    // Assert the iceberg table's records.
+    SimpleDataUtil.assertTableRows(table, convertToRowData(rows));
   }
 }

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkManifest.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.Table;
@@ -94,7 +93,8 @@ public class TestFlinkManifest {
     String operatorId = newOperatorUniqueId();
     for (long checkpointId = 1; checkpointId <= 3; checkpointId++) {
       ManifestOutputFileFactory factory =
-          FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+          FlinkManifestUtil.createOutputFileFactory(
+              () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
       final long curCkpId = checkpointId;
 
       List<DataFile> dataFiles = generateDataFiles(10);
@@ -135,14 +135,7 @@ public class TestFlinkManifest {
     Map<String, String> props =
         ImmutableMap.of(FLINK_MANIFEST_LOCATION, userProvidedFolder.getAbsolutePath() + "///");
     ManifestOutputFileFactory factory =
-        new ManifestOutputFileFactory(
-            ((HasTableOperations) table).operations(),
-            table.io(),
-            props,
-            flinkJobId,
-            operatorId,
-            1,
-            1);
+        new ManifestOutputFileFactory(() -> table, props, flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(5);
     DeltaManifests deltaManifests =
@@ -177,7 +170,8 @@ public class TestFlinkManifest {
     String flinkJobId = newFlinkJobId();
     String operatorId = newOperatorUniqueId();
     ManifestOutputFileFactory factory =
-        FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+        FlinkManifestUtil.createOutputFileFactory(
+            () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(10);
     List<DeleteFile> eqDeleteFiles = generateEqDeleteFiles(10);
@@ -214,7 +208,8 @@ public class TestFlinkManifest {
     String flinkJobId = newFlinkJobId();
     String operatorId = newOperatorUniqueId();
     ManifestOutputFileFactory factory =
-        FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, operatorId, 1, 1);
+        FlinkManifestUtil.createOutputFileFactory(
+            () -> table, table.properties(), flinkJobId, operatorId, 1, 1);
 
     List<DataFile> dataFiles = generateDataFiles(10);
     ManifestFile manifest =

--- a/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -376,7 +376,7 @@ public class TestIcebergStreamWriter {
             icebergTable, Maps.newHashMap(), new org.apache.flink.configuration.Configuration());
 
     IcebergStreamWriter<RowData> streamWriter =
-        FlinkSink.createStreamWriter(icebergTable, flinkWriteConfig, flinkRowType, null);
+        FlinkSink.createStreamWriter(() -> icebergTable, flinkWriteConfig, flinkRowType, null);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness =
         new OneInputStreamOperatorTestHarness<>(streamWriter, 1, 1, 0);
 

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -198,8 +198,8 @@ public class FlinkWriteConf {
   public Duration tableRefreshInterval() {
     return confParser
         .durationConf()
-        .option(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key())
-        .flinkConfig(FlinkWriteOptions.TABLE_REFRSH_INTERVAL)
+        .option(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key())
+        .flinkConfig(FlinkWriteOptions.TABLE_REFRESH_INTERVAL)
         .parseOptional();
   }
 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -20,7 +20,7 @@ package org.apache.iceberg.flink;
 
 import java.time.Duration;
 import java.util.Map;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -68,6 +68,6 @@ public class FlinkWriteOptions {
       ConfigOptions.key("write-parallelism").intType().noDefaultValue();
 
   @Experimental
-  public static final ConfigOption<Duration> TABLE_REFRSH_INTERVAL =
+  public static final ConfigOption<Duration> TABLE_REFRESH_INTERVAL =
       ConfigOptions.key("table-refresh-interval").durationType().noDefaultValue();
 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -19,7 +19,7 @@
 package org.apache.iceberg.flink;
 
 import java.time.Duration;
-import org.apache.calcite.linq4j.function.Experimental;
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -379,7 +379,7 @@ public class TestFlinkIcebergSink extends TestFlinkIcebergSinkBase {
             .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
 
     Configuration flinkConf = new Configuration();
-    flinkConf.setString(FlinkWriteOptions.TABLE_REFRSH_INTERVAL.key(), "100ms");
+    flinkConf.setString(FlinkWriteOptions.TABLE_REFRESH_INTERVAL.key(), "100ms");
 
     FlinkSink.forRowData(dataStream)
         .table(table)


### PR DESCRIPTION
This PR ports the changes from #8555 (optional table refresh) to Flink version 1.15 and 1.16.

This includes two minor updates for all versions, that were missed in the original PR:
* typo fix `TABLE_REFRSH_INTERVAL` -> `TABLE_REFRESH_INTERVAL`
* import fix `org.apache.calcite.linq4j.function.Experimental` -> `org.apache.flink.annotation.Experimental`