### PR TITLE
Parquet: parquet/*: replaced .size() > 0 with isEmpty()

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -116,7 +116,7 @@ public class ParquetBloomRowGroupFilter {
           Binder.boundReferences(schema.asStruct(), ImmutableList.of(expr), caseSensitive);
       // If the filter's column set doesn't overlap with any bloom filter columns, exit early with
       // ROWS_MIGHT_MATCH
-      if (filterRefs.size() > 0 && Sets.intersection(fieldsWithBloomFilter, filterRefs).isEmpty()) {
+      if (!filterRefs.isEmpty() && Sets.intersection(fieldsWithBloomFilter, filterRefs).isEmpty()) {
         return ROWS_MIGHT_MATCH;
       }
 


### PR DESCRIPTION
From issue #8810.