### PR TITLE
AWS, Core: Chore replacing null/empty checks with Apache Commons StringUtils

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
@@ -189,8 +190,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     this.catalogName = name;
     this.awsProperties = properties;
     this.s3FileIOProperties = s3Properties;
-    this.warehousePath =
-        (path != null && path.length() > 0) ? LocationUtil.stripTrailingSlash(path) : null;
+    this.warehousePath = !StringUtils.isEmpty(path) ? LocationUtil.stripTrailingSlash(path) : null;
     this.glue = client;
     this.lockManager = lock;
 
@@ -285,7 +285,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     }
 
     ValidationException.check(
-        warehousePath != null && warehousePath.length() > 0,
+        !StringUtils.isEmpty(warehousePath),
         "Cannot derive default warehouse location, warehouse path must not be null or empty");
 
     return String.format(

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -18,14 +18,14 @@
  */
 package org.apache.iceberg.util;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class LocationUtil {
   private LocationUtil() {}
 
   public static String stripTrailingSlash(String path) {
-    Preconditions.checkArgument(
-        path != null && path.length() > 0, "path must not be null or empty");
+    Preconditions.checkArgument(!StringUtils.isEmpty(path), "path must not be null or empty");
 
     String result = path;
     while (result.endsWith("/")) {


### PR DESCRIPTION
Just something I observed when reading the code, there's a few places where we do an explicit null + empty check for Strings. I think it's a bit cleaner to use Apache Commons StringUtils here for null safe checks, reduces boilerplate checks. There's more places throughout the code, but if we agree on this practice here I'll create an issue and others can contribute for addressing the remaining cases.