### PR TITLE
Spark: spark/*: replaced .size() > 0 with isEmpty()

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/FileScanTaskSetManager.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/FileScanTaskSetManager.java
@@ -44,7 +44,7 @@ public class FileScanTaskSetManager {
 
   public void stageTasks(Table table, String setID, List<FileScanTask> tasks) {
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "Cannot stage null or empty tasks");
+        tasks != null && !tasks.isEmpty(), "Cannot stage null or empty tasks");
     Pair<String, String> id = toID(table, setID);
     tasksMap.put(id, tasks);
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -229,7 +229,7 @@ public class RewriteDataFilesSparkAction
             Iterable<FileScanTask> filtered = strategy.selectFilesToRewrite(tasks);
             Iterable<List<FileScanTask>> groupedTasks = strategy.planFileGroups(filtered);
             List<List<FileScanTask>> fileGroups = ImmutableList.copyOf(groupedTasks);
-            if (fileGroups.size() > 0) {
+            if (!fileGroups.isEmpty()) {
               fileGroupsByPartition.put(partition, fileGroups);
             }
           });

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -112,7 +112,7 @@ class SparkBatch implements Batch {
   private boolean parquetBatchReadsEnabled() {
     return readConf.parquetVectorizationEnabled()
         && // vectorization enabled
-        expectedSchema.columns().size() > 0
+        !expectedSchema.columns().isEmpty()
         && // at least one column is projected
         expectedSchema.columns().stream()
             .allMatch(c -> c.type().isPrimitiveType()); // only primitives

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -117,7 +117,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
 
     File data = temp.newFile();
     Assert.assertTrue(data.delete());
@@ -141,7 +141,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -269,7 +269,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
@@ -279,7 +279,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", results2, expected2);
   }
 
@@ -313,7 +313,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", results, expected);
   }
 
@@ -351,7 +351,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
@@ -360,7 +360,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", expected2, results2);
   }
 
@@ -392,7 +392,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -806,7 +806,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -828,7 +828,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -853,7 +853,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -880,7 +880,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -904,7 +904,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
@@ -45,7 +45,7 @@ public class ScanTaskSetManager {
 
   public <T extends ScanTask> void stageTasks(Table table, String setId, List<T> tasks) {
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "Cannot stage null or empty tasks");
+        tasks != null && !tasks.isEmpty(), "Cannot stage null or empty tasks");
     Pair<String, String> id = toId(table, setId);
     tasksMap.put(id, tasks);
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -91,7 +91,7 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
 
   protected void doRewrite(String groupId, List<PositionDeletesScanTask> group) {
     // all position deletes are of the same partition, because they are in same file group
-    Preconditions.checkArgument(group.size() > 0, "Empty group");
+    Preconditions.checkArgument(!group.isEmpty(), "Empty group");
     Types.StructType partitionType = group.get(0).spec().partitionType();
     StructLike partition = group.get(0).partition();
 

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
@@ -176,7 +176,7 @@ class SparkZOrderDataRewriter extends SparkShufflingDataRewriter {
     }
 
     Preconditions.checkArgument(
-        validZOrderColNames.size() > 0,
+        !validZOrderColNames.isEmpty(),
         "Cannot ZOrder, all columns provided were identity partition columns and cannot be used");
 
     return validZOrderColNames;

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -119,7 +119,7 @@ class SparkBatch implements Batch {
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()
-        && expectedSchema.columns().size() > 0
+        && !expectedSchema.columns().isEmpty()
         && expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType())
         && taskGroups.stream().allMatch(this::supportsParquetBatchReads);
   }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
@@ -81,7 +81,7 @@ public class SparkPositionDeletesRewriteBuilder implements WriteBuilder {
     ScanTaskSetManager taskSetManager = ScanTaskSetManager.get();
     List<PositionDeletesScanTask> tasks = taskSetManager.fetchTasks(table, fileSetId);
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "No scan tasks found for %s", fileSetId);
+        tasks != null && !tasks.isEmpty(), "No scan tasks found for %s", fileSetId);
 
     int specId = specId(fileSetId, tasks);
     StructLike partition = partition(fileSetId, tasks);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -117,7 +117,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
 
     File data = temp.newFile();
     Assert.assertTrue(data.delete());
@@ -141,7 +141,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -269,7 +269,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
@@ -279,7 +279,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", results2, expected2);
   }
 
@@ -313,7 +313,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", results, expected);
   }
 
@@ -351,7 +351,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
@@ -360,7 +360,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", expected2, results2);
   }
 
@@ -392,7 +392,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -806,7 +806,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -828,7 +828,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -853,7 +853,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -880,7 +880,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -904,7 +904,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -807,7 +807,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
       deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
       List<Row> rows = deletes.collectAsList();
-      Assert.assertTrue("Empty delete file found", rows.size() > 0);
+      Assert.assertFalse("Empty delete file found", rows.isEmpty());
       int lastPos = 0;
       String lastPath = "";
       for (Row row : rows) {

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
@@ -45,7 +45,7 @@ public class ScanTaskSetManager {
 
   public <T extends ScanTask> void stageTasks(Table table, String setId, List<T> tasks) {
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "Cannot stage null or empty tasks");
+        tasks != null && !tasks.isEmpty(), "Cannot stage null or empty tasks");
     Pair<String, String> id = toId(table, setId);
     tasksMap.put(id, tasks);
   }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -91,7 +91,7 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
 
   protected void doRewrite(String groupId, List<PositionDeletesScanTask> group) {
     // all position deletes are of the same partition, because they are in same file group
-    Preconditions.checkArgument(group.size() > 0, "Empty group");
+    Preconditions.checkArgument(!group.isEmpty(), "Empty group");
     Types.StructType partitionType = group.get(0).spec().partitionType();
     StructLike partition = group.get(0).partition();
 

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
@@ -181,7 +181,7 @@ class SparkZOrderDataRewriter extends SparkShufflingDataRewriter {
     }
 
     Preconditions.checkArgument(
-        validZOrderColNames.size() > 0,
+        !validZOrderColNames.isEmpty(),
         "Cannot ZOrder, all columns provided were identity partition columns and cannot be used");
 
     return validZOrderColNames;

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
@@ -76,7 +76,7 @@ public class SparkPositionDeletesRewriteBuilder implements WriteBuilder {
     ScanTaskSetManager taskSetManager = ScanTaskSetManager.get();
     List<PositionDeletesScanTask> tasks = taskSetManager.fetchTasks(table, fileSetId);
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "No scan tasks found for %s", fileSetId);
+        tasks != null && !tasks.isEmpty(), "No scan tasks found for %s", fileSetId);
 
     int specId = specId(fileSetId, tasks);
     StructLike partition = partition(fileSetId, tasks);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -117,7 +117,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
 
     File data = temp.newFile();
     Assert.assertTrue(data.delete());
@@ -141,7 +141,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertFalse("Task group can't be empty", taskGroup.tasks().isEmpty());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -269,7 +269,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
@@ -279,7 +279,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", results2, expected2);
   }
 
@@ -313,7 +313,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", results, expected);
   }
 
@@ -351,7 +351,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
@@ -360,7 +360,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", expected2, results2);
   }
 
@@ -392,7 +392,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -806,7 +806,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -828,7 +828,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -853,7 +853,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -880,7 +880,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -904,7 +904,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -806,7 +806,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
       deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
       List<Row> rows = deletes.collectAsList();
-      Assert.assertTrue("Empty delete file found", rows.size() > 0);
+      Assert.assertFalse("Empty delete file found", rows.isEmpty());
       int lastPos = 0;
       String lastPath = "";
       for (Row row : rows) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/ScanTaskSetManager.java
@@ -45,7 +45,7 @@ public class ScanTaskSetManager {
 
   public <T extends ScanTask> void stageTasks(Table table, String setId, List<T> tasks) {
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "Cannot stage null or empty tasks");
+        tasks != null && !tasks.isEmpty(), "Cannot stage null or empty tasks");
     Pair<String, String> id = toId(table, setId);
     tasksMap.put(id, tasks);
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkBinPackPositionDeletesRewriter.java
@@ -91,7 +91,7 @@ class SparkBinPackPositionDeletesRewriter extends SizeBasedPositionDeletesRewrit
 
   protected void doRewrite(String groupId, List<PositionDeletesScanTask> group) {
     // all position deletes are of the same partition, because they are in same file group
-    Preconditions.checkArgument(group.size() > 0, "Empty group");
+    Preconditions.checkArgument(!group.isEmpty(), "Empty group");
     Types.StructType partitionType = group.get(0).spec().partitionType();
     StructLike partition = group.get(0).partition();
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkZOrderDataRewriter.java
@@ -181,7 +181,7 @@ class SparkZOrderDataRewriter extends SparkShufflingDataRewriter {
     }
 
     Preconditions.checkArgument(
-        validZOrderColNames.size() > 0,
+        !validZOrderColNames.isEmpty(),
         "Cannot ZOrder, all columns provided were identity partition columns and cannot be used");
 
     return validZOrderColNames;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeletesRewriteBuilder.java
@@ -76,7 +76,7 @@ public class SparkPositionDeletesRewriteBuilder implements WriteBuilder {
     ScanTaskSetManager taskSetManager = ScanTaskSetManager.get();
     List<PositionDeletesScanTask> tasks = taskSetManager.fetchTasks(table, fileSetId);
     Preconditions.checkArgument(
-        tasks != null && tasks.size() > 0, "No scan tasks found for %s", fileSetId);
+        tasks != null && !tasks.isEmpty(), "No scan tasks found for %s", fileSetId);
 
     int specId = specId(fileSetId, tasks);
     StructLike partition = partition(fileSetId, tasks);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -117,7 +117,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupKryoSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
 
     File data = temp.newFile();
     Assert.assertTrue(data.delete());
@@ -141,7 +141,7 @@ public class TestScanTaskSerialization extends SparkTestBase {
   public void testBaseScanTaskGroupJavaSerialization() throws Exception {
     BaseScanTaskGroup<FileScanTask> taskGroup = prepareBaseScanTaskGroupForSerDeTest();
 
-    Assert.assertTrue("Task group can't be empty", taskGroup.tasks().size() > 0);
+    Assert.assertTrue("Task group can't be empty", !taskGroup.tasks().isEmpty());
 
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -269,7 +269,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", results1, expected1);
 
     String newCol2 = "newCol2";
@@ -279,7 +279,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", results2, expected2);
   }
 
@@ -313,7 +313,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", results, expected);
   }
 
@@ -351,7 +351,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results1 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results1.size() > 0);
+    Assert.assertFalse(results1.isEmpty());
     assertEquals("Output must match", expected1, results1);
 
     sql("ALTER TABLE %s DROP COLUMN %s", dest, colName2);
@@ -360,7 +360,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should succeed without any exceptions
     List<Object[]> results2 = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results2.size() > 0);
+    Assert.assertFalse(results2.isEmpty());
     assertEquals("Output must match", expected2, results2);
   }
 
@@ -392,7 +392,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // reads should return same output as that of non-iceberg table
     List<Object[]> results = sql("select * from %s order by id", dest);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -806,7 +806,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -828,7 +828,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -853,7 +853,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -880,7 +880,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -904,7 +904,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     // check migrated table is returning expected result
     List<Object[]> results = sql("SELECT * FROM %s", tableName);
-    Assert.assertTrue(results.size() > 0);
+    Assert.assertFalse(results.isEmpty());
     assertEquals("Output must match", expected, results);
   }
 
@@ -982,7 +982,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
       throws NoSuchDatabaseException, NoSuchTableException, ParseException {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
-    if (sourceTable.partitionColumnNames().size() == 0) {
+    if (sourceTable.partitionColumnNames().isEmpty()) {
       uris = Lists.newArrayList();
       uris.add(sourceTable.location());
     } else {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewritePositionDeleteFilesAction.java
@@ -806,7 +806,7 @@ public class TestRewritePositionDeleteFilesAction extends SparkCatalogTestBase {
           spark.read().format("iceberg").load("default." + TABLE_NAME + ".position_deletes");
       deletes.filter(deletes.col("delete_file_path").equalTo(deleteFile.path().toString()));
       List<Row> rows = deletes.collectAsList();
-      Assert.assertTrue("Empty delete file found", rows.size() > 0);
+      Assert.assertFalse("Empty delete file found", rows.isEmpty());
       int lastPos = 0;
       String lastPath = "";
       for (Row row : rows) {


### PR DESCRIPTION
From issue #8810.

Replaced .`size() > 0` with `isEmpty()` where was possible inside spark module.