### PR TITLE
Built: Update revapi to 1.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,7 @@ subprojects {
     revapi {
       oldGroup = project.group
       oldName = project.name
-      oldVersion = "1.4.0"
+      oldVersion = "1.4.1"
     }
 
     tasks.register('showDeprecationRulesOnRevApiFailure') {


### PR DESCRIPTION
I don't think this is necessary since the API doesn't change between minor versions, but it is part of the release process :)