### PR TITLE
JDBC: JDBC Catalog should do exact namespace search for get namespace queries

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -135,7 +135,7 @@ final class JdbcUtil {
           + CATALOG_NAME
           + " = ? AND "
           + TABLE_NAMESPACE
-          + " LIKE ? LIMIT 1";
+          + " = ? LIMIT 1";
   static final String LIST_NAMESPACES_SQL =
       "SELECT DISTINCT "
           + TABLE_NAMESPACE
@@ -205,7 +205,7 @@ final class JdbcUtil {
           + CATALOG_NAME
           + " = ? AND "
           + NAMESPACE_NAME
-          + " LIKE ? LIMIT 1";
+          + " = ? LIMIT 1";
   static final String INSERT_NAMESPACE_PROPERTIES_SQL =
       "INSERT INTO "
           + NAMESPACE_PROPERTIES_TABLE_NAME

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -576,6 +576,13 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     assertThat(catalog.namespaceExists(Namespace.of("db", "db2", "not_exist")))
         .as("Should false to namespace doesn't exist")
         .isFalse();
+
+    Lists.newArrayList(TableIdentifier.of("ns", "t1"), TableIdentifier.of("ns_1", "t1"))
+        .forEach(t -> catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned()));
+    catalog.dropTable(TableIdentifier.of("ns", "t1"));
+    catalog.dropNamespace(Namespace.of("ns"));
+    assertThat(catalog.namespaceExists(Namespace.of("ns"))).isFalse();
+    assertThat(catalog.namespaceExists(Namespace.of("ns_1"))).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Fixes #8832

Currently the SQL query to get namespace does a regex based search + limit 1 , which is used during namespace existence checks. I believe this behavior is not correct, it should do an exact lookup