### PR TITLE
Nessie: Remove dead code in NessieCatalog

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hadoop.Configurable;
@@ -48,7 +47,6 @@ import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.api.NessieApiV2;
 import org.projectnessie.client.config.NessieClientConfigSource;
 import org.projectnessie.client.config.NessieClientConfigSources;
-import org.projectnessie.client.http.HttpClientBuilder;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.TableReference;
 import org.slf4j.Logger;
@@ -183,22 +181,6 @@ public class NessieCatalog extends BaseMetastoreCatalog
       throw new IllegalStateException("Parameter 'warehouse' not set, Nessie can't store data.");
     }
     return warehouseLocation;
-  }
-
-  private static NessieClientBuilder createNessieClientBuilder(String customBuilder) {
-    NessieClientBuilder clientBuilder;
-    if (customBuilder != null) {
-      try {
-        clientBuilder =
-            DynMethods.builder("builder").impl(customBuilder).build().asStatic().invoke();
-      } catch (Exception e) {
-        throw new RuntimeException(
-            String.format("Failed to use custom NessieClientBuilder '%s'.", customBuilder), e);
-      }
-    } else {
-      clientBuilder = HttpClientBuilder.builder();
-    }
-    return clientBuilder;
   }
 
   @Override


### PR DESCRIPTION
After https://github.com/apache/iceberg/pull/8607, 
`createNessieClientBuilder` is not used anymore in the code. So, it should be removed. 