### PR TITLE
Open-API: Make error required

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -460,7 +460,7 @@ class IcebergErrorResponse(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    error: Optional[ErrorModel] = None
+    error: ErrorModel
 
 
 class CreateNamespaceResponse(BaseModel):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2322,6 +2322,8 @@ components:
 
     IcebergErrorResponse:
       type: object
+      required:
+        - error
       properties:
         error:
           $ref: '#/components/schemas/ErrorModel'


### PR DESCRIPTION
I think we want to make `error` required, otherwise it would just be an empty document `{}`.