### PR TITLE
Core: Use ParallelIterable in Deletes::toPositionIndex (6387)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -42,6 +42,13 @@ public class SystemConfigs {
           Math.max(2, Runtime.getRuntime().availableProcessors()),
           Integer::parseUnsignedInt);
 
+  public static final ConfigEntry<Integer> DELETE_WORKER_THREAD_POOL_SIZE =
+      new ConfigEntry<>(
+          "iceberg.worker.delete-num-threads",
+          "ICEBERG_WORKER_DELETE_NUM_THREADS",
+          Math.max(2, Runtime.getRuntime().availableProcessors()),
+          Integer::parseUnsignedInt);
+
   /** Whether to use the shared worker pool when planning table scans. */
   public static final ConfigEntry<Boolean> SCAN_THREAD_POOL_ENABLED =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -42,6 +42,10 @@ public class SystemConfigs {
           Math.max(2, Runtime.getRuntime().availableProcessors()),
           Integer::parseUnsignedInt);
 
+  /**
+   * Sets the size of the delete worker pool. This limits the number of threads used to compute the
+   * PositionDeleteIndex from the position deletes for a data file.
+   */
   public static final ConfigEntry<Integer> DELETE_WORKER_THREAD_POOL_SIZE =
       new ConfigEntry<>(
           "iceberg.worker.delete-num-threads",

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -28,7 +28,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   }
 
   @Override
-  public void delete(long position) {
+  public synchronized void delete(long position) {
     roaring64Bitmap.add(position);
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -144,7 +144,7 @@ public class Deletes {
             deletes ->
                 CloseableIterable.transform(
                     locationFilter.filter(deletes), row -> (Long) POSITION_ACCESSOR.get(row)));
-    if (positions.size() > 1 && (deleteWorkerPool != null)) {
+    if (positions.size() > 1 && deleteWorkerPool != null) {
       return toPositionIndex(new ParallelIterable<>(positions, deleteWorkerPool));
     } else {
       return toPositionIndex(CloseableIterable.concat(positions));

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.deletes;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -37,8 +38,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Filter;
+import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.StructLikeSet;
+import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +130,13 @@ public class Deletes {
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(
       CharSequence dataLocation, List<CloseableIterable<T>> deleteFiles) {
+    return toPositionIndex(dataLocation, deleteFiles, ThreadPools.getDeleteWorkerPool());
+  }
+
+  public static <T extends StructLike> PositionDeleteIndex toPositionIndex(
+      CharSequence dataLocation,
+      List<CloseableIterable<T>> deleteFiles,
+      ExecutorService deletePosThreadPool) {
     DataFileFilter<T> locationFilter = new DataFileFilter<>(dataLocation);
     List<CloseableIterable<Long>> positions =
         Lists.transform(
@@ -134,7 +144,10 @@ public class Deletes {
             deletes ->
                 CloseableIterable.transform(
                     locationFilter.filter(deletes), row -> (Long) POSITION_ACCESSOR.get(row)));
-    return toPositionIndex(CloseableIterable.concat(positions));
+    return toPositionIndex(
+        (positions.size() > 1 && (deletePosThreadPool != null))
+            ? new ParallelIterable<>(positions, deletePosThreadPool)
+            : CloseableIterable.concat(positions));
   }
 
   public static PositionDeleteIndex toPositionIndex(CloseableIterable<Long> posDeletes) {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -44,6 +44,12 @@ public class ThreadPools {
 
   private static final ExecutorService WORKER_POOL = newWorkerPool("iceberg-worker-pool");
 
+  public static final int DELETE_WORKER_THREAD_POOL_SIZE =
+      SystemConfigs.DELETE_WORKER_THREAD_POOL_SIZE.value();
+
+  private static final ExecutorService DELETE_WORKER_POOL =
+      newWorkerPool("iceberg-delete-worker-pool", DELETE_WORKER_THREAD_POOL_SIZE);
+
   /**
    * Return an {@link ExecutorService} that uses the "worker" thread-pool.
    *
@@ -57,6 +63,18 @@ public class ThreadPools {
    */
   public static ExecutorService getWorkerPool() {
     return WORKER_POOL;
+  }
+
+  /**
+   * Return an {@link ExecutorService} that uses "delete worker" thread-pool.
+   *
+   * <p>The size of this thread-pool is controlled by the Java system property {@code
+   * iceberg.worker.delete-num-threads}.
+   *
+   * @return an {@link ExecutorService} that uses delete worker pool
+   */
+  public static ExecutorService getDeleteWorkerPool() {
+    return DELETE_WORKER_POOL;
   }
 
   public static ExecutorService newWorkerPool(String namePrefix) {

--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -66,12 +66,15 @@ public class ThreadPools {
   }
 
   /**
-   * Return an {@link ExecutorService} that uses "delete worker" thread-pool.
+   * Return an {@link ExecutorService} that uses the "delete worker" thread-pool.
+   *
+   * <p>The size of the delete worker pool limits the number of threads used to compute the
+   * PositionDeleteIndex from the position deletes for a data file.
    *
    * <p>The size of this thread-pool is controlled by the Java system property {@code
    * iceberg.worker.delete-num-threads}.
    *
-   * @return an {@link ExecutorService} that uses delete worker pool
+   * @return an {@link ExecutorService} that uses the delete worker pool
    */
   public static ExecutorService getDeleteWorkerPool() {
     return DELETE_WORKER_POOL;

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -288,10 +288,10 @@ public class TestPositionFilter {
   }
 
   static Stream<ExecutorService> executorServiceProvider() {
-    ExecutorService executorService =
+    return Stream.of(
+        null,
         MoreExecutors.getExitingExecutorService(
-            (ThreadPoolExecutor) Executors.newFixedThreadPool(4));
-    return Stream.of(null, executorService);
+            (ThreadPoolExecutor) Executors.newFixedThreadPool(4)));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This is a continuation of https://github.com/apache/iceberg/pull/6432 by @rbalamohan, as he is not working on it anymore.
I have squashed all his commits in that PR into one, rebased it on master, and made some minor changes.