### PR TITLE
Update release template

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -156,7 +156,7 @@ Convenience binary artifacts are staged on Nexus. The Maven repository URL is:
 
 Please download, verify, and test.
 
-Please vote in the next 72 hours. (Weekends excluded)
+Please vote in the next 72 hours.
 
 [ ] +1 Release this as Apache Iceberg ${version}
 [ ] +0


### PR DESCRIPTION
I think we should remove the excluding weekends part of the wait period. With a patch release like we're doing now, I don't think we want to be constrained by this. In practice, I don't think many releases are being published over the weekend.

Apache states that a vote **should** be open for 72 hours. https://www.apache.org/foundation/voting.html#expressing-votes-1-0-1-and-fractions.

If we agree on it, I'll open up a PR on the docs site as well 👍