### PR TITLE
Spark: Clean up FileIO instances on executors for metadata tables

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -70,15 +70,29 @@ public class SerializableTableWithSize extends SerializableTable
   }
 
   public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
-      implements KnownSizeEstimation {
+      implements KnownSizeEstimation, AutoCloseable {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(SerializableMetadataTableWithSize.class);
+
+    private final transient Object serializationMarker;
 
     protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
       super(metadataTable);
+      this.serializationMarker = new Object();
     }
 
     @Override
     public long estimatedSize() {
       return SIZE_ESTIMATE;
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (serializationMarker == null) {
+        LOG.info("Releasing resources");
+        io().close();
+      }
     }
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -70,15 +70,29 @@ public class SerializableTableWithSize extends SerializableTable
   }
 
   public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
-      implements KnownSizeEstimation {
+      implements KnownSizeEstimation, AutoCloseable {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(SerializableMetadataTableWithSize.class);
+
+    private final transient Object serializationMarker;
 
     protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
       super(metadataTable);
+      this.serializationMarker = new Object();
     }
 
     @Override
     public long estimatedSize() {
       return SIZE_ESTIMATE;
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (serializationMarker == null) {
+        LOG.info("Releasing resources");
+        io().close();
+      }
     }
   }
 }

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -86,40 +88,44 @@ public class TestTableSerialization {
 
   @Test
   public void testCloseSerializableTableKryoSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
   public void testCloseSerializableTableJavaSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
@@ -153,5 +159,18 @@ public class TestTableSerialization {
 
     TestHelpers.assertSerializedMetadata(
         txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
+  }
+
+  private List<Table> tables() {
+    List<Table> tables = Lists.newArrayList();
+
+    tables.add(table);
+
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Table metadataTable = MetadataTableUtils.createMetadataTableInstance(table, type);
+      tables.add(metadataTable);
+    }
+
+    return tables;
   }
 }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -70,15 +70,29 @@ public class SerializableTableWithSize extends SerializableTable
   }
 
   public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
-      implements KnownSizeEstimation {
+      implements KnownSizeEstimation, AutoCloseable {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(SerializableMetadataTableWithSize.class);
+
+    private final transient Object serializationMarker;
 
     protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
       super(metadataTable);
+      this.serializationMarker = new Object();
     }
 
     @Override
     public long estimatedSize() {
       return SIZE_ESTIMATE;
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (serializationMarker == null) {
+        LOG.info("Releasing resources");
+        io().close();
+      }
     }
   }
 }

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -86,40 +88,44 @@ public class TestTableSerialization {
 
   @Test
   public void testCloseSerializableTableKryoSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
   public void testCloseSerializableTableJavaSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
@@ -153,5 +159,18 @@ public class TestTableSerialization {
 
     TestHelpers.assertSerializedMetadata(
         txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
+  }
+
+  private List<Table> tables() {
+    List<Table> tables = Lists.newArrayList();
+
+    tables.add(table);
+
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Table metadataTable = MetadataTableUtils.createMetadataTableInstance(table, type);
+      tables.add(metadataTable);
+    }
+
+    return tables;
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SerializableTableWithSize.java
@@ -70,15 +70,29 @@ public class SerializableTableWithSize extends SerializableTable
   }
 
   public static class SerializableMetadataTableWithSize extends SerializableMetadataTable
-      implements KnownSizeEstimation {
+      implements KnownSizeEstimation, AutoCloseable {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(SerializableMetadataTableWithSize.class);
+
+    private final transient Object serializationMarker;
 
     protected SerializableMetadataTableWithSize(BaseMetadataTable metadataTable) {
       super(metadataTable);
+      this.serializationMarker = new Object();
     }
 
     @Override
     public long estimatedSize() {
       return SIZE_ESTIMATE;
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (serializationMarker == null) {
+        LOG.info("Releasing resources");
+        io().close();
+      }
     }
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/TestTableSerialization.java
@@ -28,10 +28,12 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SerializableTableWithSize;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -86,40 +88,44 @@ public class TestTableSerialization {
 
   @Test
   public void testCloseSerializableTableKryoSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(KryoHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
   public void testCloseSerializableTableJavaSerialization() throws Exception {
-    Table spyTable = spy(table);
-    FileIO spyIO = spy(table.io());
-    when(spyTable.io()).thenReturn(spyIO);
+    for (Table tbl : tables()) {
+      Table spyTable = spy(tbl);
+      FileIO spyIO = spy(tbl.io());
+      when(spyTable.io()).thenReturn(spyIO);
 
-    Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
+      Table serializableTable = SerializableTableWithSize.copyOf(spyTable);
 
-    Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
-    FileIO spyFileIOCopy = spy(serializableTableCopy.io());
-    when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
+      Table serializableTableCopy = spy(TestHelpers.roundTripSerialize(serializableTable));
+      FileIO spyFileIOCopy = spy(serializableTableCopy.io());
+      when(serializableTableCopy.io()).thenReturn(spyFileIOCopy);
 
-    ((AutoCloseable) serializableTable).close(); // mimics close on the driver
-    ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
+      ((AutoCloseable) serializableTable).close(); // mimics close on the driver
+      ((AutoCloseable) serializableTableCopy).close(); // mimics close on executors
 
-    verify(spyIO, never()).close();
-    verify(spyFileIOCopy, times(1)).close();
+      verify(spyIO, never()).close();
+      verify(spyFileIOCopy, times(1)).close();
+    }
   }
 
   @Test
@@ -153,5 +159,18 @@ public class TestTableSerialization {
 
     TestHelpers.assertSerializedMetadata(
         txnTable, KryoHelpers.roundTripSerialize(serializableTxnTable));
+  }
+
+  private List<Table> tables() {
+    List<Table> tables = Lists.newArrayList();
+
+    tables.add(table);
+
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Table metadataTable = MetadataTableUtils.createMetadataTableInstance(table, type);
+      tables.add(metadataTable);
+    }
+
+    return tables;
   }
 }


### PR DESCRIPTION
This PR implements the same approach as in PR #8685 but for metadata tables.