### PR TITLE
Spark 3.4: Use Awaitility instead of Thread.sleep()

### DIFF
--- a/spark/v3.4/build.gradle
+++ b/spark/v3.4/build.gradle
@@ -101,6 +101,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
     testImplementation libs.sqlite.jdbc
+    testImplementation libs.awaitility
   }
 
   test {


### PR DESCRIPTION
Continuing from [here](https://github.com/apache/iceberg/pull/8853/files) 