### PR TITLE
Build: increase open-pull-requests-limit to 50

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,5 +29,5 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 50
 


### PR DESCRIPTION
Close #8764 

It seems it's not possible to set `open-pull-requests-limit` to unlimited value (default is 5, and 0 means disabling it).

In this change, I propose to open up to 50 PRs by dependabot