### PR TITLE
Core: Ignore split offsets array when split offset is past file length

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -460,21 +460,27 @@ abstract class BaseFile<F>
 
   @Override
   public List<Long> splitOffsets() {
-    if (splitOffsets == null || splitOffsets.length == 0) {
-      return null;
+    if (hasWellDefinedOffsets()) {
+      return ArrayUtil.toUnmodifiableLongList(splitOffsets);
     }
 
-    // If the last split offset is past the file size this means the split offsets are corrupted and
-    // should not be used
-    if (splitOffsets[splitOffsets.length - 1] >= fileSizeInBytes) {
-      return null;
-    }
-
-    return ArrayUtil.toUnmodifiableLongList(splitOffsets);
+    return null;
   }
 
   long[] splitOffsetArray() {
-    return splitOffsets;
+    if (hasWellDefinedOffsets()) {
+      return splitOffsets;
+    }
+
+    return null;
+  }
+
+  private boolean hasWellDefinedOffsets() {
+    // If the last split offset is past the file size this means the split offsets are corrupted and
+    // should not be used
+    return splitOffsets != null
+        && splitOffsets.length != 0
+        && splitOffsets[splitOffsets.length - 1] < fileSizeInBytes;
   }
 
   @Override


### PR DESCRIPTION
Follow up from a miss in the fix done in https://github.com/apache/iceberg/pull/8860. There's an additional splitOffsetArray method which gets used here https://github.com/apache/iceberg/blob/aa891acf20040d15e7ca59dc503adb3c1e4325b8/core/src/main/java/org/apache/iceberg/BaseContentScanTask.java#L134 . We would want to surface null for this array in case we know the split offsets are corrupted and invalid (stemming from an issue in 1.4.0). The split offsets are invalid when the final offset is beyond the end of the file.

Alternatively, we can undo the optimization done here: https://github.com/apache/iceberg/pull/8336#discussion_r1296190234 and then the original fix in #8860 would be sufficient, and be simpler. Since the optimization seemed impactful and there was community interest in it, this fix retains it and currently just fixes both cases explicitly.