### PR TITLE
Spark 3.5: Fix specific field values treated as unequal while comparing rows for carry-over removal

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/ComputeUpdateIterator.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/ComputeUpdateIterator.java
@@ -130,11 +130,7 @@ public class ComputeUpdateIterator extends ChangelogIterator {
   }
 
   private boolean sameLogicalRow(Row currentRow, Row nextRow) {
-    for (int idx : identifierFieldIdx) {
-      if (isDifferentValue(currentRow, nextRow, idx)) {
-        return false;
-      }
-    }
-    return true;
+    return isSameRecord(
+        currentRow, nextRow, identifierFieldIdx.stream().mapToInt(i -> i).toArray());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestChangelogIterator.java
@@ -307,6 +307,27 @@ public class TestChangelogIterator extends SparkTestHelperBase {
     validateIterators(rowsWithDuplication, expectedRows);
   }
 
+  @Test
+  public void testCarryRowsRemoveSparkRowEquality() {
+    // these payload values are picked according to the implementation of Spark Row equality
+    Object[] thisPayloads = new Object[] {"data".getBytes(), Float.NaN, Double.NaN};
+    // need separate instances to avoid satisfying object (reference) equality
+    Object[] nextPayloads = new Object[] {"data".getBytes(), Float.NaN, Double.NaN};
+
+    for (int i = 0; i < 3; i++) {
+      // one delete and one insert, identical payload (= carry-over)
+      List<Row> rows =
+          Lists.newArrayList(
+              new GenericRowWithSchema(new Object[] {1, "d", thisPayloads[i], DELETE, 0, 0}, null),
+              new GenericRowWithSchema(new Object[] {1, "d", nextPayloads[i], INSERT, 0, 0}, null));
+
+      // expect both rows removed
+      List<Object[]> expectedRows = Lists.newArrayList();
+
+      validateIterators(rows, expectedRows);
+    }
+  }
+
   private void validateIterators(List<Row> rowsWithDuplication, List<Object[]> expectedRows) {
     Iterator<Row> iterator =
         ChangelogIterator.removeCarryovers(rowsWithDuplication.iterator(), SCHEMA);


### PR DESCRIPTION
This change fixes a bug that a carry-over row might be mistaken as change, due to the changelog iterators perform comparison based on Java object equality instead of row equality in Spark.

- Add test cases that unveil the bug (Binary field; also add Float/Double NaN to ensure Spark row equality is respected).
- Only covers Spark 3.5 for now; will port to 3.3 & 3.4 after approval.
- An performance implication of this change is that all the fields to be compared have to be materialized into a new GenericRow at once (instead of being checked 1-by-1).
