### PR TITLE
Spec: `snapshot_id` is optional for V1

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -143,9 +143,6 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     Preconditions.checkArgument(
         !manifest.hasDeletedFiles(), "Cannot add manifest with deleted files");
     Preconditions.checkArgument(
-        manifest.snapshotId() == null || manifest.snapshotId() == -1,
-        "Snapshot id must be assigned during commit");
-    Preconditions.checkArgument(
         manifest.sequenceNumber() == -1, "Sequence must be assigned during commit");
 
     if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -110,9 +110,6 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
     Preconditions.checkArgument(
         !manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
     Preconditions.checkArgument(
-        manifest.snapshotId() == null || manifest.snapshotId() == -1,
-        "Snapshot id must be assigned during commit");
-    Preconditions.checkArgument(
         manifest.sequenceNumber() == -1, "Sequence number must be assigned during commit");
 
     if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -141,6 +141,8 @@ public class ManifestFiles {
    * @param spec {@link PartitionSpec} used to produce {@link DataFile} partition tuples
    * @param outputFile the destination file location
    * @return a manifest writer
+   * @deprecated Use {@link ManifestFiles#write(int, PartitionSpec, OutputFile, Long)} instead since
+   *     the SnapshotID cannot be null for a V1 manifest
    */
   public static ManifestWriter<DataFile> write(PartitionSpec spec, OutputFile outputFile) {
     return write(1, spec, outputFile, null);

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -39,7 +39,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   private final OutputFile file;
   private final int specId;
   private final FileAppender<ManifestEntry<F>> writer;
-  private final Long snapshotId;
+  protected final Long snapshotId;
   private final GenericManifestEntry<F> reused;
   private final PartitionSummary stats;
 
@@ -291,11 +291,16 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
 
     V1Writer(PartitionSpec spec, OutputFile file, Long snapshotId) {
       super(spec, file, snapshotId);
+      Preconditions.checkNotNull(snapshotId, "SnapshotId cannot be null");
       this.entryWrapper = new V1Metadata.IndexedManifestEntry(spec.partitionType());
     }
 
     @Override
     protected ManifestEntry<DataFile> prepare(ManifestEntry<DataFile> entry) {
+      if (entry.snapshotId() == null && this.snapshotId != null) {
+        entry.setSnapshotId(this.snapshotId);
+      }
+
       return entryWrapper.wrap(entry);
     }
 

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -61,9 +61,6 @@ class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements Append
     Preconditions.checkArgument(
         !manifest.hasDeletedFiles(), "Cannot append manifest with deleted files");
     Preconditions.checkArgument(
-        manifest.snapshotId() == null || manifest.snapshotId() == -1,
-        "Snapshot id must be assigned during commit");
-    Preconditions.checkArgument(
         manifest.sequenceNumber() == -1, "Sequence must be assigned during commit");
     add(manifest);
     return this;

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -200,7 +200,7 @@ class V1Metadata {
     // this is used to build projection schemas
     return new Schema(
         ManifestEntry.STATUS,
-        ManifestEntry.SNAPSHOT_ID,
+        ManifestEntry.SNAPSHOT_ID.asRequired(),
         required(ManifestEntry.DATA_FILE_ID, "data_file", fileSchema));
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestFastAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestFastAppend.java
@@ -387,14 +387,18 @@ public class TestFastAppend extends TableTestBase {
     Assert.assertNull("Should not have a current snapshot", base.currentSnapshot());
 
     ManifestFile manifestWithExistingFiles =
-        writeManifest("manifest-file-1.avro", manifestEntry(Status.EXISTING, null, FILE_A));
+        writeManifest(
+            "manifest-file-1.avro",
+            manifestEntry(Status.EXISTING, table.ops().newSnapshotId(), FILE_A));
     Assertions.assertThatThrownBy(
             () -> table.newFastAppend().appendManifest(manifestWithExistingFiles).commit())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot append manifest with existing files");
 
     ManifestFile manifestWithDeletedFiles =
-        writeManifest("manifest-file-2.avro", manifestEntry(Status.DELETED, null, FILE_A));
+        writeManifest(
+            "manifest-file-2.avro",
+            manifestEntry(Status.DELETED, table.ops().newSnapshotId(), FILE_A));
     Assertions.assertThatThrownBy(
             () -> table.newFastAppend().appendManifest(manifestWithDeletedFiles).commit())
         .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -72,14 +71,6 @@ public class TestManifestReader extends TableTestBase {
           Lists.newArrayList(FILE_A.path(), FILE_B.path(), FILE_C.path()),
           files);
     }
-  }
-
-  @Test
-  public void testInvalidUsage() throws IOException {
-    ManifestFile manifest = writeManifest(FILE_A, FILE_B);
-    Assertions.assertThatThrownBy(() -> ManifestFiles.read(manifest, FILE_IO))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot read from ManifestFile with null (unassigned) snapshot ID");
   }
 
   @Test

--- a/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestManifestFileSerialization.java
+++ b/flink/v1.17/flink/src/test/java/org/apache/iceberg/flink/TestManifestFileSerialization.java
@@ -154,15 +154,14 @@ public class TestManifestFileSerialization {
   private ManifestFile writeManifest(DataFile... files) throws IOException {
     File manifestFile = temp.newFile("input.m0.avro");
     Assert.assertTrue(manifestFile.delete());
+
     OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter<DataFile> writer = ManifestFiles.write(SPEC, outputFile);
-    try {
+    ManifestWriter<DataFile> writer = ManifestFiles.write(1, SPEC, outputFile, 0L);
+    try (ManifestWriter<DataFile> writerRef = writer) {
       for (DataFile file : files) {
-        writer.add(file);
+        writerRef.add(file);
       }
-    } finally {
-      writer.close();
     }
 
     return writer.toManifestFile();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
@@ -199,13 +199,11 @@ public class TestManifestFileSerialization {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = FILE_IO.newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter<DataFile> writer = ManifestFiles.write(SPEC, outputFile);
-    try {
+    ManifestWriter<DataFile> writer = ManifestFiles.write(1, SPEC, outputFile, 0L);
+    try (ManifestWriter<DataFile> writerRef = writer) {
       for (DataFile file : files) {
-        writer.add(file);
+        writerRef.add(file);
       }
-    } finally {
-      writer.close();
     }
 
     return writer.toManifestFile();


### PR DESCRIPTION
It should be required according to the spec:

![image](https://github.com/apache/iceberg/assets/1134248/b6e2d1fc-aca0-4e4c-9600-8dedb79363dd)

And with Spark, we just write the V2 struct for a V1 table:

```json
{
    "status": 1,
    "snapshot_id": {
        "long": 3668892875277885400
    },
    "data_sequence_number": null,
    "file_sequence_number": null,
    "data_file": {
        "content": {
            "int": 0
        },
        "file_path": "s3://warehouse/default/coordinates/data/00000-0-0397b63a-731b-4ab6-8bde-25672c92546c-0.parquet",
        "file_format": "PARQUET",
        "partition": {},
        "record_count": 3,
        "file_size_in_bytes": 1108,
        "block_size_in_bytes": {
            "long": 67108864
        },
        "column_sizes": {
            "array": [
                {
                    "key": 1,
                    "value": 113
                },
                {
                    "key": 2,
                    "value": 113
                }
            ]
        },
        "value_counts": {
            "array": [
                {
                    "key": 1,
                    "value": 3
                },
                {
                    "key": 2,
                    "value": 3
                }
            ]
        },
        "null_value_counts": {
            "array": [
                {
                    "key": 1,
                    "value": 0
                },
                {
                    "key": 2,
                    "value": 0
                }
            ]
        },
        "nan_value_counts": {
            "array": []
        },
        "lower_bounds": {
            "array": [
                {
                    "key": 1,
                    "value": "ß3\\u0012¡\\u0011\nJ@"
                },
                {
                    "key": 2,
                    "value": "´è\n¸'\\u0011@"
                }
            ]
        },
        "upper_bounds": {
            "array": [
                {
                    "key": 1,
                    "value": "ÑvLÝ1J@"
                },
                {
                    "key": 2,
                    "value": "\\u0002\\u0012M \\u0013@"
                }
            ]
        },
        "key_metadata": null,
        "split_offsets": {
            "array": [
                4
            ]
        },
        "equality_ids": {
            "array": []
        },
        "sort_order_id": {
            "int": 0
        },
        "spec_id": {
            "int": 0
        }
    }
}
```

Where:

```json
"snapshot_id": {
        "long": 3668892875277885400
    }
```
Indicates that it is an optional field (it is encoded as a union `[None, Long]`, where the long is present).

Disclaimer: **Don't look too much at the code, I was playing around to see what's needed to get this fixed. But the fixes are not correct since I just generated new SnapshotIds (but they should come from the snapshot**.