### PR TITLE
AWS: avoid static global credentials provider which doesn't play well with lifecycle management

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -226,7 +226,7 @@ public class AwsClientFactories {
             AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
       }
     } else {
-      return DefaultCredentialsProvider.create();
+      return DefaultCredentialsProvider.builder().build();
     }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -226,6 +226,7 @@ public class AwsClientFactories {
             AwsSessionCredentials.create(accessKeyId, secretAccessKey, sessionToken));
       }
     } else {
+      // Create a new credential provider for each client
       return DefaultCredentialsProvider.builder().build();
     }
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -150,6 +150,7 @@ public class AwsClientProperties implements Serializable {
       return credentialsProvider(this.clientCredentialsProvider);
     }
 
+    // Create a new credential provider for each client
     return DefaultCredentialsProvider.builder().build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -150,7 +150,7 @@ public class AwsClientProperties implements Serializable {
       return credentialsProvider(this.clientCredentialsProvider);
     }
 
-    return DefaultCredentialsProvider.create();
+    return DefaultCredentialsProvider.builder().build();
   }
 
   private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -485,7 +485,7 @@ public class AwsProperties implements Serializable {
       return credentialsProvider(this.clientCredentialsProvider);
     }
 
-    return DefaultCredentialsProvider.create();
+    return DefaultCredentialsProvider.builder().build();
   }
 
   private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -485,6 +485,7 @@ public class AwsProperties implements Serializable {
       return credentialsProvider(this.clientCredentialsProvider);
     }
 
+    // Create a new credential provider for each client
     return DefaultCredentialsProvider.builder().build();
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsClientPropertiesTest.java
@@ -62,6 +62,19 @@ public class AwsClientPropertiesTest {
   }
 
   @Test
+  public void testCreatesNewInstanceOfDefaultCredentialsConfiguration() {
+    AwsClientProperties awsClientProperties = new AwsClientProperties();
+    AwsCredentialsProvider credentialsProvider =
+        awsClientProperties.credentialsProvider(null, null, null);
+    AwsCredentialsProvider credentialsProvider2 =
+        awsClientProperties.credentialsProvider(null, null, null);
+
+    Assertions.assertThat(credentialsProvider)
+        .withFailMessage("Should create a new instance in each call")
+        .isNotSameAs(credentialsProvider2);
+  }
+
+  @Test
   public void testBasicCredentialsConfiguration() {
     AwsClientProperties awsClientProperties = new AwsClientProperties();
     // set access key id and secret access key


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/8601

It replaces `DefaultCredentialsProvider.create()` with `DefaultCredentialsProvider.builder().build()` to avoid sharing the same credentials provider across multiple clients.

This PR changes 3 places calling `DefaultCredentialsProvider.create()`, and adds one test for `AwsCredentialsProvider.credentialsProvider`. The other two are deprecated so no tests were added for them.