### PR TITLE
AWS: Glue catalog strip trailing slash on DB URI

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -281,6 +281,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
                 .build());
     String dbLocationUri = response.database().locationUri();
     if (dbLocationUri != null) {
+      dbLocationUri = LocationUtil.stripTrailingSlash(dbLocationUri);
       return String.format("%s/%s", dbLocationUri, tableIdentifier.name());
     }
 
@@ -514,7 +515,9 @@ public class GlueCatalog extends BaseMetastoreCatalog
       Map<String, String> result = Maps.newHashMap(database.parameters());
 
       if (database.locationUri() != null) {
-        result.put(IcebergToGlueConverter.GLUE_DB_LOCATION_KEY, database.locationUri());
+        result.put(
+            IcebergToGlueConverter.GLUE_DB_LOCATION_KEY,
+            LocationUtil.stripTrailingSlash(database.locationUri()));
       }
 
       if (database.description() != null) {

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -153,6 +153,19 @@ public class TestGlueCatalog {
   }
 
   @Test
+  public void testDefaultWarehouseLocationDbUriTrailingSlash() {
+    Mockito.doReturn(
+            GetDatabaseResponse.builder()
+                .database(Database.builder().name("db").locationUri("s3://bucket2/db/").build())
+                .build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+    String location = glueCatalog.defaultWarehouseLocation(TableIdentifier.of("db", "table"));
+
+    Assertions.assertThat(location).isEqualTo("s3://bucket2/db/table");
+  }
+
+  @Test
   public void testDefaultWarehouseLocationCustomCatalogId() {
     GlueCatalog catalogWithCustomCatalogId = new GlueCatalog();
     String catalogId = "myCatalogId";
@@ -478,9 +491,15 @@ public class TestGlueCatalog {
   public void testLoadNamespaceMetadata() {
     Map<String, String> parameters = Maps.newHashMap();
     parameters.put("key", "val");
+    parameters.put(IcebergToGlueConverter.GLUE_DB_LOCATION_KEY, "s3://bucket2/db");
     Mockito.doReturn(
             GetDatabaseResponse.builder()
-                .database(Database.builder().name("db1").parameters(parameters).build())
+                .database(
+                    Database.builder()
+                        .name("db1")
+                        .parameters(parameters)
+                        .locationUri("s3://bucket2/db/")
+                        .build())
                 .build())
         .when(glue)
         .getDatabase(Mockito.any(GetDatabaseRequest.class));


### PR DESCRIPTION
Currently the Glue catalog does not strip the trailing slash on default DB location this can lead to path issues as seen in the below issue.

Related to: https://github.com/tabular-io/iceberg-kafka-connect/issues/127 