### PR TITLE
Kafka Connect: Initial project setup and event data structures

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -185,3 +185,9 @@ AZURE:
       'azure/**/*',
       'azure-bundle/**/*'
     ]
+
+KAFKACONNECT:
+  - changed-files:
+    - any-glob-to-any-file: [
+      'kafka-connect/**/*'
+    ]

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
@@ -59,7 +60,7 @@ public class AvroSchemaUtil {
 
   public static Schema convert(
       org.apache.iceberg.Schema schema, Map<Types.StructType, String> names) {
-    return TypeUtil.visit(schema, new TypeToSchema(names));
+    return TypeUtil.visit(schema, new TypeToSchema.WithTypeToName(names));
   }
 
   public static Schema convert(Type type) {
@@ -71,7 +72,12 @@ public class AvroSchemaUtil {
   }
 
   public static Schema convert(Type type, Map<Types.StructType, String> names) {
-    return TypeUtil.visit(type, new TypeToSchema(names));
+    return TypeUtil.visit(type, new TypeToSchema.WithTypeToName(names));
+  }
+
+  public static Schema convert(
+      Type type, BiFunction<Integer, Types.StructType, String> namesFunction) {
+    return TypeUtil.visit(type, new TypeToSchema.WithNamesFunction(namesFunction));
   }
 
   public static Type convert(Schema schema) {
@@ -111,7 +117,8 @@ public class AvroSchemaUtil {
   }
 
   public static Map<Type, Schema> convertTypes(Types.StructType type, String name) {
-    TypeToSchema converter = new TypeToSchema(ImmutableMap.of(type, name));
+    TypeToSchema.WithTypeToName converter =
+        new TypeToSchema.WithTypeToName(ImmutableMap.of(type, name));
     TypeUtil.visit(type, converter);
     return ImmutableMap.copyOf(converter.getConversionMap());
   }

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -30,7 +31,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
-class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
+abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   private static final Schema BOOLEAN_SCHEMA = Schema.create(Schema.Type.BOOLEAN);
   private static final Schema INTEGER_SCHEMA = Schema.create(Schema.Type.INT);
   private static final Schema LONG_SCHEMA = Schema.create(Schema.Type.LONG);
@@ -55,15 +56,10 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   }
 
   private final Deque<Integer> fieldIds = Lists.newLinkedList();
-  private final Map<Type, Schema> results = Maps.newHashMap();
-  private final Map<Types.StructType, String> names;
+  private final BiFunction<Integer, Types.StructType, String> namesFunction;
 
-  TypeToSchema(Map<Types.StructType, String> names) {
-    this.names = names;
-  }
-
-  Map<Type, Schema> getConversionMap() {
-    return results;
+  TypeToSchema(BiFunction<Integer, Types.StructType, String> namesFunction) {
+    this.namesFunction = namesFunction;
   }
 
   @Override
@@ -83,14 +79,12 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
   @Override
   public Schema struct(Types.StructType struct, List<Schema> fieldSchemas) {
-    Schema recordSchema = results.get(struct);
-    if (recordSchema != null) {
-      return recordSchema;
-    }
+    Schema recordSchema;
 
-    String recordName = names.get(struct);
+    Integer fieldId = fieldIds.peek();
+    String recordName = namesFunction.apply(fieldId, struct);
     if (recordName == null) {
-      recordName = "r" + fieldIds.peek();
+      recordName = "r" + fieldId;
     }
 
     List<Types.NestedField> structFields = struct.fields();
@@ -115,8 +109,6 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
     recordSchema = Schema.createRecord(recordName, null, null, false, fields);
 
-    results.put(struct, recordSchema);
-
     return recordSchema;
   }
 
@@ -131,11 +123,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
   @Override
   public Schema list(Types.ListType list, Schema elementSchema) {
-    Schema listSchema = results.get(list);
-    if (listSchema != null) {
-      return listSchema;
-    }
-
+    Schema listSchema;
     if (list.isElementOptional()) {
       listSchema = Schema.createArray(AvroSchemaUtil.toOption(elementSchema));
     } else {
@@ -144,18 +132,12 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
     listSchema.addProp(AvroSchemaUtil.ELEMENT_ID_PROP, list.elementId());
 
-    results.put(list, listSchema);
-
     return listSchema;
   }
 
   @Override
   public Schema map(Types.MapType map, Schema keySchema, Schema valueSchema) {
-    Schema mapSchema = results.get(map);
-    if (mapSchema != null) {
-      return mapSchema;
-    }
-
+    Schema mapSchema;
     if (keySchema.getType() == Schema.Type.STRING) {
       // if the map has string keys, use Avro's map type
       mapSchema =
@@ -172,8 +154,6 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
               map.valueId(),
               map.isValueOptional() ? AvroSchemaUtil.toOption(valueSchema) : valueSchema);
     }
-
-    results.put(map, mapSchema);
 
     return mapSchema;
   }
@@ -238,8 +218,68 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
         throw new UnsupportedOperationException("Unsupported type ID: " + primitive.typeId());
     }
 
-    results.put(primitive, primitiveSchema);
-
     return primitiveSchema;
+  }
+
+  static class WithTypeToName extends TypeToSchema {
+
+    private final Map<Type, Schema> results = Maps.newHashMap();
+
+    WithTypeToName(Map<Types.StructType, String> names) {
+      super((id, struct) -> names.get(struct));
+    }
+
+    Map<Type, Schema> getConversionMap() {
+      return results;
+    }
+
+    @Override
+    public Schema struct(Types.StructType struct, List<Schema> fieldSchemas) {
+      Schema recordSchema = results.get(struct);
+      if (recordSchema != null) {
+        return recordSchema;
+      }
+
+      recordSchema = super.struct(struct, fieldSchemas);
+      results.put(struct, recordSchema);
+      return recordSchema;
+    }
+
+    @Override
+    public Schema list(Types.ListType list, Schema elementSchema) {
+      Schema listSchema = results.get(list);
+      if (listSchema != null) {
+        return listSchema;
+      }
+
+      listSchema = super.list(list, elementSchema);
+      results.put(list, listSchema);
+      return listSchema;
+    }
+
+    @Override
+    public Schema map(Types.MapType map, Schema keySchema, Schema valueSchema) {
+      Schema mapSchema = results.get(map);
+      if (mapSchema != null) {
+        return mapSchema;
+      }
+
+      mapSchema = super.map(map, keySchema, valueSchema);
+      results.put(map, mapSchema);
+      return mapSchema;
+    }
+
+    @Override
+    public Schema primitive(Type.PrimitiveType primitive) {
+      Schema primitiveSchema = super.primitive(primitive);
+      results.put(primitive, primitiveSchema);
+      return primitiveSchema;
+    }
+  }
+
+  static class WithNamesFunction extends TypeToSchema {
+    WithNamesFunction(BiFunction<Integer, Types.StructType, String> namesFunction) {
+      super(namesFunction);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DecoderResolver.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DecoderResolver.java
@@ -51,6 +51,10 @@ public class DecoderResolver {
     return value;
   }
 
+  public static void clearCache() {
+    DECODER_CACHES.get().clear();
+  }
+
   @VisibleForTesting
   static ResolvingDecoder resolve(Decoder decoder, Schema readSchema, Schema fileSchema)
       throws IOException {

--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+project(":iceberg-kafka-connect:iceberg-kafka-connect-events") {
+  dependencies {
+    api project(':iceberg-api')
+    implementation project(':iceberg-core')
+    implementation project(':iceberg-common')
+    implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    implementation libs.avro.avro
+  }
+
+  test {
+    useJUnitPlatform()
+  }  
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.avro.AvroEncoderUtil;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.data.avro.DecoderResolver;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+
+/** Class for Avro-related utility methods. */
+class AvroUtil {
+  static final Map<Integer, String> FIELD_ID_TO_CLASS =
+      ImmutableMap.of(
+          10_102,
+          TopicPartitionOffset.class.getName(),
+          DataFile.PARTITION_ID,
+          PartitionData.class.getName(),
+          10_301,
+          TableReference.class.getName(),
+          10_303,
+          "org.apache.iceberg.GenericDataFile",
+          10_305,
+          "org.apache.iceberg.GenericDeleteFile",
+          10_401,
+          TableReference.class.getName());
+
+  public static byte[] encode(Event event) {
+    try {
+      return AvroEncoderUtil.encode(event, event.getSchema());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static Event decode(byte[] bytes) {
+    try {
+      Event event = AvroEncoderUtil.decode(bytes);
+      // clear the cache to avoid memory leak
+      DecoderResolver.clearCache();
+      return event;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  static Schema convert(Types.StructType icebergSchema) {
+    return AvroSchemaUtil.convert(
+        icebergSchema, (fieldId, struct) -> FIELD_ID_TO_CLASS.get(fieldId));
+  }
+
+  private AvroUtil() {}
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.avro.AvroEncoderUtil;
@@ -66,9 +67,18 @@ class AvroUtil {
     }
   }
 
-  static Schema convert(Types.StructType icebergSchema) {
+  static Schema convert(Types.StructType icebergSchema, Class<? extends IndexedRecord> javaClass) {
+    return convert(icebergSchema, javaClass, FIELD_ID_TO_CLASS);
+  }
+
+  static Schema convert(
+      Types.StructType icebergSchema,
+      Class<? extends IndexedRecord> javaClass,
+      Map<Integer, String> typeMap) {
     return AvroSchemaUtil.convert(
-        icebergSchema, (fieldId, struct) -> FIELD_ID_TO_CLASS.get(fieldId));
+        icebergSchema,
+        (fieldId, struct) ->
+            struct.equals(icebergSchema) ? javaClass.getName() : typeMap.get(fieldId));
   }
 
   private AvroUtil() {}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.avro.AvroEncoderUtil;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.avro.DecoderResolver;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
@@ -82,14 +83,11 @@ class AvroUtil {
             struct.equals(icebergSchema) ? javaClass.getName() : typeMap.get(fieldId));
   }
 
-  static int[] positionsToIds(Schema avroSchema) {
-    int[] result = new int[avroSchema.getFields().size()];
+  static int positionToId(int position, Schema avroSchema) {
     List<Schema.Field> fields = avroSchema.getFields();
-    for (int i = 0; i < result.length; i++) {
-      Object val = fields.get(i).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
-      result[i] = val == null ? -1 : (int) val;
-    }
-    return result;
+    Preconditions.checkArgument(position < fields.size(), "Invalid field position: " + position);
+    Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
+    return val == null ? -1 : (int) val;
   }
 
   private AvroUtil() {}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/AvroUtil.java
@@ -85,7 +85,8 @@ class AvroUtil {
 
   static int positionToId(int position, Schema avroSchema) {
     List<Schema.Field> fields = avroSchema.getFields();
-    Preconditions.checkArgument(position < fields.size(), "Invalid field position: " + position);
+    Preconditions.checkArgument(
+        position >= 0 && position < fields.size(), "Invalid field position: " + position);
     Object val = fields.get(position).getObjectProp(AvroSchemaUtil.FIELD_ID_PROP);
     return val == null ? -1 : (int) val;
   }

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitComplete.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitComplete.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * A control event payload for events sent by a coordinator that indicates it has completed a commit
+ * cycle. Events with this payload are not consumed by the sink, they are informational and can be
+ * used by consumers to trigger downstream processes.
+ */
+public class CommitComplete implements Payload {
+
+  private UUID commitId;
+  private Long validThroughTs;
+  private final Schema avroSchema;
+
+  private static final StructType ICEBERG_SCHEMA =
+      StructType.of(
+          NestedField.required(10_000, "commit_id", UUIDType.get()),
+          NestedField.optional(10_001, "valid_through_ts", TimestampType.withZone()));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public CommitComplete(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public CommitComplete(UUID commitId, Long validThroughTs) {
+    this.commitId = commitId;
+    this.validThroughTs = validThroughTs;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  @Override
+  public PayloadType type() {
+    return PayloadType.COMMIT_COMPLETE;
+  }
+
+  public UUID commitId() {
+    return commitId;
+  }
+
+  /**
+   * Valid-through timestamp, which is the min-of-max record timestamps across all workers for the
+   * commit.
+   */
+  public Long validThroughTs() {
+    return validThroughTs;
+  }
+
+  @Override
+  public StructType writeSchema() {
+    return ICEBERG_SCHEMA;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.validThroughTs = (Long) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return validThroughTs;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitComplete.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitComplete.java
@@ -41,7 +41,7 @@ public class CommitComplete implements Payload {
           NestedField.required(10_000, "commit_id", UUIDType.get()),
           NestedField.optional(10_001, "valid_through_ts", TimestampType.withZone()));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, CommitComplete.class);
 
   // Used by Avro reflection to instantiate this class when reading events
   public CommitComplete(Schema avroSchema) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
@@ -46,7 +46,7 @@ public class CommitToTable implements Payload {
           NestedField.optional(10_402, "snapshot_id", LongType.get()),
           NestedField.optional(10_403, "valid_through_ts", TimestampType.withZone()));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, CommitToTable.class);
 
   // Used by Avro reflection to instantiate this class when reading events
   public CommitToTable(Schema avroSchema) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * A control event payload for events sent by a coordinator that indicates it has completed a commit
+ * cycle. Events with this payload are not consumed by the sink, they are informational and can be
+ * used by consumers to trigger downstream processes.
+ */
+public class CommitToTable implements Payload {
+
+  private UUID commitId;
+  private TableReference tableReference;
+  private Long snapshotId;
+  private Long validThroughTs;
+  private final Schema avroSchema;
+
+  private static final StructType ICEBERG_SCHEMA =
+      StructType.of(
+          NestedField.required(10_400, "commit_id", UUIDType.get()),
+          NestedField.required(10_401, "table_reference", TableReference.ICEBERG_SCHEMA),
+          NestedField.optional(10_402, "snapshot_id", LongType.get()),
+          NestedField.optional(10_403, "valid_through_ts", TimestampType.withZone()));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public CommitToTable(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public CommitToTable(
+      UUID commitId, TableReference tableReference, Long snapshotId, Long validThroughTs) {
+    this.commitId = commitId;
+    this.tableReference = tableReference;
+    this.snapshotId = snapshotId;
+    this.validThroughTs = validThroughTs;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  @Override
+  public PayloadType type() {
+    return PayloadType.COMMIT_TO_TABLE;
+  }
+
+  public UUID commitId() {
+    return commitId;
+  }
+
+  public TableReference tableReference() {
+    return tableReference;
+  }
+
+  public Long snapshotId() {
+    return snapshotId;
+  }
+
+  public Long validThroughTs() {
+    return validThroughTs;
+  }
+
+  @Override
+  public StructType writeSchema() {
+    return ICEBERG_SCHEMA;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.tableReference = (TableReference) v;
+        return;
+      case 2:
+        this.snapshotId = (Long) v;
+        return;
+      case 3:
+        this.validThroughTs = (Long) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return tableReference;
+      case 2:
+        return snapshotId;
+      case 3:
+        return validThroughTs;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
@@ -35,7 +35,6 @@ public class DataComplete implements Payload {
   private UUID commitId;
   private List<TopicPartitionOffset> assignments;
   private final Schema avroSchema;
-  private final int[] positionsToIds;
 
   static final int COMMIT_ID = 10_100;
   static final int ASSIGNMENTS = 10_101;
@@ -49,19 +48,16 @@ public class DataComplete implements Payload {
               "assignments",
               ListType.ofRequired(ASSIGNMENTS_ELEMENT, TopicPartitionOffset.ICEBERG_SCHEMA)));
   private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, DataComplete.class);
-  private static final int[] POSITIONS_TO_IDS = AvroUtil.positionsToIds(AVRO_SCHEMA);
 
   // Used by Avro reflection to instantiate this class when reading events
   public DataComplete(Schema avroSchema) {
     this.avroSchema = avroSchema;
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public DataComplete(UUID commitId, List<TopicPartitionOffset> assignments) {
     this.commitId = commitId;
     this.assignments = assignments;
     this.avroSchema = AVRO_SCHEMA;
-    this.positionsToIds = POSITIONS_TO_IDS;
   }
 
   @Override
@@ -90,7 +86,7 @@ public class DataComplete implements Payload {
   @Override
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         this.commitId = (UUID) v;
         return;
@@ -104,7 +100,7 @@ public class DataComplete implements Payload {
 
   @Override
   public Object get(int i) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         return commitId;
       case ASSIGNMENTS:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * A control event payload for events sent by a worker that indicates it has finished sending all
+ * data for a commit request.
+ */
+public class DataComplete implements Payload {
+
+  private UUID commitId;
+  private List<TopicPartitionOffset> assignments;
+  private final Schema avroSchema;
+
+  private static final StructType ICEBERG_SCHEMA =
+      StructType.of(
+          NestedField.required(10_100, "commit_id", UUIDType.get()),
+          NestedField.optional(
+              10_101,
+              "assignments",
+              ListType.ofRequired(10_102, TopicPartitionOffset.ICEBERG_SCHEMA)));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public DataComplete(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public DataComplete(UUID commitId, List<TopicPartitionOffset> assignments) {
+    this.commitId = commitId;
+    this.assignments = assignments;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  @Override
+  public PayloadType type() {
+    return PayloadType.DATA_COMPLETE;
+  }
+
+  public UUID commitId() {
+    return commitId;
+  }
+
+  public List<TopicPartitionOffset> assignments() {
+    return assignments;
+  }
+
+  @Override
+  public StructType writeSchema() {
+    return ICEBERG_SCHEMA;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.assignments = (List<TopicPartitionOffset>) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return assignments;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataComplete.java
@@ -44,7 +44,7 @@ public class DataComplete implements Payload {
               "assignments",
               ListType.ofRequired(10_102, TopicPartitionOffset.ICEBERG_SCHEMA)));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, DataComplete.class);
 
   // Used by Avro reflection to instantiate this class when reading events
   public DataComplete(Schema avroSchema) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.List;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * A control event payload for events sent by a worker that contains the table data that has been
+ * written and is ready to commit.
+ */
+public class DataWritten implements Payload {
+
+  private UUID commitId;
+  private TableReference tableReference;
+  private List<DataFile> dataFiles;
+  private List<DeleteFile> deleteFiles;
+  private StructType icebergSchema;
+  private final Schema avroSchema;
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public DataWritten(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public DataWritten(
+      StructType partitionType,
+      UUID commitId,
+      TableReference tableReference,
+      List<DataFile> dataFiles,
+      List<DeleteFile> deleteFiles) {
+    this.commitId = commitId;
+    this.tableReference = tableReference;
+    this.dataFiles = dataFiles;
+    this.deleteFiles = deleteFiles;
+
+    StructType dataFileStruct = DataFile.getType(partitionType);
+
+    this.icebergSchema =
+        StructType.of(
+            NestedField.required(10_300, "commit_id", UUIDType.get()),
+            NestedField.required(10_301, "table_reference", TableReference.ICEBERG_SCHEMA),
+            NestedField.optional(10_302, "data_files", ListType.ofRequired(10_303, dataFileStruct)),
+            NestedField.optional(
+                10_304, "delete_files", ListType.ofRequired(10_305, dataFileStruct)));
+
+    this.avroSchema = AvroUtil.convert(icebergSchema);
+  }
+
+  @Override
+  public PayloadType type() {
+    return PayloadType.DATA_WRITTEN;
+  }
+
+  public UUID commitId() {
+    return commitId;
+  }
+
+  public TableReference tableReference() {
+    return tableReference;
+  }
+
+  public List<DataFile> dataFiles() {
+    return dataFiles;
+  }
+
+  public List<DeleteFile> deleteFiles() {
+    return deleteFiles;
+  }
+
+  @Override
+  public StructType writeSchema() {
+    return icebergSchema;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      case 1:
+        this.tableReference = (TableReference) v;
+        return;
+      case 2:
+        this.dataFiles = (List<DataFile>) v;
+        return;
+      case 3:
+        this.deleteFiles = (List<DeleteFile>) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      case 1:
+        return tableReference;
+      case 2:
+        return dataFiles;
+      case 3:
+        return deleteFiles;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
@@ -43,7 +43,8 @@ public class DataWritten implements Payload {
   private StructType icebergSchema;
   private Schema avroSchema;
 
-  // Used by Avro reflection to instantiate this class when reading events
+  // Used by Avro reflection to instantiate this class when reading events, note that this does not
+  // set the partition type so the instance cannot be re-serialized
   public DataWritten(Schema avroSchema) {
     this.avroSchema = avroSchema;
   }

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/DataWritten.java
@@ -42,7 +42,6 @@ public class DataWritten implements Payload {
   private List<DeleteFile> deleteFiles;
   private StructType icebergSchema;
   private final Schema avroSchema;
-  private final int[] positionsToIds;
 
   static final int COMMIT_ID = 10_300;
   static final int TABLE_REFERENCE = 10_301;
@@ -55,7 +54,6 @@ public class DataWritten implements Payload {
   // set the partition type so the instance cannot be re-serialized
   public DataWritten(Schema avroSchema) {
     this.avroSchema = avroSchema;
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public DataWritten(
@@ -70,7 +68,6 @@ public class DataWritten implements Payload {
     this.dataFiles = dataFiles;
     this.deleteFiles = deleteFiles;
     this.avroSchema = AvroUtil.convert(writeSchema(), getClass());
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   @Override
@@ -125,7 +122,7 @@ public class DataWritten implements Payload {
   @Override
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         this.commitId = (UUID) v;
         return;
@@ -145,7 +142,7 @@ public class DataWritten implements Payload {
 
   @Override
   public Object get(int i) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         return commitId;
       case TABLE_REFERENCE:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.Map;
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * Class representing all events produced to the control topic. Different event types have different
+ * payloads.
+ */
+public class Event implements IndexedRecord {
+
+  private UUID id;
+  private PayloadType type;
+  private Long timestamp;
+  private String groupId;
+  private Payload payload;
+  private final Schema avroSchema;
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public Event(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public Event(String groupId, Payload payload) {
+    this.id = UUID.randomUUID();
+    this.type = payload.type();
+    this.timestamp = System.currentTimeMillis();
+    this.groupId = groupId;
+    this.payload = payload;
+
+    StructType icebergSchema =
+        StructType.of(
+            NestedField.required(10_500, "id", UUIDType.get()),
+            NestedField.required(10_501, "type", IntegerType.get()),
+            NestedField.required(10_502, "timestamp", TimestampType.withZone()),
+            NestedField.required(10_503, "group_id", StringType.get()),
+            NestedField.required(10_504, "payload", payload.writeSchema()));
+
+    Map<Integer, String> typeMap = Maps.newHashMap(AvroUtil.FIELD_ID_TO_CLASS);
+    typeMap.put(10_504, payload.getClass().getName());
+
+    this.avroSchema =
+        AvroSchemaUtil.convert(
+            icebergSchema,
+            (fieldId, struct) ->
+                struct.equals(icebergSchema) ? getClass().getName() : typeMap.get(fieldId));
+  }
+
+  public UUID id() {
+    return id;
+  }
+
+  public PayloadType type() {
+    return type;
+  }
+
+  public Long timestamp() {
+    return timestamp;
+  }
+
+  public Payload payload() {
+    return payload;
+  }
+
+  public String groupId() {
+    return groupId;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.id = (UUID) v;
+        return;
+      case 1:
+        this.type = v == null ? null : PayloadType.values()[(Integer) v];
+        return;
+      case 2:
+        this.timestamp = (Long) v;
+        return;
+      case 3:
+        this.groupId = v == null ? null : v.toString();
+        return;
+      case 4:
+        this.payload = (Payload) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return id;
+      case 1:
+        return type == null ? null : type.id();
+      case 2:
+        return timestamp;
+      case 3:
+        return groupId;
+      case 4:
+        return payload;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -46,7 +46,6 @@ public class Event implements IndexedRecord {
   private String groupId;
   private Payload payload;
   private final Schema avroSchema;
-  private final int[] positionsToIds;
 
   static final int ID = 10_500;
   static final int TYPE = 10_501;
@@ -57,7 +56,6 @@ public class Event implements IndexedRecord {
   // Used by Avro reflection to instantiate this class when reading events
   public Event(Schema avroSchema) {
     this.avroSchema = avroSchema;
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public Event(String groupId, Payload payload) {
@@ -79,7 +77,6 @@ public class Event implements IndexedRecord {
     typeMap.put(PAYLOAD, payload.getClass().getName());
 
     this.avroSchema = AvroUtil.convert(icebergSchema, getClass(), typeMap);
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public UUID id() {
@@ -109,7 +106,7 @@ public class Event implements IndexedRecord {
 
   @Override
   public void put(int i, Object v) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case ID:
         this.id = (UUID) v;
         return;
@@ -132,7 +129,7 @@ public class Event implements IndexedRecord {
 
   @Override
   public Object get(int i) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case ID:
         return id;
       case TYPE:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.NestedField;
@@ -67,11 +66,7 @@ public class Event implements IndexedRecord {
     Map<Integer, String> typeMap = Maps.newHashMap(AvroUtil.FIELD_ID_TO_CLASS);
     typeMap.put(10_504, payload.getClass().getName());
 
-    this.avroSchema =
-        AvroSchemaUtil.convert(
-            icebergSchema,
-            (fieldId, struct) ->
-                struct.equals(icebergSchema) ? getClass().getName() : typeMap.get(fieldId));
+    this.avroSchema = AvroUtil.convert(icebergSchema, getClass(), typeMap);
   }
 
   public UUID id() {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.connect.events;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.avro.Schema;
@@ -29,6 +31,7 @@ import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
+import org.apache.iceberg.util.DateTimeUtil;
 
 /**
  * Class representing all events produced to the control topic. Different event types have different
@@ -38,7 +41,7 @@ public class Event implements IndexedRecord {
 
   private UUID id;
   private PayloadType type;
-  private Long timestamp;
+  private OffsetDateTime timestamp;
   private String groupId;
   private Payload payload;
   private final Schema avroSchema;
@@ -51,7 +54,7 @@ public class Event implements IndexedRecord {
   public Event(String groupId, Payload payload) {
     this.id = UUID.randomUUID();
     this.type = payload.type();
-    this.timestamp = System.currentTimeMillis();
+    this.timestamp = OffsetDateTime.now(ZoneOffset.UTC);
     this.groupId = groupId;
     this.payload = payload;
 
@@ -77,7 +80,7 @@ public class Event implements IndexedRecord {
     return type;
   }
 
-  public Long timestamp() {
+  public OffsetDateTime timestamp() {
     return timestamp;
   }
 
@@ -104,7 +107,7 @@ public class Event implements IndexedRecord {
         this.type = v == null ? null : PayloadType.values()[(Integer) v];
         return;
       case 2:
-        this.timestamp = (Long) v;
+        this.timestamp = v == null ? null : DateTimeUtil.timestamptzFromMicros((Long) v);
         return;
       case 3:
         this.groupId = v == null ? null : v.toString();
@@ -125,7 +128,7 @@ public class Event implements IndexedRecord {
       case 1:
         return type == null ? null : type.id();
       case 2:
-        return timestamp;
+        return timestamp == null ? null : DateTimeUtil.microsFromTimestamptz(timestamp);
       case 3:
         return groupId;
       case 4:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Event.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.connect.events;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.avro.Schema;
@@ -54,7 +55,7 @@ public class Event implements IndexedRecord {
   public Event(String groupId, Payload payload) {
     this.id = UUID.randomUUID();
     this.type = payload.type();
-    this.timestamp = OffsetDateTime.now(ZoneOffset.UTC);
+    this.timestamp = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
     this.groupId = groupId;
     this.payload = payload;
 

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Payload.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/Payload.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Interface for an element that is an event payload. Different event types contain different
+ * payloads.
+ */
+public interface Payload extends IndexedRecord {
+
+  PayloadType type();
+
+  Types.StructType writeSchema();
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/PayloadType.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/PayloadType.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+/** Control event types. */
+public enum PayloadType {
+  /** Maps to payload of type {@link StartCommit} */
+  START_COMMIT(0),
+  /** Maps to payload of type {@link DataWritten} */
+  DATA_WRITTEN(1),
+  /** Maps to payload of type {@link DataComplete} */
+  DATA_COMPLETE(2),
+  /** Maps to payload of type {@link CommitToTable} */
+  COMMIT_TO_TABLE(3),
+  /** Maps to payload of type {@link CommitComplete} */
+  COMMIT_COMPLETE(4);
+
+  private final int id;
+
+  PayloadType(int id) {
+    this.id = id;
+  }
+
+  public int id() {
+    return id;
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
@@ -32,25 +32,21 @@ public class StartCommit implements Payload {
 
   private UUID commitId;
   private final Schema avroSchema;
-  private final int[] positionsToIds;
 
   static final int COMMIT_ID = 10_200;
 
   private static final StructType ICEBERG_SCHEMA =
       StructType.of(NestedField.required(COMMIT_ID, "commit_id", UUIDType.get()));
   private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, StartCommit.class);
-  private static final int[] POSITIONS_TO_IDS = AvroUtil.positionsToIds(AVRO_SCHEMA);
 
   // Used by Avro reflection to instantiate this class when reading events
   public StartCommit(Schema avroSchema) {
     this.avroSchema = avroSchema;
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public StartCommit(UUID commitId) {
     this.commitId = commitId;
     this.avroSchema = AVRO_SCHEMA;
-    this.positionsToIds = POSITIONS_TO_IDS;
   }
 
   @Override
@@ -74,7 +70,7 @@ public class StartCommit implements Payload {
 
   @Override
   public void put(int i, Object v) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         this.commitId = (UUID) v;
         return;
@@ -85,7 +81,7 @@ public class StartCommit implements Payload {
 
   @Override
   public Object get(int i) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case COMMIT_ID:
         return commitId;
       default:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
@@ -36,7 +36,7 @@ public class StartCommit implements Payload {
   private static final StructType ICEBERG_SCHEMA =
       StructType.of(NestedField.required(10_200, "commit_id", UUIDType.get()));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, StartCommit.class);
 
   // Used by Avro reflection to instantiate this class when reading events
   public StartCommit(Schema avroSchema) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
@@ -32,20 +32,25 @@ public class StartCommit implements Payload {
 
   private UUID commitId;
   private final Schema avroSchema;
+  private final int[] positionsToIds;
+
+  static final int COMMIT_ID = 10_200;
 
   private static final StructType ICEBERG_SCHEMA =
-      StructType.of(NestedField.required(10_200, "commit_id", UUIDType.get()));
-
+      StructType.of(NestedField.required(COMMIT_ID, "commit_id", UUIDType.get()));
   private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, StartCommit.class);
+  private static final int[] POSITIONS_TO_IDS = AvroUtil.positionsToIds(AVRO_SCHEMA);
 
   // Used by Avro reflection to instantiate this class when reading events
   public StartCommit(Schema avroSchema) {
     this.avroSchema = avroSchema;
+    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public StartCommit(UUID commitId) {
     this.commitId = commitId;
     this.avroSchema = AVRO_SCHEMA;
+    this.positionsToIds = POSITIONS_TO_IDS;
   }
 
   @Override
@@ -69,8 +74,8 @@ public class StartCommit implements Payload {
 
   @Override
   public void put(int i, Object v) {
-    switch (i) {
-      case 0:
+    switch (positionsToIds[i]) {
+      case COMMIT_ID:
         this.commitId = (UUID) v;
         return;
       default:
@@ -80,8 +85,8 @@ public class StartCommit implements Payload {
 
   @Override
   public Object get(int i) {
-    switch (i) {
-      case 0:
+    switch (positionsToIds[i]) {
+      case COMMIT_ID:
         return commitId;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/StartCommit.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.util.UUID;
+import org.apache.avro.Schema;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.UUIDType;
+
+/**
+ * A control event payload for events sent by a coordinator to request workers to send back the
+ * table data that has been written and is ready to commit.
+ */
+public class StartCommit implements Payload {
+
+  private UUID commitId;
+  private final Schema avroSchema;
+
+  private static final StructType ICEBERG_SCHEMA =
+      StructType.of(NestedField.required(10_200, "commit_id", UUIDType.get()));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public StartCommit(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public StartCommit(UUID commitId) {
+    this.commitId = commitId;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  @Override
+  public PayloadType type() {
+    return PayloadType.START_COMMIT;
+  }
+
+  public UUID commitId() {
+    return commitId;
+  }
+
+  @Override
+  public StructType writeSchema() {
+    return ICEBERG_SCHEMA;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.commitId = (UUID) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return commitId;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.StructType;
+
+/** Element representing a table identifier, with namespace and name. */
+public class TableReference implements IndexedRecord {
+
+  private String catalog;
+  private List<String> namespace;
+  private String name;
+  private final Schema avroSchema;
+
+  public static final StructType ICEBERG_SCHEMA =
+      StructType.of(
+          NestedField.required(10_600, "catalog", StringType.get()),
+          NestedField.required(10_601, "namespace", ListType.ofRequired(10_602, StringType.get())),
+          NestedField.required(10_603, "name", StringType.get()));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  public static TableReference of(String catalog, TableIdentifier tableIdentifier) {
+    return new TableReference(
+        catalog, Arrays.asList(tableIdentifier.namespace().levels()), tableIdentifier.name());
+  }
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public TableReference(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public TableReference(String catalog, List<String> namespace, String name) {
+    this.catalog = catalog;
+    this.namespace = namespace;
+    this.name = name;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  public String catalog() {
+    return catalog;
+  }
+
+  public TableIdentifier identifier() {
+    Namespace icebergNamespace = Namespace.of(namespace.toArray(new String[0]));
+    return TableIdentifier.of(icebergNamespace, name);
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.catalog = v == null ? null : v.toString();
+        return;
+      case 1:
+        this.namespace =
+            v == null ? null : ((List<Utf8>) v).stream().map(Utf8::toString).collect(toList());
+        return;
+      case 2:
+        this.name = v == null ? null : v.toString();
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return catalog;
+      case 1:
+        return namespace;
+      case 2:
+        return name;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
@@ -39,7 +39,6 @@ public class TableReference implements IndexedRecord {
   private List<String> namespace;
   private String name;
   private final Schema avroSchema;
-  private final int[] positionsToIds;
 
   static final int CATALOG = 10_600;
   static final int NAMESPACE = 10_601;
@@ -52,7 +51,6 @@ public class TableReference implements IndexedRecord {
               NAMESPACE, "namespace", ListType.ofRequired(NAMESPACE + 1, StringType.get())),
           NestedField.required(NAME, "name", StringType.get()));
   private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, TableReference.class);
-  private static final int[] POSITIONS_TO_IDS = AvroUtil.positionsToIds(AVRO_SCHEMA);
 
   public static TableReference of(String catalog, TableIdentifier tableIdentifier) {
     return new TableReference(
@@ -62,7 +60,6 @@ public class TableReference implements IndexedRecord {
   // Used by Avro reflection to instantiate this class when reading events
   public TableReference(Schema avroSchema) {
     this.avroSchema = avroSchema;
-    this.positionsToIds = AvroUtil.positionsToIds(avroSchema);
   }
 
   public TableReference(String catalog, List<String> namespace, String name) {
@@ -70,7 +67,6 @@ public class TableReference implements IndexedRecord {
     this.namespace = namespace;
     this.name = name;
     this.avroSchema = AVRO_SCHEMA;
-    this.positionsToIds = POSITIONS_TO_IDS;
   }
 
   public String catalog() {
@@ -90,7 +86,7 @@ public class TableReference implements IndexedRecord {
   @Override
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case CATALOG:
         this.catalog = v == null ? null : v.toString();
         return;
@@ -108,7 +104,7 @@ public class TableReference implements IndexedRecord {
 
   @Override
   public Object get(int i) {
-    switch (positionsToIds[i]) {
+    switch (AvroUtil.positionToId(i, avroSchema)) {
       case CATALOG:
         return catalog;
       case NAMESPACE:

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
@@ -46,7 +46,7 @@ public class TableReference implements IndexedRecord {
           NestedField.required(10_601, "namespace", ListType.ofRequired(10_602, StringType.get())),
           NestedField.required(10_603, "name", StringType.get()));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, TableReference.class);
 
   public static TableReference of(String catalog, TableIdentifier tableIdentifier) {
     return new TableReference(

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
@@ -43,7 +43,8 @@ public class TopicPartitionOffset implements IndexedRecord {
           NestedField.optional(10_702, "offset", LongType.get()),
           NestedField.optional(10_703, "timestamp", TimestampType.withZone()));
 
-  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+  private static final Schema AVRO_SCHEMA =
+      AvroUtil.convert(ICEBERG_SCHEMA, TopicPartitionOffset.class);
 
   // Used by Avro reflection to instantiate this class when reading events
   public TopicPartitionOffset(Schema avroSchema) {

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.apache.iceberg.types.Types.LongType;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampType;
+
+/** Element representing an offset, with topic name, partition number, and offset. */
+public class TopicPartitionOffset implements IndexedRecord {
+
+  private String topic;
+  private Integer partition;
+  private Long offset;
+  private Long timestamp;
+  private final Schema avroSchema;
+
+  public static final StructType ICEBERG_SCHEMA =
+      StructType.of(
+          NestedField.required(10_700, "topic", StringType.get()),
+          NestedField.required(10_701, "partition", IntegerType.get()),
+          NestedField.optional(10_702, "offset", LongType.get()),
+          NestedField.optional(10_703, "timestamp", TimestampType.withZone()));
+
+  private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA);
+
+  // Used by Avro reflection to instantiate this class when reading events
+  public TopicPartitionOffset(Schema avroSchema) {
+    this.avroSchema = avroSchema;
+  }
+
+  public TopicPartitionOffset(String topic, int partition, Long offset, Long timestamp) {
+    this.topic = topic;
+    this.partition = partition;
+    this.offset = offset;
+    this.timestamp = timestamp;
+    this.avroSchema = AVRO_SCHEMA;
+  }
+
+  public String topic() {
+    return topic;
+  }
+
+  public Integer partition() {
+    return partition;
+  }
+
+  public Long offset() {
+    return offset;
+  }
+
+  public Long timestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return avroSchema;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    switch (i) {
+      case 0:
+        this.topic = v == null ? null : v.toString();
+        return;
+      case 1:
+        this.partition = (Integer) v;
+        return;
+      case 2:
+        this.offset = (Long) v;
+        return;
+      case 3:
+        this.timestamp = (Long) v;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return topic;
+      case 1:
+        return partition;
+      case 2:
+        return offset;
+      case 3:
+        return timestamp;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TopicPartitionOffset.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.connect.events;
 
+import java.time.OffsetDateTime;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -26,6 +27,7 @@ import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.iceberg.util.DateTimeUtil;
 
 /** Element representing an offset, with topic name, partition number, and offset. */
 public class TopicPartitionOffset implements IndexedRecord {
@@ -33,7 +35,7 @@ public class TopicPartitionOffset implements IndexedRecord {
   private String topic;
   private Integer partition;
   private Long offset;
-  private Long timestamp;
+  private OffsetDateTime timestamp;
   private final Schema avroSchema;
 
   public static final StructType ICEBERG_SCHEMA =
@@ -51,7 +53,7 @@ public class TopicPartitionOffset implements IndexedRecord {
     this.avroSchema = avroSchema;
   }
 
-  public TopicPartitionOffset(String topic, int partition, Long offset, Long timestamp) {
+  public TopicPartitionOffset(String topic, int partition, Long offset, OffsetDateTime timestamp) {
     this.topic = topic;
     this.partition = partition;
     this.offset = offset;
@@ -71,7 +73,7 @@ public class TopicPartitionOffset implements IndexedRecord {
     return offset;
   }
 
-  public Long timestamp() {
+  public OffsetDateTime timestamp() {
     return timestamp;
   }
 
@@ -93,7 +95,7 @@ public class TopicPartitionOffset implements IndexedRecord {
         this.offset = (Long) v;
         return;
       case 3:
-        this.timestamp = (Long) v;
+        this.timestamp = v == null ? null : DateTimeUtil.timestamptzFromMicros((Long) v);
         return;
       default:
         // ignore the object, it must be from a newer version of the format
@@ -110,7 +112,7 @@ public class TopicPartitionOffset implements IndexedRecord {
       case 2:
         return offset;
       case 3:
-        return timestamp;
+        return timestamp == null ? null : DateTimeUtil.microsFromTimestamptz(timestamp);
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);
     }

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.connect.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -77,7 +79,7 @@ public class EventSerializationTest {
             new DataComplete(
                 commitId,
                 Arrays.asList(
-                    new TopicPartitionOffset("topic", 1, 1L, 1L),
+                    new TopicPartitionOffset("topic", 1, 1L, OffsetDateTime.now(ZoneOffset.UTC)),
                     new TopicPartitionOffset("topic", 2, null, null))));
 
     byte[] data = AvroUtil.encode(event);
@@ -99,7 +101,7 @@ public class EventSerializationTest {
                 commitId,
                 new TableReference("catalog", Collections.singletonList("db"), "tbl"),
                 1L,
-                2L));
+                OffsetDateTime.now(ZoneOffset.UTC)));
 
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
@@ -113,7 +115,8 @@ public class EventSerializationTest {
   @Test
   public void testCommitCompleteSerialization() {
     UUID commitId = UUID.randomUUID();
-    Event event = new Event("cg-connector", new CommitComplete(commitId, 2L));
+    Event event =
+        new Event("cg-connector", new CommitComplete(commitId, OffsetDateTime.now(ZoneOffset.UTC)));
 
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
@@ -60,7 +60,11 @@ public class EventSerializationTest {
     assertThat(result)
         .usingRecursiveComparison()
         .ignoringFieldsMatchingRegexes(
-            ".*avroSchema", ".*icebergSchema", ".*schema", ".*fromProjectionPos")
+            "payload\\.partitionType",
+            ".*avroSchema",
+            ".*icebergSchema",
+            ".*schema",
+            ".*fromProjectionPos")
         .isEqualTo(event);
   }
 

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types.StructType;
+import org.junit.jupiter.api.Test;
+
+public class EventSerializationTest {
+
+  @Test
+  public void testStartCommitSerialization() {
+    UUID commitId = UUID.randomUUID();
+    Event event = new Event("cg-connector", new StartCommit(commitId));
+
+    byte[] data = AvroUtil.encode(event);
+    Event result = AvroUtil.decode(data);
+
+    assertThat(result.type()).isEqualTo(event.type());
+    StartCommit payload = (StartCommit) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
+  }
+
+  @Test
+  public void testDataWrittenSerialization() {
+    UUID commitId = UUID.randomUUID();
+    Event event =
+        new Event(
+            "cg-connector",
+            new DataWritten(
+                StructType.of(),
+                commitId,
+                new TableReference("catalog", Collections.singletonList("db"), "tbl"),
+                Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
+                Arrays.asList(EventTestUtil.createDeleteFile(), EventTestUtil.createDeleteFile())));
+
+    byte[] data = AvroUtil.encode(event);
+    Event result = AvroUtil.decode(data);
+
+    assertThat(result.type()).isEqualTo(event.type());
+    DataWritten payload = (DataWritten) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(payload.tableReference().catalog()).isEqualTo("catalog");
+    assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.parse("db.tbl"));
+    assertThat(payload.dataFiles()).hasSize(2);
+    assertThat(payload.dataFiles()).allMatch(f -> f.specId() == 1);
+    assertThat(payload.deleteFiles()).hasSize(2);
+    assertThat(payload.deleteFiles()).allMatch(f -> f.specId() == 1);
+  }
+
+  @Test
+  public void testDataCompleteSerialization() {
+    UUID commitId = UUID.randomUUID();
+    Event event =
+        new Event(
+            "cg-connector",
+            new DataComplete(
+                commitId,
+                Arrays.asList(
+                    new TopicPartitionOffset("topic", 1, 1L, 1L),
+                    new TopicPartitionOffset("topic", 2, null, null))));
+
+    byte[] data = AvroUtil.encode(event);
+    Event result = AvroUtil.decode(data);
+
+    assertThat(result.type()).isEqualTo(event.type());
+    DataComplete payload = (DataComplete) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(payload.assignments()).hasSize(2);
+    assertThat(payload.assignments()).allMatch(tp -> tp.topic().equals("topic"));
+  }
+
+  @Test
+  public void testCommitToTableSerialization() {
+    UUID commitId = UUID.randomUUID();
+    Event event =
+        new Event(
+            "cg-connector",
+            new CommitToTable(
+                commitId,
+                new TableReference("catalog", Collections.singletonList("db"), "tbl"),
+                1L,
+                2L));
+
+    byte[] data = AvroUtil.encode(event);
+    Event result = AvroUtil.decode(data);
+
+    assertThat(result.type()).isEqualTo(event.type());
+    CommitToTable payload = (CommitToTable) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(payload.tableReference().catalog()).isEqualTo("catalog");
+    assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.parse("db.tbl"));
+    assertThat(payload.snapshotId()).isEqualTo(1L);
+    assertThat(payload.validThroughTs()).isEqualTo(2L);
+  }
+
+  @Test
+  public void testCommitCompleteSerialization() {
+    UUID commitId = UUID.randomUUID();
+    Event event = new Event("cg-connector", new CommitComplete(commitId, 2L));
+
+    byte[] data = AvroUtil.encode(event);
+    Event result = AvroUtil.decode(data);
+
+    assertThat(result.type()).isEqualTo(event.type());
+    CommitComplete payload = (CommitComplete) result.payload();
+    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(payload.validThroughTs()).isEqualTo(2L);
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
@@ -23,8 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.types.Types.StructType;
 import org.junit.jupiter.api.Test;
 
 public class EventSerializationTest {
@@ -37,9 +35,10 @@ public class EventSerializationTest {
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
 
-    assertThat(result.type()).isEqualTo(event.type());
-    StartCommit payload = (StartCommit) result.payload();
-    assertThat(payload.commitId()).isEqualTo(commitId);
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes(".*avroSchema")
+        .isEqualTo(event);
   }
 
   @Test
@@ -49,7 +48,7 @@ public class EventSerializationTest {
         new Event(
             "cg-connector",
             new DataWritten(
-                StructType.of(),
+                EventTestUtil.SPEC.partitionType(),
                 commitId,
                 new TableReference("catalog", Collections.singletonList("db"), "tbl"),
                 Arrays.asList(EventTestUtil.createDataFile(), EventTestUtil.createDataFile()),
@@ -58,15 +57,11 @@ public class EventSerializationTest {
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
 
-    assertThat(result.type()).isEqualTo(event.type());
-    DataWritten payload = (DataWritten) result.payload();
-    assertThat(payload.commitId()).isEqualTo(commitId);
-    assertThat(payload.tableReference().catalog()).isEqualTo("catalog");
-    assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.parse("db.tbl"));
-    assertThat(payload.dataFiles()).hasSize(2);
-    assertThat(payload.dataFiles()).allMatch(f -> f.specId() == 1);
-    assertThat(payload.deleteFiles()).hasSize(2);
-    assertThat(payload.deleteFiles()).allMatch(f -> f.specId() == 1);
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes(
+            ".*avroSchema", ".*icebergSchema", ".*schema", ".*fromProjectionPos")
+        .isEqualTo(event);
   }
 
   @Test
@@ -84,11 +79,10 @@ public class EventSerializationTest {
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
 
-    assertThat(result.type()).isEqualTo(event.type());
-    DataComplete payload = (DataComplete) result.payload();
-    assertThat(payload.commitId()).isEqualTo(commitId);
-    assertThat(payload.assignments()).hasSize(2);
-    assertThat(payload.assignments()).allMatch(tp -> tp.topic().equals("topic"));
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes(".*avroSchema")
+        .isEqualTo(event);
   }
 
   @Test
@@ -106,13 +100,10 @@ public class EventSerializationTest {
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
 
-    assertThat(result.type()).isEqualTo(event.type());
-    CommitToTable payload = (CommitToTable) result.payload();
-    assertThat(payload.commitId()).isEqualTo(commitId);
-    assertThat(payload.tableReference().catalog()).isEqualTo("catalog");
-    assertThat(payload.tableReference().identifier()).isEqualTo(TableIdentifier.parse("db.tbl"));
-    assertThat(payload.snapshotId()).isEqualTo(1L);
-    assertThat(payload.validThroughTs()).isEqualTo(2L);
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes(".*avroSchema")
+        .isEqualTo(event);
   }
 
   @Test
@@ -123,9 +114,9 @@ public class EventSerializationTest {
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
 
-    assertThat(result.type()).isEqualTo(event.type());
-    CommitComplete payload = (CommitComplete) result.payload();
-    assertThat(payload.commitId()).isEqualTo(commitId);
-    assertThat(payload.validThroughTs()).isEqualTo(2L);
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFieldsMatchingRegexes(".*avroSchema")
+        .isEqualTo(event);
   }
 }

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventSerializationTest.java
@@ -20,8 +20,6 @@ package org.apache.iceberg.connect.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
@@ -79,7 +77,7 @@ public class EventSerializationTest {
             new DataComplete(
                 commitId,
                 Arrays.asList(
-                    new TopicPartitionOffset("topic", 1, 1L, OffsetDateTime.now(ZoneOffset.UTC)),
+                    new TopicPartitionOffset("topic", 1, 1L, EventTestUtil.now()),
                     new TopicPartitionOffset("topic", 2, null, null))));
 
     byte[] data = AvroUtil.encode(event);
@@ -101,7 +99,7 @@ public class EventSerializationTest {
                 commitId,
                 new TableReference("catalog", Collections.singletonList("db"), "tbl"),
                 1L,
-                OffsetDateTime.now(ZoneOffset.UTC)));
+                EventTestUtil.now()));
 
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);
@@ -115,8 +113,7 @@ public class EventSerializationTest {
   @Test
   public void testCommitCompleteSerialization() {
     UUID commitId = UUID.randomUUID();
-    Event event =
-        new Event("cg-connector", new CommitComplete(commitId, OffsetDateTime.now(ZoneOffset.UTC)));
+    Event event = new Event("cg-connector", new CommitComplete(commitId, EventTestUtil.now()));
 
     byte[] data = AvroUtil.encode(event);
     Event result = AvroUtil.decode(data);

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.events;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+
+public class EventTestUtil {
+  private EventTestUtil() {}
+
+  public static DataFile createDataFile() {
+    Schema schema =
+        new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").withSpecId(1).build();
+    SortOrder order =
+        SortOrder.builderFor(schema).sortBy("id", SortDirection.ASC, NullOrder.NULLS_FIRST).build();
+
+    Metrics metrics =
+        new Metrics(
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
+
+    return DataFiles.builder(spec)
+        .withEncryptionKeyMetadata(ByteBuffer.wrap(new byte[] {0}))
+        .withFileSizeInBytes(1L)
+        .withFormat(FileFormat.PARQUET)
+        .withMetrics(metrics)
+        .withPath("path")
+        .withSortOrder(order)
+        .withSplitOffsets(ImmutableList.of(4L))
+        .build();
+  }
+
+  public static DeleteFile createDeleteFile() {
+    Schema schema =
+        new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").withSpecId(1).build();
+    SortOrder order =
+        SortOrder.builderFor(schema).sortBy("id", SortDirection.ASC, NullOrder.NULLS_FIRST).build();
+
+    Metrics metrics =
+        new Metrics(
+            1L,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap());
+
+    return FileMetadata.deleteFileBuilder(spec)
+        .ofEqualityDeletes(1)
+        .withEncryptionKeyMetadata(ByteBuffer.wrap(new byte[] {0}))
+        .withFileSizeInBytes(1L)
+        .withFormat(FileFormat.PARQUET)
+        .withMetrics(metrics)
+        .withPath("path")
+        .withSortOrder(order)
+        .withSplitOffsets(ImmutableList.of(4L))
+        .build();
+  }
+}

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
@@ -19,6 +19,9 @@
 package org.apache.iceberg.connect.events;
 
 import java.nio.ByteBuffer;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -54,6 +57,10 @@ class EventTestUtil {
           Collections.emptyMap(),
           Collections.emptyMap(),
           Collections.emptyMap());
+
+  static OffsetDateTime now() {
+    return OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+  }
 
   static DataFile createDataFile() {
     PartitionData data = new PartitionData(SPEC.partitionType());

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
@@ -34,58 +35,55 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.types.Types;
 
-public class EventTestUtil {
+class EventTestUtil {
   private EventTestUtil() {}
 
-  public static DataFile createDataFile() {
-    Schema schema =
-        new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").withSpecId(1).build();
-    SortOrder order =
-        SortOrder.builderFor(schema).sortBy("id", SortDirection.ASC, NullOrder.NULLS_FIRST).build();
+  static final Schema SCHEMA =
+      new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
 
-    Metrics metrics =
-        new Metrics(
-            1L,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap());
+  static final PartitionSpec SPEC =
+      PartitionSpec.builderFor(SCHEMA).identity("id").withSpecId(1).build();
 
-    return DataFiles.builder(spec)
+  static final SortOrder ORDER =
+      SortOrder.builderFor(SCHEMA).sortBy("id", SortDirection.ASC, NullOrder.NULLS_FIRST).build();
+
+  static final Metrics METRICS =
+      new Metrics(
+          1L,
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap(),
+          Collections.emptyMap());
+
+  static DataFile createDataFile() {
+    PartitionData data = new PartitionData(SPEC.partitionType());
+    data.set(0, 1L);
+
+    return DataFiles.builder(SPEC)
         .withEncryptionKeyMetadata(ByteBuffer.wrap(new byte[] {0}))
-        .withFileSizeInBytes(1L)
+        .withFileSizeInBytes(100L)
         .withFormat(FileFormat.PARQUET)
-        .withMetrics(metrics)
+        .withMetrics(METRICS)
+        .withPartition(data)
         .withPath("path")
-        .withSortOrder(order)
+        .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();
   }
 
-  public static DeleteFile createDeleteFile() {
-    Schema schema =
-        new Schema(ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").withSpecId(1).build();
-    SortOrder order =
-        SortOrder.builderFor(schema).sortBy("id", SortDirection.ASC, NullOrder.NULLS_FIRST).build();
+  static DeleteFile createDeleteFile() {
+    PartitionData data = new PartitionData(SPEC.partitionType());
+    data.set(0, 1L);
 
-    Metrics metrics =
-        new Metrics(
-            1L,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            Collections.emptyMap());
-
-    return FileMetadata.deleteFileBuilder(spec)
+    return FileMetadata.deleteFileBuilder(SPEC)
         .ofEqualityDeletes(1)
         .withEncryptionKeyMetadata(ByteBuffer.wrap(new byte[] {0}))
-        .withFileSizeInBytes(1L)
+        .withFileSizeInBytes(100L)
         .withFormat(FileFormat.PARQUET)
-        .withMetrics(metrics)
+        .withMetrics(METRICS)
+        .withPartition(data)
         .withPath("path")
-        .withSortOrder(order)
+        .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();
   }

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/EventTestUtil.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
@@ -36,6 +35,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
 class EventTestUtil {
@@ -53,10 +53,12 @@ class EventTestUtil {
   static final Metrics METRICS =
       new Metrics(
           1L,
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap(),
-          Collections.emptyMap());
+          ImmutableMap.of(1, 1L),
+          ImmutableMap.of(1, 1L),
+          ImmutableMap.of(1, 1L),
+          ImmutableMap.of(1, 1L),
+          ImmutableMap.of(1, ByteBuffer.wrap(new byte[10])),
+          ImmutableMap.of(1, ByteBuffer.wrap(new byte[10])));
 
   static OffsetDateTime now() {
     return OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
@@ -72,7 +74,7 @@ class EventTestUtil {
         .withFormat(FileFormat.PARQUET)
         .withMetrics(METRICS)
         .withPartition(data)
-        .withPath("path")
+        .withPath("path/to/file.parquet")
         .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();
@@ -89,7 +91,7 @@ class EventTestUtil {
         .withFormat(FileFormat.PARQUET)
         .withMetrics(METRICS)
         .withPartition(data)
-        .withPath("path")
+        .withPath("path/to/file.parquet")
         .withSortOrder(ORDER)
         .withSplitOffsets(ImmutableList.of(4L))
         .build();

--- a/settings.gradle
+++ b/settings.gradle
@@ -40,6 +40,7 @@ include 'gcp-bundle'
 include 'dell'
 include 'snowflake'
 include 'delta-lake'
+include 'kafka-connect'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -63,6 +64,7 @@ project(':gcp-bundle').name = 'iceberg-gcp-bundle'
 project(':dell').name = 'iceberg-dell'
 project(':snowflake').name = 'iceberg-snowflake'
 project(':delta-lake').name = 'iceberg-delta-lake'
+project(':kafka-connect').name = 'iceberg-kafka-connect'
 
 if (null != System.getProperty("allVersions")) {
   System.setProperty("flinkVersions", System.getProperty("knownFlinkVersions"))
@@ -188,3 +190,6 @@ if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
   }
 }
 
+include ":iceberg-kafka-connect:kafka-connect-events"
+project(":iceberg-kafka-connect:kafka-connect-events").projectDir = file('kafka-connect/kafka-connect-events')
+project(":iceberg-kafka-connect:kafka-connect-events").name = "iceberg-kafka-connect-events"


### PR DESCRIPTION
We (Tabular) would like to submit our Iceberg Kafka Connect sink connector to the Iceberg project. Kafka Connect is a popular, efficient, and easy to use framework for reading from and writing to Kafka. This sink gives Iceberg users another option for landing data from Kafka into Iceberg tables. Having the backing of the Iceberg community will help it evolve and improve over time.

The sink codebase is on the larger side, so the thought was to break the submission into different PRs to make it easier to review. This initial PR includes the starting build setup and the project for the Avro event data structures.

The original repo can be found at https://github.com/tabular-io/iceberg-kafka-connect. Some design docs can be found in the `docs` directory, and that includes an explanation of what the events are used for, and why Avro was chosen for serialization.

The events were put in a separate project so the library can be used independently to read messages from the control topic outside of the connector, for debugging or notification purposes.