### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -21,7 +21,7 @@ name: "API Binary Compatibility Checks"
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - '0.**'
     tags:
       - 'apache-iceberg-**'

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -21,7 +21,7 @@ name: "Delta Conversion CI"
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - '0.**'
     tags:
       - 'apache-iceberg-**'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -21,7 +21,7 @@ name: "Flink CI"
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - '0.**'
     tags:
     - 'apache-iceberg-**'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -21,7 +21,7 @@ name: "Hive CI"
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - '0.**'
     tags:
     - 'apache-iceberg-**'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -21,7 +21,7 @@ name: "Java CI"
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - '0.**'
     tags:
     - 'apache-iceberg-**'

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -21,7 +21,7 @@ name: "Open-API"
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - '0.**'
     tags:
       - 'apache-iceberg-**'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -21,7 +21,7 @@ name: "Spark CI"
 on:
   push:
     branches:
-    - 'master'
+    - 'main'
     - '0.**'
     tags:
     - 'apache-iceberg-**'

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The core Java library that tracks table snapshots and metadata is complete, but 
 
 The [Iceberg format specification][iceberg-spec] is being actively updated and is open for comment. Until the specification is complete and released, it carries no compatibility guarantees. The spec is currently evolving as the Java reference implementation changes.
 
-[Java API javadocs][iceberg-javadocs] are available for the master.
+[Java API javadocs][iceberg-javadocs] are available for the main.
 
-[iceberg-javadocs]: https://iceberg.apache.org/javadoc/master
+[iceberg-javadocs]: https://iceberg.apache.org/javadoc/main
 [iceberg-spec]: https://iceberg.apache.org/spec
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ subprojects {
                 "\nAPI/ABI breaks detected.\n" +
                 "Adding RevAPI breaks should only be done after going through a deprecation cycle." +
                 "\nPlease make sure to follow the deprecation rules defined in\n" +
-                "https://github.com/apache/iceberg/blob/master/CONTRIBUTING.md#semantic-versioning.\n" +
+                "https://github.com/apache/iceberg/blob/main/CONTRIBUTING.md#semantic-versioning.\n" +
                 "==================================================================================")
       }
       onlyIf {

--- a/docs/flink-writes.md
+++ b/docs/flink-writes.md
@@ -111,7 +111,7 @@ FlinkSink.forRowData(input)
 env.execute("Test Iceberg DataStream");
 ```
 
-The iceberg API also allows users to write generic `DataStream<T>` to iceberg table, more example could be found in this [unit test](https://github.com/apache/iceberg/blob/master/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java).
+The iceberg API also allows users to write generic `DataStream<T>` to iceberg table, more example could be found in this [unit test](https://github.com/apache/iceberg/blob/main/flink/v1.16/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java).
 
 ### Overwrite data
 

--- a/docs/metrics-reporting.md
+++ b/docs/metrics-reporting.md
@@ -125,7 +125,7 @@ CommitReport{
 
 ### [`RESTMetricsReporter`](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/rest/RESTMetricsReporter.html)
 
-This is the default when using the [`RESTCatalog`](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/rest/RESTCatalog.html) and its purpose is to send metrics to a REST server at the `/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics` endpoint as defined in the [REST OpenAPI spec](https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml).
+This is the default when using the [`RESTCatalog`](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/rest/RESTCatalog.html) and its purpose is to send metrics to a REST server at the `/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics` endpoint as defined in the [REST OpenAPI spec](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml).
 
 Sending metrics via REST can be controlled with the `rest-metrics-reporting-enabled` (defaults to `true`) property.
 


### PR DESCRIPTION
This PR rename resources using `master` to `main`. This PR should be merged only when the renaming has been done by Apache INRA.