### PR TITLE
[1.4.x] Flink: Reverting the default custom partitioner for bucket column (#8848)

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -525,13 +525,7 @@ public class FlinkSink {
                       + "and table is unpartitioned");
               return input;
             } else {
-              if (BucketPartitionerUtil.hasOneBucketField(partitionSpec)) {
-                return input.partitionCustom(
-                    new BucketPartitioner(partitionSpec),
-                    new BucketPartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              } else {
-                return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              }
+              return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
             }
           } else {
             if (partitionSpec.isUnpartitioned()) {

--- a/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.16/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -525,13 +525,7 @@ public class FlinkSink {
                       + "and table is unpartitioned");
               return input;
             } else {
-              if (BucketPartitionerUtil.hasOneBucketField(partitionSpec)) {
-                return input.partitionCustom(
-                    new BucketPartitioner(partitionSpec),
-                    new BucketPartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              } else {
-                return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              }
+              return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
             }
           } else {
             if (partitionSpec.isUnpartitioned()) {

--- a/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.17/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -525,13 +525,7 @@ public class FlinkSink {
                       + "and table is unpartitioned");
               return input;
             } else {
-              if (BucketPartitionerUtil.hasOneBucketField(partitionSpec)) {
-                return input.partitionCustom(
-                    new BucketPartitioner(partitionSpec),
-                    new BucketPartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              } else {
-                return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
-              }
+              return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
             }
           } else {
             if (partitionSpec.isUnpartitioned()) {


### PR DESCRIPTION
This backports #8848 to 1.4.x