### PR TITLE
Core: Fix negation in `requireStrictCleanup`

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -320,7 +320,7 @@ public class BaseTransaction implements Transaction {
 
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update
-      if (!ops.requireStrictCleanup() || e instanceof CleanableFailure) {
+      if (ops.requireStrictCleanup() || e instanceof CleanableFailure) {
         cleanAllUpdates();
       }
 
@@ -375,7 +375,7 @@ public class BaseTransaction implements Transaction {
 
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
-      if (!ops.requireStrictCleanup() || e instanceof CleanableFailure) {
+      if (ops.requireStrictCleanup() || e instanceof CleanableFailure) {
         cleanAllUpdates();
       }
 
@@ -423,7 +423,7 @@ public class BaseTransaction implements Transaction {
       cleanUpOnCommitFailure();
       throw e.wrapped();
     } catch (RuntimeException e) {
-      if (!ops.requireStrictCleanup() || e instanceof CleanableFailure) {
+      if (ops.requireStrictCleanup() || e instanceof CleanableFailure) {
         cleanUpOnCommitFailure();
       }
 


### PR DESCRIPTION
Found a regression that the snapshots are still around after the commit fails: https://github.com/trinodb/trino/pull/19188

```
io.trino.plugin.iceberg.catalog.file.TestIcebergFileMetastoreCreateTableFailure.testCreateTableFailureMetadataCleanedUp; (took: 0.0 seconds)
2023-09-28T18:24:02.9837549Z java.lang.AssertionError: [Metadata file should not exist] 
2023-09-28T18:24:02.9837847Z Expecting actual:
2023-09-28T18:24:02.9838206Z   /tmp/test_iceberg_create_table_failure482309508502886299/test_create_failure_4huakfy1pd/metadata
2023-09-28T18:24:02.9838580Z to be an empty directory but it contained:
2023-09-28T18:24:02.9839258Z   [/tmp/test_iceberg_create_table_failure482309508502886299/test_create_failure_4huakfy1pd/metadata/.snap-905595869249987831-1-7e5e14a9-79ec-449d-abf4-9cae0d693663.avro.crc,
```

This is a result of: https://github.com/apache/iceberg/pull/8599 It was actually enabled before, but now it is disabled.


After the fix, I checked locally, the test passes:

