### PR TITLE
Core: Optimize the process of find start delete file index

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -660,20 +660,18 @@ class DeleteFileIndex {
     }
 
     private int findStartIndex(long seq) {
-      int pos = Arrays.binarySearch(seqs, seq);
-      int start;
-      if (pos < 0) {
-        // the sequence number was not found, where it would be inserted is -(pos + 1)
-        start = -(pos + 1);
-      } else {
-        // the sequence number was found, but may not be the first
-        // find the first delete file with the given sequence number by decrementing the position
-        start = pos;
-        while (start > 0 && seqs[start - 1] >= seq) {
-          start -= 1;
+      int start = 0;
+      int len = seqs.length;
+      while (len > 0) {
+        int half = len >> 1;
+        int mid = start + half;
+        if (seqs[mid] < seq) {
+          start = mid + 1;
+          len -= (half + 1);
+        } else {
+          len = half;
         }
       }
-
       return start;
     }
 


### PR DESCRIPTION
This change optimize the process of find start delete file index about limit match deletes. Avoid the algorithm efficiency degradation issue caused by many delete files have the same sequence number as seqs[pos] (while loop at origin code line 672). 

I think this process is equivalent to the  [lower bound](https://www.geeksforgeeks.org/lower_bound-in-cpp/) which has corresponding implementations in C++ and other languages. However, I couldn't find a direct method to call in Java, so I re-implemented it.