### PR TITLE
Add an optional way to mount custom adapters and auth on request's session object

### DIFF
--- a/python/pyiceberg/catalog/rest.py
+++ b/python/pyiceberg/catalog/rest.py
@@ -204,6 +204,13 @@ class RestCatalog(Catalog):
         self.uri = properties[URI]
         self._fetch_config()
         self._session = self._create_session()
+        # Mount custom adapters
+        if session_adapters := properties.pop('session_adapters', None):
+            for prefix, adapter in session_adapters.items():
+                self._session.mount(prefix, adapter)        
+        # Add custom auth
+        if session_auth := properties.pop('session_auth', None):
+            self._session.auth = session_auth
 
     def _create_session(self) -> Session:
         """Create a request session with provided catalog configuration."""


### PR DESCRIPTION
* Add a way to pass session adapters via properties that can be mounted after creating a session object. This helps override the default HTTP adapter with a custom one.
* More details on how to mount adapter here
> [here](https://requests.readthedocs.io/en/latest/user/advanced/#transport-adapters)

* Also add a way to pass custom session auth via properties. Doc explaining the behavior [here](https://requests.readthedocs.io/en/latest/user/advanced/#custom-authentication)