### PR TITLE
Nessie: Adapt to Nessie 0.71.1 release

### DIFF
--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.projectnessie.client.NessieClientBuilder.AbstractNessieClientBuilder;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.client.api.NessieApi;
-import org.projectnessie.client.http.HttpClientBuilder;
 
 public class TestCustomNessieClient extends BaseTestIceberg {
 
@@ -60,8 +59,8 @@ public class TestCustomNessieClient extends BaseTestIceberg {
             temp.toUri().toString(),
             CatalogProperties.URI,
             uri,
-            NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL,
-            HttpClientBuilder.class.getName(),
+            NessieConfigConstants.CONF_NESSIE_CLIENT_NAME,
+            "HTTP",
             "client-api-version",
             apiVersion));
   }
@@ -78,30 +77,11 @@ public class TestCustomNessieClient extends BaseTestIceberg {
                       temp.toUri().toString(),
                       CatalogProperties.URI,
                       uri,
-                      NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL,
-                      "non.existent.ClientBuilderImpl"));
+                      NessieConfigConstants.CONF_NESSIE_CLIENT_NAME,
+                      "non_existent_Client"));
             })
         .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("Cannot load Nessie client builder implementation class");
-  }
-
-  @Test
-  public void testCustomClientByImpl() {
-    assertThatThrownBy(
-            () -> {
-              NessieCatalog catalog = new NessieCatalog();
-              catalog.initialize(
-                  "nessie",
-                  ImmutableMap.of(
-                      CatalogProperties.WAREHOUSE_LOCATION,
-                      temp.toUri().toString(),
-                      CatalogProperties.URI,
-                      uri,
-                      NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL,
-                      DummyClientBuilderImpl.class.getName()));
-            })
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage("BUILD CALLED");
+        .hasMessageContaining("Requested Nessie client named non_existent_Client not found");
   }
 
   @Test


### PR DESCRIPTION
extending the previous change #8607 .
Removing the use of deprecated [HttpClientBuilder](https://github.com/projectnessie/nessie/blob/5e028514f84e9dfd8ad54d5b591a9f3e083df146/api/client/src/main/java/org/projectnessie/client/http/HttpClientBuilder.java) and  [CONF_NESSIE_CLIENT_BUILDER_IMPL](https://github.com/projectnessie/nessie/blob/5e028514f84e9dfd8ad54d5b591a9f3e083df146/api/client/src/main/java/org/projectnessie/client/NessieConfigConstants.java#L258) . 