### PR TITLE
Build: Let revapi compare against 1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ subprojects {
     revapi {
       oldGroup = project.group
       oldName = project.name
-      oldVersion = "1.3.0"
+      oldVersion = "1.4.0"
     }
 
     tasks.register('showDeprecationRulesOnRevApiFailure') {


### PR DESCRIPTION
This PR updates our base version in revapi checks after the 1.4.0 release.