### PR TITLE
Spark 3.5: Requested advisory partition size must respect Spark config

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -697,7 +697,12 @@ public class SparkWriteConf {
   private long advisoryPartitionSize(
       long expectedFileSize, FileFormat outputFileFormat, String outputCodec) {
     double shuffleCompressionRatio = shuffleCompressionRatio(outputFileFormat, outputCodec);
-    return (long) (expectedFileSize * shuffleCompressionRatio);
+    long suggestedAdvisoryPartitionSize = (long) (expectedFileSize * shuffleCompressionRatio);
+    return Math.max(suggestedAdvisoryPartitionSize, sparkAdvisoryPartitionSize());
+  }
+
+  private long sparkAdvisoryPartitionSize() {
+    return (long) spark.sessionState().conf().getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES());
   }
 
   private double shuffleCompressionRatio(FileFormat outputFileFormat, String outputCodec) {


### PR DESCRIPTION
This PR adjusts the requested advisory partition size to be at least as big as the configured built-in Spark value. This is needed to avoid breaking pipelines where this property was configured big enough manually.