### PR TITLE
Spark 3.5: Use fanout writers for unsorted tables by default

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRequiredDistributionAndOrdering.java
@@ -195,6 +195,7 @@ public class TestRequiredDistributionAndOrdering extends SparkExtensionsTestBase
             inputDF
                 .writeTo(tableName)
                 .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+                .option(SparkWriteOptions.FANOUT_ENABLED, "false")
                 .append();
           } catch (NoSuchTableException e) {
             throw new RuntimeException(e);

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestWriteAborts.java
@@ -112,6 +112,7 @@ public class TestWriteAborts extends SparkExtensionsTestBase {
                     .sortWithinPartitions("id")
                     .writeTo(tableName)
                     .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+                    .option(SparkWriteOptions.FANOUT_ENABLED, "false")
                     .append())
         .isInstanceOf(SparkException.class)
         .hasMessageContaining("Encountered records that belong to already closed files");

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -174,12 +174,21 @@ public class SparkWriteConf {
         .parse();
   }
 
-  public boolean fanoutWriterEnabled() {
+  public boolean useFanoutWriter(SparkWriteRequirements writeRequirements) {
+    boolean defaultValue = !writeRequirements.hasOrdering();
+    return fanoutWriterEnabled(defaultValue);
+  }
+
+  private boolean fanoutWriterEnabled() {
+    return fanoutWriterEnabled(true /* enabled by default */);
+  }
+
+  private boolean fanoutWriterEnabled(boolean defaultValue) {
     return confParser
         .booleanConf()
         .option(SparkWriteOptions.FANOUT_ENABLED)
         .tableProperty(TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED)
-        .defaultValue(TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)
+        .defaultValue(defaultValue)
         .parse();
   }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -406,11 +406,10 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
         Table table, SparkFileWriterFactory writers, OutputFileFactory files, Context context) {
 
       FileIO io = table.io();
-      boolean fanoutEnabled = context.fanoutWriterEnabled();
-      boolean inputOrdered = context.inputOrdered();
+      boolean useFanoutWriter = context.useFanoutWriter();
       long targetFileSize = context.targetDataFileSize();
 
-      if (table.spec().isPartitioned() && fanoutEnabled && !inputOrdered) {
+      if (table.spec().isPartitioned() && useFanoutWriter) {
         return new FanoutDataWriter<>(writers, files, io, targetFileSize);
       } else {
         return new ClusteredDataWriter<>(writers, files, io, targetFileSize);
@@ -670,7 +669,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
     private final FileFormat deleteFileFormat;
     private final long targetDeleteFileSize;
     private final String queryId;
-    private final boolean fanoutWriterEnabled;
+    private final boolean useFanoutWriter;
     private final boolean inputOrdered;
 
     Context(
@@ -687,7 +686,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       this.targetDeleteFileSize = writeConf.targetDeleteFileSize();
       this.metadataSparkType = info.metadataSchema().get();
       this.queryId = info.queryId();
-      this.fanoutWriterEnabled = writeConf.fanoutWriterEnabled();
+      this.useFanoutWriter = writeConf.useFanoutWriter(writeRequirements);
       this.inputOrdered = writeRequirements.hasOrdering();
     }
 
@@ -723,8 +722,8 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
       return queryId;
     }
 
-    boolean fanoutWriterEnabled() {
-      return fanoutWriterEnabled;
+    boolean useFanoutWriter() {
+      return useFanoutWriter;
     }
 
     boolean inputOrdered() {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -98,7 +98,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final Schema writeSchema;
   private final StructType dsSchema;
   private final Map<String, String> extraSnapshotMetadata;
-  private final boolean partitionedFanoutEnabled;
+  private final boolean useFanoutWriter;
   private final SparkWriteRequirements writeRequirements;
   private final Map<String, String> writeProperties;
 
@@ -126,7 +126,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
-    this.partitionedFanoutEnabled = writeConf.fanoutWriterEnabled();
+    this.useFanoutWriter = writeConf.useFanoutWriter(writeRequirements);
     this.writeRequirements = writeRequirements;
     this.outputSpecId = writeConf.outputSpecId();
     this.writeProperties = writeConf.writeProperties();
@@ -188,7 +188,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
         targetFileSize,
         writeSchema,
         dsSchema,
-        partitionedFanoutEnabled,
+        useFanoutWriter,
         writeProperties);
   }
 
@@ -617,7 +617,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     private final long targetFileSize;
     private final Schema writeSchema;
     private final StructType dsSchema;
-    private final boolean partitionedFanoutEnabled;
+    private final boolean useFanoutWriter;
     private final String queryId;
     private final Map<String, String> writeProperties;
 
@@ -629,7 +629,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
         long targetFileSize,
         Schema writeSchema,
         StructType dsSchema,
-        boolean partitionedFanoutEnabled,
+        boolean useFanoutWriter,
         Map<String, String> writeProperties) {
       this.tableBroadcast = tableBroadcast;
       this.format = format;
@@ -637,7 +637,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       this.targetFileSize = targetFileSize;
       this.writeSchema = writeSchema;
       this.dsSchema = dsSchema;
-      this.partitionedFanoutEnabled = partitionedFanoutEnabled;
+      this.useFanoutWriter = useFanoutWriter;
       this.queryId = queryId;
       this.writeProperties = writeProperties;
     }
@@ -678,7 +678,7 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
             writeSchema,
             dsSchema,
             targetFileSize,
-            partitionedFanoutEnabled);
+            useFanoutWriter);
       }
     }
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -241,6 +241,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -252,23 +254,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testDefaultWritePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
@@ -285,6 +272,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -296,27 +285,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testHashWritePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
@@ -333,6 +303,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -342,31 +314,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testRangeWritePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    SortOrder[] expectedOrdering =
-        new SortOrder[] {
-          Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-          Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
-        };
-
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+    enableFanoutWriters(table);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, EMPTY_ORDERING);
   }
@@ -434,6 +383,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.replaceSortOrder().asc("id").commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -443,29 +394,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testRangeWritePartitionedSortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date)",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table.replaceSortOrder().asc("id").commit();
-
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
-
-    SortOrder[] expectedOrdering =
-        new SortOrder[] {
-          Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-          Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING)
-        };
-
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+    enableFanoutWriters(table);
 
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
@@ -642,6 +572,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -653,23 +585,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testDefaultCopyOnWriteDeletePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -686,6 +603,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -694,23 +613,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     checkCopyOnWriteDistributionAndOrdering(
         table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
-  }
 
-  @Test
-  public void testNoneCopyOnWriteDeletePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(
         table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
@@ -728,6 +632,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -739,27 +645,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testHashCopyOnWriteDeletePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -776,6 +663,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -785,30 +674,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testRangeCopyOnWriteDeletePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    SortOrder[] expectedOrdering =
-        new SortOrder[] {
-          Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-          Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
-        };
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1086,6 +953,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -1097,23 +966,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testDefaultCopyOnWriteUpdatePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1130,6 +984,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -1138,23 +994,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     checkCopyOnWriteDistributionAndOrdering(
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
-  }
 
-  @Test
-  public void testNoneCopyOnWriteUpdatePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
@@ -1172,6 +1013,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -1183,27 +1026,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testHashCopyOnWriteUpdatePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1220,6 +1044,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -1229,30 +1055,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testRangeCopyOnWriteUpdatePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    SortOrder[] expectedOrdering =
-        new SortOrder[] {
-          Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-          Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
-        };
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1526,6 +1330,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -1537,23 +1343,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testDefaultCopyOnWriteMergePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1570,6 +1361,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -1578,23 +1371,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     checkCopyOnWriteDistributionAndOrdering(
         table, MERGE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
-  }
 
-  @Test
-  public void testNoneCopyOnWriteMergePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
@@ -1611,6 +1389,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
@@ -1622,27 +1402,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         };
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testHashCopyOnWriteMergePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    Expression[] expectedClustering =
-        new Expression[] {Expressions.identity("date"), Expressions.days("ts")};
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1659,6 +1420,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
@@ -1668,30 +1431,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, expectedOrdering);
-  }
 
-  @Test
-  public void testRangeCopyOnWriteMergePartitionedUnsortedTableFanout() {
-    sql(
-        "CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) "
-            + "USING iceberg "
-            + "PARTITIONED BY (date, days(ts))",
-        tableName);
-
-    Table table = validationCatalog.loadTable(tableIdent);
-
-    table
-        .updateProperties()
-        .set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
-        .set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-        .commit();
-
-    SortOrder[] expectedOrdering =
-        new SortOrder[] {
-          Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-          Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
-        };
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+    enableFanoutWriters(table);
 
     checkCopyOnWriteDistributionAndOrdering(table, MERGE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -1838,6 +1579,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table,
         DELETE,
@@ -1858,6 +1601,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table, DELETE, UNSPECIFIED_DISTRIBUTION, SPEC_ID_PARTITION_FILE_POSITION_ORDERING);
 
@@ -1874,6 +1619,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     checkPositionDeltaDistributionAndOrdering(
         table,
@@ -1895,6 +1642,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     Distribution expectedDistribution = Distributions.ordered(SPEC_ID_PARTITION_FILE_ORDERING);
 
     checkPositionDeltaDistributionAndOrdering(
@@ -1914,6 +1663,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
+
+    disableFanoutWriters(table);
 
     checkPositionDeltaDistributionAndOrdering(
         table,
@@ -1939,6 +1690,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table, DELETE, UNSPECIFIED_DISTRIBUTION, SPEC_ID_PARTITION_FILE_POSITION_ORDERING);
 
@@ -1959,6 +1712,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     checkPositionDeltaDistributionAndOrdering(
         table,
@@ -1983,6 +1738,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
+
+    disableFanoutWriters(table);
 
     Distribution expectedDistribution = Distributions.ordered(SPEC_ID_PARTITION_ORDERING);
 
@@ -2063,6 +1820,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table,
         UPDATE,
@@ -2083,6 +1842,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table, UPDATE, UNSPECIFIED_DISTRIBUTION, SPEC_ID_PARTITION_FILE_POSITION_ORDERING);
 
@@ -2099,6 +1860,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     checkPositionDeltaDistributionAndOrdering(
         table,
@@ -2120,12 +1883,14 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
 
+    disableFanoutWriters(table);
+
     Distribution expectedDistribution = Distributions.ordered(SPEC_ID_PARTITION_FILE_ORDERING);
 
     checkPositionDeltaDistributionAndOrdering(
         table, UPDATE, expectedDistribution, SPEC_ID_PARTITION_FILE_POSITION_ORDERING);
 
-    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+    enableFanoutWriters(table);
 
     checkPositionDeltaDistributionAndOrdering(table, UPDATE, expectedDistribution, EMPTY_ORDERING);
   }
@@ -2263,6 +2028,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {
           Expressions.column(MetadataColumns.SPEC_ID.name()),
@@ -2306,6 +2073,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(
@@ -2340,6 +2109,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     Expression[] expectedClustering =
         new Expression[] {
@@ -2383,6 +2154,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
+
+    disableFanoutWriters(table);
 
     SortOrder[] expectedDistributionOrdering =
         new SortOrder[] {
@@ -2647,6 +2420,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {
           Expressions.column(MetadataColumns.SPEC_ID.name()),
@@ -2671,6 +2446,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     checkPositionDeltaDistributionAndOrdering(
         table, MERGE, UNSPECIFIED_DISTRIBUTION, SPEC_ID_PARTITION_FILE_POSITION_ORDERING);
 
@@ -2687,6 +2464,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     Expression[] expectedClustering =
         new Expression[] {
@@ -2711,6 +2490,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
+
+    disableFanoutWriters(table);
 
     SortOrder[] expectedDistributionOrdering =
         new SortOrder[] {
@@ -2877,6 +2658,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    disableFanoutWriters(table);
+
     Expression[] expectedClustering =
         new Expression[] {
           Expressions.column(MetadataColumns.SPEC_ID.name()),
@@ -2919,6 +2702,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE).commit();
 
+    disableFanoutWriters(table);
+
     SortOrder[] expectedOrdering =
         new SortOrder[] {
           Expressions.sort(
@@ -2953,6 +2738,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH).commit();
+
+    disableFanoutWriters(table);
 
     Expression[] expectedClustering =
         new Expression[] {
@@ -2995,6 +2782,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Table table = validationCatalog.loadTable(tableIdent);
 
     table.updateProperties().set(MERGE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE).commit();
+
+    disableFanoutWriters(table);
 
     SortOrder[] expectedDistributionOrdering =
         new SortOrder[] {
@@ -3225,6 +3014,10 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     SortOrder[] ordering = requirements.ordering();
     Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
+  }
+
+  private void disableFanoutWriters(Table table) {
+    table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "false").commit();
   }
 
   private void enableFanoutWriters(Table table) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -296,11 +296,13 @@ public class TestPartitionValues {
       Table table = tables.create(SUPPORTED_PRIMITIVES, spec, location.toString());
       table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
 
+      // disable distribution/ordering and fanout writers to preserve the original ordering
       sourceDF
           .write()
           .format("iceberg")
           .mode(SaveMode.Append)
           .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+          .option(SparkWriteOptions.FANOUT_ENABLED, "false")
           .save(location.toString());
 
       List<Row> actual =
@@ -374,11 +376,13 @@ public class TestPartitionValues {
       Table table = tables.create(nestedSchema, spec, location.toString());
       table.updateProperties().set(TableProperties.DEFAULT_FILE_FORMAT, format).commit();
 
+      // disable distribution/ordering and fanout writers to preserve the original ordering
       sourceDF
           .write()
           .format("iceberg")
           .mode(SaveMode.Append)
           .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+          .option(SparkWriteOptions.FANOUT_ENABLED, "false")
           .save(location.toString());
 
       List<Row> actual =

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestRequiredDistributionAndOrdering.java
@@ -167,6 +167,7 @@ public class TestRequiredDistributionAndOrdering extends SparkCatalogTestBase {
                 inputDF
                     .writeTo(tableName)
                     .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING, "false")
+                    .option(SparkWriteOptions.FANOUT_ENABLED, "false")
                     .append())
         .cause()
         .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
This PR enables fanout writers for **_unsorted_** tables by default to speed up writes. This should be safe as we distribute the incoming records using the transforms for all operations in partitioned tables (unless configured otherwise). The ability to skip local sorts reduces the probability of expensive spills. This becomes critical given that we consider requesting larger advisory partition sizes.
