### PR TITLE
Open-API: Error response in the spec don’t align with the expected model.

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -461,6 +461,10 @@ class OAuthTokenResponse(BaseModel):
 
 
 class IcebergErrorResponse(BaseModel):
+    """
+    JSON wrapper for all error responses (non-2xx)
+    """
+
     class Config:
         extra = Extra.forbid
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -226,7 +226,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -266,7 +266,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceAlreadyExists:
                   $ref: '#/components/examples/NamespaceAlreadyExistsError'
@@ -302,7 +302,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -334,7 +334,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -364,7 +364,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -415,7 +415,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -426,7 +426,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 UnprocessableEntityDuplicateKey:
                   $ref: '#/components/examples/UnprocessableEntityDuplicateKey'
@@ -462,7 +462,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -510,7 +510,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -519,7 +519,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
@@ -562,7 +562,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -571,7 +571,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 NamespaceAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
@@ -637,7 +637,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -691,7 +691,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -701,7 +701,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         500:
@@ -710,7 +710,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Internal Server Error",
@@ -726,7 +726,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Invalid response from the upstream server",
@@ -740,7 +740,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Gateway timed out during commit",
@@ -754,7 +754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Bad Gateway",
@@ -792,7 +792,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToDeleteDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -825,7 +825,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -875,7 +875,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToRenameDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -888,7 +888,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example:
                 $ref: '#/components/examples/TableAlreadyExistsError'
         419:
@@ -931,7 +931,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -984,7 +984,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               examples:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -994,7 +994,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
         419:
           $ref: '#/components/responses/AuthenticationTimeoutResponse'
         500:
@@ -1003,7 +1003,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Internal Server Error",
@@ -1019,7 +1019,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Invalid response from the upstream server",
@@ -1033,7 +1033,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Gateway timed out during commit",
@@ -1047,7 +1047,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorModel'
+                $ref: '#/components/schemas/IcebergErrorResponse'
               example: {
                 "error": {
                   "message": "Bad Gateway",
@@ -2322,6 +2322,7 @@ components:
           description: Authorization scope for client credentials or token exchange
 
     IcebergErrorResponse:
+      description: JSON wrapper for all error responses (non-2xx)
       type: object
       required:
         - error
@@ -2329,6 +2330,14 @@ components:
         error:
           $ref: '#/components/schemas/ErrorModel'
       additionalProperties: false
+      example:
+        {
+          "error": {
+            "message": "The server does not support this operation",
+            "type": "UnsupportedOperationException",
+            "code": 406
+          }
+        }
 
     CreateNamespaceResponse:
       type: object
@@ -2450,7 +2459,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Malformed request",
@@ -2467,7 +2476,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Not authorized to make this request",
@@ -2483,7 +2492,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Not authorized to make this request",
@@ -2499,7 +2508,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "The server does not support this operation",
@@ -2507,19 +2516,6 @@ components:
               "code": 406
             }
           }
-
-    IcebergErrorResponse:
-      description: JSON wrapper for all error responses (non-2xx)
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/IcebergErrorResponse'
-            example: {
-              "error": {
-                "message": "The server does not support this operation",
-                "type": "UnsupportedOperationException",
-                "code": 406
-              } }
 
     CreateNamespaceResponse:
       description:
@@ -2575,7 +2571,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Credentials have timed out",
@@ -2593,7 +2589,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Slow down",
@@ -2610,7 +2606,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            $ref: '#/components/schemas/IcebergErrorResponse'
           example: {
             "error": {
               "message": "Internal Server Error",

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2508,7 +2508,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "The server does not support this operation",
@@ -2516,6 +2516,19 @@ components:
               "code": 406
             }
           }
+
+    IcebergErrorResponse:
+      description: JSON wrapper for all error responses (non-2xx)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/IcebergErrorResponse'
+            example: {
+              "error": {
+                "message": "The server does not support this operation",
+                "type": "UnsupportedOperationException",
+                "code": 406
+              } }
 
     CreateNamespaceResponse:
       description:


### PR DESCRIPTION
When generating a REST client using the current OpenAPI specification, the non-200 Iceberg error responses are defined as:

```
{
  "message": "Malformed request",
  "type": "BadRequestException",
  "code": 400
}
```

However, the provided examples in the spec correctly enclose the error details within an error JSON node:

```
{
  "error": {
    "message": "Malformed request",
    "type": "BadRequestException",
    "code": 400
  }
}
```

Iceberg error responses point to the `ErrorModel` as their schema, as seen [here](https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L1102-L1126). Following the current convention and returning the above-stated non-200 error structure to the client results in a precondition failure within the [ErrorResponseParser](https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java#L80). This is due to the parsers expectation for all error responses to be wrapped within the error JSON node.

example: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L2444

**Testing** 
```
make lint
OK
```
