### PR TITLE
Core: fix reading of split offsets in manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -31,8 +31,6 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
-import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -462,7 +460,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    return splitOffsets == null ? null : Longs.asList(splitOffsets);
+    return ArrayUtil.toUnmodifiableLongList(splitOffsets);
   }
 
   long[] splitOffsetArray() {
@@ -471,7 +469,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return equalityIds == null ? null : Ints.asList(equalityIds);
+    return ArrayUtil.toIntList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -30,7 +30,6 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
@@ -463,7 +462,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    return splitOffsets == null ? ImmutableList.of() : Longs.asList(splitOffsets);
+    return splitOffsets == null ? null : Longs.asList(splitOffsets);
   }
 
   long[] splitOffsetArray() {
@@ -472,7 +471,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return equalityIds == null ? ImmutableList.of() : Ints.asList(equalityIds);
+    return equalityIds == null ? null : Ints.asList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -30,7 +30,10 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
+import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -81,9 +84,6 @@ abstract class BaseFile<F>
 
   // cached schema
   private transient Schema avroSchema = null;
-
-  // lazy variables
-  private transient volatile List<Long> splitOffsetList = null;
 
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   BaseFile(Schema avroSchema) {
@@ -463,11 +463,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    if (splitOffsetList == null && splitOffsets != null) {
-      this.splitOffsetList = ArrayUtil.toUnmodifiableLongList(splitOffsets);
-    }
-
-    return splitOffsetList;
+    return splitOffsets == null ? ImmutableList.of() : Longs.asList(splitOffsets);
   }
 
   long[] splitOffsetArray() {
@@ -476,7 +472,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return ArrayUtil.toIntList(equalityIds);
+    return equalityIds == null ? ImmutableList.of() : Ints.asList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -31,8 +31,6 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
-import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -462,7 +460,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    return splitOffsets == null ? null : Longs.asList(splitOffsets);
+    return ArrayUtil.toLongList(splitOffsets);
   }
 
   long[] splitOffsetArray() {
@@ -471,7 +469,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return equalityIds == null ? null : Ints.asList(equalityIds);
+    return ArrayUtil.toIntList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -31,6 +31,8 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
+import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -460,7 +462,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    return ArrayUtil.toLongList(splitOffsets);
+    return splitOffsets == null ? null : Longs.asList(splitOffsets);
   }
 
   long[] splitOffsetArray() {
@@ -469,7 +471,7 @@ abstract class BaseFile<F>
 
   @Override
   public List<Integer> equalityFieldIds() {
-    return ArrayUtil.toIntList(equalityIds);
+    return equalityIds == null ? null : Ints.asList(equalityIds);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -21,7 +21,9 @@ package org.apache.iceberg.util;
 import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
-import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 
 public class ArrayUtil {
@@ -37,7 +39,7 @@ public class ArrayUtil {
 
   public static List<Integer> toIntList(int[] ints) {
     if (ints != null) {
-      return Ints.asList(ints);
+      return IntStream.of(ints).boxed().collect(Collectors.toList());
     } else {
       return null;
     }
@@ -53,7 +55,7 @@ public class ArrayUtil {
 
   public static List<Long> toLongList(long[] longs) {
     if (longs != null) {
-      return Longs.asList(longs);
+      return LongStream.of(longs).boxed().collect(Collectors.toList());
     } else {
       return null;
     }

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -21,9 +21,7 @@ package org.apache.iceberg.util;
 import java.lang.reflect.Array;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
+import org.apache.iceberg.relocated.com.google.common.primitives.Ints;
 import org.apache.iceberg.relocated.com.google.common.primitives.Longs;
 
 public class ArrayUtil {
@@ -39,7 +37,7 @@ public class ArrayUtil {
 
   public static List<Integer> toIntList(int[] ints) {
     if (ints != null) {
-      return IntStream.of(ints).boxed().collect(Collectors.toList());
+      return Ints.asList(ints);
     } else {
       return null;
     }
@@ -55,7 +53,7 @@ public class ArrayUtil {
 
   public static List<Long> toLongList(long[] longs) {
     if (longs != null) {
-      return LongStream.of(longs).boxed().collect(Collectors.toList());
+      return Longs.asList(longs);
     } else {
       return null;
     }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -97,6 +97,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=1") // easy way to set partition data for now
           .withRecordCount(1)
+          .withSplitOffsets(ImmutableList.of(4L))
           .build();
   static final DeleteFile FILE_B_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
@@ -112,6 +113,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=2") // easy way to set partition data for now
           .withRecordCount(1)
+          .withSplitOffsets(ImmutableList.of(4L, 10_000_000L))
           .build();
   static final DeleteFile FILE_C2_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
@@ -127,6 +129,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=3") // easy way to set partition data for now
           .withRecordCount(1)
+          .withSplitOffsets(ImmutableList.of(4L, 10_000_000L, 20_000_000L))
           .build();
   static final DeleteFile FILE_D2_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -97,7 +97,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=1") // easy way to set partition data for now
           .withRecordCount(1)
-          .withSplitOffsets(ImmutableList.of(4L))
+          .withSplitOffsets(ImmutableList.of(1L))
           .build();
   static final DeleteFile FILE_B_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
@@ -113,7 +113,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=2") // easy way to set partition data for now
           .withRecordCount(1)
-          .withSplitOffsets(ImmutableList.of(4L, 10_000_000L))
+          .withSplitOffsets(ImmutableList.of(2L, 2_000_000L))
           .build();
   static final DeleteFile FILE_C2_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
@@ -129,7 +129,7 @@ public class TableTestBase {
           .withFileSizeInBytes(10)
           .withPartitionPath("data_bucket=3") // easy way to set partition data for now
           .withRecordCount(1)
-          .withSplitOffsets(ImmutableList.of(4L, 10_000_000L, 20_000_000L))
+          .withSplitOffsets(ImmutableList.of(3L, 3_000L, 3_000_000L))
           .build();
   static final DeleteFile FILE_D2_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -40,6 +43,12 @@ public class TestManifestReader extends TableTestBase {
   public static Object[] parameters() {
     return new Object[] {1, 2};
   }
+
+  private static final RecursiveComparisonConfiguration FILE_COMPARISON_CONFIG =
+      RecursiveComparisonConfiguration.builder()
+          .withIgnoredFields(
+              "dataSequenceNumber", "fileOrdinal", "fileSequenceNumber", "fromProjectionPos")
+          .build();
 
   public TestManifestReader(int formatVersion) {
     super(formatVersion);
@@ -61,16 +70,14 @@ public class TestManifestReader extends TableTestBase {
     ManifestFile manifest = writeManifest(1000L, FILE_A, FILE_B, FILE_C);
     try (ManifestReader<DataFile> reader =
         ManifestFiles.read(manifest, FILE_IO).filterRows(Expressions.equal("id", 0))) {
-      List<String> files =
-          Streams.stream(reader).map(file -> file.path().toString()).collect(Collectors.toList());
+      List<DataFile> files = Streams.stream(reader).collect(Collectors.toList());
 
       // note that all files are returned because the reader returns data files that may match, and
       // the partition is
       // bucketing by data, which doesn't help filter files
-      Assert.assertEquals(
-          "Should read the expected files",
-          Lists.newArrayList(FILE_A.path(), FILE_B.path(), FILE_C.path()),
-          files);
+      assertThat(files)
+          .usingRecursiveComparison(FILE_COMPARISON_CONFIG)
+          .isEqualTo(Lists.newArrayList(FILE_A, FILE_B, FILE_C));
     }
   }
 


### PR DESCRIPTION
This PR fixes a critical bug in reading split offsets from manifests. A change in https://github.com/apache/iceberg/pull/8336 added caching of the offsets collection in `BaseFile` to avoid reallocation. However, the Avro reader will reuse the same BaseFile object when reading, thus only the offsets from the first entry are allocated, and then those are reused for all  other entries.

cc @aokolnychyi @RussellSpitzer @rdblue @danielcweeks This can result in corrupted metadata in cases the invalid offsets are read in then written back, e.g. when rewriting manifests.
