### PR TITLE
Spark 3.5: Honor Spark conf spark.sql.files.maxPartitionBytes in read split

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -160,6 +160,7 @@ class SparkConfParser {
     private final List<String> optionNames = Lists.newArrayList();
     private String sessionConfName;
     private String tablePropertyName;
+    private String defaultSessionConfName;
 
     protected abstract ThisT self();
 
@@ -175,6 +176,11 @@ class SparkConfParser {
 
     public ThisT tableProperty(String name) {
       this.tablePropertyName = name;
+      return self();
+    }
+
+    public ThisT defaultSessionConfName(String name) {
+      this.defaultSessionConfName = name;
       return self();
     }
 
@@ -201,6 +207,13 @@ class SparkConfParser {
         String propertyValue = properties.get(tablePropertyName);
         if (propertyValue != null) {
           return conversion.apply(propertyValue);
+        }
+      }
+
+      if (defaultSessionConfName != null) {
+        String defaultSessionConfValue = sessionConf.get(defaultSessionConfName, null);
+        if (defaultSessionConfValue != null) {
+          return conversion.apply(defaultSessionConfValue);
         }
       }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
 
 /**
  * A class for common Iceberg configs for Spark reads.
@@ -195,6 +196,7 @@ public class SparkReadConf {
         .longConf()
         .option(SparkReadOptions.SPLIT_SIZE)
         .tableProperty(TableProperties.SPLIT_SIZE)
+        .defaultSessionConfName(SQLConf.FILES_MAX_PARTITION_BYTES().key())
         .defaultValue(TableProperties.SPLIT_SIZE_DEFAULT)
         .parse();
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkReadConf.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.util.Map;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.spark.sql.RuntimeConfig;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestSparkReadConf {
+
+  private SparkSession spark;
+  private Table table;
+
+  @Before
+  public void before() {
+    RuntimeConfig conf = Mockito.mock(RuntimeConfig.class);
+    Mockito.when(conf.get(Mockito.anyString(), Mockito.anyString()))
+        .thenAnswer(invocation -> invocation.getArgument(1));
+    spark = Mockito.mock(SparkSession.class);
+    Mockito.when(spark.conf()).thenReturn(conf);
+    table = Mockito.mock(Table.class);
+    Mockito.when(table.name()).thenReturn("cat.db.tbl");
+  }
+
+  @Test
+  public void splitSizeReadOption() {
+    long splitSizeOption = 12345;
+    Map<String, String> options =
+        ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, Long.toString(splitSizeOption));
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, options);
+    Assert.assertEquals(splitSizeOption, readConf.splitSize());
+    Assert.assertEquals(splitSizeOption, readConf.splitSizeOption().longValue());
+  }
+
+  @Test
+  public void splitSizeTableProp() {
+    long splitSizeTableProp = 7654;
+    Mockito.when(table.properties())
+        .thenReturn(
+            ImmutableMap.of(TableProperties.SPLIT_SIZE, String.valueOf(splitSizeTableProp)));
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(splitSizeTableProp, readConf.splitSize());
+    Assert.assertEquals(null, readConf.splitSizeOption());
+  }
+
+  @Test
+  public void splitSizeMaxPartitionBytes() {
+    long maxPartitionBytes = 67890000;
+    Mockito.when(spark.conf().get(SQLConf.FILES_MAX_PARTITION_BYTES().key(), null))
+        .thenReturn(String.valueOf(maxPartitionBytes));
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(maxPartitionBytes, readConf.splitSize());
+    Assert.assertEquals(null, readConf.splitSizeOption());
+  }
+
+  @Test
+  public void splitSizeDefault() {
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(TableProperties.SPLIT_SIZE_DEFAULT, readConf.splitSize());
+    Assert.assertEquals(null, readConf.splitSizeOption());
+  }
+
+  @Test
+  public void splitSizeReadOptionAndTableProp() {
+    long splitSizeOption = 12345;
+    Map<String, String> options =
+        ImmutableMap.of(SparkReadOptions.SPLIT_SIZE, Long.toString(splitSizeOption));
+
+    long splitSizeTableProp = 7654;
+    Mockito.when(table.properties())
+        .thenReturn(
+            ImmutableMap.of(TableProperties.SPLIT_SIZE, String.valueOf(splitSizeTableProp)));
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, options);
+    Assert.assertEquals(splitSizeOption, readConf.splitSize());
+    Assert.assertEquals(splitSizeOption, readConf.splitSizeOption().longValue());
+  }
+
+  @Test
+  public void splitSizeTablePropAndMaxPartitionBytes() {
+    long splitSizeTableProp = 7654;
+    Mockito.when(table.properties())
+        .thenReturn(
+            ImmutableMap.of(TableProperties.SPLIT_SIZE, String.valueOf(splitSizeTableProp)));
+
+    long maxPartitionBytes = 67890000;
+    Mockito.when(spark.conf().get(SQLConf.FILES_MAX_PARTITION_BYTES().key(), null))
+        .thenReturn(String.valueOf(maxPartitionBytes));
+
+    SparkReadConf readConf = new SparkReadConf(spark, table, ImmutableMap.of());
+    Assert.assertEquals(splitSizeTableProp, readConf.splitSize());
+    Assert.assertEquals(null, readConf.splitSizeOption());
+  }
+}


### PR DESCRIPTION
Honor Spark conf `spark.sql.files.maxPartitionBytes` in read split size, right before the default value.

Here is the proposed order:

1. DataFrame read option `split-size`
2. Table property `read.split.target-size`
3. Spark conf `spark.sql.files.maxPartitionBytes`
4. Constant `SPLIT_SIZE_DEFAULT`

More context in https://apache-iceberg.slack.com/archives/C03LG1D563F/p1698258652032969