### PR TITLE
Remove set-out command (deprecated) and use GITHUB_OUTPUT instead

### DIFF
--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -50,8 +50,8 @@ jobs:
         run: |
           matrix=$(echo '[${{ github.event.inputs.benchmarks }}]' | jq '.[] | select(endswith("Benchmark")) | .')
           matrix=$(echo $matrix | sed 's/ /,/g' | sed 's/"/\"/g')
-          echo "::set-output name=matrix::[$matrix]"
-          echo "::set-output name=foundlabel::$(echo "[$matrix]" | jq 'if . | length > 0 then true else false end')"
+          echo "matrix=[$matrix]" >> $GITHUB_OUTPUT
+          echo "foundlabel=$(echo "[$matrix]" | jq 'if . | length > 0 then true else false end')" >> $GITHUB_OUTPUT
 
   show-matrix:
     needs: matrix


### PR DESCRIPTION
set-out command is now deprecated in GitHub Actions. Instead we should use GITHUB_OUTPUT env variable.

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for details.