### PR TITLE
Spark: Avoid extra copies of manifests while optimizing V2 tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -20,8 +20,6 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
-import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
-import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -57,7 +55,6 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   private final TableOperations ops;
   private final Map<Integer, PartitionSpec> specsById;
   private final long manifestTargetSizeBytes;
-  private final boolean snapshotIdInheritanceEnabled;
 
   private final Set<ManifestFile> deletedManifests = Sets.newHashSet();
   private final List<ManifestFile> addedManifests = Lists.newArrayList();
@@ -82,10 +79,6 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     this.manifestTargetSizeBytes =
         ops.current()
             .propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
-    this.snapshotIdInheritanceEnabled =
-        ops.current()
-            .propertyAsBoolean(
-                SNAPSHOT_ID_INHERITANCE_ENABLED, SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT);
   }
 
   @Override
@@ -148,7 +141,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     Preconditions.checkArgument(
         manifest.sequenceNumber() == -1, "Sequence must be assigned during commit");
 
-    if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {
+    if (canInheritSnapshotId() && manifest.snapshotId() == null) {
       addedManifests.add(manifest);
     } else {
       // the manifest must be rewritten with this update's snapshot ID

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -28,6 +28,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.MANIFEST_TARGET_SIZE_BYTES_DEFAULT;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
+import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -85,6 +87,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   private final TableOperations ops;
   private final boolean strictCleanup;
+  private final boolean canInheritSnapshotId;
   private final String commitUUID = UUID.randomUUID().toString();
   private final AtomicInteger manifestCount = new AtomicInteger(0);
   private final AtomicInteger attempt = new AtomicInteger(0);
@@ -116,6 +119,11 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     this.targetManifestSizeBytes =
         ops.current()
             .propertyAsLong(MANIFEST_TARGET_SIZE_BYTES, MANIFEST_TARGET_SIZE_BYTES_DEFAULT);
+    boolean snapshotIdInheritanceEnabled =
+        ops.current()
+            .propertyAsBoolean(
+                SNAPSHOT_ID_INHERITANCE_ENABLED, SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT);
+    this.canInheritSnapshotId = ops.current().formatVersion() > 1 || snapshotIdInheritanceEnabled;
   }
 
   protected abstract ThisT self();
@@ -534,6 +542,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       }
     }
     return snapshotId;
+  }
+
+  protected boolean canInheritSnapshotId() {
+    return canInheritSnapshotId;
   }
 
   private static ManifestFile addMetadata(TableOperations ops, ManifestFile manifest) {

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -443,6 +444,14 @@ public class TestRewriteManifests extends TableTestBase {
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
     Assert.assertEquals(3, manifests.size());
 
+    if (formatVersion == 1) {
+      assertThat(manifests.get(0).path()).isNotEqualTo(firstNewManifest.path());
+      assertThat(manifests.get(1).path()).isNotEqualTo(secondNewManifest.path());
+    } else {
+      assertThat(manifests.get(0).path()).isEqualTo(firstNewManifest.path());
+      assertThat(manifests.get(1).path()).isEqualTo(secondNewManifest.path());
+    }
+
     validateSummary(snapshot, 1, 1, 2, 0);
 
     validateManifestEntries(
@@ -498,6 +507,9 @@ public class TestRewriteManifests extends TableTestBase {
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
     Assert.assertEquals(3, manifests.size());
+
+    assertThat(manifests.get(0).path()).isEqualTo(firstNewManifest.path());
+    assertThat(manifests.get(1).path()).isEqualTo(secondNewManifest.path());
 
     validateSummary(snapshot, 1, 1, 2, 0);
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,7 +124,7 @@ The value of these properties are not persisted as a part of the table metadata.
 
 | Property                                      | Default  | Description                                                   |
 | --------------------------------------------- | -------- | ------------------------------------------------------------- |
-| compatibility.snapshot-id-inheritance.enabled | false    | Enables committing snapshots without explicit snapshot IDs    |
+| compatibility.snapshot-id-inheritance.enabled | false    | Enables committing snapshots without explicit snapshot IDs (always true if the format version is > 1) |
 
 ## Catalog properties
 

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -652,7 +652,7 @@ Warning : Files added by this method can be physically deleted by Iceberg operat
 | `changed_partition_count` | long | The number of partitioned changed by this command |
 
 {{< hint warning >}}
-changed_partition_count will be 0 when table property `compatibility.snapshot-id-inheritance.enabled` is set to true
+changed_partition_count will be 0 when table property `compatibility.snapshot-id-inheritance.enabled` is set to true or if the table format version is > 1.
 {{< /hint >}}
 #### Examples
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -328,7 +328,7 @@ public class RewriteManifestsSparkAction
       addedManifests.forEach(rewriteManifests::addManifest);
       commit(rewriteManifests);
 
-      if (!snapshotIdInheritanceEnabled) {
+      if (formatVersion == 1 && !snapshotIdInheritanceEnabled) {
         // delete new manifests as they were rewritten before the commit
         deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
       }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -328,7 +328,7 @@ public class RewriteManifestsSparkAction
       addedManifests.forEach(rewriteManifests::addManifest);
       commit(rewriteManifests);
 
-      if (!snapshotIdInheritanceEnabled) {
+      if (formatVersion == 1 && !snapshotIdInheritanceEnabled) {
         // delete new manifests as they were rewritten before the commit
         deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
       }

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -328,7 +328,7 @@ public class RewriteManifestsSparkAction
       addedManifests.forEach(rewriteManifests::addManifest);
       commit(rewriteManifests);
 
-      if (!snapshotIdInheritanceEnabled) {
+      if (formatVersion == 1 && !snapshotIdInheritanceEnabled) {
         // delete new manifests as they were rewritten before the commit
         deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
       }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteManifestsSparkAction.java
@@ -328,7 +328,7 @@ public class RewriteManifestsSparkAction
       addedManifests.forEach(rewriteManifests::addManifest);
       commit(rewriteManifests);
 
-      if (!snapshotIdInheritanceEnabled) {
+      if (formatVersion == 1 && !snapshotIdInheritanceEnabled) {
         // delete new manifests as they were rewritten before the commit
         deleteFiles(Iterables.transform(addedManifests, ManifestFile::path));
       }


### PR DESCRIPTION
This PR avoids extra copies of manifests while optimizing metadata for V2 tables via Spark. Specifically, we have to rewrite all remotely produced manifests while committing again to assign explicit snapshot IDs in V1 tables unless the snapshot ID inheritance is enabled (false by default). In V2 tables, however, snapshot ID inheritance is always enabled. That's why it is safe to reuse the remotely produced manifests without an expensive rewrite on the driver as long as we have a V2 table. Before this change, we always relied on the table property to check if snapshot ID inheritance is enabled, which was added before the V2 spec.