### PR TITLE
Core: Add alias for glue, nessie, snowflake, jdbc catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -67,10 +67,18 @@ public class CatalogUtil {
   public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
   public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
   public static final String ICEBERG_CATALOG_TYPE_REST = "rest";
+  public static final String ICEBERG_CATALOG_TYPE_GLUE = "glue";
+  public static final String ICEBERG_CATALOG_TYPE_NESSIE = "nessie";
+  public static final String ICEBERG_CATALOG_TYPE_SNOWFLAKE = "snowflake";
+  public static final String ICEBERG_CATALOG_TYPE_JDBC = "jdbc";
 
   public static final String ICEBERG_CATALOG_HADOOP = "org.apache.iceberg.hadoop.HadoopCatalog";
   public static final String ICEBERG_CATALOG_HIVE = "org.apache.iceberg.hive.HiveCatalog";
   public static final String ICEBERG_CATALOG_REST = "org.apache.iceberg.rest.RESTCatalog";
+  public static final String ICEBERG_CATALOG_GLUE = "org.apache.iceberg.aws.glue.GlueCatalog";
+  public static final String ICEBERG_CATALOG_NESSIE = "org.apache.iceberg.nessie.NessieCatalog";
+  public static final String ICEBERG_CATALOG_SNOWFLAKE = "org.apache.iceberg.snowflake.SnowflakeCatalog";
+  public static final String ICEBERG_CATALOG_JDBC = "org.apache.iceberg.jdbc.JdbcCatalog";
 
   private CatalogUtil() {}
 
@@ -267,6 +275,18 @@ public class CatalogUtil {
           break;
         case ICEBERG_CATALOG_TYPE_REST:
           catalogImpl = ICEBERG_CATALOG_REST;
+          break;
+        case ICEBERG_CATALOG_TYPE_GLUE:
+          catalogImpl = ICEBERG_CATALOG_GLUE;
+          break;
+        case ICEBERG_CATALOG_TYPE_NESSIE:
+          catalogImpl = ICEBERG_CATALOG_NESSIE;
+          break;
+        case ICEBERG_CATALOG_TYPE_SNOWFLAKE:
+          catalogImpl = ICEBERG_CATALOG_SNOWFLAKE;
+          break;
+        case ICEBERG_CATALOG_TYPE_JDBC:
+          catalogImpl = ICEBERG_CATALOG_JDBC;
           break;
         default:
           throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);


### PR DESCRIPTION
Add an alias to make use easier.