### PR TITLE
AWS: Fix DefaultAwsClientFactory#S3FileIOEndpointOverride test

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -55,7 +55,7 @@ public class TestDefaultAwsClientFactory {
     AssertHelpers.assertThrowsCause(
         "Should refuse connection to unknown endpoint",
         SdkClientException.class,
-        "Unable to execute HTTP request: unknown",
+        "Unable to execute HTTP request: bucket.unknown",
         () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
   }
 


### PR DESCRIPTION
I'm not sure yet what caused this failure to be introduced,my hunch is a recent AWS SDK update but the S3FileIOEndpointOverride test is failing because the request is made via "virtual hosted" style requests, so the domain in the request is "<bucket>.<endpoint>" . This change fixes the assertion in the test to reflect this.