### PR TITLE
Build: Fix minor compilation warnings

### DIFF
--- a/core/src/jmh/java/org/apache/iceberg/metrics/CountersBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/metrics/CountersBenchmark.java
@@ -56,7 +56,7 @@ public class CountersBenchmark {
       Tasks.range(WORKER_POOL_SIZE)
           .executeWith(workerPool)
           .run(
-              (id) -> {
+              id -> {
                 for (int operation = 0; operation < NUM_OPERATIONS; operation++) {
                   counter.increment(INCREMENT_AMOUNT);
                 }

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -172,6 +172,7 @@ class DataStatisticsCoordinator<D extends DataStatistics<D, S>, S> implements Op
     }
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void sendDataStatisticsToSubtasks(
       long checkpointId, DataStatistics<D, S> globalDataStatistics) {
     callInCoordinatorThread(


### PR DESCRIPTION
There were few warnings with `./gradlew clean build -x test -x integrationTest` . 
this change is to make build **green**. 
