### PR TITLE
Nessie: Support views for NessieCatalog

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.nessie;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -394,7 +395,7 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
         fromReference.equalsIgnoreCase(toReference),
         "Cannot rename %s '%s' on reference '%s' to '%s' on reference '%s':"
             + " source and target references must be the same.",
-        NessieUtil.contentTypeString(type).toLowerCase(),
+        NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH),
         fromTableReference.getName(),
         fromReference,
         toTableReference.getName(),

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -241,7 +241,7 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
     TableReference tableReference = parseTableReference(identifier);
     return client
         .withReference(tableReference.getReference(), tableReference.getHash())
-        .dropTable(identifierWithoutTableReference(identifier, tableReference), false);
+        .dropTable(identifierWithoutTableReference(identifier, tableReference), purge);
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -167,7 +168,7 @@ public class NessieIcebergClient implements AutoCloseable {
       throw new NoSuchNamespaceException(
           ex,
           "Unable to list %ss due to missing ref '%s'",
-          NessieUtil.contentTypeString(type).toLowerCase(),
+          NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH),
           getRef().getName());
     }
   }
@@ -433,7 +434,7 @@ public class NessieIcebergClient implements AutoCloseable {
     IcebergContent existingToContent = fetchContent(to);
     validateToContentForRename(from, to, existingToContent);
 
-    String contentType = NessieUtil.contentTypeString(type).toLowerCase();
+    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH);
     try {
       commitRetry(
           String.format("Iceberg rename %s from '%s' to '%s'", contentType, from, to),
@@ -533,7 +534,7 @@ public class NessieIcebergClient implements AutoCloseable {
               identifier, NessieUtil.contentTypeString(type)));
     }
 
-    String contentType = NessieUtil.contentTypeString(type).toLowerCase();
+    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH);
 
     if (purge) {
       LOG.info(

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -546,7 +546,7 @@ public class NessieIcebergClient implements AutoCloseable {
     // We try to drop the content. Simple retry after ref update.
     try {
       commitRetry(
-          String.format("Iceberg delete table %s", identifier),
+          String.format("Iceberg delete %s %s", contentType, identifier),
           Operation.Delete.of(NessieUtil.toKey(identifier)));
       return true;
     } catch (NessieConflictException e) {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -137,8 +137,8 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
       NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_TABLE);
     } catch (NessieBadRequestException ex) {
       failure = true;
-      NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_TABLE);
-      throw ex;
+      throw NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_TABLE)
+          .orElse(ex);
     } finally {
       if (failure) {
         io().deleteFile(newMetadataLocation);

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -134,7 +134,13 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
       if (ex instanceof NessieConflictException || ex instanceof NessieNotFoundException) {
         failure = true;
       }
-      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_TABLE);
+
+      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_TABLE)
+          .ifPresent(
+              exception -> {
+                throw exception;
+              });
+
     } catch (NessieBadRequestException ex) {
       failure = true;
       throw NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_TABLE)

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.nessie;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,13 +32,25 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.view.ViewMetadata;
+import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.error.NessieReferenceConflictException;
 import org.projectnessie.error.ReferenceConflicts;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Conflict;
+import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableCommitMeta;
@@ -189,5 +202,116 @@ public final class NessieUtil {
 
     Conflict conflict = conflicts.get(0);
     return Optional.of(conflict);
+  }
+
+  public static ViewMetadata loadViewMetadata(
+      ViewMetadata metadata, String metadataLocation, Reference reference) {
+    Map<String, String> newProperties = Maps.newHashMap(metadata.properties());
+    newProperties.put(NessieTableOperations.NESSIE_COMMIT_ID_PROPERTY, reference.getHash());
+
+    return ViewMetadata.buildFrom(
+            ViewMetadata.buildFrom(metadata).setProperties(newProperties).build())
+        .setMetadataLocation(metadataLocation)
+        .build();
+  }
+
+  static void handleExceptionsForCommits(Exception exception, String refName, Content.Type type) {
+    if (exception instanceof NessieConflictException) {
+      if (exception instanceof NessieReferenceConflictException) {
+        // Throws a specialized exception, if possible
+        NessieUtil.maybeThrowSpecializedException(
+            (NessieReferenceConflictException) exception, type);
+      }
+
+      throw new CommitFailedException(
+          exception,
+          "Cannot commit: Reference hash is out of date. Update the reference '%s' and try again",
+          refName);
+    }
+
+    if (exception instanceof NessieNotFoundException) {
+      throw new RuntimeException(
+          String.format("Cannot commit: Reference '%s' no longer exists", refName), exception);
+    }
+
+    if (exception instanceof HttpClientException) {
+      // Intentionally catch all nessie-client-exceptions here and not just the "timeout" variant
+      // to catch all kinds of network errors (e.g. connection reset). Network code implementation
+      // details and all kinds of network devices can induce unexpected behavior. So better be
+      // safe than sorry.
+      throw new CommitStateUnknownException(exception);
+    }
+  }
+
+  static void handleBadRequestForCommit(
+      NessieIcebergClient client, ContentKey key, Content.Type type) {
+    Content.Type anotherType =
+        type == Content.Type.ICEBERG_TABLE ? Content.Type.ICEBERG_VIEW : Content.Type.ICEBERG_TABLE;
+    try {
+      Content content =
+          client.getApi().getContent().key(key).reference(client.getReference()).get().get(key);
+      if (content != null) {
+        if (content.getType().equals(anotherType)) {
+          throw new AlreadyExistsException(
+              "%s with same name already exists: %s in %s",
+              NessieUtil.contentTypeString(anotherType), key, client.getReference());
+        } else if (!content.getType().equals(type)) {
+          throw new AlreadyExistsException(
+              "Another content with same name already exists: %s in %s",
+              key, client.getReference());
+        }
+      }
+    } catch (NessieNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void maybeThrowSpecializedException(
+      NessieReferenceConflictException ex, Content.Type type) {
+    String contentType = contentTypeString(type);
+
+    NessieUtil.extractSingleConflict(
+            ex,
+            EnumSet.of(
+                Conflict.ConflictType.NAMESPACE_ABSENT,
+                Conflict.ConflictType.NAMESPACE_NOT_EMPTY,
+                Conflict.ConflictType.KEY_DOES_NOT_EXIST,
+                Conflict.ConflictType.KEY_EXISTS))
+        .ifPresent(
+            conflict -> {
+              switch (conflict.conflictType()) {
+                case NAMESPACE_ABSENT:
+                  throw new NoSuchNamespaceException(
+                      ex, "Namespace does not exist: %s", conflict.key());
+                case NAMESPACE_NOT_EMPTY:
+                  throw new NamespaceNotEmptyException(
+                      ex, "Namespace not empty: %s", conflict.key());
+                case KEY_DOES_NOT_EXIST:
+                  if (type == Content.Type.ICEBERG_VIEW) {
+                    throw new NoSuchViewException(
+                        ex, "%s does not exist: %s", contentType, conflict.key());
+                  } else {
+                    throw new NoSuchTableException(
+                        ex, "%s does not exist: %s", contentType, conflict.key());
+                  }
+                case KEY_EXISTS:
+                  throw new AlreadyExistsException(
+                      ex, "%s already exists: %s", contentType, conflict.key());
+                default:
+                  // Explicit fall-through
+                  break;
+              }
+            });
+  }
+
+  static String contentTypeString(Content.Type type) {
+    if (type.equals(Content.Type.ICEBERG_VIEW)) {
+      return "View";
+    } else if (type.equals(Content.Type.ICEBERG_TABLE)) {
+      return "Table";
+    } else if (type.equals(Content.Type.NAMESPACE)) {
+      return "Namespace";
+    }
+    throw new IllegalArgumentException("Unsupported Nessie content type " + type.name());
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -248,6 +248,7 @@ public final class NessieUtil {
       // safe than sorry.
       return Optional.of(new CommitStateUnknownException(exception));
     }
+
     return Optional.empty();
   }
 
@@ -274,6 +275,7 @@ public final class NessieUtil {
     } catch (NessieNotFoundException e) {
       return Optional.of(new RuntimeException(e));
     }
+
     return Optional.empty();
   }
 
@@ -325,6 +327,7 @@ public final class NessieUtil {
     } else if (type.equals(Content.Type.NAMESPACE)) {
       return "Namespace";
     }
+
     throw new IllegalArgumentException("Unsupported Nessie content type " + type.name());
   }
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -116,8 +116,7 @@ public class NessieViewOperations extends BaseViewOperations {
       NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_VIEW);
     } catch (NessieBadRequestException ex) {
       failure = true;
-      NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_VIEW);
-      throw ex;
+      throw NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_VIEW).orElse(ex);
     } finally {
       if (failure) {
         io().deleteFile(newMetadataLocation);

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -18,12 +18,12 @@
  */
 package org.apache.iceberg.nessie;
 
-import org.apache.iceberg.BaseMetastoreTableOperations;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.view.BaseViewOperations;
+import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.view.ViewMetadataParser;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.NessieBadRequestException;
 import org.projectnessie.error.NessieConflictException;
@@ -36,38 +36,23 @@ import org.projectnessie.model.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Nessie implementation of Iceberg TableOperations. */
-public class NessieTableOperations extends BaseMetastoreTableOperations {
+public class NessieViewOperations extends BaseViewOperations {
 
-  private static final Logger LOG = LoggerFactory.getLogger(NessieTableOperations.class);
-
-  /**
-   * Name of the `{@link TableMetadata} property that holds the Nessie commit-ID from which the
-   * metadata has been loaded.
-   */
-  public static final String NESSIE_COMMIT_ID_PROPERTY = "nessie.commit.id";
-
-  public static final String NESSIE_GC_NO_WARNING_PROPERTY = "nessie.gc.no-warning";
+  private static final Logger LOG = LoggerFactory.getLogger(NessieViewOperations.class);
 
   private final NessieIcebergClient client;
   private final ContentKey key;
-  private IcebergTable table;
   private final FileIO fileIO;
+  private IcebergView icebergView;
 
-  /** Create a nessie table operations given a table identifier. */
-  NessieTableOperations(ContentKey key, NessieIcebergClient client, FileIO fileIO) {
+  NessieViewOperations(ContentKey key, NessieIcebergClient client, FileIO fileIO) {
     this.key = key;
     this.client = client;
     this.fileIO = fileIO;
   }
 
   @Override
-  protected String tableName() {
-    return key.toString();
-  }
-
-  @Override
-  protected void doRefresh() {
+  public void doRefresh() {
     try {
       client.refresh();
     } catch (NessieNotFoundException e) {
@@ -83,29 +68,28 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
       LOG.debug("Content '{}' at '{}': {}", key, reference, content);
       if (content == null) {
         if (currentMetadataLocation() != null) {
-          throw new NoSuchTableException("No such table '%s' in '%s'", key, reference);
+          throw new NoSuchViewException("View does not exist: %s in %s", key, reference);
         }
       } else {
-        this.table =
+        this.icebergView =
             content
-                .unwrap(IcebergTable.class)
+                .unwrap(IcebergView.class)
                 .orElseThrow(
                     () -> {
-                      if (content instanceof IcebergView) {
+                      if (content instanceof IcebergTable) {
                         return new AlreadyExistsException(
-                            "View with same name already exists: %s", key);
+                            "Table with same name already exists: %s in %s", key, reference);
                       } else {
                         return new AlreadyExistsException(
-                            "Cannot refresh Iceberg table: "
-                                + "Nessie points to a non-Iceberg object for path: %s.",
-                            key);
+                            "Cannot refresh Iceberg view: Nessie points to a non-Iceberg object for path: %s in %s",
+                            key, reference);
                       }
                     });
-        metadataLocation = table.getMetadataLocation();
+        metadataLocation = icebergView.getMetadataLocation();
       }
     } catch (NessieNotFoundException ex) {
       if (currentMetadataLocation() != null) {
-        throw new NoSuchTableException(ex, "No such table '%s'", key);
+        throw new NoSuchViewException("View does not exist: %s in %s", key, reference);
       }
     }
     refreshFromMetadataLocation(
@@ -113,37 +97,37 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
         null,
         2,
         location ->
-            NessieUtil.updateTableMetadataWithNessieSpecificProperties(
-                TableMetadataParser.read(fileIO, location),
-                location,
-                table,
-                key.toString(),
-                reference));
+            NessieUtil.loadViewMetadata(
+                ViewMetadataParser.read(io().newInputFile(location)), location, reference));
   }
 
   @Override
-  protected void doCommit(TableMetadata base, TableMetadata metadata) {
-    boolean newTable = base == null;
-    String newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
+  public void doCommit(ViewMetadata base, ViewMetadata metadata) {
+    String newMetadataLocation = writeNewMetadataIfRequired(metadata);
 
     boolean failure = false;
     try {
-      String contentId = table == null ? null : table.getId();
-      client.commitTable(base, metadata, newMetadataLocation, contentId, key);
+      String contentId = icebergView == null ? null : icebergView.getId();
+      client.commitView(base, metadata, newMetadataLocation, contentId, key);
     } catch (NessieConflictException | NessieNotFoundException | HttpClientException ex) {
       if (ex instanceof NessieConflictException || ex instanceof NessieNotFoundException) {
         failure = true;
       }
-      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_TABLE);
+      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_VIEW);
     } catch (NessieBadRequestException ex) {
       failure = true;
-      NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_TABLE);
+      NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_VIEW);
       throw ex;
     } finally {
       if (failure) {
         io().deleteFile(newMetadataLocation);
       }
     }
+  }
+
+  @Override
+  protected String viewName() {
+    return key.toString();
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -102,6 +102,7 @@ public class NessieViewOperations extends BaseViewOperations {
       if (ex instanceof NessieConflictException || ex instanceof NessieNotFoundException) {
         failure = true;
       }
+
       NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_VIEW)
           .ifPresent(
               exception -> {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieViewOperations.java
@@ -113,7 +113,11 @@ public class NessieViewOperations extends BaseViewOperations {
       if (ex instanceof NessieConflictException || ex instanceof NessieNotFoundException) {
         failure = true;
       }
-      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_VIEW);
+      NessieUtil.handleExceptionsForCommits(ex, client.refName(), Content.Type.ICEBERG_VIEW)
+          .ifPresent(
+              exception -> {
+                throw exception;
+              });
     } catch (NessieBadRequestException ex) {
       failure = true;
       throw NessieUtil.handleBadRequestForCommit(client, key, Content.Type.ICEBERG_VIEW).orElse(ex);

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -62,7 +62,8 @@ class UpdateableReference {
 
   public void checkMutable() {
     Preconditions.checkArgument(
-        mutable, "You can only mutate tables when using a branch without a hash or timestamp.");
+        mutable,
+        "You can only mutate tables/views when using a branch without a hash or timestamp.");
   }
 
   public String getName() {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -18,14 +18,19 @@
  */
 package org.apache.iceberg.nessie;
 
+import static org.apache.iceberg.TableMetadataParser.getFileExtension;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
@@ -35,6 +40,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.catalog.Namespace;
@@ -46,6 +52,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -180,6 +188,32 @@ public abstract class BaseTestIceberg {
     return catalog.createTable(tableIdentifier, schema);
   }
 
+  protected View createView(NessieCatalog nessieCatalog, TableIdentifier tableIdentifier) {
+    Schema schema = new Schema(StructType.of(required(1, "id", LongType.get())).fields());
+    return createView(nessieCatalog, tableIdentifier, schema);
+  }
+
+  protected View createView(
+      NessieCatalog nessieCatalog, TableIdentifier tableIdentifier, Schema schema) {
+    createMissingNamespaces(tableIdentifier);
+    return nessieCatalog
+        .buildView(tableIdentifier)
+        .withSchema(schema)
+        .withDefaultNamespace(tableIdentifier.namespace())
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+  }
+
+  protected View replaceView(NessieCatalog nessieCatalog, TableIdentifier identifier) {
+    Schema schema = new Schema(StructType.of(required(2, "age", Types.IntegerType.get())).fields());
+    return nessieCatalog
+        .buildView(identifier)
+        .withSchema(schema)
+        .withDefaultNamespace(identifier.namespace())
+        .withQuery("trino", "select age from ns.tbl")
+        .replace();
+  }
+
   protected void createMissingNamespaces(TableIdentifier tableIdentifier) {
     createMissingNamespaces(catalog, tableIdentifier);
   }
@@ -247,6 +281,10 @@ public abstract class BaseTestIceberg {
     return icebergOps.currentMetadataLocation();
   }
 
+  static String viewMetadataLocation(NessieCatalog catalog, TableIdentifier identifier) {
+    return ((BaseView) catalog.loadView(identifier)).operations().current().metadataFileLocation();
+  }
+
   static String writeRecordsToFile(
       Table table, Schema schema, String filename, List<Record> records) throws IOException {
     String fileLocation =
@@ -266,5 +304,24 @@ public abstract class BaseTestIceberg {
         .withPath(fileLocation)
         .withFileSizeInBytes(Files.localInput(fileLocation).getLength())
         .build();
+  }
+
+  protected static List<String> metadataVersionFiles(String tablePath) {
+    return filterByExtension(tablePath, getFileExtension(TableMetadataParser.Codec.NONE));
+  }
+
+  protected static List<String> filterByExtension(String tablePath, String extension) {
+    return metadataFiles(tablePath).stream()
+        .filter(f -> f.endsWith(extension))
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings(
+      "RegexpSinglelineJava") // respecting this rule requires a lot more lines of code
+  private static List<String> metadataFiles(String tablePath) {
+    return Arrays.stream(
+            Objects.requireNonNull(new File((tablePath + "/" + "metadata")).listFiles()))
+        .map(File::getAbsolutePath)
+        .collect(Collectors.toList());
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -51,7 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.LongType;
-import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.AfterEach;
@@ -179,7 +178,7 @@ public abstract class BaseTestIceberg {
 
   protected void createTable(TableIdentifier tableIdentifier) {
     createMissingNamespaces(tableIdentifier);
-    Schema schema = new Schema(StructType.of(required(1, "id", LongType.get())).fields());
+    Schema schema = new Schema(required(1, "id", LongType.get()));
     catalog.createTable(tableIdentifier, schema).location();
   }
 
@@ -189,7 +188,7 @@ public abstract class BaseTestIceberg {
   }
 
   protected View createView(NessieCatalog nessieCatalog, TableIdentifier tableIdentifier) {
-    Schema schema = new Schema(StructType.of(required(1, "id", LongType.get())).fields());
+    Schema schema = new Schema(required(1, "id", LongType.get()));
     return createView(nessieCatalog, tableIdentifier, schema);
   }
 
@@ -205,7 +204,7 @@ public abstract class BaseTestIceberg {
   }
 
   protected View replaceView(NessieCatalog nessieCatalog, TableIdentifier identifier) {
-    Schema schema = new Schema(StructType.of(required(2, "age", Types.IntegerType.get())).fields());
+    Schema schema = new Schema(required(2, "age", Types.IntegerType.get()));
     return nessieCatalog
         .buildView(identifier)
         .withSchema(schema)

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -69,6 +69,7 @@ import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableTableReference;
 import org.projectnessie.model.LogResponse.LogEntry;
 import org.projectnessie.model.Operation;
+import org.projectnessie.model.TableReference;
 import org.projectnessie.model.Tag;
 
 public class TestNessieTable extends BaseTestIceberg {
@@ -249,12 +250,12 @@ public class TestNessieTable extends BaseTestIceberg {
     TableIdentifier renameTableIdentifier =
         TableIdentifier.of(TABLE_IDENTIFIER.namespace(), renamedTableName);
 
-    ImmutableTableReference fromTableReference =
+    TableReference fromTableReference =
         ImmutableTableReference.builder()
             .reference(catalog.currentRefName())
             .name(TABLE_IDENTIFIER.name())
             .build();
-    ImmutableTableReference toTableReference =
+    TableReference toTableReference =
         ImmutableTableReference.builder()
             .reference(catalog.currentRefName())
             .name(renameTableIdentifier.name())
@@ -288,12 +289,12 @@ public class TestNessieTable extends BaseTestIceberg {
     TableIdentifier renameTableIdentifier =
         TableIdentifier.of(TABLE_IDENTIFIER.namespace(), renamedTableName);
 
-    ImmutableTableReference fromTableReference =
+    TableReference fromTableReference =
         ImmutableTableReference.builder()
             .reference("Something")
             .name(TABLE_IDENTIFIER.name())
             .build();
-    ImmutableTableReference toTableReference =
+    TableReference toTableReference =
         ImmutableTableReference.builder()
             .reference(catalog.currentRefName())
             .name(renameTableIdentifier.name())

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.nessie;
 
-import static org.apache.iceberg.TableMetadataParser.getFileExtension;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -28,10 +27,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,7 +42,6 @@ import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.AvroSchemaUtil;
@@ -309,7 +305,8 @@ public class TestNessieTable extends BaseTestIceberg {
 
     Assertions.assertThatThrownBy(() -> catalog.renameTable(fromIdentifier, toIdentifier))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("from: Something and to: iceberg-table-test reference name must be same");
+        .hasMessage(
+            "Cannot rename table 'tbl' on reference 'Something' to 'rename_table_name' on reference 'iceberg-table-test': source and target references must be the same.");
 
     fromTableReference =
         ImmutableTableReference.builder()
@@ -328,7 +325,8 @@ public class TestNessieTable extends BaseTestIceberg {
 
     Assertions.assertThatThrownBy(() -> catalog.renameTable(fromIdentifierNew, toIdentifierNew))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("from: iceberg-table-test and to: Something reference name must be same");
+        .hasMessage(
+            "Cannot rename table 'tbl' on reference 'iceberg-table-test' to 'rename_table_name' on reference 'Something': source and target references must be the same.");
   }
 
   private void verifyCommitMetadata() throws NessieNotFoundException {
@@ -487,7 +485,8 @@ public class TestNessieTable extends BaseTestIceberg {
     Assertions.assertThatThrownBy(
             () -> catalog.registerTable(tagIdentifier, "file:" + metadataVersionFiles.get(0)))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("You can only mutate tables when using a branch without a hash or timestamp.");
+        .hasMessage(
+            "You can only mutate tables/views when using a branch without a hash or timestamp.");
     // Case 4: non-null metadata path with null metadata location
     Assertions.assertThatThrownBy(
             () ->
@@ -670,27 +669,8 @@ public class TestNessieTable extends BaseTestIceberg {
     return temp.toUri() + DB_NAME + "/" + tableName;
   }
 
-  @SuppressWarnings(
-      "RegexpSinglelineJava") // respecting this rule requires a lot more lines of code
-  private List<String> metadataFiles(String tablePath) {
-    return Arrays.stream(
-            Objects.requireNonNull(new File((tablePath + "/" + "metadata")).listFiles()))
-        .map(File::getAbsolutePath)
-        .collect(Collectors.toList());
-  }
-
-  protected List<String> metadataVersionFiles(String tablePath) {
-    return filterByExtension(tablePath, getFileExtension(TableMetadataParser.Codec.NONE));
-  }
-
   protected List<String> manifestFiles(String tablePath) {
     return filterByExtension(tablePath, ".avro");
-  }
-
-  private List<String> filterByExtension(String tablePath, String extension) {
-    return metadataFiles(tablePath).stream()
-        .filter(f -> f.endsWith(extension))
-        .collect(Collectors.toList());
   }
 
   private static String addRecordsToFile(Table table, String filename) throws IOException {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieView.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieView.java
@@ -236,13 +236,9 @@ public class TestNessieView extends BaseTestIceberg {
     TableIdentifier toIdentifier =
         TableIdentifier.of(VIEW_IDENTIFIER.namespace(), toTableReference.toString());
 
-    View viewBeforeRename = catalog.loadView(fromIdentifier);
     catalog.renameView(fromIdentifier, toIdentifier);
     Assertions.assertThat(catalog.viewExists(fromIdentifier)).isFalse();
     Assertions.assertThat(catalog.viewExists(toIdentifier)).isTrue();
-    View viewAfterRename = catalog.loadView(toIdentifier);
-    Assertions.assertThat(viewBeforeRename.currentVersion().versionId())
-        .isEqualTo(viewAfterRename.currentVersion().versionId());
 
     Assertions.assertThat(catalog.dropView(toIdentifier)).isTrue();
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieView.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieView.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.nessie;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.SQLViewRepresentation;
+import org.apache.iceberg.view.View;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.ext.NessieClientFactory;
+import org.projectnessie.client.ext.NessieClientUri;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.CommitMeta;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergView;
+import org.projectnessie.model.ImmutableTableReference;
+import org.projectnessie.model.LogResponse.LogEntry;
+
+public class TestNessieView extends BaseTestIceberg {
+
+  private static final String BRANCH = "iceberg-view-test";
+
+  private static final String DB_NAME = "db";
+  private static final String VIEW_NAME = "view";
+  private static final TableIdentifier VIEW_IDENTIFIER = TableIdentifier.of(DB_NAME, VIEW_NAME);
+  private static final ContentKey KEY = ContentKey.of(DB_NAME, VIEW_NAME);
+  private static final Schema SCHEMA =
+      new Schema(Types.StructType.of(required(1, "id", Types.LongType.get())).fields());
+  private static final Schema ALTERED =
+      new Schema(
+          Types.StructType.of(
+                  required(1, "id", Types.LongType.get()),
+                  optional(2, "data", Types.LongType.get()))
+              .fields());
+
+  private String viewLocation;
+
+  public TestNessieView() {
+    super(BRANCH);
+  }
+
+  @Override
+  @BeforeEach
+  public void beforeEach(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws IOException {
+    super.beforeEach(clientFactory, nessieUri);
+    this.viewLocation =
+        createView(catalog, VIEW_IDENTIFIER, SCHEMA).location().replaceFirst("file:", "");
+  }
+
+  @Override
+  @AfterEach
+  public void afterEach() throws Exception {
+    // drop the view data
+    if (viewLocation != null) {
+      try (Stream<Path> walk = Files.walk(Paths.get(viewLocation))) {
+        walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+      }
+      catalog.dropView(VIEW_IDENTIFIER);
+    }
+
+    super.afterEach();
+  }
+
+  private IcebergView getView(ContentKey key) throws NessieNotFoundException {
+    return getView(BRANCH, key);
+  }
+
+  private IcebergView getView(String ref, ContentKey key) throws NessieNotFoundException {
+    return api.getContent().key(key).refName(ref).get().get(key).unwrap(IcebergView.class).get();
+  }
+
+  /** Verify that Nessie always returns the globally-current global-content w/ only DMLs. */
+  @Test
+  public void verifyStateMovesForDML() throws Exception {
+    //  1. initialize view
+    View icebergView = catalog.loadView(VIEW_IDENTIFIER);
+    icebergView
+        .replaceVersion()
+        .withQuery("spark", "some query")
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(VIEW_IDENTIFIER.namespace())
+        .commit();
+
+    //  2. create 2nd branch
+    String testCaseBranch = "verify-global-moving";
+    api.createReference()
+        .sourceRefName(BRANCH)
+        .reference(Branch.of(testCaseBranch, catalog.currentHash()))
+        .create();
+    IcebergView contentInitialMain = getView(BRANCH, KEY);
+    IcebergView contentInitialBranch = getView(testCaseBranch, KEY);
+    View viewInitialMain = catalog.loadView(VIEW_IDENTIFIER);
+
+    // verify view-metadata-location + version-id
+    Assertions.assertThat(contentInitialMain)
+        .as("global-contents + snapshot-id equal on both branches in Nessie")
+        .isEqualTo(contentInitialBranch);
+    Assertions.assertThat(viewInitialMain.currentVersion()).isNotNull();
+
+    //  3. modify view in "main" branch
+
+    icebergView
+        .replaceVersion()
+        .withQuery("trino", "some other query")
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(VIEW_IDENTIFIER.namespace())
+        .commit();
+
+    IcebergView contentsAfter1Main = getView(KEY);
+    IcebergView contentsAfter1Branch = getView(testCaseBranch, KEY);
+    View viewAfter1Main = catalog.loadView(VIEW_IDENTIFIER);
+
+    //  --> assert getValue() against both branches returns the updated metadata-location
+    // verify view-metadata-location
+    Assertions.assertThat(contentInitialMain.getMetadataLocation())
+        .describedAs("metadata-location must change on %s", BRANCH)
+        .isNotEqualTo(contentsAfter1Main.getMetadataLocation());
+    Assertions.assertThat(contentInitialBranch.getMetadataLocation())
+        .describedAs("metadata-location must not change on %s", testCaseBranch)
+        .isEqualTo(contentsAfter1Branch.getMetadataLocation());
+    Assertions.assertThat(contentsAfter1Main)
+        .extracting(IcebergView::getSchemaId)
+        .describedAs("schema ID must be same across branches")
+        .isEqualTo(contentsAfter1Branch.getSchemaId());
+    // verify updates
+    Assertions.assertThat(
+            ((SQLViewRepresentation) viewAfter1Main.currentVersion().representations().get(0))
+                .dialect())
+        .isEqualTo("trino");
+
+    //  4. modify view in "main" branch again
+
+    icebergView
+        .replaceVersion()
+        .withQuery("flink", "some query")
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(VIEW_IDENTIFIER.namespace())
+        .commit();
+
+    IcebergView contentsAfter2Main = getView(KEY);
+    IcebergView contentsAfter2Branch = getView(testCaseBranch, KEY);
+    View viewAfter2Main = catalog.loadView(VIEW_IDENTIFIER);
+
+    //  --> assert getValue() against both branches returns the updated metadata-location
+    // verify view-metadata-location
+    Assertions.assertThat(contentsAfter2Main.getMetadataLocation())
+        .describedAs("metadata-location must change on %s", BRANCH)
+        .isNotEqualTo(contentsAfter1Main.getMetadataLocation());
+    Assertions.assertThat(contentsAfter2Branch.getMetadataLocation())
+        .describedAs("on-reference-state must not change on %s", testCaseBranch)
+        .isEqualTo(contentsAfter1Branch.getMetadataLocation());
+    Assertions.assertThat(
+            ((SQLViewRepresentation) viewAfter2Main.currentVersion().representations().get(0))
+                .dialect())
+        .isEqualTo("flink");
+  }
+
+  @Test
+  public void testUpdate() throws IOException {
+    String viewName = VIEW_IDENTIFIER.name();
+    View icebergView = catalog.loadView(VIEW_IDENTIFIER);
+    // add a column
+    icebergView
+        .replaceVersion()
+        .withQuery("spark", "some query")
+        .withSchema(ALTERED)
+        .withDefaultNamespace(VIEW_IDENTIFIER.namespace())
+        .commit();
+
+    getView(KEY); // sanity, check view exists
+    // check parameters are in expected state
+    String expected = temp.toUri() + DB_NAME + "/" + viewName;
+    Assertions.assertThat(getViewBasePath(viewName)).isEqualTo(expected);
+
+    Assertions.assertThat(metadataVersionFiles(viewLocation)).isNotNull().hasSize(2);
+
+    verifyCommitMetadata();
+  }
+
+  @Test
+  public void testRenameWithTableReference() throws NessieNotFoundException {
+    String renamedViewName = "rename_view_name";
+    TableIdentifier renameViewIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), renamedViewName);
+
+    ImmutableTableReference fromTableReference =
+        ImmutableTableReference.builder()
+            .reference(catalog.currentRefName())
+            .name(VIEW_IDENTIFIER.name())
+            .build();
+    ImmutableTableReference toTableReference =
+        ImmutableTableReference.builder()
+            .reference(catalog.currentRefName())
+            .name(renameViewIdentifier.name())
+            .build();
+    TableIdentifier fromIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), fromTableReference.toString());
+    TableIdentifier toIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), toTableReference.toString());
+
+    catalog.renameView(fromIdentifier, toIdentifier);
+    Assertions.assertThat(catalog.viewExists(fromIdentifier)).isFalse();
+    Assertions.assertThat(catalog.viewExists(toIdentifier)).isTrue();
+
+    Assertions.assertThat(catalog.dropView(toIdentifier)).isTrue();
+
+    verifyCommitMetadata();
+  }
+
+  @Test
+  public void testRenameWithTableReferenceInvalidCase() {
+    String renamedViewName = "rename_view_name";
+    TableIdentifier renameViewIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), renamedViewName);
+
+    ImmutableTableReference fromTableReference =
+        ImmutableTableReference.builder()
+            .reference("Something")
+            .name(VIEW_IDENTIFIER.name())
+            .build();
+    ImmutableTableReference toTableReference =
+        ImmutableTableReference.builder()
+            .reference(catalog.currentRefName())
+            .name(renameViewIdentifier.name())
+            .build();
+    TableIdentifier fromIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), fromTableReference.toString());
+    TableIdentifier toIdentifier =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), toTableReference.toString());
+
+    Assertions.assertThatThrownBy(() -> catalog.renameView(fromIdentifier, toIdentifier))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot rename view 'view' on reference 'Something' to 'rename_view_name' on reference 'iceberg-view-test': source and target references must be the same.");
+
+    fromTableReference =
+        ImmutableTableReference.builder()
+            .reference(catalog.currentRefName())
+            .name(VIEW_IDENTIFIER.name())
+            .build();
+    toTableReference =
+        ImmutableTableReference.builder()
+            .reference("Something")
+            .name(renameViewIdentifier.name())
+            .build();
+    TableIdentifier fromIdentifierNew =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), fromTableReference.toString());
+    TableIdentifier toIdentifierNew =
+        TableIdentifier.of(VIEW_IDENTIFIER.namespace(), toTableReference.toString());
+
+    Assertions.assertThatThrownBy(() -> catalog.renameView(fromIdentifierNew, toIdentifierNew))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot rename view 'view' on reference 'iceberg-view-test' to 'rename_view_name' on reference 'Something': source and target references must be the same.");
+  }
+
+  private void verifyCommitMetadata() throws NessieNotFoundException {
+    // check that the author is properly set
+    List<LogEntry> log = api.getCommitLog().refName(BRANCH).get().getLogEntries();
+    Assertions.assertThat(log)
+        .isNotNull()
+        .isNotEmpty()
+        .filteredOn(e -> !e.getCommitMeta().getMessage().startsWith("create namespace "))
+        .allSatisfy(
+            logEntry -> {
+              CommitMeta commit = logEntry.getCommitMeta();
+              Assertions.assertThat(commit.getAuthor()).isNotNull().isNotEmpty();
+              Assertions.assertThat(commit.getAuthor()).isEqualTo(System.getProperty("user.name"));
+              Assertions.assertThat(commit.getProperties().get(NessieUtil.APPLICATION_TYPE))
+                  .isEqualTo("iceberg");
+              Assertions.assertThat(commit.getMessage()).startsWith("Iceberg");
+            });
+  }
+
+  @Test
+  public void testDrop() throws NessieNotFoundException {
+    Assertions.assertThat(catalog.viewExists(VIEW_IDENTIFIER)).isTrue();
+    Assertions.assertThat(catalog.dropView(VIEW_IDENTIFIER)).isTrue();
+    Assertions.assertThat(catalog.viewExists(VIEW_IDENTIFIER)).isFalse();
+    Assertions.assertThat(catalog.dropView(VIEW_IDENTIFIER)).isFalse();
+    verifyCommitMetadata();
+  }
+
+  @Test
+  public void testListviews() {
+    TableIdentifier newIdentifier = TableIdentifier.of(DB_NAME, "newView");
+    createView(catalog, newIdentifier, SCHEMA);
+
+    List<TableIdentifier> tableIdents = catalog.listViews(VIEW_IDENTIFIER.namespace());
+    List<TableIdentifier> expectedIdents =
+        tableIdents.stream()
+            .filter(t -> t.equals(newIdentifier) || t.equals(VIEW_IDENTIFIER))
+            .collect(Collectors.toList());
+    Assertions.assertThat(expectedIdents).hasSize(2);
+    Assertions.assertThat(catalog.viewExists(VIEW_IDENTIFIER)).isTrue();
+    Assertions.assertThat(catalog.viewExists(newIdentifier)).isTrue();
+  }
+
+  private String getViewBasePath(String viewName) {
+    return temp.toUri() + DB_NAME + "/" + viewName;
+  }
+}

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.view.ViewCatalogTests;
 import org.apache.iceberg.view.ViewMetadata;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -64,7 +65,7 @@ public class TestNessieViewCatalog extends ViewCatalogTests<NessieCatalog> {
   @RegisterExtension
   static NessieJaxRsExtension server = NessieJaxRsExtension.jaxRsExtension(() -> persist);
 
-  @TempDir public Path temp;
+  @TempDir private Path temp;
 
   private NessieCatalog catalog;
   private NessieApiV1 api;
@@ -151,6 +152,7 @@ public class TestNessieViewCatalog extends ViewCatalogTests<NessieCatalog> {
   // Nessie adds extra properties (like commit id) on every operation. Hence, view metadata will not
   // be same after rename.
   @Override
+  @Test
   public void renameView() {
     TableIdentifier from = TableIdentifier.of("ns", "view");
     TableIdentifier to = TableIdentifier.of("ns", "renamedView");
@@ -185,6 +187,7 @@ public class TestNessieViewCatalog extends ViewCatalogTests<NessieCatalog> {
   }
 
   @Override
+  @Test
   public void renameViewUsingDifferentNamespace() {
     TableIdentifier from = TableIdentifier.of("ns", "view");
     TableIdentifier to = TableIdentifier.of("other_ns", "renamedView");

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieViewCatalog.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.nessie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.view.BaseView;
+import org.apache.iceberg.view.View;
+import org.apache.iceberg.view.ViewCatalogTests;
+import org.apache.iceberg.view.ViewMetadata;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.ext.NessieApiVersion;
+import org.projectnessie.client.ext.NessieApiVersions;
+import org.projectnessie.client.ext.NessieClientFactory;
+import org.projectnessie.client.ext.NessieClientUri;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.jaxrs.ext.NessieJaxRsExtension;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+import org.projectnessie.versioned.storage.common.persist.Persist;
+import org.projectnessie.versioned.storage.inmemory.InmemoryBackendTestFactory;
+import org.projectnessie.versioned.storage.testextension.NessieBackend;
+import org.projectnessie.versioned.storage.testextension.NessiePersist;
+import org.projectnessie.versioned.storage.testextension.PersistExtension;
+
+@ExtendWith(PersistExtension.class)
+@NessieBackend(InmemoryBackendTestFactory.class)
+@NessieApiVersions // test all versions
+public class TestNessieViewCatalog extends ViewCatalogTests<NessieCatalog> {
+
+  @NessiePersist static Persist persist;
+
+  @RegisterExtension
+  static NessieJaxRsExtension server = NessieJaxRsExtension.jaxRsExtension(() -> persist);
+
+  @TempDir public Path temp;
+
+  private NessieCatalog catalog;
+  private NessieApiV1 api;
+  private NessieApiVersion apiVersion;
+  private Configuration hadoopConfig;
+  private String initialHashOfDefaultBranch;
+  private String uri;
+
+  @BeforeEach
+  public void setUp(NessieClientFactory clientFactory, @NessieClientUri URI nessieUri)
+      throws NessieNotFoundException {
+    api = clientFactory.make();
+    apiVersion = clientFactory.apiVersion();
+    initialHashOfDefaultBranch = api.getDefaultBranch().getHash();
+    uri = nessieUri.toASCIIString();
+    hadoopConfig = new Configuration();
+    catalog = initNessieCatalog("main");
+  }
+
+  @AfterEach
+  public void afterEach() throws IOException {
+    resetData();
+    try {
+      if (catalog != null) {
+        catalog.close();
+      }
+      api.close();
+    } finally {
+      catalog = null;
+      api = null;
+      hadoopConfig = null;
+    }
+  }
+
+  private void resetData() throws NessieConflictException, NessieNotFoundException {
+    Branch defaultBranch = api.getDefaultBranch();
+    for (Reference r : api.getAllReferences().get().getReferences()) {
+      if (r instanceof Branch && !r.getName().equals(defaultBranch.getName())) {
+        api.deleteBranch().branch((Branch) r).delete();
+      }
+      if (r instanceof Tag) {
+        api.deleteTag().tag((Tag) r).delete();
+      }
+    }
+    api.assignBranch()
+        .assignTo(Branch.of(defaultBranch.getName(), initialHashOfDefaultBranch))
+        .branch(defaultBranch)
+        .assign();
+  }
+
+  private NessieCatalog initNessieCatalog(String ref) {
+    NessieCatalog newCatalog = new NessieCatalog();
+    newCatalog.setConf(hadoopConfig);
+    ImmutableMap<String, String> options =
+        ImmutableMap.of(
+            "ref",
+            ref,
+            CatalogProperties.URI,
+            uri,
+            CatalogProperties.WAREHOUSE_LOCATION,
+            temp.toUri().toString(),
+            "client-api-version",
+            apiVersion == NessieApiVersion.V2 ? "2" : "1");
+    newCatalog.initialize("nessie", options);
+    return newCatalog;
+  }
+
+  @Override
+  protected NessieCatalog catalog() {
+    return catalog;
+  }
+
+  @Override
+  protected Catalog tableCatalog() {
+    return catalog;
+  }
+
+  @Override
+  protected boolean requiresNamespaceCreate() {
+    return true;
+  }
+
+  // Overriding the below rename view testcases to exclude checking same view metadata after rename.
+  // Nessie adds extra properties (like commit id) on every operation. Hence, view metadata will not
+  // be same after rename.
+  @Override
+  public void renameView() {
+    TableIdentifier from = TableIdentifier.of("ns", "view");
+    TableIdentifier to = TableIdentifier.of("ns", "renamedView");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(from.namespace());
+    }
+
+    assertThat(catalog().viewExists(from)).as("View should not exist").isFalse();
+
+    View view =
+        catalog()
+            .buildView(from)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(from.namespace())
+            .withQuery("spark", "select * from ns.tbl")
+            .create();
+
+    assertThat(catalog().viewExists(from)).as("View should exist").isTrue();
+
+    ViewMetadata original = ((BaseView) view).operations().current();
+    assertThat(original.metadataFileLocation()).isNotNull();
+
+    catalog().renameView(from, to);
+
+    assertThat(catalog().viewExists(from)).as("View should not exist with old name").isFalse();
+    assertThat(catalog().viewExists(to)).as("View should exist with new name").isTrue();
+
+    assertThat(catalog().dropView(from)).isFalse();
+    assertThat(catalog().dropView(to)).isTrue();
+    assertThat(catalog().viewExists(to)).as("View should not exist").isFalse();
+  }
+
+  @Override
+  public void renameViewUsingDifferentNamespace() {
+    TableIdentifier from = TableIdentifier.of("ns", "view");
+    TableIdentifier to = TableIdentifier.of("other_ns", "renamedView");
+
+    if (requiresNamespaceCreate()) {
+      catalog().createNamespace(from.namespace());
+      catalog().createNamespace(to.namespace());
+    }
+
+    assertThat(catalog().viewExists(from)).as("View should not exist").isFalse();
+
+    catalog()
+        .buildView(from)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(from.namespace())
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    assertThat(catalog().viewExists(from)).as("View should exist").isTrue();
+
+    catalog().renameView(from, to);
+
+    assertThat(catalog().viewExists(from)).as("View should not exist with old name").isFalse();
+    assertThat(catalog().viewExists(to)).as("View should exist with new name").isTrue();
+
+    assertThat(catalog().dropView(from)).isFalse();
+    assertThat(catalog().dropView(to)).isTrue();
+    assertThat(catalog().viewExists(to)).as("View should not exist").isFalse();
+  }
+}


### PR DESCRIPTION
- Extend `NessieCatalog` with `BaseMetastoreViewCatalog`.
- Move some common code to `NessieUtil` for reusing between tables and views.
- Generalize `ViewCatalogTests` to reuse for Nessie catalog.

Fixes: https://github.com/apache/iceberg/issues/8696