### PR TITLE
Core: Use visibility string instead of enum for Immutable visibility

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFiles.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFiles.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableDeleteOrphanFiles",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseDeleteOrphanFiles extends DeleteOrphanFiles {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFiles.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFiles.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableDeleteReachableFiles",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseDeleteReachableFiles extends DeleteReachableFiles {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshots.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableExpireSnapshots",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseExpireSnapshots extends ExpireSnapshots {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTable.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseMigrateTable.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableMigrateTable",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseMigrateTable extends MigrateTable {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFiles.java
@@ -20,15 +20,13 @@ package org.apache.iceberg.actions;
 
 import java.util.List;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableRewriteDataFiles",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseRewriteDataFiles extends RewriteDataFiles {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteManifests.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableRewriteManifests",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseRewriteManifests extends RewriteManifests {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewritePositionalDeleteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewritePositionalDeleteFiles.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableRewritePositionDeleteFiles",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseRewritePositionalDeleteFiles extends RewritePositionDeleteFiles {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTable.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseSnapshotTable.java
@@ -19,15 +19,13 @@
 package org.apache.iceberg.actions;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 @Value.Enclosing
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutableEnclosing = "ImmutableSnapshotTable",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseSnapshotTable extends SnapshotTable {
 
   @Value.Immutable

--- a/core/src/main/java/org/apache/iceberg/view/BaseViewHistoryEntry.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewHistoryEntry.java
@@ -19,8 +19,6 @@
 package org.apache.iceberg.view;
 
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 /**
  * View history entry.
@@ -32,6 +30,6 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutable = "ImmutableViewHistoryEntry",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseViewHistoryEntry extends ViewHistoryEntry {}

--- a/core/src/main/java/org/apache/iceberg/view/BaseViewVersion.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewVersion.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.view;
 import javax.annotation.Nullable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.BuilderVisibility;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 
 /**
  * A version of the view at a point in time.
@@ -35,8 +33,8 @@ import org.immutables.value.Value.Style.ImplementationVisibility;
 @SuppressWarnings("ImmutablesStyle")
 @Value.Style(
     typeImmutable = "ImmutableViewVersion",
-    visibility = ImplementationVisibility.PUBLIC,
-    builderVisibility = BuilderVisibility.PUBLIC)
+    visibilityString = "PUBLIC",
+    builderVisibilityString = "PUBLIC")
 interface BaseViewVersion extends ViewVersion {
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewMetadata.java
@@ -38,13 +38,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.immutables.value.Value;
-import org.immutables.value.Value.Style.ImplementationVisibility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("ImmutablesStyle")
 @Value.Immutable(builder = false)
-@Value.Style(allParameters = true, visibility = ImplementationVisibility.PACKAGE)
+@Value.Style(allParameters = true, visibilityString = "PACKAGE")
 public interface ViewMetadata extends Serializable {
   Logger LOG = LoggerFactory.getLogger(ViewMetadata.class);
   int SUPPORTED_VIEW_FORMAT_VERSION = 1;


### PR DESCRIPTION
Now that https://github.com/immutables/immutables/pull/1474 has been fixed and was shipped as part of Immutables [2.10.0](https://github.com/immutables/immutables/releases), we can switch to using the visibility string to fix the below compiler warnings for consuming projects:

```
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found
warning: unknown enum constant ImplementationVisibility.PACKAGE
  reason: class file for org.immutables.value.Value$Style$ImplementationVisibility not found

```