### PR TITLE
INFRA: Avoid Running engine and core CI on template update

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -27,7 +27,7 @@ on:
       - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
-      - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+      - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/flink-ci.yml'
       - '.github/workflows/hive-ci.yml'
       - '.gitignore'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -27,7 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
-    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+    - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/hive-ci.yml'
     - '.gitignore'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -27,7 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
-    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+    - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/flink-ci.yml'
     - '.gitignore'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -27,7 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
-    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+    - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/spark-ci.yml'
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -27,7 +27,7 @@ on:
     - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
-    - '.github/ISSUE_TEMPLATE/iceberg_bug_report.yml'
+    - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/flink-ci.yml'
     - '.github/workflows/hive-ci.yml'
     - '.gitignore'


### PR DESCRIPTION
On updating the issue templates we should not run the CI which tests code correctness this pr attempts to allow list the complete ISSUE_TEMPLATE folder so that when ever this is updated we don't waste the compute on running CI as it's effectively testing nothing. 

Sample PR : 
- https://github.com/apache/iceberg/pull/8889

cc @Fokko @nastra @ajantha-bhat 