### PR TITLE
Update CachingCatalog to use expireAfterWrite instead of expireAfterAccess

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -109,7 +109,7 @@ public class CachingCatalog implements Catalog {
       return cacheBuilder
           .removalListener(new MetadataTableInvalidatingRemovalListener())
           .executor(Runnable::run) // Makes the callbacks to removal listener synchronous
-          .expireAfterAccess(Duration.ofMillis(expirationIntervalMillis))
+          .expireAfterWrite(Duration.ofMillis(expirationIntervalMillis))
           .ticker(ticker)
           .build();
     }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -54,8 +54,8 @@ public class CatalogProperties {
    * <ul>
    *   <li>Zero - Caching and cache expiration are both disabled
    *   <li>Negative Values - Cache expiration is turned off and entries expire only on refresh etc
-   *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
-   *       milliseconds
+   *   <li>Positive Values - Cache entries expire after a fixed time period, regardless of whether
+   *       they are accessed via the cache during this time
    * </ul>
    */
   public static final String CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";

--- a/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
@@ -60,7 +60,7 @@ public class TestableCachingCatalog extends CachingCatalog {
 
   // Throws a NoSuchElementException if this entry is not in the cache (has already been TTL'd).
   public Optional<Duration> ageOf(TableIdentifier identifier) {
-    return tableCache.policy().expireAfterAccess().get().ageOf(identifier);
+    return tableCache.policy().expireAfterWrite().get().ageOf(identifier);
   }
 
   // Throws a NoSuchElementException if the entry is not in the cache (has already been TTL'd).


### PR DESCRIPTION
Fix issue https://github.com/apache/iceberg/issues/7792, we need to add a policy to expire cache regardless of access status.