### PR TITLE
Core: Drop unused MERGE cardinality check table properties

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -832,6 +832,12 @@ acceptedBreaks:
     - code: "java.class.removed"
       old: "interface org.apache.iceberg.actions.RewritePositionDeleteStrategy"
       justification: "Removing deprecated code"
+    - code: "java.field.removedWithConstant"
+      old: "field org.apache.iceberg.TableProperties.MERGE_CARDINALITY_CHECK_ENABLED"
+      justification: "Spark 3.1 has been dropped"
+    - code: "java.field.removedWithConstant"
+      old: "field org.apache.iceberg.TableProperties.MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT"
+      justification: "Spark 3.1 has been dropped"
     - code: "java.method.removed"
       old: "method java.util.List<org.apache.iceberg.DataFile> org.apache.iceberg.MergingSnapshotProducer<ThisT>::addedFiles()\
         \ @ org.apache.iceberg.BaseOverwriteFiles"

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -356,19 +356,6 @@ public class TableProperties {
   public static final String MERGE_MODE = "write.merge.mode";
   public static final String MERGE_MODE_DEFAULT = RowLevelOperationMode.COPY_ON_WRITE.modeName();
 
-  /**
-   * @deprecated will be removed once Spark 3.1 support is dropped, the cardinality check is always
-   *     performed starting from 0.13.0.
-   */
-  @Deprecated
-  public static final String MERGE_CARDINALITY_CHECK_ENABLED =
-      "write.merge.cardinality-check.enabled";
-  /**
-   * @deprecated will be removed once Spark 3.1 support is dropped, the cardinality check is always
-   *     performed starting from 0.13.0.
-   */
-  @Deprecated public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
-
   public static final String MERGE_DISTRIBUTION_MODE = "write.merge.distribution-mode";
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";


### PR DESCRIPTION
This PR removes no longer used MERGE cardinality check table properties.