### PR TITLE
Hive: Refactor TestHiveCatalog tests to use the core CatalogTests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -723,6 +723,7 @@ project(':iceberg-hive-metastore') {
     }
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
+    testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
     testImplementation libs.awaitility
   }
 }

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -164,6 +164,10 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     return true;
   }
 
+  protected boolean supportsNamesWithDot() {
+    return true;
+  }
+
   @Test
   public void testCreateNamespace() {
     C catalog = catalog();
@@ -470,6 +474,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testNamespaceWithDot() {
+    Assumptions.assumeTrue(supportsNamesWithDot());
+
     C catalog = catalog();
 
     Namespace withDot = Namespace.of("new.db");
@@ -547,6 +553,8 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
 
   @Test
   public void testTableNameWithDot() {
+    Assumptions.assumeTrue(supportsNamesWithDot());
+
     C catalog = catalog();
 
     TableIdentifier ident = TableIdentifier.of("ns", "ta.ble");

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -288,7 +288,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
 
     } catch (AlreadyExistsException e) {
       throw new org.apache.iceberg.exceptions.AlreadyExistsException(
-          e, "Namespace '%s' already exists!", namespace);
+          e, "Namespace already exists: %s", namespace);
 
     } catch (TException e) {
       throw new RuntimeException(
@@ -500,6 +500,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
         return String.format("%s/%s", databaseData.getLocationUri(), tableIdentifier.name());
       }
 
+    } catch (NoSuchObjectException e) {
+      throw new NoSuchNamespaceException(
+          e, "Namespace does not exist: %s", tableIdentifier.namespace().levels()[0]);
     } catch (TException e) {
       throw new RuntimeException(
           String.format("Metastore operation failed for %s", tableIdentifier), e);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -209,7 +209,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
       if (!Objects.equals(baseMetadataLocation, metadataLocation)) {
         throw new CommitFailedException(
-            "Base metadata location '%s' is not same as the current table metadata location '%s' for %s.%s",
+            "Cannot commit: Base metadata location '%s' is not same as the current table metadata location '%s' for %s.%s",
             baseMetadataLocation, metadataLocation, database, tableName);
       }
 


### PR DESCRIPTION
Currently HiveTests are not using the Core catalog tests. Ideally unlike other catalog [Nessie](https://github.com/apache/iceberg/blob/main/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java) , [JDBC](https://github.com/apache/iceberg/blob/main/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieCatalog.java), Hive should also extent the core [CatalogTests](https://github.com/apache/iceberg/blob/main/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java). 
Depends upon feedback other duplicate tests will be removed and remaining will be moved to this new class. 