### PR TITLE
API, Core: Add UUID API to Table

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -332,6 +333,15 @@ public interface Table {
    * @return the current refs for the table
    */
   Map<String, SnapshotRef> refs();
+
+  /**
+   * Returns the UUID of the table
+   *
+   * @return the UUID of the table
+   */
+  default UUID uuid() {
+    throw new UnsupportedOperationException(this.getClass().getName() + " doesn't implement uuid");
+  }
 
   /**
    * Returns the snapshot referenced by the given name or null if no such reference exists.

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
@@ -197,6 +198,11 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable
   @Override
   public Map<String, SnapshotRef> refs() {
     return table().refs();
+  }
+
+  @Override
+  public UUID uuid() {
+    return UUID.randomUUID();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -257,6 +258,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   @Override
   public Map<String, SnapshotRef> refs() {
     return ops.current().refs();
+  }
+
+  @Override
+  public UUID uuid() {
+    return UUID.fromString(ops.current().uuid());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -31,6 +31,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.iceberg.encryption.EncryptionManager;
@@ -768,6 +769,11 @@ public class BaseTransaction implements Transaction {
     @Override
     public Map<String, SnapshotRef> refs() {
       return current.refs();
+    }
+
+    @Override
+    public UUID uuid() {
+      return UUID.fromString(current.uuid());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
@@ -67,6 +68,7 @@ public class SerializableTable implements Table, Serializable {
   private transient volatile Schema lazySchema = null;
   private transient volatile Map<Integer, PartitionSpec> lazySpecs = null;
   private transient volatile SortOrder lazySortOrder = null;
+  private final UUID uuid;
 
   protected SerializableTable(Table table) {
     this.name = table.name();
@@ -83,6 +85,7 @@ public class SerializableTable implements Table, Serializable {
     this.encryption = table.encryption();
     this.locationProvider = table.locationProvider();
     this.refs = SerializableMap.copyOf(table.refs());
+    this.uuid = table.uuid();
   }
 
   /**
@@ -245,6 +248,11 @@ public class SerializableTable implements Table, Serializable {
   @Override
   public Map<String, SnapshotRef> refs() {
     return refs;
+  }
+
+  @Override
+  public UUID uuid() {
+    return uuid;
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
@@ -634,6 +635,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     Assertions.assertThat(table.properties().entrySet())
         .as("Table properties should be a superset of the requested properties")
         .containsAll(properties.entrySet());
+    Assertions.assertThat(table.uuid())
+        .isEqualTo(UUID.fromString(((BaseTable) table).operations().current().uuid()));
   }
 
   @Test


### PR DESCRIPTION
This change exposes the underlying table metadata UUID via the Table API for easier access (currently one has to go through multiple hops + casting to get these details, but since a table should always have a defined UUID it will make it easier for clients to just access it via an API)

