### PR TITLE
Nessie: Remove deprecated usage of Operation.Put.of()

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -138,7 +138,8 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     String refName = client.refName();
     boolean failure = false;
     try {
-      client.commitTable(base, metadata, newMetadataLocation, table, key);
+      String contentId = table == null ? null : table.getId();
+      client.commitTable(base, metadata, newMetadataLocation, contentId, key);
     } catch (NessieConflictException ex) {
       failure = true;
       if (ex instanceof NessieReferenceConflictException) {


### PR DESCRIPTION
`expectedContent` for put operation is not required for the latest Nessie versions.  Hence the constructor was deprecated from https://github.com/projectnessie/nessie/pull/6438. 

This PR updated the deprecated API usage with the alternative. 
Also introduces a simple interface for commit. 