### PR TITLE
Core: Allow missing object in ErrorResponse

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -22,7 +22,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.RESTResponse;
 
 /** Standard response body for all API errors */
@@ -30,10 +29,10 @@ public class ErrorResponse implements RESTResponse {
 
   private String message;
   private String type;
-  private int code;
+  private Integer code;
   private List<String> stack;
 
-  private ErrorResponse(String message, String type, int code, List<String> stack) {
+  private ErrorResponse(String message, String type, Integer code, List<String> stack) {
     this.message = message;
     this.type = type;
     this.code = code;
@@ -127,7 +126,6 @@ public class ErrorResponse implements RESTResponse {
     }
 
     public ErrorResponse build() {
-      Preconditions.checkArgument(code != null, "Invalid response, missing field: code");
       return new ErrorResponse(message, type, code, stack);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
@@ -76,17 +76,20 @@ public class ErrorResponseParser {
         jsonNode != null && jsonNode.isObject(),
         "Cannot parse error response from non-object value: %s",
         jsonNode);
-    Preconditions.checkArgument(jsonNode.has(ERROR), "Cannot parse missing field: error");
-    JsonNode error = JsonUtil.get(ERROR, jsonNode);
-    String message = JsonUtil.getStringOrNull(MESSAGE, error);
-    String type = JsonUtil.getStringOrNull(TYPE, error);
-    Integer code = JsonUtil.getIntOrNull(CODE, error);
-    List<String> stack = JsonUtil.getStringListOrNull(STACK, error);
-    return ErrorResponse.builder()
-        .withMessage(message)
-        .withType(type)
-        .responseCode(code)
-        .withStackTrace(stack)
-        .build();
+    if (jsonNode.has(ERROR)) {
+      JsonNode error = JsonUtil.get(ERROR, jsonNode);
+      String message = JsonUtil.getStringOrNull(MESSAGE, error);
+      String type = JsonUtil.getStringOrNull(TYPE, error);
+      Integer code = JsonUtil.getIntOrNull(CODE, error);
+      List<String> stack = JsonUtil.getStringListOrNull(STACK, error);
+      return ErrorResponse.builder()
+          .withMessage(message)
+          .withType(type)
+          .responseCode(code)
+          .withStackTrace(stack)
+          .build();
+    } else {
+      return ErrorResponse.builder().build();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCatalogErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCatalogErrorResponseParser.java
@@ -78,6 +78,13 @@ public class TestCatalogErrorResponseParser {
   }
 
   @Test
+  public void testErrorResponseFromJsonWithoutError() {
+    String json = "{}";
+    ErrorResponse expected = ErrorResponse.builder().build();
+    assertEquals(expected, ErrorResponseParser.fromJson(json));
+  }
+
+  @Test
   public void testErrorResponseFromJsonWithStack() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";


### PR DESCRIPTION
It is not marked as required:

https://github.com/apache/iceberg/blob/master/open-api/rest-catalog-open-api.yaml#L2323-L2328