### PR TITLE
Python: Remove D106 Docstring Issue

### DIFF
--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
       - id: pydocstyle
         args:
           [
-            "--ignore=D100,D102,D101,D103,D104,D106,D107,D203,D212,D213,D404,D405,D406,D407,D411,D413,D415,D417",
+            "--ignore=D100,D102,D101,D103,D104,D107,D203,D212,D213,D404,D405,D406,D407,D411,D413,D415,D417",
           ]
         additional_dependencies:
           - tomli==2.0.1


### PR DESCRIPTION
D106: Missing docstring in public nested class. No linter violations, just remove from the ignore list.

[#7776](https://github.com/apache/iceberg/issues/7776)