### PR TITLE
API: Fix REST Catalog schema error: uniqueItems is not valid on type object

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1170,7 +1170,6 @@ components:
             type: string
           example: [ "department", "access_group" ]
         updates:
-          uniqueItems: true
           type: object
           example: { "owner": "Hank Bendickson" }
           additionalProperties:


### PR DESCRIPTION
OpenAPI schema fails code generation on row 1173:
```
  - rest-catalog-open-api.yaml:1173:24 -> uniqueItems: unexpected field for type "object"
```

As far as I can tell `uniqueItems` is not valid for objects, so I assume this is a mistake.