### PR TITLE
INFRA: Disable merging explicitly

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,16 @@ github:
     - iceberg
     - apache
     - hacktoberfest
+  
+  enabled_merge_buttons:
+    merge: false
+    squash: true
+    rebase: true
+
+  protected_branches:
+    main:
+      required_linear_history: true
+  
   features:
     wiki: true
     issues: true


### PR DESCRIPTION
This was done earlier before there was a `.asf.yaml` through an INFRA ticket, but I think it is good to also add it to the `yaml`.