### PR TITLE
Core: Reduce unnecessary add operations in deletedPaths set

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -450,8 +450,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                           // only add the file to deletes if it is a new delete
                           // this keeps the snapshot summary accurate for non-duplicate data
                           deletedFiles.add(entry.file().copyWithoutStats());
+                          deletedPaths.add(wrapper);
                         }
-                        deletedPaths.add(wrapper);
                       } else {
                         writer.existing(entry);
                       }


### PR DESCRIPTION
This change will make deletedPaths call 'add' function only if it not contains file path, thus avoiding the unnecessary cost caused by 'add' function calls