### PR TITLE
Spec: Clarify missing fields when writing

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -128,7 +128,7 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 #### Writer requirements
 
-Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata (including manifests files and manifest lists) files to a table with the given version.
+Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata files (including manifests files and manifest lists) to a table with the given version.
 
 | Requirement | Write behavior |
 |-------------|----------------|

--- a/format/spec.md
+++ b/format/spec.md
@@ -128,7 +128,7 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 #### Writer requirements
 
-Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata/manifest files to a table with the given version.
+Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata, manifest files, or manifest lists to a table with the given version.
 
 | Requirement | Write behavior                                        |
 |-------------|-------------------------------------------------------|

--- a/format/spec.md
+++ b/format/spec.md
@@ -128,13 +128,13 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 #### Writer requirements
 
-Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata files to a table with the given version.
+Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata/manifest files to a table with the given version.
 
-| Requirement | Write behavior |
-|-------------|----------------|
-| (blank)     | The field should be omitted |
-| _optional_  | The field can be written |
-| _required_  | The field must be written |
+| Requirement | Write behavior                                        |
+|-------------|-------------------------------------------------------|
+| (blank)     | The field should not be present in the schema         |
+| _optional_  | The field should be in the schema, and can be written |
+| _required_  | The field should in the schema and must be written    |
 
 Readers should be more permissive because v1 metadata files are allowed in v2 tables so that tables can be upgraded to v2 without rewriting the metadata tree. For manifest list and manifest files, this table shows the expected v2 read behavior:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -130,11 +130,11 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata (including manifests files and manifest lists) files to a table with the given version.
 
-| Requirement | Write behavior                      |
-|-------------|-------------------------------------|
-| (blank)     | The field should be omitted         |
+| Requirement | Write behavior |
+|-------------|----------------|
+| (blank)     | The field should be omitted |
 | _optional_  | The field can be written or omitted |
-| _required_  | The field must be written           |
+| _required_  | The field must be written |
 
 Readers should be more permissive because v1 metadata files are allowed in v2 tables so that tables can be upgraded to v2 without rewriting the metadata tree. For manifest list and manifest files, this table shows the expected v2 read behavior:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -128,13 +128,13 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 #### Writer requirements
 
-Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata, manifest files, or manifest lists to a table with the given version.
+Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata (including manifests files and manifest lists) files to a table with the given version.
 
-| Requirement | Write behavior                                      |
-|-------------|-----------------------------------------------------|
-| (blank)     | The field is not present in the schema              |
-| _optional_  | The field is part of the schema, and can be written |
-| _required_  | The field is part of schema and must be written     |
+| Requirement | Write behavior                      |
+|-------------|-------------------------------------|
+| (blank)     | The field should be omitted         |
+| _optional_  | The field can be written or omitted |
+| _required_  | The field must be written           |
 
 Readers should be more permissive because v1 metadata files are allowed in v2 tables so that tables can be upgraded to v2 without rewriting the metadata tree. For manifest list and manifest files, this table shows the expected v2 read behavior:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -130,11 +130,11 @@ Tables do not require rename, except for tables that use atomic rename to implem
 
 Some tables in this spec have columns that specify requirements for v1 and v2 tables. These requirements are intended for writers when adding metadata, manifest files, or manifest lists to a table with the given version.
 
-| Requirement | Write behavior                                        |
-|-------------|-------------------------------------------------------|
-| (blank)     | The field should not be present in the schema         |
-| _optional_  | The field should be in the schema, and can be written |
-| _required_  | The field should in the schema and must be written    |
+| Requirement | Write behavior                                      |
+|-------------|-----------------------------------------------------|
+| (blank)     | The field is not present in the schema              |
+| _optional_  | The field is part of the schema, and can be written |
+| _required_  | The field is part of schema and must be written     |
 
 Readers should be more permissive because v1 metadata files are allowed in v2 tables so that tables can be upgraded to v2 without rewriting the metadata tree. For manifest list and manifest files, this table shows the expected v2 read behavior:
 


### PR DESCRIPTION
Jan raised a point on Slack of the semantic meaning of a field that can be written:

https://apache-iceberg.slack.com/archives/C03LG1D563F/p1695834739711569

There are two options:

- The field is not part of the schema, and is omitted from the file
- The field is part of the schema, but the value is not written (nullable)

My personal take on this is that we should use static schema when writing Avro files so that all the fields that are either optional or required are in the schema.

I'm well aware that this doesn't impose any issues if you dogfood the Iceberg Avro reader, where you can add required fields, for example, the `134: content` field in the manifest.

However, I think we should try to stick to the concept of writing strictly, read permissive where we try to encourage people to write all the fields that are in the spec (even if the value itself is all null).