### PR TITLE
Flink, Aliyun, MR, Delta-lake, Hive3, Parquet, Data: replaced .size() > 0 with isEmpty()

### DIFF
--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockLocalStore.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/mock/AliyunOSSMockLocalStore.java
@@ -110,7 +110,7 @@ public class AliyunOSSMockLocalStore {
         findBucketsByFilter(
             file -> Files.isDirectory(file) && file.getFileName().endsWith(bucketName));
 
-    return buckets.size() > 0 ? buckets.get(0) : null;
+    return !buckets.isEmpty() ? buckets.get(0) : null;
   }
 
   void deleteBucket(String bucketName) throws IOException {

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -82,7 +82,7 @@ public class ResidualEvaluator implements Serializable {
    * @return a residual evaluator for the expression
    */
   public static ResidualEvaluator of(PartitionSpec spec, Expression expr, boolean caseSensitive) {
-    if (spec.fields().size() > 0) {
+    if (!spec.fields().isEmpty()) {
       return new ResidualEvaluator(spec, expr, caseSensitive);
     } else {
       return unpartitioned(expr);

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogNamespace.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogNamespace.java
@@ -105,7 +105,7 @@ public class TestGlueCatalogNamespace extends GlueTestBase {
   public void testListNamespace() {
     String namespace = createNamespace();
     List<Namespace> namespaceList = glueCatalog.listNamespaces();
-    Assert.assertTrue(namespaceList.size() > 0);
+    Assert.assertFalse(namespaceList.isEmpty());
     Assert.assertTrue(namespaceList.contains(Namespace.of(namespace)));
     namespaceList = glueCatalog.listNamespaces(Namespace.of(namespace));
     Assert.assertTrue(namespaceList.isEmpty());

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -975,7 +975,7 @@ public class TestMetricsRowGroupFilter {
             .filter(expression)
             .caseSensitive(caseSensitive)
             .build()) {
-      return Lists.newArrayList(reader).size() > 0;
+      return !Lists.newArrayList(reader).isEmpty();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
@@ -310,7 +310,7 @@ public class TestMetricsRowGroupFilterTypes {
             .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(SCHEMA, fileSchema))
             .filter(Expressions.equal(column, value))
             .build()) {
-      return Lists.newArrayList(reader).size() > 0;
+      return !Lists.newArrayList(reader).isEmpty();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -312,18 +312,18 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
       migratedDataFilesBuilder.add(dataFile.path().toString());
     }
 
-    if (filesToAdd.size() > 0 && filesToRemove.size() > 0) {
+    if (!filesToAdd.isEmpty() && !filesToRemove.isEmpty()) {
       // OverwriteFiles case
       OverwriteFiles overwriteFiles = transaction.newOverwrite();
       filesToAdd.forEach(overwriteFiles::addFile);
       filesToRemove.forEach(overwriteFiles::deleteFile);
       overwriteFiles.commit();
-    } else if (filesToAdd.size() > 0) {
+    } else if (!filesToAdd.isEmpty()) {
       // AppendFiles case
       AppendFiles appendFiles = transaction.newAppend();
       filesToAdd.forEach(appendFiles::appendFile);
       appendFiles.commit();
-    } else if (filesToRemove.size() > 0) {
+    } else if (!filesToRemove.isEmpty()) {
       // DeleteFiles case
       DeleteFiles deleteFiles = transaction.newDelete();
       filesToRemove.forEach(deleteFiles::deleteFile);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -386,7 +386,7 @@ public class FlinkSink {
     @VisibleForTesting
     List<Integer> checkAndGetEqualityFieldIds() {
       List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().identifierFieldIds());
-      if (equalityFieldColumns != null && equalityFieldColumns.size() > 0) {
+      if (equalityFieldColumns != null && !equalityFieldColumns.isEmpty()) {
         Set<Integer> equalityFieldSet =
             Sets.newHashSetWithExpectedSize(equalityFieldColumns.size());
         for (String column : equalityFieldColumns) {

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -386,7 +386,7 @@ public class FlinkSink {
     @VisibleForTesting
     List<Integer> checkAndGetEqualityFieldIds() {
       List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().identifierFieldIds());
-      if (equalityFieldColumns != null && equalityFieldColumns.size() > 0) {
+      if (equalityFieldColumns != null && !equalityFieldColumns.isEmpty()) {
         Set<Integer> equalityFieldSet =
             Sets.newHashSetWithExpectedSize(equalityFieldColumns.size());
         for (String column : equalityFieldColumns) {

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -386,7 +386,7 @@ public class FlinkSink {
     @VisibleForTesting
     List<Integer> checkAndGetEqualityFieldIds() {
       List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().identifierFieldIds());
-      if (equalityFieldColumns != null && equalityFieldColumns.size() > 0) {
+      if (equalityFieldColumns != null && !equalityFieldColumns.isEmpty()) {
         Set<Integer> equalityFieldSet =
             Sets.newHashSetWithExpectedSize(equalityFieldColumns.size());
         for (String column : equalityFieldColumns) {

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -340,7 +340,7 @@ class DataStatisticsCoordinator<D extends DataStatistics<D, S>, S> implements Op
 
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
-          gateways[subtaskIndex].size() > 0,
+              !gateways[subtaskIndex].isEmpty(),
           "Coordinator of %s subtask %d is not ready yet to receive events",
           operatorName,
           subtaskIndex);

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -340,7 +340,7 @@ class DataStatisticsCoordinator<D extends DataStatistics<D, S>, S> implements Op
 
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
-              !gateways[subtaskIndex].isEmpty(),
+          !gateways[subtaskIndex].isEmpty(),
           "Coordinator of %s subtask %d is not ready yet to receive events",
           operatorName,
           subtaskIndex);

--- a/hive3/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
+++ b/hive3/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
@@ -238,7 +238,7 @@ public class OrcSplit extends FileSplit implements ColumnarSplit, LlapAwareSplit
    * @return true if is ACID
    */
   public boolean isAcid() {
-    return hasBase || deltas.size() > 0;
+    return hasBase || !deltas.isEmpty();
   }
 
   public long getProjectedColumnsUncompressedSize() {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -269,7 +269,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
                     dataFiles(fileExecutor, table.location(), jobContext, table.io(), false);
 
                 // Check if we have files already committed and remove data files if there are any
-                if (dataFiles.size() > 0) {
+                if (!dataFiles.isEmpty()) {
                   Tasks.foreach(dataFiles)
                       .retry(3)
                       .suppressFailureWhenFinished()
@@ -327,7 +327,7 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
 
     Collection<DataFile> dataFiles = dataFiles(executor, location, jobContext, io, true);
 
-    if (dataFiles.size() > 0) {
+    if (!dataFiles.isEmpty()) {
       // Appending data files to the table
       AppendFiles append = table.newAppend();
       dataFiles.forEach(append::appendFile);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -116,7 +116,7 @@ public class ParquetBloomRowGroupFilter {
           Binder.boundReferences(schema.asStruct(), ImmutableList.of(expr), caseSensitive);
       // If the filter's column set doesn't overlap with any bloom filter columns, exit early with
       // ROWS_MIGHT_MATCH
-      if (filterRefs.size() > 0 && Sets.intersection(fieldsWithBloomFilter, filterRefs).isEmpty()) {
+      if (!filterRefs.isEmpty() && Sets.intersection(fieldsWithBloomFilter, filterRefs).isEmpty()) {
         return ROWS_MIGHT_MATCH;
       }
 


### PR DESCRIPTION
From issue #8810.